### PR TITLE
Require display name before app access

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -30,6 +30,7 @@ export default function SettingsPage() {
   const [displayName, setDisplayName] = useState("");
   const [defaultPart, setDefaultPart] = useState("");
   const [message, setMessage] = useState("");
+  const [displayNameError, setDisplayNameError] = useState("");
   const [showRepertoireNextStep, setShowRepertoireNextStep] = useState(false);
 
   useEffect(() => {
@@ -68,11 +69,13 @@ export default function SettingsPage() {
 
   async function saveSettings() {
     if (!displayName.trim()) {
-      setMessage("Add a display name before saving settings.");
+      setDisplayNameError("Display name is required.");
+      setMessage("");
       return;
     }
 
     try {
+      setDisplayNameError("");
       await upsertMyProfile(displayName.trim(), defaultPart);
       const repertoire = await getMyRepertoire();
 
@@ -121,9 +124,25 @@ export default function SettingsPage() {
             </span>
             <input
               value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+              onChange={(e) => {
+                setDisplayName(e.target.value);
+                if (displayNameError) setDisplayNameError("");
+              }}
+              aria-invalid={Boolean(displayNameError)}
+              aria-describedby={
+                displayNameError ? "display-name-error" : undefined
+              }
+              className={`mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none focus:ring-2 ${
+                displayNameError
+                  ? "ring-2 ring-rose-300"
+                  : "ring-cyan-300"
+              }`}
             />
+            {displayNameError && (
+              <p id="display-name-error" className="mt-2 text-sm text-rose-200">
+                {displayNameError}
+              </p>
+            )}
           </label>
 
           <label className="mt-5 block">

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getLoginRedirectUrl, isPublicAuthPath } from "../authRoute";
+import {
+  allowsMissingDisplayName,
+  getLoginRedirectUrl,
+  getSettingsRedirectUrl,
+  isPublicAuthPath,
+} from "../authRoute";
 
 describe("isPublicAuthPath", () => {
   it("allows the login route", () => {
@@ -35,5 +40,35 @@ describe("getLoginRedirectUrl", () => {
     expect(url.toString()).toBe(
       "https://example.com/login?redirect=%2Fjoin%2FABC123%3Ffoo%3Dbar"
     );
+  });
+});
+
+describe("allowsMissingDisplayName", () => {
+  it("allows settings so users can add their display name", () => {
+    expect(allowsMissingDisplayName("/settings")).toBe(true);
+  });
+
+  it("does not allow protected app routes", () => {
+    expect(allowsMissingDisplayName("/")).toBe(false);
+    expect(allowsMissingDisplayName("/session")).toBe(false);
+    expect(allowsMissingDisplayName("/join/ABC123")).toBe(false);
+  });
+});
+
+describe("getSettingsRedirectUrl", () => {
+  it("preserves the route the user tried to access", () => {
+    const url = getSettingsRedirectUrl(
+      new URL("https://example.com/join/ABC123?foo=bar")
+    );
+
+    expect(url.toString()).toBe(
+      "https://example.com/settings?redirect=%2Fjoin%2FABC123%3Ffoo%3Dbar"
+    );
+  });
+
+  it("does not create a redirect loop for settings", () => {
+    const url = getSettingsRedirectUrl(new URL("https://example.com/settings"));
+
+    expect(url.toString()).toBe("https://example.com/settings");
   });
 });

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -7,6 +7,14 @@ export function isPublicAuthPath(pathname: string): boolean {
   );
 }
 
+export function allowsMissingDisplayName(pathname: string): boolean {
+  return (
+    isPublicAuthPath(pathname) ||
+    pathname === "/settings" ||
+    pathname.startsWith("/settings/")
+  );
+}
+
 export function getLoginRedirectUrl(requestUrl: URL): URL {
   const loginUrl = new URL(requestUrl);
   const destination = `${requestUrl.pathname}${requestUrl.search}`;
@@ -19,4 +27,18 @@ export function getLoginRedirectUrl(requestUrl: URL): URL {
   }
 
   return loginUrl;
+}
+
+export function getSettingsRedirectUrl(requestUrl: URL): URL {
+  const settingsUrl = new URL(requestUrl);
+  const destination = `${requestUrl.pathname}${requestUrl.search}`;
+
+  settingsUrl.pathname = "/settings";
+  settingsUrl.search = "";
+
+  if (destination !== "/settings") {
+    settingsUrl.searchParams.set("redirect", destination);
+  }
+
+  return settingsUrl;
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,11 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { getLoginRedirectUrl, isPublicAuthPath } from "@/lib/authRoute";
+import {
+  allowsMissingDisplayName,
+  getLoginRedirectUrl,
+  getSettingsRedirectUrl,
+  isPublicAuthPath,
+} from "@/lib/authRoute";
 
 export async function proxy(request: NextRequest) {
   if (isPublicAuthPath(request.nextUrl.pathname)) {
@@ -50,6 +55,18 @@ export async function proxy(request: NextRequest) {
 
   if (!user) {
     return NextResponse.redirect(getLoginRedirectUrl(request.nextUrl));
+  }
+
+  if (!allowsMissingDisplayName(request.nextUrl.pathname)) {
+    const { data: profile, error } = await supabase
+      .from("profiles")
+      .select("display_name")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (error || !profile?.display_name?.trim()) {
+      return NextResponse.redirect(getSettingsRedirectUrl(request.nextUrl));
+    }
   }
 
   return response;


### PR DESCRIPTION
Closes #33.

## Summary
- Add shared route helpers for display-name-required redirects without creating settings loops.
- Update the proxy to redirect authenticated users without a display name to `/settings` before protected app routes.
- Add inline settings validation so display name cannot be saved empty.
- Cover the route helper behavior with tests.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.