### PR TITLE
Label arranger field as optional

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -265,7 +265,7 @@ export default function RepertoireManager() {
 
             <label className="block">
               <span className="text-sm font-medium text-slate-300">
-                Arranger optional
+                Arranger (optional)
               </span>
               <input
                 value={arrangerName}
@@ -372,7 +372,7 @@ export default function RepertoireManager() {
 
                       <label className="block">
                         <span className="text-sm font-medium text-slate-300">
-                          Arranger optional
+                          Arranger (optional)
                         </span>
                         <input
                           value={editForm.arrangerName}


### PR DESCRIPTION
## Summary
- Update both add and edit repertoire form labels to `Arranger (optional)`
- Leave validation and form behavior unchanged

Closes #32.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.