### PR TITLE
Remove form placeholder text

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -122,14 +122,13 @@ export default function SettingsPage() {
             <input
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
-              placeholder="Tim"
               className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
             />
           </label>
 
           <label className="mt-5 block">
             <span className="text-sm font-medium text-slate-300">
-              Default part optional
+              Default voice part (optional)
             </span>
             <select
               value={defaultPart}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -258,7 +258,6 @@ export default function RepertoireManager() {
               <input
                 value={songTitle}
                 onChange={(e) => setSongTitle(e.target.value)}
-                placeholder="Hello Mary Lou"
                 className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
               />
             </label>
@@ -270,7 +269,6 @@ export default function RepertoireManager() {
               <input
                 value={arrangerName}
                 onChange={(e) => setArrangerName(e.target.value)}
-                placeholder="Unknown is okay"
                 className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
               />
             </label>
@@ -379,7 +377,6 @@ export default function RepertoireManager() {
                           onChange={(e) =>
                             updateEditForm({ arrangerName: e.target.value })
                           }
-                          placeholder="Unknown is okay"
                           className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                         />
                       </label>


### PR DESCRIPTION
## Summary
- Remove placeholder text from repertoire song title and arranger inputs
- Remove placeholder text from settings display name input
- Rename the default part label to `Default voice part (optional)`

Closes #48.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.