### PR TITLE
Improve session results UI

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { MatchCard } from "@/components/MatchCard";
 import { findMatches, SingerEntry } from "@/lib/matching";
 import {
   addParticipant,
@@ -12,6 +13,12 @@ import {
 } from "@/lib/sessionStore";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
+
+const matchSections = [
+  { category: "ready", title: "Ready to sing" },
+  { category: "possible", title: "Possible matches — confirm arrangement" },
+  { category: "one_part_missing", title: "One part missing" },
+] as const;
 
 export default function JoinSessionPage() {
   const params = useParams<{ code: string }>();
@@ -130,6 +137,10 @@ export default function JoinSessionPage() {
 
   const allEntries: SingerEntry[] = participants.flatMap((p) => p.repertoire);
   const matches = findMatches(allEntries);
+  const groupedMatches = matchSections.map((section) => ({
+    ...section,
+    matches: matches.filter((match) => match.category === section.category),
+  }));
 
   if (loading) {
     return (
@@ -208,68 +219,32 @@ export default function JoinSessionPage() {
         <div className="mt-10">
           <h2 className="text-2xl font-semibold">Matches</h2>
 
-          <div className="mt-4 space-y-4">
+          <div className="mt-4 space-y-6">
             {matches.length === 0 && (
               <p className="rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-300">
                 No matches yet. Add more singers or repertoire.
               </p>
             )}
 
-            {matches.map((match) => (
-              <div
-                key={match.songTitle + match.voicing}
-                className="rounded-2xl border border-white/10 bg-white/10 p-5 shadow-lg"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <h3 className="text-2xl font-bold">
-                      {match.songTitle} — {match.voicing}
+            {groupedMatches.map(
+              (section) =>
+                section.matches.length > 0 && (
+                  <section key={section.category} className="space-y-3">
+                    <h3 className="text-lg font-semibold text-slate-100">
+                      {section.title}
                     </h3>
 
-                    <p className="mt-1 text-sm text-slate-300">
-                      {match.category === "ready" && "Ready to sing"}
-                      {match.category === "possible" &&
-                        "Possible match — confirm arrangement"}
-                      {match.category === "one_part_missing" &&
-                        `One part missing: ${match.missingParts.join(", ")}`}
-                    </p>
-                  </div>
-
-                  <span className="rounded-full bg-cyan-300 px-3 py-1 text-sm font-semibold text-slate-950">
-                    {match.category.replaceAll("_", " ")}
-                  </span>
-                </div>
-
-                <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                  {Object.entries(match.assignments).map(([part, singers]) => (
-                    <div key={part} className="rounded-xl bg-slate-900/70 p-3">
-                      <p className="font-semibold">{part}</p>
-                      <p className="text-sm text-slate-300">
-                        {singers.map((s) => s.displayName).join(", ")}
-                      </p>
+                    <div className="space-y-4">
+                      {section.matches.map((match) => (
+                        <MatchCard
+                          key={match.songTitle + match.voicing}
+                          match={match}
+                        />
+                      ))}
                     </div>
-                  ))}
-
-                  {match.missingParts.map((part) => (
-                    <div
-                      key={part}
-                      className="rounded-xl border border-rose-300/30 bg-rose-400/10 p-3"
-                    >
-                      <p className="font-semibold text-rose-200">{part}</p>
-                      <p className="text-sm text-rose-200">Missing</p>
-                    </div>
-                  ))}
-                </div>
-
-                {match.warnings.length > 0 && (
-                  <div className="mt-4 rounded-xl bg-amber-300/10 p-3 text-sm text-amber-200">
-                    {match.warnings.map((warning) => (
-                      <p key={warning}>⚠ {warning}</p>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
+                  </section>
+                )
+            )}
           </div>
         </div>
       </div>

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -1,0 +1,66 @@
+import type { MatchResult } from "@/lib/matching";
+
+type MatchCardProps = {
+  match: MatchResult;
+};
+
+const categoryLabels: Record<MatchResult["category"], string> = {
+  ready: "Ready to sing",
+  possible: "Confirm arrangement",
+  one_part_missing: "One part missing",
+};
+
+export function MatchCard({ match }: MatchCardProps) {
+  return (
+    <article className="rounded-2xl border border-white/10 bg-white/10 p-4 shadow-lg sm:p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="break-words text-xl font-bold sm:text-2xl">
+            {match.songTitle} — {match.voicing}
+          </h3>
+
+          <p className="mt-1 text-sm text-slate-300">
+            {match.category === "ready" && "Ready to sing"}
+            {match.category === "possible" &&
+              "Possible match — confirm arrangement"}
+            {match.category === "one_part_missing" &&
+              `One part missing: ${match.missingParts.join(", ")}`}
+          </p>
+        </div>
+
+        <span className="w-fit rounded-full bg-cyan-300 px-3 py-1 text-sm font-semibold text-slate-950">
+          {categoryLabels[match.category]}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        {Object.entries(match.assignments).map(([part, singers]) => (
+          <div key={part} className="rounded-xl bg-slate-900/70 p-3">
+            <p className="font-semibold">{part}</p>
+            <p className="text-sm text-slate-300">
+              {singers.map((singer) => singer.displayName).join(", ")}
+            </p>
+          </div>
+        ))}
+
+        {match.missingParts.map((part) => (
+          <div
+            key={part}
+            className="rounded-xl border border-rose-300/30 bg-rose-400/10 p-3"
+          >
+            <p className="font-semibold text-rose-200">{part}</p>
+            <p className="text-sm text-rose-200">Missing</p>
+          </div>
+        ))}
+      </div>
+
+      {match.warnings.length > 0 && (
+        <div className="mt-4 rounded-xl bg-amber-300/10 p-3 text-sm text-amber-200">
+          {match.warnings.map((warning) => (
+            <p key={warning}>⚠ {warning}</p>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- extract reusable `MatchCard` component for session match rendering
- group matches into Ready to sing, Possible matches, and One part missing sections
- preserve existing ranked order within each section without changing matching logic
- tighten match card layout for small screens

## Verification
- `npm run test:run`
- `npm run build`
- Husky pre-commit ran `npm run test:run` successfully during commit

No tests added because matching behavior did not change.