### PR TITLE
Limit quartets to four singers

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -39,6 +39,8 @@ const matchSections = [
   },
 ] as const;
 
+const MAX_QUARTET_PARTICIPANTS = 4;
+
 function leftQuartetStorageKey(code: string) {
   return `left-quartet:${code}`;
 }
@@ -108,6 +110,14 @@ export default function JoinSessionPage() {
       const existingParticipant = existingParticipants.find(
         (participant) => participant.user_id === userId
       );
+
+      if (
+        !existingParticipant &&
+        existingParticipants.length >= MAX_QUARTET_PARTICIPANTS
+      ) {
+        setMessage("This quartet already has four singers.");
+        return;
+      }
 
       const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();


### PR DESCRIPTION
Closes #63.

## Summary
- Limit join-session writes to four unique authenticated participants.
- Show the fifth unique user: "This quartet already has four singers."
- Allow existing participants to rejoin or refresh even when the quartet is full.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.