### PR TITLE
Fix magic link redirect URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Public app URL used in Supabase magic-link emails.
+# Production example: https://what-can-we-sing.vercel.app
+# Leave blank for local development; localhost falls back to window.location.origin.
+NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # what-can-we-sing
 An app to allow a pick-up barbershop quartet to quickly find songs they can sing together
+
+## Environment variables
+
+Copy `.env.example` to `.env.local` for local development.
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your Supabase project URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your Supabase anon key
+NEXT_PUBLIC_SITE_URL=https://your-production-app-url
+```
+
+`NEXT_PUBLIC_SITE_URL` is used for Supabase magic-link redirects in production. Set it to the deployed Vercel app URL, without a trailing path. If it is blank during local development, login links fall back to the current localhost origin.
+
+In Supabase Auth URL configuration, add the production URL and any required local development URL, such as `http://localhost:3000`, to the allowed redirect URLs.
+
+## Supabase auth email
+
+Hosted Supabase projects configure Auth email templates in the Supabase dashboard, not in this repo. Use the recommended Magic Link template in [docs/auth-email-template.md](docs/auth-email-template.md) so login emails are clearly branded as What Can We Sing and include a button plus fallback link.

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getMagicLinkRedirectUrl } from "@/lib/authRedirect";
 import { supabase } from "@/lib/supabase";
 import { useState } from "react";
 
@@ -10,10 +11,21 @@ export default function LoginPage() {
   async function sendMagicLink() {
     if (!email.trim()) return;
 
+    const emailRedirectTo = getMagicLinkRedirectUrl({
+      siteUrl: process.env.NEXT_PUBLIC_SITE_URL,
+      origin: window.location.origin,
+      search: window.location.search,
+    });
+
+    if (!emailRedirectTo) {
+      setMessage("Login is not configured for this site yet.");
+      return;
+    }
+
     const { error } = await supabase.auth.signInWithOtp({
       email: email.trim(),
       options: {
-        emailRedirectTo: `${window.location.origin}/settings`,
+        emailRedirectTo,
       },
     });
 

--- a/docs/auth-email-template.md
+++ b/docs/auth-email-template.md
@@ -1,0 +1,38 @@
+# Supabase Magic Link Email Template
+
+This project does not include a checked-in Supabase `config.toml`, so the hosted Supabase Auth email template must be configured in the Supabase dashboard.
+
+In Supabase, go to **Authentication > Email Templates > Magic Link** and use this template.
+
+Subject:
+
+```text
+Log in to What Can We Sing
+```
+
+Body:
+
+```html
+<div style="font-family: Arial, sans-serif; color: #0f172a; line-height: 1.5;">
+  <h2 style="margin: 0 0 16px;">Log in to What Can We Sing</h2>
+  <p style="margin: 0 0 16px;">
+    Click the button below to log in to What Can We Sing.
+  </p>
+  <p style="margin: 0 0 24px;">
+    <a
+      href="{{ .ConfirmationURL }}"
+      style="display: inline-block; border-radius: 8px; background: #67e8f9; color: #0f172a; font-weight: 700; padding: 12px 18px; text-decoration: none;"
+    >
+      Log in to What Can We Sing
+    </a>
+  </p>
+  <p style="margin: 0 0 8px; font-size: 14px; color: #475569;">
+    If the button does not work, copy and paste this link into your browser.
+  </p>
+  <p style="margin: 0; font-size: 14px; word-break: break-all;">
+    <a href="{{ .ConfirmationURL }}" style="color: #0369a1;">{{ .ConfirmationURL }}</a>
+  </p>
+</div>
+```
+
+Supabase provides `{{ .ConfirmationURL }}` for the one-time login URL. Keep that variable in both links.

--- a/lib/__tests__/authRedirect.test.ts
+++ b/lib/__tests__/authRedirect.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { getMagicLinkRedirectUrl } from "../authRedirect";
+
+describe("getMagicLinkRedirectUrl", () => {
+  it("uses NEXT_PUBLIC_SITE_URL when configured", () => {
+    expect(
+      getMagicLinkRedirectUrl({
+        siteUrl: "https://what-can-we-sing.vercel.app",
+        origin: "http://localhost:3000",
+        search: "",
+      })
+    ).toBe("https://what-can-we-sing.vercel.app/settings");
+  });
+
+  it("preserves a safe redirect parameter", () => {
+    expect(
+      getMagicLinkRedirectUrl({
+        siteUrl: "https://what-can-we-sing.vercel.app/",
+        origin: "http://localhost:3000",
+        search: "?redirect=/join/ABC123",
+      })
+    ).toBe("https://what-can-we-sing.vercel.app/join/ABC123");
+  });
+
+  it("falls back to the browser origin for local development", () => {
+    expect(
+      getMagicLinkRedirectUrl({
+        siteUrl: undefined,
+        origin: "http://localhost:3000",
+        search: "",
+      })
+    ).toBe("http://localhost:3000/settings");
+  });
+
+  it("does not fall back to a production browser origin", () => {
+    expect(
+      getMagicLinkRedirectUrl({
+        siteUrl: undefined,
+        origin: "https://preview.example.com",
+        search: "",
+      })
+    ).toBeNull();
+  });
+
+  it("ignores unsafe absolute redirect parameters", () => {
+    expect(
+      getMagicLinkRedirectUrl({
+        siteUrl: "https://what-can-we-sing.vercel.app",
+        origin: "http://localhost:3000",
+        search: "?redirect=https://example.com",
+      })
+    ).toBe("https://what-can-we-sing.vercel.app/settings");
+  });
+});

--- a/lib/authRedirect.ts
+++ b/lib/authRedirect.ts
@@ -1,0 +1,48 @@
+const DEFAULT_AUTH_REDIRECT_PATH = "/settings";
+
+function normalizeSiteUrl(siteUrl: string | undefined): string | null {
+  if (!siteUrl?.trim()) return null;
+
+  try {
+    const url = new URL(siteUrl.trim());
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLocalOrigin(origin: string): boolean {
+  try {
+    const { hostname } = new URL(origin);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function safeRedirectPath(search: string): string {
+  const redirect = new URLSearchParams(search).get("redirect");
+
+  if (!redirect || !redirect.startsWith("/") || redirect.startsWith("//")) {
+    return DEFAULT_AUTH_REDIRECT_PATH;
+  }
+
+  return redirect;
+}
+
+export function getMagicLinkRedirectUrl({
+  siteUrl,
+  origin,
+  search,
+}: {
+  siteUrl: string | undefined;
+  origin: string;
+  search: string;
+}): string | null {
+  const redirectPath = safeRedirectPath(search);
+  const baseUrl = normalizeSiteUrl(siteUrl) ?? (isLocalOrigin(origin) ? origin : null);
+
+  if (!baseUrl) return null;
+
+  return new URL(redirectPath, baseUrl).toString();
+}


### PR DESCRIPTION
## Summary
- Use `NEXT_PUBLIC_SITE_URL` for Supabase magic-link redirects when configured
- Preserve safe `redirect` params while defaulting to `/settings`
- Add redirect helper tests and document the Supabase Magic Link email template

## Verification
- `npm run test:run`
- `npm run build`