### PR TITLE
Standardize Bass display label

### DIFF
--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -35,14 +35,14 @@ function partAbbreviation(voicing: Voicing, part: Part): string {
     if (part === "Tenor") return "T";
     if (part === "Lead") return "L";
     if (part === "Baritone") return "Bari";
-    if (part === "Bass") return "Bs";
+    if (part === "Bass") return "Bass";
   }
 
   if (voicing === "SATB") {
     if (part === "Soprano") return "S";
     if (part === "Alto") return "A";
     if (part === "Tenor") return "T";
-    if (part === "Bass") return "B";
+    if (part === "Bass") return "Bass";
   }
 
   if (part === "Soprano 1") return "S1";

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -39,14 +39,14 @@ function partAbbreviation(voicing: Voicing, part: Part): string {
     if (part === "Tenor") return "T";
     if (part === "Lead") return "L";
     if (part === "Baritone") return "Bari";
-    if (part === "Bass") return "Bs";
+    if (part === "Bass") return "Bass";
   }
 
   if (voicing === "SATB") {
     if (part === "Soprano") return "S";
     if (part === "Alto") return "A";
     if (part === "Tenor") return "T";
-    if (part === "Bass") return "B";
+    if (part === "Bass") return "Bass";
   }
 
   if (part === "Soprano 1") return "S1";


### PR DESCRIPTION
## Summary
- Show `Bass` instead of `Bs` in compact TTBB repertoire rows and session results
- Show `Bass` instead of `B` in compact SATB repertoire rows and session results
- Preserve `Bari` for Baritone and leave matching logic unchanged

Closes #60.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.