### PR TITLE
Simplify repertoire setup and add-song flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ alter table public.sessions
   alter column last_activity_at set default now(),
   alter column last_activity_at set not null;
 ```
+
+The app no longer uses a default voice part on profiles. If your `profiles`
+table still has that older column and you want to clean it up, run this in the
+Supabase SQL editor:
+
+```sql
+alter table public.profiles
+  drop column if exists default_part;
+```

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -9,26 +9,11 @@ import {
 import { getMyRepertoire } from "@/lib/repertoireStore";
 import { useEffect, useState } from "react";
 
-const defaultParts = [
-  "",
-  "Tenor",
-  "Lead",
-  "Baritone",
-  "Bass",
-  "Soprano",
-  "Alto",
-  "Soprano 1",
-  "Soprano 2",
-  "Alto 1",
-  "Alto 2",
-];
-
 export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
-  const [defaultPart, setDefaultPart] = useState("");
   const [message, setMessage] = useState("");
   const [displayNameError, setDisplayNameError] = useState("");
   const [showRepertoireNextStep, setShowRepertoireNextStep] = useState(false);
@@ -50,7 +35,6 @@ export default function SettingsPage() {
 
         if (profile) {
           setDisplayName(profile.display_name ?? "");
-          setDefaultPart(profile.default_part ?? "");
         } else {
           setMessage(
             "Add a display name before joining a quartet so other singers know who you are."
@@ -76,7 +60,7 @@ export default function SettingsPage() {
 
     try {
       setDisplayNameError("");
-      await upsertMyProfile(displayName.trim(), defaultPart);
+      await upsertMyProfile(displayName.trim());
       const repertoire = await getMyRepertoire();
 
       if (repertoire.length === 0) {
@@ -143,23 +127,6 @@ export default function SettingsPage() {
                 {displayNameError}
               </p>
             )}
-          </label>
-
-          <label className="mt-5 block">
-            <span className="text-sm font-medium text-slate-300">
-              Default voice part (optional)
-            </span>
-            <select
-              value={defaultPart}
-              onChange={(e) => setDefaultPart(e.target.value)}
-              className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-            >
-              {defaultParts.map((part) => (
-                <option key={part} value={part}>
-                  {part || "No default"}
-                </option>
-              ))}
-            </select>
           </label>
 
           <button

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
 import {
@@ -57,7 +57,15 @@ function partAbbreviation(voicing: Voicing, part: Part): string {
   return part;
 }
 
+function partButtonLabel(voicing: Voicing, part: Part): string {
+  const abbreviation = partAbbreviation(voicing, part);
+
+  if (abbreviation === part) return part;
+  return `${abbreviation} ${part}`;
+}
+
 export default function RepertoireManager() {
+  const songTitleInputRef = useRef<HTMLInputElement>(null);
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<RepertoireRow[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -67,6 +75,7 @@ export default function RepertoireManager() {
   const [partsKnown, setPartsKnown] = useState<Part[]>([]);
   const [confidence, setConfidence] = useState<Confidence | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [showArranger, setShowArranger] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<RepertoireForm | null>(null);
   const [message, setMessage] = useState("");
@@ -117,12 +126,23 @@ export default function RepertoireManager() {
     load();
   }, []);
 
+  useEffect(() => {
+    if (!isAddOpen) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      songTitleInputRef.current?.focus();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [isAddOpen]);
+
   function resetAddForm() {
     setSongTitle("");
     setVoicing("");
     setArrangerName("");
     setPartsKnown([]);
     setConfidence("");
+    setShowArranger(false);
   }
 
   function openAddModal() {
@@ -467,13 +487,13 @@ export default function RepertoireManager() {
                             key={part}
                             type="button"
                             onClick={() => toggleEditPart(part)}
-                            className={`rounded-full px-4 py-2 text-sm font-semibold ${
+                            className={`min-h-12 rounded-xl px-4 py-3 text-sm font-semibold ring-1 ${
                               editForm.partsKnown.includes(part)
-                                ? "bg-cyan-300 text-slate-950"
-                                : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                                ? "bg-cyan-300 text-slate-950 ring-cyan-200"
+                                : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
                             }`}
                           >
-                            {part}
+                            {partButtonLabel(editForm.voicing, part)}
                           </button>
                         ))}
                       </div>
@@ -589,93 +609,112 @@ export default function RepertoireManager() {
                 <p className="mt-4 text-sm text-slate-300">{message}</p>
               )}
 
-              <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <div className="mt-5 space-y-5">
                 <label className="block">
                   <span className="text-sm font-medium text-slate-300">
                     Song title
                   </span>
                   <input
+                    ref={songTitleInputRef}
                     value={songTitle}
                     onChange={(e) => setSongTitle(e.target.value)}
                     className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                   />
                 </label>
 
-                <label className="block">
-                  <span className="text-sm font-medium text-slate-300">
-                    Arranger (optional)
-                  </span>
-                  <input
-                    value={arrangerName}
-                    onChange={(e) => setArrangerName(e.target.value)}
-                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                  />
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-medium text-slate-300">
-                    Voicing
-                  </span>
-                  <select
-                    value={voicing}
-                    onChange={(e) => {
-                      setVoicing(e.target.value as Voicing | "");
-                      setPartsKnown([]);
-                    }}
-                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                  >
-                    <option value="">Choose voicing</option>
+                <div>
+                  <p className="text-sm font-medium text-slate-300">Voicing</p>
+                  <div className="mt-2 grid grid-cols-3 gap-2">
                     {voicings.map((v) => (
-                      <option key={v}>{v}</option>
-                    ))}
-                  </select>
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-medium text-slate-300">
-                    Confidence
-                  </span>
-                  <select
-                    value={confidence}
-                    onChange={(e) =>
-                      setConfidence(e.target.value as Confidence | "")
-                    }
-                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                  >
-                    <option value="">Choose confidence</option>
-                    {confidenceLevels.map((level) => (
-                      <option key={level} value={level}>
-                        {level}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-
-              <div className="mt-5">
-                <p className="text-sm font-medium text-slate-300">
-                  Parts you know
-                </p>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {voicing ? (
-                    partsByVoicing[voicing].map((part) => (
                       <button
-                        key={part}
+                        key={v}
                         type="button"
-                        onClick={() => togglePart(part)}
-                        className={`rounded-full px-4 py-2 text-sm font-semibold ${
-                          partsKnown.includes(part)
-                            ? "bg-cyan-300 text-slate-950"
-                            : "bg-slate-800 text-slate-200 hover:bg-slate-700"
+                        onClick={() => {
+                          setVoicing(v);
+                          setPartsKnown([]);
+                        }}
+                        className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
+                          voicing === v
+                            ? "bg-cyan-300 text-slate-950 ring-cyan-200"
+                            : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
                         }`}
                       >
-                        {part}
+                        {v}
                       </button>
-                    ))
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium text-slate-300">
+                    Parts you know
+                  </p>
+                  <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                    {voicing ? (
+                      partsByVoicing[voicing].map((part) => (
+                        <button
+                          key={part}
+                          type="button"
+                          onClick={() => togglePart(part)}
+                          className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
+                            partsKnown.includes(part)
+                              ? "bg-cyan-300 text-slate-950 ring-cyan-200"
+                              : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
+                          }`}
+                        >
+                          {partButtonLabel(voicing, part)}
+                        </button>
+                      ))
+                    ) : (
+                      <p className="col-span-2 text-sm text-slate-400 sm:col-span-4">
+                        Choose a voicing first.
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="text-sm font-medium text-slate-300">
+                    Confidence
+                  </p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-3">
+                    {confidenceLevels.map((level) => (
+                      <button
+                        key={level}
+                        type="button"
+                        onClick={() => setConfidence(level)}
+                        className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
+                          confidence === level
+                            ? "bg-cyan-300 text-slate-950 ring-cyan-200"
+                            : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
+                        }`}
+                      >
+                        {level}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  {showArranger ? (
+                    <label className="block">
+                      <span className="text-sm font-medium text-slate-300">
+                        Arranger (optional)
+                      </span>
+                      <input
+                        value={arrangerName}
+                        onChange={(e) => setArrangerName(e.target.value)}
+                        className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
                   ) : (
-                    <p className="text-sm text-slate-400">
-                      Choose a voicing first.
-                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setShowArranger(true)}
+                      className="rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold text-cyan-200 hover:bg-white/20"
+                    >
+                      Add arranger (optional)
+                    </button>
                   )}
                 </div>
               </div>

--- a/lib/profileStore.ts
+++ b/lib/profileStore.ts
@@ -3,7 +3,6 @@ import { supabase } from "@/lib/supabase";
 export type Profile = {
   id: string;
   display_name: string;
-  default_part: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -28,7 +27,7 @@ export async function getMyProfile() {
   return data as Profile | null;
 }
 
-export async function upsertMyProfile(displayName: string, defaultPart?: string) {
+export async function upsertMyProfile(displayName: string) {
   const user = await getCurrentUser();
   if (!user) throw new Error("You must be logged in.");
 
@@ -37,7 +36,6 @@ export async function upsertMyProfile(displayName: string, defaultPart?: string)
     .upsert({
       id: user.id,
       display_name: displayName,
-      default_part: defaultPart || null,
       updated_at: new Date().toISOString(),
     })
     .select()


### PR DESCRIPTION
Closes #80.

## Summary
- Remove the default voice part field from settings and profile upsert logic.
- Make the add-song sheet faster for mobile entry with autofocus, button-based voicing/confidence choices, and larger multi-select part buttons.
- Hide arranger behind an optional Add arranger control so the main flow stays focused.
- Keep add/edit/delete/search behavior and matching logic unchanged.

## Testing
- npm run test:run
- npm run build

## Manual steps
- Optional Supabase cleanup: drop the old `profiles.default_part` column if it exists:

```sql
alter table public.profiles
  drop column if exists default_part;
```