### PR TITLE
Standardize privacy statement text

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -83,12 +83,12 @@ export default function LoginPage() {
         </div>
 
         <p className="mt-5 text-sm text-slate-400">
-          Want the quick data note?{" "}
+          See what data is stored and why on the{" "}
           <a
             href="/privacy"
             className="font-semibold text-cyan-300 hover:text-cyan-200"
           >
-            Read privacy
+            privacy page
           </a>
           .
         </p>

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -282,12 +282,12 @@ export default function RepertoireManager() {
           Add songs you know, the parts you can sing, and how confident you are.
         </p>
         <p className="mt-3 text-sm text-slate-400">
-          Your repertoire is stored so the app can find quartet matches.{" "}
+          See what data is stored and why on the{" "}
           <a
             href="/privacy"
             className="font-semibold text-cyan-300 hover:text-cyan-200"
           >
-            Read privacy
+            privacy page
           </a>
           .
         </p>


### PR DESCRIPTION
## Summary
- Update login privacy text to match the settings page wording
- Update repertoire privacy text to match the settings page wording
- Keep `privacy page` linked to `/privacy` on all three pages

Closes #58.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.