### PR TITLE
Redirect unauthenticated users globally

### DIFF
--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getLoginRedirectUrl, isPublicAuthPath } from "../authRoute";
+
+describe("isPublicAuthPath", () => {
+  it("allows the login route", () => {
+    expect(isPublicAuthPath("/login")).toBe(true);
+  });
+
+  it("protects app routes", () => {
+    expect(isPublicAuthPath("/repertoire")).toBe(false);
+    expect(isPublicAuthPath("/join/ABC123")).toBe(false);
+  });
+});
+
+describe("getLoginRedirectUrl", () => {
+  it("redirects root to login without a redirect parameter", () => {
+    const url = getLoginRedirectUrl(new URL("https://example.com/"));
+
+    expect(url.toString()).toBe("https://example.com/login");
+  });
+
+  it("preserves the intended protected route", () => {
+    const url = getLoginRedirectUrl(
+      new URL("https://example.com/join/ABC123?foo=bar")
+    );
+
+    expect(url.toString()).toBe(
+      "https://example.com/login?redirect=%2Fjoin%2FABC123%3Ffoo%3Dbar"
+    );
+  });
+});

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -1,0 +1,17 @@
+export function isPublicAuthPath(pathname: string): boolean {
+  return pathname === "/login" || pathname.startsWith("/login/");
+}
+
+export function getLoginRedirectUrl(requestUrl: URL): URL {
+  const loginUrl = new URL(requestUrl);
+  const destination = `${requestUrl.pathname}${requestUrl.search}`;
+
+  loginUrl.pathname = "/login";
+  loginUrl.search = "";
+
+  if (destination !== "/") {
+    loginUrl.searchParams.set("redirect", destination);
+  }
+
+  return loginUrl;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,62 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import { getLoginRedirectUrl, isPublicAuthPath } from "@/lib/authRoute";
+
+export async function proxy(request: NextRequest) {
+  if (isPublicAuthPath(request.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet, headersToSet) {
+          cookiesToSet.forEach(({ name, value }) => {
+            request.cookies.set(name, value);
+          });
+
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          });
+
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+
+          Object.entries(headersToSet).forEach(([key, value]) => {
+            response.headers.set(key, value);
+          });
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.redirect(getLoginRedirectUrl(request.nextUrl));
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- Add a global Next proxy auth guard that redirects logged-out users from protected routes to `/login`
- Preserve the intended protected destination in the `redirect` query parameter
- Keep `/login` public to avoid redirect loops
- Add tests for public-route detection and login redirect URL generation

Closes #22.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.