### PR TITLE
Expire inactive quartets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,20 @@ create unique index if not exists session_participants_session_user_unique
 ```
 
 The delete only clears participant snapshots created before `user_id` existed; singers can rejoin active quartets to recreate their current snapshots.
+
+Quartets expire after 24 hours of inactivity. Inactivity is based on the
+`sessions.last_activity_at` timestamp, which is refreshed whenever a singer joins
+or refreshes their repertoire. If your `sessions` table does not already have
+that column, run this in the Supabase SQL editor:
+
+```sql
+alter table public.sessions
+  add column if not exists last_activity_at timestamptz;
+
+update public.sessions
+set last_activity_at = coalesce(last_activity_at, created_at, now());
+
+alter table public.sessions
+  alter column last_activity_at set default now(),
+  alter column last_activity_at set not null;
+```

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -6,12 +6,17 @@ import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { findMatches, SingerEntry } from "@/lib/matching";
 import {
+  type DbSession,
   type DbParticipant,
   getParticipants,
   getSessionByCode,
   subscribeToSessionParticipants,
   upsertParticipant,
 } from "@/lib/sessionStore";
+import {
+  isSessionExpired,
+  sessionExpirationLabel,
+} from "@/lib/sessionExpiration";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 
@@ -41,11 +46,13 @@ export default function JoinSessionPage() {
 
   const [loading, setLoading] = useState(true);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [session, setSession] = useState<DbSession | null>(null);
   const [currentUserId, setCurrentUserId] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [participants, setParticipants] = useState<DbParticipant[]>([]);
   const [message, setMessage] = useState("");
   const [loadError, setLoadError] = useState("");
+  const [now, setNow] = useState(() => new Date());
 
   async function refreshParticipants(id: string) {
     const data = await getParticipants(id);
@@ -72,6 +79,11 @@ export default function JoinSessionPage() {
     name = displayName,
     userId = currentUserId
   ) {
+    if (session && isSessionExpired(session)) {
+      setLoadError("This quartet has expired.");
+      return;
+    }
+
     if (!id || !name || !userId) {
       setMessage("Could not refresh yet. Wait for the quartet to finish loading.");
       return;
@@ -85,8 +97,12 @@ export default function JoinSessionPage() {
       );
 
       const entries = await getMyEntries(name);
+      const lastActivityAt = new Date().toISOString();
 
-      await upsertParticipant(id, userId, name, entries);
+      await upsertParticipant(id, userId, name, entries, lastActivityAt);
+      setSession((current) =>
+        current ? { ...current, last_activity_at: lastActivityAt } : current
+      );
       await refreshParticipants(id);
 
       if (existingParticipant) {
@@ -103,6 +119,9 @@ export default function JoinSessionPage() {
 
   useEffect(() => {
     let unsubscribe: undefined | (() => void);
+    const timer = window.setInterval(() => {
+      setNow(new Date());
+    }, 60 * 1000);
 
     async function load() {
       try {
@@ -129,9 +148,16 @@ export default function JoinSessionPage() {
           return;
         }
 
+        if (isSessionExpired(session)) {
+          setSession(session);
+          setLoadError("This quartet has expired.");
+          return;
+        }
+
         setCurrentUserId(user.id);
         setDisplayName(profile.display_name);
         setSessionId(session.id);
+        setSession(session);
 
         const currentParticipants = await refreshParticipants(session.id);
 
@@ -162,6 +188,7 @@ export default function JoinSessionPage() {
     load();
 
     return () => {
+      window.clearInterval(timer);
       if (unsubscribe) unsubscribe();
     };
   }, [code]);
@@ -172,6 +199,8 @@ export default function JoinSessionPage() {
     ...section,
     matches: matches.filter((match) => match.category === section.category),
   }));
+  const quartetExpired = session ? isSessionExpired(session, now) : false;
+  const expirationLabel = session ? sessionExpirationLabel(session, now) : "";
 
   if (loading) {
     return (
@@ -186,27 +215,41 @@ export default function JoinSessionPage() {
       <div className="mx-auto max-w-5xl">
         <AppNav />
 
-        <h1 className="mt-4 text-4xl font-bold">Quartet {code}</h1>
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-4xl font-bold">Quartet {code}</h1>
+          {expirationLabel && (
+            <p className="w-fit rounded-full border border-white/10 bg-white/10 px-3 py-1 text-sm font-semibold text-slate-300">
+              {expirationLabel}
+            </p>
+          )}
+        </div>
 
-        {loadError && (
+        {(loadError || quartetExpired) && (
           <div className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
-            <p className="font-semibold text-rose-100">{loadError}</p>
+            <p className="font-semibold text-rose-100">
+              {quartetExpired ? "This quartet has expired." : loadError}
+            </p>
+            {quartetExpired && (
+              <p className="mt-2 text-sm text-rose-100">
+                Start a new quartet to make a fresh code.
+              </p>
+            )}
             <a
-              href="/join"
+              href={quartetExpired ? "/session" : "/join"}
               className="mt-4 inline-block rounded-xl bg-rose-100 px-5 py-3 font-semibold text-slate-950 hover:bg-white"
             >
-              Enter a different code
+              {quartetExpired ? "Start a new quartet" : "Enter a different code"}
             </a>
           </div>
         )}
 
-        {!loadError && message && (
+        {!loadError && !quartetExpired && message && (
           <p className="mt-4 rounded-xl bg-white/10 p-4 text-slate-200">
             {message}
           </p>
         )}
 
-        {!loadError && (
+        {!loadError && !quartetExpired && (
           <>
             <div className="mt-6 rounded-2xl border border-white/10 bg-white/10 p-6">
               <p className="text-slate-300">You are in this quartet as:</p>
@@ -216,7 +259,7 @@ export default function JoinSessionPage() {
 
               <button
                 onClick={() => joinSession()}
-                disabled={!sessionId || !displayName || !currentUserId}
+                disabled={!sessionId || !displayName || !currentUserId || quartetExpired}
                 className="mt-4 rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
               >
                 Rejoin / refresh my repertoire

--- a/lib/__tests__/sessionExpiration.test.ts
+++ b/lib/__tests__/sessionExpiration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSessionExpired,
+  sessionExpirationLabel,
+  sessionLastActivityAt,
+} from "../sessionExpiration";
+
+describe("session expiration", () => {
+  const now = new Date("2026-04-27T12:00:00.000Z");
+
+  it("uses last_activity_at when present", () => {
+    expect(
+      sessionLastActivityAt({
+        created_at: "2026-04-25T12:00:00.000Z",
+        last_activity_at: "2026-04-27T10:00:00.000Z",
+      })
+    ).toBe("2026-04-27T10:00:00.000Z");
+  });
+
+  it("falls back to created_at for older rows", () => {
+    expect(
+      sessionLastActivityAt({
+        created_at: "2026-04-27T10:00:00.000Z",
+      })
+    ).toBe("2026-04-27T10:00:00.000Z");
+  });
+
+  it("marks quartets expired after 24 hours of inactivity", () => {
+    expect(
+      isSessionExpired(
+        {
+          created_at: "2026-04-26T11:59:59.000Z",
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("keeps quartets active before the 24 hour window ends", () => {
+    expect(
+      isSessionExpired(
+        {
+          created_at: "2026-04-26T12:00:01.000Z",
+        },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it("shows a rounded hours label", () => {
+    expect(
+      sessionExpirationLabel(
+        {
+          created_at: "2026-04-27T11:00:01.000Z",
+        },
+        now
+      )
+    ).toBe("Expires in 24h");
+  });
+
+  it("shows expires soon with less than one hour left", () => {
+    expect(
+      sessionExpirationLabel(
+        {
+          created_at: "2026-04-26T12:30:01.000Z",
+        },
+        now
+      )
+    ).toBe("Expires soon");
+  });
+});

--- a/lib/sessionExpiration.ts
+++ b/lib/sessionExpiration.ts
@@ -1,0 +1,35 @@
+export type ExpiringSession = {
+  created_at: string;
+  last_activity_at?: string | null;
+};
+
+export const QUARTET_EXPIRATION_HOURS = 24;
+export const QUARTET_EXPIRATION_MS = QUARTET_EXPIRATION_HOURS * 60 * 60 * 1000;
+
+export function sessionLastActivityAt(session: ExpiringSession): string {
+  return session.last_activity_at ?? session.created_at;
+}
+
+export function isSessionExpired(session: ExpiringSession, now = new Date()) {
+  const lastActivity = new Date(sessionLastActivityAt(session)).getTime();
+
+  if (Number.isNaN(lastActivity)) return false;
+
+  return now.getTime() - lastActivity >= QUARTET_EXPIRATION_MS;
+}
+
+export function sessionExpirationLabel(
+  session: ExpiringSession,
+  now = new Date()
+) {
+  const lastActivity = new Date(sessionLastActivityAt(session)).getTime();
+
+  if (Number.isNaN(lastActivity)) return "Expires in 24h";
+
+  const remainingMs = QUARTET_EXPIRATION_MS - (now.getTime() - lastActivity);
+
+  if (remainingMs <= 0) return "Expired";
+  if (remainingMs < 60 * 60 * 1000) return "Expires soon";
+
+  return `Expires in ${Math.ceil(remainingMs / (60 * 60 * 1000))}h`;
+}

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -5,6 +5,7 @@ export type DbSession = {
   id: string;
   join_code: string;
   created_at: string;
+  last_activity_at?: string | null;
 };
 
 export type DbParticipant = {
@@ -19,12 +20,24 @@ export type DbParticipant = {
 export async function createSession(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
-    .insert({ join_code: joinCode })
+    .insert({
+      join_code: joinCode,
+      last_activity_at: new Date().toISOString(),
+    })
     .select()
     .single();
 
   if (error) throw error;
   return data as DbSession;
+}
+
+async function updateSessionActivity(sessionId: string, lastActivityAt: string) {
+  const { error } = await supabase
+    .from("sessions")
+    .update({ last_activity_at: lastActivityAt })
+    .eq("id", sessionId);
+
+  if (error) throw error;
 }
 
 export async function getSessionByCode(joinCode: string) {
@@ -42,7 +55,8 @@ export async function upsertParticipant(
   sessionId: string,
   userId: string,
   displayName: string,
-  repertoire: SingerEntry[]
+  repertoire: SingerEntry[],
+  lastActivityAt = new Date().toISOString()
 ) {
   const { data, error } = await supabase
     .from("session_participants")
@@ -59,6 +73,7 @@ export async function upsertParticipant(
     .single();
 
   if (error) throw error;
+  await updateSessionActivity(sessionId, lastActivityAt);
   return data as DbParticipant;
 }
 


### PR DESCRIPTION
## Summary
- Add 24-hour soft expiration handling for quartets based on `sessions.last_activity_at`
- Refresh `last_activity_at` with ISO timestamps when singers join or refresh repertoire
- Show subtle expiration status in the quartet view and block expired quartets from joining/refreshing
- Add unit tests for expiration calculations

Closes #16.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
Run the documented Supabase SQL migration in `README.md` to add `sessions.last_activity_at` before deploying this change.