### PR TITLE
Improve match ranking

### DIFF
--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -161,10 +161,10 @@ describe("findMatches", () => {
 
   it("ranks complete matches above one-part-missing matches", () => {
     const entries: SingerEntry[] = [
-      { userId: "1", displayName: "A", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
-      { userId: "2", displayName: "B", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
-      { userId: "3", displayName: "C", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
-      { userId: "4", displayName: "D", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+      { userId: "1", displayName: "A", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Music Required" },
+      { userId: "2", displayName: "B", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Music Required" },
+      { userId: "3", displayName: "C", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Music Required" },
+      { userId: "4", displayName: "D", songTitle: "Complete Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Music Required" },
 
       { userId: "1", displayName: "A", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
       { userId: "2", displayName: "B", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
@@ -174,6 +174,45 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].songTitle).toBe("Complete Song");
+  });
+
+  it("ranks ready matches above possible matches even when confidence is weaker", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Ready Song", voicing: "TTBB", arrangerName: "Same Arranger", partsKnown: ["Tenor"], confidence: "Music Required" },
+      { userId: "2", displayName: "B", songTitle: "Ready Song", voicing: "TTBB", arrangerName: "Same Arranger", partsKnown: ["Lead"], confidence: "Music Required" },
+      { userId: "3", displayName: "C", songTitle: "Ready Song", voicing: "TTBB", arrangerName: "Same Arranger", partsKnown: ["Baritone"], confidence: "Music Required" },
+      { userId: "4", displayName: "D", songTitle: "Ready Song", voicing: "TTBB", arrangerName: "Same Arranger", partsKnown: ["Bass"], confidence: "Music Required" },
+
+      { userId: "1", displayName: "A", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "Two", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].songTitle).toBe("Ready Song");
+    expect(matches[0].category).toBe("ready");
+    expect(matches[1].category).toBe("possible");
+  });
+
+  it("ranks possible matches above one-part-missing matches", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Tenor"], confidence: "Music Required" },
+      { userId: "2", displayName: "B", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "Two", partsKnown: ["Lead"], confidence: "Music Required" },
+      { userId: "3", displayName: "C", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Baritone"], confidence: "Music Required" },
+      { userId: "4", displayName: "D", songTitle: "Possible Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Bass"], confidence: "Music Required" },
+
+      { userId: "1", displayName: "A", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Almost Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].songTitle).toBe("Possible Song");
+    expect(matches[0].category).toBe("possible");
+    expect(matches[1].category).toBe("one_part_missing");
   });
 
   it("prefers stronger confidence when ranking within the same category", () => {
@@ -192,6 +231,46 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].songTitle).toBe("Strong Song");
+    expect(matches[0].score).toBeGreaterThan(matches[1].score);
+  });
+
+  it("uses extra part coverage as a modest tie-breaker", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Flexible Song", voicing: "TTBB", partsKnown: ["Tenor", "Lead"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Flexible Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Flexible Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Flexible Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+
+      { userId: "1", displayName: "A", songTitle: "Exact Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Exact Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Exact Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Exact Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].songTitle).toBe("Flexible Song");
+    expect(matches[0].score - matches[1].score).toBeLessThan(10);
+  });
+
+  it("penalizes warnings when ranking otherwise similar matches", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Missing Arranger Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Missing Arranger Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Missing Arranger Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Missing Arranger Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+
+      { userId: "1", displayName: "A", songTitle: "Conflict Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "B", songTitle: "Conflict Song", voicing: "TTBB", arrangerName: "Two", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "3", displayName: "C", songTitle: "Conflict Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "D", songTitle: "Conflict Song", voicing: "TTBB", arrangerName: "One", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].songTitle).toBe("Missing Arranger Song");
+    expect(matches[0].category).toBe("possible");
+    expect(matches[1].category).toBe("possible");
     expect(matches[0].score).toBeGreaterThan(matches[1].score);
   });
 });

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -148,10 +148,12 @@ function scoreMatch(
   requiredParts: Part[],
   warnings: string[]
 ): number {
+  // Keep category bands wide so a weaker ready match still beats any possible
+  // match, and any possible match still beats a one-part-missing result.
   const categoryBase = {
-    ready: 300,
-    possible: 200,
-    one_part_missing: 100,
+    ready: 3000,
+    possible: 2000,
+    one_part_missing: 1000,
   }[category];
 
   const assignedConfidence = Object.values(assignment).reduce(
@@ -159,13 +161,20 @@ function scoreMatch(
     0
   );
 
+  // Flexibility is backup coverage: additional singers who can cover required
+  // parts. It is useful in real pickup quartets, but stays a small tie-breaker.
   const flexibility = requiredParts.reduce((sum, part) => {
-    return sum + group.filter((entry) => entry.partsKnown.includes(part)).length;
+    const coverage = group.filter((entry) => entry.partsKnown.includes(part)).length;
+    return sum + Math.max(0, coverage - 1);
   }, 0);
 
-  const warningPenalty = warnings.length * 5;
+  const warningPenalty = warnings.reduce((sum, warning) => {
+    if (warning === "Possible arranger conflict.") return sum + 50;
+    if (warning.startsWith("Confidence warning:")) return sum + 30;
+    return sum + 20;
+  }, 0);
 
-  return categoryBase + assignedConfidence * 10 + flexibility - warningPenalty;
+  return categoryBase + assignedConfidence * 20 + flexibility * 2 - warningPenalty;
 }
 
 export function findMatches(entries: SingerEntry[]): MatchResult[] {


### PR DESCRIPTION
Closes #18.

## Summary
- Widen match scoring bands so ready matches rank above possible matches, and possible matches rank above one-part-missing matches.
- Increase the influence of assigned singer confidence within a category.
- Add a small backup-coverage tie-breaker for flexible part coverage.
- Apply weighted penalties for warnings, with arranger conflicts and confidence warnings carrying stronger penalties.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.