### PR TITLE
Improve developer workflow tooling

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run test:run

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,13 +3,14 @@
   "tasks": [
     {
       "label": "Ship: test, build, commit, push",
-      "type": "shell",
-      "command": "./scripts/ship.sh",
-      "args": ["${input:commitMessage}"],
+      "type": "npm",
+      "script": "ship",
+      "args": ["--", "${input:commitMessage}"],
       "group": {
         "kind": "build",
         "isDefault": true
-      }
+      },
+      "problemMatcher": []
     }
   ],
   "inputs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
+        "husky": "^9.1.7",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.5"
@@ -4704,6 +4705,22 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iceberg-js": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "vitest",
     "test:run": "vitest run",
-     "ship": "./scripts/ship.sh"
+    "ship": "./scripts/ship.sh",
+    "prepare": "husky"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
+    "husky": "^9.1.7",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"


### PR DESCRIPTION
## Summary
- add Husky setup with a pre-commit hook that runs `npm run test:run` only
- route the VS Code ship task through the npm `ship` script
- keep the ship script unchanged; it already exits on test/build failure via `set -euo pipefail`

## Verification
- `npm run test:run`
- `npm run build`
- commit hook also ran `npm run test:run` successfully during commit