### PR TITLE
Keep privacy out of login redirects

### DIFF
--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -10,6 +10,10 @@ describe("isPublicAuthPath", () => {
     expect(isPublicAuthPath("/auth/callback")).toBe(true);
   });
 
+  it("allows the privacy route without an auth redirect", () => {
+    expect(isPublicAuthPath("/privacy")).toBe(true);
+  });
+
   it("protects app routes", () => {
     expect(isPublicAuthPath("/repertoire")).toBe(false);
     expect(isPublicAuthPath("/join/ABC123")).toBe(false);

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -2,7 +2,8 @@ export function isPublicAuthPath(pathname: string): boolean {
   return (
     pathname === "/login" ||
     pathname.startsWith("/login/") ||
-    pathname === "/auth/callback"
+    pathname === "/auth/callback" ||
+    pathname === "/privacy"
   );
 }
 


### PR DESCRIPTION
## Summary
- Treat `/privacy` as a public route so privacy links do not create `/login?redirect=/privacy`
- Preserve protected-route redirect behavior for app destinations like `/join/[code]`
- Add auth-route test coverage for public privacy access

Closes #66.

## Verification
- `npm run test:run`
- `npm run build`

## Manual steps
- None. No database migration or Supabase dashboard change required.