### PR TITLE
Track active quartet state

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,48 +26,17 @@ Hosted Supabase projects configure Auth email templates in the Supabase dashboar
 
 ## Supabase database
 
-Session participants are keyed by the authenticated Supabase user so one singer can refresh their repertoire without creating duplicate rows, while different singers with the same display name can still join the same quartet.
+The Supabase project should have the current production schema applied:
 
-If your `session_participants` table does not already have `user_id` and a unique constraint for each user in each session, run this in the Supabase SQL editor:
+- `profiles` stores each user's required `display_name`.
+- `user_repertoire` stores each user's songs, voicing, parts known, confidence,
+  and optional arranger name.
+- `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
+  expiration.
+- `session_participants` stores participant repertoire snapshots and is keyed by
+  `(session_id, user_id)` so one singer can refresh without creating duplicate
+  rows.
 
-```sql
-alter table public.session_participants
-  add column if not exists user_id uuid references auth.users(id) on delete cascade;
-
-delete from public.session_participants
-where user_id is null;
-
-alter table public.session_participants
-  alter column user_id set not null;
-
-create unique index if not exists session_participants_session_user_unique
-  on public.session_participants (session_id, user_id);
-```
-
-The delete only clears participant snapshots created before `user_id` existed; singers can rejoin active quartets to recreate their current snapshots.
-
-Quartets expire after 24 hours of inactivity. Inactivity is based on the
-`sessions.last_activity_at` timestamp, which is refreshed whenever a singer joins
-or refreshes their repertoire. If your `sessions` table does not already have
-that column, run this in the Supabase SQL editor:
-
-```sql
-alter table public.sessions
-  add column if not exists last_activity_at timestamptz;
-
-update public.sessions
-set last_activity_at = coalesce(last_activity_at, created_at, now());
-
-alter table public.sessions
-  alter column last_activity_at set default now(),
-  alter column last_activity_at set not null;
-```
-
-The app no longer uses a default voice part on profiles. If your `profiles`
-table still has that older column and you want to clean it up, run this in the
-Supabase SQL editor:
-
-```sql
-alter table public.profiles
-  drop column if exists default_part;
-```
+One-time migration SQL is intentionally not kept in this README after it has
+been applied. Add any future schema change to the PR that introduces it, then
+remove the one-time instructions after production is updated.

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -18,6 +18,10 @@ import {
   isSessionExpired,
   sessionExpirationLabel,
 } from "@/lib/sessionExpiration";
+import {
+  clearActiveQuartetIfMatches,
+  setActiveQuartet,
+} from "@/lib/activeQuartet";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 
@@ -123,6 +127,7 @@ export default function JoinSessionPage() {
       const lastActivityAt = new Date().toISOString();
 
       await upsertParticipant(id, userId, name, entries, lastActivityAt);
+      setActiveQuartet({ sessionId: id, code, joinedAt: lastActivityAt });
       setSession((current) =>
         current ? { ...current, last_activity_at: lastActivityAt } : current
       );
@@ -151,6 +156,7 @@ export default function JoinSessionPage() {
 
     try {
       await removeParticipant(sessionId, currentUserId);
+      clearActiveQuartetIfMatches(sessionId);
       window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
       await refreshParticipants(sessionId);
       window.location.href = "/?leftQuartet=1";
@@ -200,6 +206,7 @@ export default function JoinSessionPage() {
 
         if (isSessionExpired(session)) {
           setSession(session);
+          clearActiveQuartetIfMatches(session.id);
           setLoadError("This quartet has expired.");
           return;
         }
@@ -226,8 +233,14 @@ export default function JoinSessionPage() {
           hasAutoJoined.current = true;
           await joinSession(session.id, profile.display_name, user.id);
         } else if (hasLeftQuartet) {
+          clearActiveQuartetIfMatches(session.id);
           setMessage("You left this quartet.");
         } else {
+          setActiveQuartet({
+            sessionId: session.id,
+            code,
+            joinedAt: new Date().toISOString(),
+          });
           setMessage(`You are already in this quartet as ${profile.display_name}.`);
         }
       } catch (err) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { AppNav } from "@/components/AppNav";
+import {
+  clearActiveQuartet,
+  getActiveQuartet,
+  type ActiveQuartet,
+} from "@/lib/activeQuartet";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 import { useEffect, useState } from "react";
@@ -47,6 +52,7 @@ const setupPrompts: Record<
 
 export default function Home() {
   const [setupState, setSetupState] = useState<SetupState>("loading");
+  const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
   const [message, setMessage] = useState("");
   const [messageTone, setMessageTone] = useState<"error" | "success">("error");
 
@@ -55,6 +61,8 @@ export default function Home() {
       try {
         const searchParams = new URLSearchParams(window.location.search);
         if (searchParams.get("leftQuartet") === "1") {
+          clearActiveQuartet();
+          setActiveQuartet(null);
           setMessage("You left the quartet.");
           setMessageTone("success");
           window.history.replaceState(null, "", window.location.pathname);
@@ -74,6 +82,7 @@ export default function Home() {
         }
 
         const repertoire = await getMyRepertoire();
+        setActiveQuartet(getActiveQuartet());
         setSetupState(repertoire.length > 0 ? "ready" : "missing_repertoire");
       } catch (err) {
         console.error(err);
@@ -138,6 +147,20 @@ export default function Home() {
             <p className="mt-6 rounded-xl bg-white/10 px-4 py-3 text-sm text-slate-300">
               Start a quartet, join with a code, or update your repertoire.
             </p>
+
+            {activeQuartet && (
+              <a
+                href={`/join/${activeQuartet.code}`}
+                className="mt-4 block rounded-xl border border-cyan-300/40 bg-cyan-300/10 px-5 py-4 hover:border-cyan-200/70 hover:bg-cyan-300/15"
+              >
+                <span className="block text-lg font-semibold text-white">
+                  Current quartet
+                </span>
+                <span className="mt-1 block text-sm font-semibold text-cyan-200">
+                  Rejoin quartet {activeQuartet.code}
+                </span>
+              </a>
+            )}
 
             <div className="mt-4 space-y-3">
               {actions.map((action) => (

--- a/lib/__tests__/activeQuartet.test.ts
+++ b/lib/__tests__/activeQuartet.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearActiveQuartet,
+  clearActiveQuartetIfMatches,
+  getActiveQuartet,
+  setActiveQuartet,
+} from "../activeQuartet";
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe("active quartet storage", () => {
+  it("stores and reads the active quartet", () => {
+    const storage = new MemoryStorage();
+
+    setActiveQuartet(
+      { sessionId: "session-1", code: "ABC123", joinedAt: "2026-04-27" },
+      storage
+    );
+
+    expect(getActiveQuartet(storage)).toEqual({
+      sessionId: "session-1",
+      code: "ABC123",
+      joinedAt: "2026-04-27",
+    });
+  });
+
+  it("clears the active quartet", () => {
+    const storage = new MemoryStorage();
+
+    setActiveQuartet(
+      { sessionId: "session-1", code: "ABC123", joinedAt: "2026-04-27" },
+      storage
+    );
+    clearActiveQuartet(storage);
+
+    expect(getActiveQuartet(storage)).toBeNull();
+  });
+
+  it("only clears a matching active quartet", () => {
+    const storage = new MemoryStorage();
+
+    setActiveQuartet(
+      { sessionId: "session-1", code: "ABC123", joinedAt: "2026-04-27" },
+      storage
+    );
+    clearActiveQuartetIfMatches("session-2", storage);
+
+    expect(getActiveQuartet(storage)?.sessionId).toBe("session-1");
+
+    clearActiveQuartetIfMatches("session-1", storage);
+
+    expect(getActiveQuartet(storage)).toBeNull();
+  });
+});

--- a/lib/activeQuartet.ts
+++ b/lib/activeQuartet.ts
@@ -1,0 +1,62 @@
+const ACTIVE_QUARTET_STORAGE_KEY = "active-quartet";
+
+type StorageLike = Pick<Storage, "getItem" | "removeItem" | "setItem">;
+
+export type ActiveQuartet = {
+  sessionId: string;
+  code: string;
+  joinedAt: string;
+};
+
+function getBrowserStorage(): StorageLike | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+export function getActiveQuartet(
+  storage = getBrowserStorage()
+): ActiveQuartet | null {
+  if (!storage) return null;
+
+  try {
+    const value = storage.getItem(ACTIVE_QUARTET_STORAGE_KEY);
+    if (!value) return null;
+
+    const activeQuartet = JSON.parse(value) as Partial<ActiveQuartet>;
+    if (!activeQuartet.sessionId || !activeQuartet.code) return null;
+
+    return {
+      sessionId: activeQuartet.sessionId,
+      code: activeQuartet.code,
+      joinedAt: activeQuartet.joinedAt ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveQuartet(
+  activeQuartet: ActiveQuartet,
+  storage = getBrowserStorage()
+) {
+  if (!storage) return;
+
+  storage.setItem(ACTIVE_QUARTET_STORAGE_KEY, JSON.stringify(activeQuartet));
+}
+
+export function clearActiveQuartet(storage = getBrowserStorage()) {
+  if (!storage) return;
+
+  storage.removeItem(ACTIVE_QUARTET_STORAGE_KEY);
+}
+
+export function clearActiveQuartetIfMatches(
+  sessionId: string,
+  storage = getBrowserStorage()
+) {
+  const activeQuartet = getActiveQuartet(storage);
+
+  if (activeQuartet?.sessionId === sessionId) {
+    clearActiveQuartet(storage);
+  }
+}


### PR DESCRIPTION
Closes #81.

## Summary
- Add a client-side active quartet storage helper backed by localStorage.
- Store active quartet state when a user joins, rejoins, refreshes, or is already in a quartet.
- Clear active quartet state when the user leaves or when the remembered quartet is expired/left.
- Show a Current quartet action on the home page so users can navigate away and return.
- Clean up README database notes by replacing old one-time SQL blocks with the current expected schema.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. Supabase changes were already applied; README now documents current schema instead of old migration SQL.