### PR TITLE
Warn before changing active quartet

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -19,7 +19,10 @@ import {
   sessionExpirationLabel,
 } from "@/lib/sessionExpiration";
 import {
+  clearActiveQuartet,
   clearActiveQuartetIfMatches,
+  getActiveQuartet,
+  type ActiveQuartet,
   setActiveQuartet,
 } from "@/lib/activeQuartet";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
@@ -66,6 +69,9 @@ export default function JoinSessionPage() {
   const [now, setNow] = useState(() => new Date());
   const [leftQuartet, setLeftQuartet] = useState(false);
   const [leaving, setLeaving] = useState(false);
+  const [pendingActiveQuartet, setPendingActiveQuartet] =
+    useState<ActiveQuartet | null>(null);
+  const [leavingCurrentQuartet, setLeavingCurrentQuartet] = useState(false);
 
   async function refreshParticipants(id: string) {
     const data = await getParticipants(id);
@@ -173,6 +179,32 @@ export default function JoinSessionPage() {
     });
   }
 
+  async function leaveCurrentAndJoinThisQuartet() {
+    if (!pendingActiveQuartet || !currentUserId || !sessionId) {
+      setMessage("Could not continue yet. Wait for this quartet to finish loading.");
+      return;
+    }
+
+    setLeavingCurrentQuartet(true);
+    setMessage("");
+
+    try {
+      await removeParticipant(pendingActiveQuartet.sessionId, currentUserId);
+      clearActiveQuartet();
+      setPendingActiveQuartet(null);
+      await joinSession(sessionId, displayName, currentUserId, {
+        clearLeftFlag: true,
+      });
+    } catch (err) {
+      console.error(err);
+      setMessage(
+        "Could not leave your current quartet. Check your connection and try again."
+      );
+    } finally {
+      setLeavingCurrentQuartet(false);
+    }
+  }
+
   useEffect(() => {
     let unsubscribe: undefined | (() => void);
     const timer = window.setInterval(() => {
@@ -228,6 +260,17 @@ export default function JoinSessionPage() {
         const alreadyJoined = currentParticipants.some(
           (participant) => participant.user_id === user.id
         );
+
+        const activeQuartet = getActiveQuartet();
+        if (
+          activeQuartet &&
+          activeQuartet.sessionId !== session.id &&
+          !hasLeftQuartet
+        ) {
+          setPendingActiveQuartet(activeQuartet);
+          setMessage("");
+          return;
+        }
 
         if (!alreadyJoined && !hasAutoJoined.current && !hasLeftQuartet) {
           hasAutoJoined.current = true;
@@ -317,7 +360,42 @@ export default function JoinSessionPage() {
           </p>
         )}
 
-        {!loadError && !quartetExpired && (
+        {!loadError && !quartetExpired && pendingActiveQuartet && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="active-quartet-title"
+            className="mt-8 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-6"
+          >
+            <h2 id="active-quartet-title" className="text-2xl font-semibold">
+              You are already in a quartet
+            </h2>
+            <p className="mt-2 text-slate-200">
+              Return to quartet {pendingActiveQuartet.code}, or leave it before
+              joining quartet {code}.
+            </p>
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={`/join/${pendingActiveQuartet.code}`}
+                className="rounded-xl bg-cyan-300 px-5 py-3 text-center font-semibold text-slate-950 hover:bg-cyan-200"
+              >
+                Return to current quartet
+              </a>
+              <button
+                type="button"
+                onClick={leaveCurrentAndJoinThisQuartet}
+                disabled={leavingCurrentQuartet}
+                className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40"
+              >
+                {leavingCurrentQuartet
+                  ? "Leaving..."
+                  : "Leave current quartet and continue"}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!loadError && !quartetExpired && !pendingActiveQuartet && (
           <>
             <div className="mt-6 rounded-2xl border border-white/10 bg-white/10 p-6">
               {leftQuartet ? (

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,10 +1,20 @@
 "use client";
 
 import { AppNav } from "@/components/AppNav";
+import {
+  clearActiveQuartet,
+  getActiveQuartet,
+  type ActiveQuartet,
+} from "@/lib/activeQuartet";
+import { getCurrentUser } from "@/lib/profileStore";
+import { removeParticipant } from "@/lib/sessionStore";
 import { useState } from "react";
 
 export default function JoinPage() {
   const [joinCode, setJoinCode] = useState("");
+  const [pendingCode, setPendingCode] = useState("");
+  const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
+  const [leavingCurrent, setLeavingCurrent] = useState(false);
   const [message, setMessage] = useState("");
 
   function joinQuartet() {
@@ -14,7 +24,37 @@ export default function JoinPage() {
       return;
     }
 
+    const currentQuartet = getActiveQuartet();
+    if (currentQuartet && currentQuartet.code !== code) {
+      setPendingCode(code);
+      setActiveQuartet(currentQuartet);
+      setMessage("");
+      return;
+    }
+
     window.location.href = `/join/${encodeURIComponent(code)}`;
+  }
+
+  async function leaveCurrentAndContinue() {
+    if (!activeQuartet || !pendingCode) return;
+
+    setLeavingCurrent(true);
+    setMessage("");
+
+    try {
+      const user = await getCurrentUser();
+      if (user) {
+        await removeParticipant(activeQuartet.sessionId, user.id);
+      }
+      clearActiveQuartet();
+      window.location.href = `/join/${encodeURIComponent(pendingCode)}`;
+    } catch (err) {
+      console.error("Failed to leave current quartet", err);
+      setMessage(
+        "Could not leave your current quartet. Check your connection and try again."
+      );
+      setLeavingCurrent(false);
+    }
   }
 
   return (
@@ -55,6 +95,41 @@ export default function JoinPage() {
 
           {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
         </section>
+
+        {activeQuartet && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="active-quartet-title"
+            className="mt-6 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5"
+          >
+            <h2 id="active-quartet-title" className="text-xl font-semibold">
+              You are already in a quartet
+            </h2>
+            <p className="mt-2 text-sm text-slate-200">
+              Return to quartet {activeQuartet.code}, or leave it before
+              joining quartet {pendingCode}.
+            </p>
+            <div className="mt-5 flex flex-col gap-3">
+              <a
+                href={`/join/${activeQuartet.code}`}
+                className="rounded-xl bg-cyan-300 px-5 py-3 text-center font-semibold text-slate-950 hover:bg-cyan-200"
+              >
+                Return to current quartet
+              </a>
+              <button
+                type="button"
+                onClick={leaveCurrentAndContinue}
+                disabled={leavingCurrent}
+                className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40"
+              >
+                {leavingCurrent
+                  ? "Leaving..."
+                  : "Leave current quartet and continue"}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -3,7 +3,13 @@
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { AppNav } from "@/components/AppNav";
-import { createSession } from "@/lib/sessionStore";
+import {
+  clearActiveQuartet,
+  getActiveQuartet,
+  type ActiveQuartet,
+} from "@/lib/activeQuartet";
+import { getCurrentUser } from "@/lib/profileStore";
+import { createSession, removeParticipant } from "@/lib/sessionStore";
 
 function makeJoinCode() {
   return Math.random().toString(36).slice(2, 8).toUpperCase();
@@ -13,9 +19,26 @@ export default function SessionPage() {
   const [joinCode, setJoinCode] = useState("");
   const [qrUrl, setQrUrl] = useState("");
   const [loading, setLoading] = useState(true);
+  const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
+  const [leavingCurrent, setLeavingCurrent] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
+    const currentQuartet = getActiveQuartet();
+
+    if (currentQuartet) {
+      setActiveQuartet(currentQuartet);
+      setLoading(false);
+      return;
+    }
+
+    createNewQuartet();
+  }, []);
+
+  async function createNewQuartet() {
+    setLoading(true);
+    setErrorMessage("");
+
     async function init() {
       const code = makeJoinCode();
 
@@ -37,7 +60,30 @@ export default function SessionPage() {
     }
 
     init();
-  }, []);
+  }
+
+  async function leaveCurrentAndContinue() {
+    if (!activeQuartet) return;
+
+    setLeavingCurrent(true);
+    setErrorMessage("");
+
+    try {
+      const user = await getCurrentUser();
+      if (user) {
+        await removeParticipant(activeQuartet.sessionId, user.id);
+      }
+      clearActiveQuartet();
+      setActiveQuartet(null);
+      await createNewQuartet();
+    } catch (err) {
+      console.error("Failed to leave current quartet", err);
+      setErrorMessage(
+        "Could not leave your current quartet. Check your connection and try again."
+      );
+      setLeavingCurrent(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -54,6 +100,41 @@ export default function SessionPage() {
 
         <h1 className="mt-4 text-4xl font-bold">Start a quartet</h1>
 
+        {activeQuartet && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="active-quartet-title"
+            className="mt-8 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-6"
+          >
+            <h2 id="active-quartet-title" className="text-2xl font-semibold">
+              You are already in a quartet
+            </h2>
+            <p className="mt-2 text-slate-200">
+              Return to quartet {activeQuartet.code}, or leave it before
+              starting a new quartet.
+            </p>
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <a
+                href={`/join/${activeQuartet.code}`}
+                className="rounded-xl bg-cyan-300 px-5 py-3 text-center font-semibold text-slate-950 hover:bg-cyan-200"
+              >
+                Return to current quartet
+              </a>
+              <button
+                type="button"
+                onClick={leaveCurrentAndContinue}
+                disabled={leavingCurrent}
+                className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40"
+              >
+                {leavingCurrent
+                  ? "Leaving..."
+                  : "Leave current quartet and continue"}
+              </button>
+            </div>
+          </div>
+        )}
+
         {errorMessage && (
           <div className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
             <p className="font-semibold text-rose-100">{errorMessage}</p>
@@ -67,7 +148,7 @@ export default function SessionPage() {
           </div>
         )}
 
-        {!errorMessage && (
+        {!activeQuartet && !errorMessage && (
           <div className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-6 text-center">
             {qrUrl && (
               <img

--- a/lib/__tests__/activeQuartet.test.ts
+++ b/lib/__tests__/activeQuartet.test.ts
@@ -3,6 +3,7 @@ import {
   clearActiveQuartet,
   clearActiveQuartetIfMatches,
   getActiveQuartet,
+  isDifferentActiveQuartet,
   setActiveQuartet,
 } from "../activeQuartet";
 
@@ -64,5 +65,19 @@ describe("active quartet storage", () => {
     clearActiveQuartetIfMatches("session-1", storage);
 
     expect(getActiveQuartet(storage)).toBeNull();
+  });
+
+  it("identifies a different active quartet", () => {
+    const storage = new MemoryStorage();
+
+    expect(isDifferentActiveQuartet("session-1", storage)).toBe(false);
+
+    setActiveQuartet(
+      { sessionId: "session-1", code: "ABC123", joinedAt: "2026-04-27" },
+      storage
+    );
+
+    expect(isDifferentActiveQuartet("session-1", storage)).toBe(false);
+    expect(isDifferentActiveQuartet("session-2", storage)).toBe(true);
   });
 });

--- a/lib/activeQuartet.ts
+++ b/lib/activeQuartet.ts
@@ -60,3 +60,12 @@ export function clearActiveQuartetIfMatches(
     clearActiveQuartet(storage);
   }
 }
+
+export function isDifferentActiveQuartet(
+  sessionId: string,
+  storage = getBrowserStorage()
+): boolean {
+  const activeQuartet = getActiveQuartet(storage);
+
+  return Boolean(activeQuartet && activeQuartet.sessionId !== sessionId);
+}


### PR DESCRIPTION
Closes #82.

## Summary
- Warn users before starting a new quartet while another quartet is active.
- Warn users before manually joining a different quartet code.
- Warn users before auto-joining a direct `/join/[code]` link for a different quartet.
- Provide clear options to return to the current quartet or leave it and continue.
- Clear active quartet state and remove the old participant row before continuing.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.