### PR TITLE
Prevent duplicate session participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,25 @@ In Supabase Auth URL configuration, add the production URL and any required loca
 ## Supabase auth email
 
 Hosted Supabase projects configure Auth email templates in the Supabase dashboard, not in this repo. Use the recommended Magic Link template in [docs/auth-email-template.md](docs/auth-email-template.md) so login emails are clearly branded as What Can We Sing and include a button plus fallback link.
+
+## Supabase database
+
+Session participants are keyed by the authenticated Supabase user so one singer can refresh their repertoire without creating duplicate rows, while different singers with the same display name can still join the same quartet.
+
+If your `session_participants` table does not already have `user_id` and a unique constraint for each user in each session, run this in the Supabase SQL editor:
+
+```sql
+alter table public.session_participants
+  add column if not exists user_id uuid references auth.users(id) on delete cascade;
+
+delete from public.session_participants
+where user_id is null;
+
+alter table public.session_participants
+  alter column user_id set not null;
+
+create unique index if not exists session_participants_session_user_unique
+  on public.session_participants (session_id, user_id);
+```
+
+The delete only clears participant snapshots created before `user_id` existed; singers can rejoin active quartets to recreate their current snapshots.

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -6,11 +6,11 @@ import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { findMatches, SingerEntry } from "@/lib/matching";
 import {
-  addParticipant,
+  type DbParticipant,
   getParticipants,
   getSessionByCode,
   subscribeToSessionParticipants,
-  updateParticipantRepertoire,
+  upsertParticipant,
 } from "@/lib/sessionStore";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
@@ -29,8 +29,9 @@ export default function JoinSessionPage() {
 
   const [loading, setLoading] = useState(true);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState("");
   const [displayName, setDisplayName] = useState("");
-  const [participants, setParticipants] = useState<any[]>([]);
+  const [participants, setParticipants] = useState<DbParticipant[]>([]);
   const [message, setMessage] = useState("");
 
   async function refreshParticipants(id: string) {
@@ -53,27 +54,30 @@ export default function JoinSessionPage() {
     }));
   }
 
-  async function joinSession(id = sessionId, name = displayName) {
-    if (!id || !name) return;
+  async function joinSession(
+    id = sessionId,
+    name = displayName,
+    userId = currentUserId
+  ) {
+    if (!id || !name || !userId) return;
 
     try {
       const existingParticipants = await refreshParticipants(id);
 
       const existingParticipant = existingParticipants.find(
-        (participant) => participant.display_name === name
+        (participant) => participant.user_id === userId
       );
 
       const entries = await getMyEntries(name);
 
+      await upsertParticipant(id, userId, name, entries);
+      await refreshParticipants(id);
+
       if (existingParticipant) {
-        await updateParticipantRepertoire(existingParticipant.id, entries);
-        await refreshParticipants(id);
         setMessage(`Updated ${name}'s repertoire with ${entries.length} songs.`);
         return;
       }
 
-      await addParticipant(id, name, entries);
-      await refreshParticipants(id);
       setMessage(`Joined as ${name} with ${entries.length} songs.`);
     } catch (err) {
       console.error(err);
@@ -102,6 +106,7 @@ export default function JoinSessionPage() {
 
         const session = await getSessionByCode(code);
 
+        setCurrentUserId(user.id);
         setDisplayName(profile.display_name);
         setSessionId(session.id);
 
@@ -112,12 +117,12 @@ export default function JoinSessionPage() {
         });
 
         const alreadyJoined = currentParticipants.some(
-          (participant) => participant.display_name === profile.display_name
+          (participant) => participant.user_id === user.id
         );
 
         if (!alreadyJoined && !hasAutoJoined.current) {
           hasAutoJoined.current = true;
-          await joinSession(session.id, profile.display_name);
+          await joinSession(session.id, profile.display_name, user.id);
         } else {
           setMessage(`You are already in this quartet as ${profile.display_name}.`);
         }
@@ -170,7 +175,7 @@ export default function JoinSessionPage() {
 
           <button
             onClick={() => joinSession()}
-            disabled={!sessionId || !displayName}
+            disabled={!sessionId || !displayName || !currentUserId}
             className="mt-4 rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
           >
             Rejoin / refresh my repertoire

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -10,6 +10,7 @@ export type DbSession = {
 export type DbParticipant = {
   id: string;
   session_id: string;
+  user_id: string;
   display_name: string;
   repertoire: SingerEntry[];
   joined_at: string;
@@ -37,33 +38,23 @@ export async function getSessionByCode(joinCode: string) {
   return data as DbSession;
 }
 
-export async function addParticipant(
+export async function upsertParticipant(
   sessionId: string,
+  userId: string,
   displayName: string,
   repertoire: SingerEntry[]
 ) {
   const { data, error } = await supabase
     .from("session_participants")
-    .insert({
-      session_id: sessionId,
-      display_name: displayName,
-      repertoire,
-    })
-    .select()
-    .single();
-
-  if (error) throw error;
-  return data as DbParticipant;
-}
-
-export async function updateParticipantRepertoire(
-  participantId: string,
-  repertoire: SingerEntry[]
-) {
-  const { data, error } = await supabase
-    .from("session_participants")
-    .update({ repertoire })
-    .eq("id", participantId)
+    .upsert(
+      {
+        session_id: sessionId,
+        user_id: userId,
+        display_name: displayName,
+        repertoire,
+      },
+      { onConflict: "session_id,user_id" }
+    )
     .select()
     .single();
 


### PR DESCRIPTION
## Summary
- Key session participants by authenticated Supabase `user_id` instead of display name
- Upsert participant snapshots on join/refresh so the same user updates their row instead of duplicating
- Preserve support for different users sharing the same display name

Closes #8.

## Verification
- `npm run test:run`
- `npm run build`

## Manual Supabase step
Run this in the Supabase SQL editor if `session_participants` does not already have `user_id` plus a unique `(session_id, user_id)` constraint:

```sql
alter table public.session_participants
  add column if not exists user_id uuid references auth.users(id) on delete cascade;

delete from public.session_participants
where user_id is null;

alter table public.session_participants
  alter column user_id set not null;

create unique index if not exists session_participants_session_user_unique
  on public.session_participants (session_id, user_id);
```

The delete clears old participant snapshots created before `user_id` existed; singers can rejoin active quartets to recreate their snapshots.