### PR TITLE
Refine home and join flow

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { AppNav } from "@/components/AppNav";
+import { useState } from "react";
+
+export default function JoinPage() {
+  const [joinCode, setJoinCode] = useState("");
+
+  function joinQuartet() {
+    const code = joinCode.trim().toUpperCase();
+    if (!code) return;
+
+    window.location.href = `/join/${encodeURIComponent(code)}`;
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
+      <div className="mx-auto max-w-md">
+        <AppNav />
+
+        <h1 className="mt-8 text-4xl font-bold tracking-tight">
+          Join a quartet
+        </h1>
+        <p className="mt-3 text-slate-300">
+          Enter the code another singer shared with you.
+        </p>
+
+        <section className="mt-8 rounded-xl border border-white/10 bg-white/10 p-5">
+          <label className="block">
+            <span className="text-sm font-medium text-slate-300">
+              Quartet code
+            </span>
+            <input
+              value={joinCode}
+              onChange={(event) => setJoinCode(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") joinQuartet();
+              }}
+              autoCapitalize="characters"
+              className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white uppercase outline-none ring-cyan-300 focus:ring-2"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={joinQuartet}
+            disabled={!joinCode.trim()}
+            className="mt-4 w-full rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+          >
+            Join quartet
+          </button>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,24 @@
-"use client";
-
 import { AppNav } from "@/components/AppNav";
-import { useState } from "react";
+
+const actions = [
+  {
+    href: "/session",
+    title: "Start a quartet",
+    description: "Create a code for others to join.",
+  },
+  {
+    href: "/join",
+    title: "Join a quartet",
+    description: "Enter a code from another singer.",
+  },
+  {
+    href: "/repertoire",
+    title: "My repertoire",
+    description: "Add or update songs you know.",
+  },
+];
 
 export default function Home() {
-  const [joinCode, setJoinCode] = useState("");
-
-  function joinQuartet() {
-    const code = joinCode.trim().toUpperCase();
-    if (!code) return;
-
-    window.location.href = `/join/${encodeURIComponent(code)}`;
-  }
-
   return (
     <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-md flex-col justify-center">
@@ -29,49 +35,20 @@ export default function Home() {
         </p>
 
         <div className="mt-10 space-y-3">
-          <a
-            href="/session"
-            className="block rounded-xl bg-cyan-300 px-5 py-4 text-center font-semibold text-slate-950 hover:bg-cyan-200"
-          >
-            Start a quartet
-          </a>
-
-          <div
-            id="join-quartet"
-            className="rounded-xl border border-white/10 bg-white/10 p-4"
-          >
-            <label className="block">
-              <span className="text-sm font-medium text-slate-300">
-                Join a quartet
+          {actions.map((action) => (
+            <a
+              key={action.href}
+              href={action.href}
+              className="block rounded-xl border border-white/10 bg-white/10 px-5 py-4 hover:border-cyan-300/60 hover:bg-white/15"
+            >
+              <span className="block text-lg font-semibold text-white">
+                {action.title}
               </span>
-              <div className="mt-2 flex gap-2">
-                <input
-                  value={joinCode}
-                  onChange={(event) => setJoinCode(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") joinQuartet();
-                  }}
-                  placeholder="Code"
-                  className="min-w-0 flex-1 rounded-xl bg-slate-900 px-4 py-3 text-white uppercase outline-none ring-cyan-300 focus:ring-2"
-                />
-                <button
-                  type="button"
-                  onClick={joinQuartet}
-                  disabled={!joinCode.trim()}
-                  className="rounded-xl bg-cyan-300 px-4 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
-                >
-                  Join
-                </button>
-              </div>
-            </label>
-          </div>
-
-          <a
-            href="/repertoire"
-            className="block rounded-xl bg-white/10 px-5 py-4 text-center font-semibold text-white hover:bg-white/20"
-          >
-            My repertoire
-          </a>
+              <span className="mt-1 block text-sm text-slate-300">
+                {action.description}
+              </span>
+            </a>
+          ))}
         </div>
       </div>
     </main>

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -15,7 +15,7 @@ const navItems = [
     isActive: (pathname: string) => pathname === "/session",
   },
   {
-    href: "/#join-quartet",
+    href: "/join",
     label: "Join a quartet",
     isActive: (pathname: string) => pathname.startsWith("/join"),
   },
@@ -42,13 +42,11 @@ export function AppNav() {
       <div className="flex flex-wrap items-center gap-2">
         {navItems.map((item) => {
           const active = item.isActive(pathname);
-          const href =
-            active && pathname.startsWith("/join") ? pathname : item.href;
 
           return (
             <a
               key={item.label}
-              href={href}
+              href={item.href}
               aria-current={active ? "page" : undefined}
               className={`rounded-xl px-3 py-2 text-sm font-semibold ${
                 active


### PR DESCRIPTION
## Summary
- Make the home page a balanced action hub with three peer-level actions
- Move manual quartet-code entry to a dedicated `/join` page
- Update navigation so Join a quartet points to `/join` while `/join/[code]` QR/deep-link behavior remains intact

Closes #35.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.