### PR TITLE
Handle Supabase magic link callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ NEXT_PUBLIC_SITE_URL=https://your-production-app-url
 
 `NEXT_PUBLIC_SITE_URL` is used for Supabase magic-link redirects in production. Set it to the deployed Vercel app URL, without a trailing path. If it is blank during local development, login links fall back to the current localhost origin.
 
-In Supabase Auth URL configuration, add the production URL and any required local development URL, such as `http://localhost:3000`, to the allowed redirect URLs.
+Magic links redirect through `/auth/callback`, where the app exchanges the Supabase code for a session before sending the user to the intended page. In Supabase Auth URL configuration, add the production callback URL and any required local development callback URL to the allowed redirect URLs, such as:
+
+```text
+https://your-production-app-url/auth/callback
+http://localhost:3000/auth/callback
+```
 
 ## Supabase auth email
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,49 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import { getAuthCallbackNextPath } from "@/lib/authRedirect";
+
+export async function GET(request: NextRequest) {
+  const nextPath = getAuthCallbackNextPath(request.nextUrl.search);
+  const code = request.nextUrl.searchParams.get("code");
+  const successUrl = new URL(nextPath, request.url);
+  const loginUrl = new URL("/login", request.url);
+
+  loginUrl.searchParams.set("redirect", nextPath);
+
+  if (!code) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  let response = NextResponse.redirect(successUrl);
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet, headersToSet) {
+          response = NextResponse.redirect(successUrl);
+
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+
+          Object.entries(headersToSet).forEach(([key, value]) => {
+            response.headers.set(key, value);
+          });
+        },
+      },
+    }
+  );
+
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return response;
+}

--- a/lib/__tests__/authRedirect.test.ts
+++ b/lib/__tests__/authRedirect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getAuthCallbackNextPath,
   getMagicLinkRedirectUrl,
   getPostLoginRedirectPath,
 } from "../authRedirect";
@@ -24,6 +25,21 @@ describe("getPostLoginRedirectPath", () => {
   });
 });
 
+describe("getAuthCallbackNextPath", () => {
+  it("defaults callback redirects to home", () => {
+    expect(getAuthCallbackNextPath("")).toBe("/");
+  });
+
+  it("preserves a safe next query parameter", () => {
+    expect(getAuthCallbackNextPath("?next=/join/ABC123")).toBe("/join/ABC123");
+  });
+
+  it("ignores unsafe next query parameters", () => {
+    expect(getAuthCallbackNextPath("?next=https://example.com")).toBe("/");
+    expect(getAuthCallbackNextPath("?next=//example.com")).toBe("/");
+  });
+});
+
 describe("getMagicLinkRedirectUrl", () => {
   it("uses NEXT_PUBLIC_SITE_URL when configured", () => {
     expect(
@@ -32,17 +48,19 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "",
       })
-    ).toBe("https://what-can-we-sing.vercel.app/");
+    ).toBe("https://what-can-we-sing.vercel.app/auth/callback");
   });
 
-  it("preserves a safe redirect parameter", () => {
+  it("passes a safe redirect parameter through the auth callback", () => {
     expect(
       getMagicLinkRedirectUrl({
         siteUrl: "https://what-can-we-sing.vercel.app/",
         origin: "http://localhost:3000",
         search: "?redirect=/join/ABC123",
       })
-    ).toBe("https://what-can-we-sing.vercel.app/join/ABC123");
+    ).toBe(
+      "https://what-can-we-sing.vercel.app/auth/callback?next=%2Fjoin%2FABC123"
+    );
   });
 
   it("falls back to the browser origin for local development", () => {
@@ -52,7 +70,7 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "",
       })
-    ).toBe("http://localhost:3000/");
+    ).toBe("http://localhost:3000/auth/callback");
   });
 
   it("does not fall back to a production browser origin", () => {
@@ -72,6 +90,6 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "?redirect=https://example.com",
       })
-    ).toBe("https://what-can-we-sing.vercel.app/");
+    ).toBe("https://what-can-we-sing.vercel.app/auth/callback");
   });
 });

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -6,6 +6,10 @@ describe("isPublicAuthPath", () => {
     expect(isPublicAuthPath("/login")).toBe(true);
   });
 
+  it("allows the auth callback route", () => {
+    expect(isPublicAuthPath("/auth/callback")).toBe(true);
+  });
+
   it("protects app routes", () => {
     expect(isPublicAuthPath("/repertoire")).toBe(false);
     expect(isPublicAuthPath("/join/ABC123")).toBe(false);

--- a/lib/authRedirect.ts
+++ b/lib/authRedirect.ts
@@ -1,4 +1,5 @@
 const DEFAULT_AUTH_REDIRECT_PATH = "/";
+const AUTH_CALLBACK_PATH = "/auth/callback";
 
 function normalizeSiteUrl(siteUrl: string | undefined): string | null {
   if (!siteUrl?.trim()) return null;
@@ -30,6 +31,16 @@ export function getPostLoginRedirectPath(search: string): string {
   return redirect;
 }
 
+export function getAuthCallbackNextPath(search: string): string {
+  const next = new URLSearchParams(search).get("next");
+
+  if (!next || !next.startsWith("/") || next.startsWith("//")) {
+    return DEFAULT_AUTH_REDIRECT_PATH;
+  }
+
+  return next;
+}
+
 export function getMagicLinkRedirectUrl({
   siteUrl,
   origin,
@@ -44,5 +55,11 @@ export function getMagicLinkRedirectUrl({
 
   if (!baseUrl) return null;
 
-  return new URL(redirectPath, baseUrl).toString();
+  const callbackUrl = new URL(AUTH_CALLBACK_PATH, baseUrl);
+
+  if (redirectPath !== DEFAULT_AUTH_REDIRECT_PATH) {
+    callbackUrl.searchParams.set("next", redirectPath);
+  }
+
+  return callbackUrl.toString();
 }

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -1,5 +1,9 @@
 export function isPublicAuthPath(pathname: string): boolean {
-  return pathname === "/login" || pathname.startsWith("/login/");
+  return (
+    pathname === "/login" ||
+    pathname.startsWith("/login/") ||
+    pathname === "/auth/callback"
+  );
 }
 
 export function getLoginRedirectUrl(requestUrl: URL): URL {


### PR DESCRIPTION
## Summary
- Route magic-link redirects through `/auth/callback` instead of directly to protected app pages
- Exchange the Supabase auth code server-side and set the session cookie before redirecting to the intended page
- Keep `/auth/callback` public in the global auth guard so magic links do not loop back to `/login`
- Add tests for callback next-path handling and callback route visibility

Closes #44.

## Verification
- `npm run test:run`
- `npm run build`

## Manual Supabase step
In Supabase Auth URL configuration, add the callback URLs to the allowed redirect URLs if they are not already present:

```text
https://your-production-app-url/auth/callback
http://localhost:3000/auth/callback
```

Also ensure `NEXT_PUBLIC_SITE_URL` is set to the deployed app origin in production, without a trailing path.