### PR TITLE
Update repertoire confidence choices

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -21,11 +21,9 @@ const partsByVoicing: Record<Voicing, Part[]> = {
 };
 
 const confidenceLevels: Confidence[] = [
-  "Performance ready",
-  "Solid",
-  "Needs review",
-  "Rusty",
-  "Learning",
+  "Good to Go",
+  "A Little Rusty",
+  "Music Required",
 ];
 
 type RepertoireForm = {
@@ -40,10 +38,10 @@ export default function RepertoireManager() {
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<RepertoireRow[]>([]);
   const [songTitle, setSongTitle] = useState("");
-  const [voicing, setVoicing] = useState<Voicing>("TTBB");
+  const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
   const [partsKnown, setPartsKnown] = useState<Part[]>([]);
-  const [confidence, setConfidence] = useState<Confidence>("Solid");
+  const [confidence, setConfidence] = useState<Confidence | "">("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<RepertoireForm | null>(null);
   const [message, setMessage] = useState("");
@@ -142,6 +140,16 @@ export default function RepertoireManager() {
       return;
     }
 
+    if (!voicing) {
+      setMessage("Choose a voicing before saving.");
+      return;
+    }
+
+    if (!confidence) {
+      setMessage("Choose a confidence level before saving.");
+      return;
+    }
+
     if (partsKnown.length === 0) {
       setMessage("Choose at least one part you know before saving.");
       return;
@@ -157,9 +165,10 @@ export default function RepertoireManager() {
       });
 
       setSongTitle("");
+      setVoicing("");
       setArrangerName("");
       setPartsKnown([]);
-      setConfidence("Solid");
+      setConfidence("");
       setMessage("Song added.");
 
       await loadRepertoire();
@@ -224,6 +233,9 @@ export default function RepertoireManager() {
     );
   }
 
+  const canAddSong =
+    Boolean(songTitle.trim()) && Boolean(voicing) && Boolean(confidence) && partsKnown.length > 0;
+
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-5xl">
@@ -278,11 +290,12 @@ export default function RepertoireManager() {
               <select
                 value={voicing}
                 onChange={(e) => {
-                  setVoicing(e.target.value as Voicing);
+                  setVoicing(e.target.value as Voicing | "");
                   setPartsKnown([]);
                 }}
                 className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
               >
+                <option value="">Choose voicing</option>
                 {voicings.map((v) => (
                   <option key={v}>{v}</option>
                 ))}
@@ -293,9 +306,10 @@ export default function RepertoireManager() {
               <span className="text-sm font-medium text-slate-300">Confidence</span>
               <select
                 value={confidence}
-                onChange={(e) => setConfidence(e.target.value as Confidence)}
+                onChange={(e) => setConfidence(e.target.value as Confidence | "")}
                 className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
               >
+                <option value="">Choose confidence</option>
                 {confidenceLevels.map((level) => (
                   <option key={level} value={level}>
                     {level}
@@ -308,25 +322,30 @@ export default function RepertoireManager() {
           <div className="mt-5">
             <p className="text-sm font-medium text-slate-300">Parts you know</p>
             <div className="mt-2 flex flex-wrap gap-2">
-              {partsByVoicing[voicing].map((part) => (
-                <button
-                  key={part}
-                  type="button"
-                  onClick={() => togglePart(part)}
-                  className={`rounded-full px-4 py-2 text-sm font-semibold ${
-                    partsKnown.includes(part)
-                      ? "bg-cyan-300 text-slate-950"
-                      : "bg-slate-800 text-slate-200 hover:bg-slate-700"
-                  }`}
-                >
-                  {part}
-                </button>
-              ))}
+              {voicing ? (
+                partsByVoicing[voicing].map((part) => (
+                  <button
+                    key={part}
+                    type="button"
+                    onClick={() => togglePart(part)}
+                    className={`rounded-full px-4 py-2 text-sm font-semibold ${
+                      partsKnown.includes(part)
+                        ? "bg-cyan-300 text-slate-950"
+                        : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                    }`}
+                  >
+                    {part}
+                  </button>
+                ))
+              ) : (
+                <p className="text-sm text-slate-400">Choose a voicing first.</p>
+              )}
             </div>
           </div>
 
           <button
             onClick={addItem}
+            disabled={!canAddSong}
             className="mt-6 rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
           >
             Add to repertoire

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { findMatches, SingerEntry } from "../matching";
+import { findMatches, normalizeConfidence, SingerEntry } from "../matching";
 
 describe("findMatches", () => {
+  it("maps legacy confidence values to the new scale", () => {
+    expect(normalizeConfidence("Performance ready")).toBe("Good to Go");
+    expect(normalizeConfidence("Solid")).toBe("Good to Go");
+    expect(normalizeConfidence("Needs review")).toBe("A Little Rusty");
+    expect(normalizeConfidence("Rusty")).toBe("A Little Rusty");
+    expect(normalizeConfidence("Learning")).toBe("Music Required");
+  });
+
   it("does not let one singer cover multiple quartet parts", () => {
     const entries: SingerEntry[] = [
       {
@@ -10,7 +18,7 @@ describe("findMatches", () => {
         songTitle: "Why Try to Change Me Now",
         voicing: "TTBB",
         partsKnown: ["Tenor", "Lead", "Baritone", "Bass"],
-        confidence: "Solid",
+        confidence: "Good to Go",
       },
     ];
 
@@ -153,14 +161,14 @@ describe("findMatches", () => {
 
   it("ranks complete matches above one-part-missing matches", () => {
     const entries: SingerEntry[] = [
-      { userId: "1", displayName: "A", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Solid" },
-      { userId: "2", displayName: "B", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Solid" },
-      { userId: "3", displayName: "C", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Solid" },
-      { userId: "4", displayName: "D", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Solid" },
+      { userId: "1", displayName: "A", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
 
-      { userId: "1", displayName: "A", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Performance ready" },
-      { userId: "2", displayName: "B", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Performance ready" },
-      { userId: "3", displayName: "C", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Performance ready" },
+      { userId: "1", displayName: "A", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
     ];
 
     const matches = findMatches(entries);
@@ -170,15 +178,15 @@ describe("findMatches", () => {
 
   it("prefers stronger confidence when ranking within the same category", () => {
     const entries: SingerEntry[] = [
-      { userId: "1", displayName: "A", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Rusty" },
-      { userId: "2", displayName: "B", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Rusty" },
-      { userId: "3", displayName: "C", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Rusty" },
-      { userId: "4", displayName: "D", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Rusty" },
+      { userId: "1", displayName: "A", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "A Little Rusty" },
+      { userId: "2", displayName: "B", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "A Little Rusty" },
+      { userId: "3", displayName: "C", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "A Little Rusty" },
+      { userId: "4", displayName: "D", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "A Little Rusty" },
 
-      { userId: "1", displayName: "A", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Performance ready" },
-      { userId: "2", displayName: "B", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Performance ready" },
-      { userId: "3", displayName: "C", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Performance ready" },
-      { userId: "4", displayName: "D", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Performance ready" },
+      { userId: "1", displayName: "A", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Strong Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
     ];
 
     const matches = findMatches(entries);

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -13,11 +13,9 @@ export type Part =
   | "Alto 2";
 
 export type Confidence =
-  | "Performance ready"
-  | "Solid"
-  | "Needs review"
-  | "Rusty"
-  | "Learning";
+  | "Good to Go"
+  | "A Little Rusty"
+  | "Music Required";
 
 export type SingerEntry = {
   userId: string;
@@ -46,28 +44,50 @@ export function requiredPartsForVoicing(voicing: Voicing): Part[] {
   return ["Soprano 1", "Soprano 2", "Alto 1", "Alto 2"];
 }
 
+export function normalizeConfidence(confidence?: string | null): Confidence | null {
+  if (confidence === "Good to Go") return "Good to Go";
+  if (confidence === "A Little Rusty") return "A Little Rusty";
+  if (confidence === "Music Required") return "Music Required";
+
+  if (confidence === "Performance ready" || confidence === "Solid") {
+    return "Good to Go";
+  }
+
+  if (confidence === "Needs review" || confidence === "Rusty") {
+    return "A Little Rusty";
+  }
+
+  if (confidence === "Learning") return "Music Required";
+
+  return null;
+}
+
 function normalizeTitle(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-function confidenceValue(confidence?: Confidence | null): number {
-  if (confidence === "Performance ready") return 5;
-  if (confidence === "Solid") return 4;
-  if (confidence === "Needs review") return 2;
-  if (confidence === "Rusty") return 1;
-  if (confidence === "Learning") return 0;
+function confidenceValue(confidence?: string | null): number {
+  const normalizedConfidence = normalizeConfidence(confidence);
+
+  if (normalizedConfidence === "Good to Go") return 5;
+  if (normalizedConfidence === "A Little Rusty") return 2;
+  if (normalizedConfidence === "Music Required") return 0;
   return 3;
 }
 
 function confidenceWarning(entries: SingerEntry[]): string | null {
-  const weak = entries.filter((e) =>
-    ["Needs review", "Rusty", "Learning"].includes(e.confidence ?? "")
-  );
+  const weak = entries.filter((e) => {
+    const normalizedConfidence = normalizeConfidence(e.confidence);
+    return (
+      normalizedConfidence === "A Little Rusty" ||
+      normalizedConfidence === "Music Required"
+    );
+  });
 
   if (!weak.length) return null;
 
   return `Confidence warning: ${weak
-    .map((e) => `${e.displayName} marked ${e.confidence}`)
+    .map((e) => `${e.displayName} marked ${normalizeConfidence(e.confidence)}`)
     .join(", ")}`;
 }
 

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -1,5 +1,5 @@
 import { supabase } from "@/lib/supabase";
-import type { Confidence, Part, Voicing } from "@/lib/matching";
+import { normalizeConfidence, type Confidence, type Part, type Voicing } from "@/lib/matching";
 import { getCurrentUser } from "@/lib/profileStore";
 
 export type RepertoireRow = {
@@ -14,6 +14,17 @@ export type RepertoireRow = {
   updated_at: string;
 };
 
+type RawRepertoireRow = Omit<RepertoireRow, "confidence"> & {
+  confidence: string | null;
+};
+
+function normalizeRepertoireRow(row: RawRepertoireRow): RepertoireRow {
+  return {
+    ...row,
+    confidence: normalizeConfidence(row.confidence) ?? "Music Required",
+  };
+}
+
 export async function getMyRepertoire() {
   const user = await getCurrentUser();
   if (!user) return [];
@@ -25,7 +36,7 @@ export async function getMyRepertoire() {
     .order("song_title", { ascending: true });
 
   if (error) throw error;
-  return data as RepertoireRow[];
+  return (data as RawRepertoireRow[]).map(normalizeRepertoireRow);
 }
 
 export async function addRepertoireItem(input: {


### PR DESCRIPTION
## Summary
- Replace repertoire confidence choices with `Good to Go`, `A Little Rusty`, and `Music Required`
- Require explicit voicing and confidence selections before adding a repertoire entry
- Normalize legacy saved confidence values so existing repertoire and session data continue to load safely

Closes #50.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.