### PR TITLE
Add simple privacy explanation

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -81,6 +81,17 @@ export default function LoginPage() {
 
           {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
         </div>
+
+        <p className="mt-5 text-sm text-slate-400">
+          Want the quick data note?{" "}
+          <a
+            href="/privacy"
+            className="font-semibold text-cyan-300 hover:text-cyan-200"
+          >
+            Read privacy
+          </a>
+          .
+        </p>
       </div>
     </main>
   );

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,54 @@
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
+      <div className="mx-auto max-w-2xl">
+        <a
+          href="/"
+          className="text-sm font-semibold text-cyan-300 hover:text-cyan-200"
+        >
+          What Can We Sing
+        </a>
+
+        <h1 className="mt-4 text-4xl font-bold tracking-tight">Privacy</h1>
+        <p className="mt-3 text-lg text-slate-300">
+          Here is the short version of what the app stores and why.
+        </p>
+
+        <section className="mt-8 space-y-5 rounded-2xl border border-white/10 bg-white/10 p-6">
+          <div>
+            <h2 className="text-xl font-semibold">What is stored</h2>
+            <p className="mt-2 text-slate-300">
+              What Can We Sing stores your display name and your repertoire:
+              song titles, parts you know, confidence level, and optional
+              arranger names.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Where it is stored</h2>
+            <p className="mt-2 text-slate-300">
+              This information is stored in Supabase, the backend database used
+              by the app.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Why it is stored</h2>
+            <p className="mt-2 text-slate-300">
+              The app uses your repertoire to help singers quickly find songs
+              they can sing together in a quartet.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">What is not done</h2>
+            <p className="mt-2 text-slate-300">
+              We do not sell your data. We do not share it with third parties
+              beyond the backend services needed to run the app.
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -161,6 +161,17 @@ export default function SettingsPage() {
             </a>
           )}
         </section>
+
+        <p className="mt-5 text-sm text-slate-400">
+          See what data is stored and why on the{" "}
+          <a
+            href="/privacy"
+            className="font-semibold text-cyan-300 hover:text-cyan-200"
+          >
+            privacy page
+          </a>
+          .
+        </p>
       </div>
     </main>
   );

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -245,6 +245,16 @@ export default function RepertoireManager() {
         <p className="mt-2 text-slate-300">
           Add songs you know, the parts you can sing, and how confident you are.
         </p>
+        <p className="mt-3 text-sm text-slate-400">
+          Your repertoire is stored so the app can find quartet matches.{" "}
+          <a
+            href="/privacy"
+            className="font-semibold text-cyan-300 hover:text-cyan-200"
+          >
+            Read privacy
+          </a>
+          .
+        </p>
 
         {loadError && (
           <div className="mt-4 rounded-xl border border-rose-300/20 bg-rose-400/10 p-4 text-sm text-rose-100">


### PR DESCRIPTION
## Summary
- Add a concise `/privacy` page explaining what data is stored, where, why, and what is not done with it
- Link to the privacy explanation from login, settings, and repertoire screens
- Keep the language plain and non-legalistic

Closes #12.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.