### PR TITLE
Add authenticated app navigation

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -2,8 +2,8 @@
 
 import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
-import { SignOutButton } from "@/components/SignOutButton";
 import { findMatches, SingerEntry } from "@/lib/matching";
 import {
   addParticipant,
@@ -77,7 +77,7 @@ export default function JoinSessionPage() {
       setMessage(`Joined as ${name} with ${entries.length} songs.`);
     } catch (err) {
       console.error(err);
-      setMessage("Could not join session.");
+      setMessage("Could not join quartet.");
     }
   }
 
@@ -119,11 +119,11 @@ export default function JoinSessionPage() {
           hasAutoJoined.current = true;
           await joinSession(session.id, profile.display_name);
         } else {
-          setMessage(`You are already in this session as ${profile.display_name}.`);
+          setMessage(`You are already in this quartet as ${profile.display_name}.`);
         }
       } catch (err) {
         console.error(err);
-        setMessage("Could not load this session.");
+        setMessage("Could not load this quartet.");
       } finally {
         setLoading(false);
       }
@@ -146,7 +146,7 @@ export default function JoinSessionPage() {
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
-        Joining session...
+        Joining quartet...
       </main>
     );
   }
@@ -154,14 +154,9 @@ export default function JoinSessionPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-5xl">
-        <div className="flex flex-wrap items-center gap-4">
-          <a href="/session" className="text-sm text-cyan-300 hover:text-cyan-200">
-            ← Start another session
-          </a>
-          <SignOutButton />
-        </div>
+        <AppNav />
 
-        <h1 className="mt-4 text-4xl font-bold">Session {code}</h1>
+        <h1 className="mt-4 text-4xl font-bold">Quartet {code}</h1>
 
         {message && (
           <p className="mt-4 rounded-xl bg-white/10 p-4 text-slate-200">
@@ -170,7 +165,7 @@ export default function JoinSessionPage() {
         )}
 
         <div className="mt-6 rounded-2xl border border-white/10 bg-white/10 p-6">
-          <p className="text-slate-300">You are in this session as:</p>
+          <p className="text-slate-300">You are in this quartet as:</p>
           <p className="mt-1 text-2xl font-bold text-cyan-300">{displayName}</p>
 
           <button
@@ -189,7 +184,7 @@ export default function JoinSessionPage() {
           </a>
 
           <a
-            href="/"
+            href="/repertoire"
             className="ml-4 inline-block text-sm text-cyan-300 hover:text-cyan-200"
           >
             Edit repertoire

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignOutButton } from "@/components/SignOutButton";
+import { AppNav } from "@/components/AppNav";
 import { useState } from "react";
 
 export default function Home() {
@@ -16,11 +16,9 @@ export default function Home() {
   return (
     <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-md flex-col justify-center">
-        <div className="mb-8 flex justify-end">
-          <SignOutButton />
-        </div>
+        <AppNav />
 
-        <p className="text-sm font-semibold uppercase text-cyan-300">
+        <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
           What Can We Sing
         </p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight">
@@ -38,7 +36,10 @@ export default function Home() {
             Start a quartet
           </a>
 
-          <div className="rounded-xl border border-white/10 bg-white/10 p-4">
+          <div
+            id="join-quartet"
+            className="rounded-xl border border-white/10 bg-white/10 p-4"
+          >
             <label className="block">
               <span className="text-sm font-medium text-slate-300">
                 Join a quartet

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -2,7 +2,7 @@
 
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
-import { SignOutButton } from "@/components/SignOutButton";
+import { AppNav } from "@/components/AppNav";
 import { createSession } from "@/lib/sessionStore";
 
 function makeJoinCode() {
@@ -46,12 +46,7 @@ export default function SessionPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-3xl">
-        <div className="flex flex-wrap items-center gap-4">
-          <a href="/" className="text-sm text-cyan-300 hover:text-cyan-200">
-            ← Back home
-          </a>
-          <SignOutButton />
-        </div>
+        <AppNav />
 
         <h1 className="mt-4 text-4xl font-bold">Start a quartet</h1>
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SignOutButton } from "@/components/SignOutButton";
+import { AppNav } from "@/components/AppNav";
 import {
   getCurrentUser,
   getMyProfile,
@@ -91,12 +91,7 @@ export default function SettingsPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-2xl">
-        <div className="flex flex-wrap items-center gap-4">
-          <a href="/" className="text-sm text-cyan-300 hover:text-cyan-200">
-            ← Back home
-          </a>
-          {isLoggedIn && <SignOutButton />}
-        </div>
+        <AppNav />
 
         <h1 className="mt-4 text-4xl font-bold">Settings</h1>
         <p className="mt-2 text-slate-300">{email}</p>

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { SignOutButton } from "@/components/SignOutButton";
+
+const navItems = [
+  {
+    href: "/",
+    label: "Home",
+    isActive: (pathname: string) => pathname === "/",
+  },
+  {
+    href: "/session",
+    label: "Start a quartet",
+    isActive: (pathname: string) => pathname === "/session",
+  },
+  {
+    href: "/#join-quartet",
+    label: "Join a quartet",
+    isActive: (pathname: string) => pathname.startsWith("/join"),
+  },
+  {
+    href: "/repertoire",
+    label: "Manage my rep",
+    isActive: (pathname: string) => pathname === "/repertoire",
+  },
+  {
+    href: "/settings",
+    label: "Settings",
+    isActive: (pathname: string) => pathname === "/settings",
+  },
+];
+
+export function AppNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Main navigation"
+      className="rounded-2xl border border-white/10 bg-white/10 p-3"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {navItems.map((item) => {
+          const active = item.isActive(pathname);
+          const href =
+            active && pathname.startsWith("/join") ? pathname : item.href;
+
+          return (
+            <a
+              key={item.label}
+              href={href}
+              aria-current={active ? "page" : undefined}
+              className={`rounded-xl px-3 py-2 text-sm font-semibold ${
+                active
+                  ? "bg-cyan-300 text-slate-950"
+                  : "text-cyan-200 hover:bg-white/10 hover:text-white"
+              }`}
+            >
+              {item.label}
+            </a>
+          );
+        })}
+
+        <SignOutButton className="rounded-xl px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/10 hover:text-white disabled:opacity-50" />
+      </div>
+    </nav>
+  );
+}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { SignOutButton } from "@/components/SignOutButton";
+import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
 import {
   addRepertoireItem,
@@ -204,15 +204,7 @@ export default function RepertoireManager() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-5xl">
-        <div className="flex flex-wrap items-center gap-4">
-          <a href="/session" className="text-sm text-cyan-300 hover:text-cyan-200">
-            → Start a quartet
-          </a>
-          <a href="/settings" className="text-sm text-cyan-300 hover:text-cyan-200">
-            → Settings
-          </a>
-          <SignOutButton />
-        </div>
+        <AppNav />
 
         <h1 className="mt-4 text-4xl font-bold tracking-tight">My Repertoire</h1>
         <p className="mt-2 text-slate-300">


### PR DESCRIPTION
## Summary
- Add a shared top-level app navigation component with Home, Start a quartet, Join a quartet, Manage my rep, Settings, and Sign out
- Highlight the active route across home, start, join, repertoire, and settings pages
- Replace one-off page header links with the shared navigation and update join-page visible copy to use quartet language

Closes #25.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.