### PR TITLE
Only show settings repertoire prompt when empty

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,6 +6,7 @@ import {
   getMyProfile,
   upsertMyProfile,
 } from "@/lib/profileStore";
+import { getMyRepertoire } from "@/lib/repertoireStore";
 import { useEffect, useState } from "react";
 
 const defaultParts = [
@@ -73,8 +74,16 @@ export default function SettingsPage() {
 
     try {
       await upsertMyProfile(displayName.trim(), defaultPart);
-      setMessage("Settings saved. Next, add a few songs you know.");
-      setShowRepertoireNextStep(true);
+      const repertoire = await getMyRepertoire();
+
+      if (repertoire.length === 0) {
+        setMessage("Settings saved. Next, add a few songs you know.");
+        setShowRepertoireNextStep(true);
+        return;
+      }
+
+      setMessage("Settings saved.");
+      setShowRepertoireNextStep(false);
     } catch (err) {
       console.error(err);
       setMessage("Could not save settings. Check your connection and try again.");


### PR DESCRIPTION
## Summary
- Check the user’s repertoire after saving settings
- Show the add-songs onboarding prompt only when repertoire is empty
- Keep the saved-settings message minimal for users who already have songs

Closes #46.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.