### PR TITLE
Show active quartet indicator

### DIFF
--- a/components/ActiveQuartetIndicator.tsx
+++ b/components/ActiveQuartetIndicator.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ACTIVE_QUARTET_CHANGED_EVENT,
+  clearActiveQuartet,
+  getActiveQuartet,
+  type ActiveQuartet,
+} from "@/lib/activeQuartet";
+import { getCurrentUser } from "@/lib/profileStore";
+import { removeParticipant } from "@/lib/sessionStore";
+
+export function ActiveQuartetIndicator() {
+  const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
+  const [leaving, setLeaving] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    function syncActiveQuartet() {
+      setActiveQuartet(getActiveQuartet());
+    }
+
+    syncActiveQuartet();
+
+    window.addEventListener("storage", syncActiveQuartet);
+    window.addEventListener(ACTIVE_QUARTET_CHANGED_EVENT, syncActiveQuartet);
+
+    return () => {
+      window.removeEventListener("storage", syncActiveQuartet);
+      window.removeEventListener(ACTIVE_QUARTET_CHANGED_EVENT, syncActiveQuartet);
+    };
+  }, []);
+
+  async function leaveQuartet() {
+    if (!activeQuartet) return;
+
+    setLeaving(true);
+    setMessage("");
+
+    try {
+      const user = await getCurrentUser();
+
+      if (user) {
+        await removeParticipant(activeQuartet.sessionId, user.id);
+      }
+
+      clearActiveQuartet();
+      setActiveQuartet(null);
+
+      if (window.location.pathname === `/join/${activeQuartet.code}`) {
+        window.location.href = "/?leftQuartet=1";
+      }
+    } catch (err) {
+      console.error("Failed to leave active quartet", err);
+      setMessage("Could not leave quartet. Try again.");
+    } finally {
+      setLeaving(false);
+    }
+  }
+
+  if (!activeQuartet) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-cyan-300/30 bg-cyan-300/10 p-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm font-semibold text-slate-100">
+          In quartet{" "}
+          <span className="text-cyan-200">{activeQuartet.code}</span>
+        </p>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <a
+            href={`/join/${activeQuartet.code}`}
+            className="rounded-lg bg-cyan-300 px-4 py-2 text-center text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+          >
+            Return to quartet
+          </a>
+          <button
+            type="button"
+            onClick={leaveQuartet}
+            disabled={leaving}
+            className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40"
+          >
+            {leaving ? "Leaving..." : "Leave quartet"}
+          </button>
+        </div>
+      </div>
+
+      {message && <p className="mt-2 text-sm text-rose-100">{message}</p>}
+    </div>
+  );
+}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ActiveQuartetIndicator } from "@/components/ActiveQuartetIndicator";
 import { usePathname } from "next/navigation";
 import { SignOutButton } from "@/components/SignOutButton";
 
@@ -61,6 +62,7 @@ export function AppNav() {
 
         <SignOutButton className="rounded-xl px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/10 hover:text-white disabled:opacity-50" />
       </div>
+      <ActiveQuartetIndicator />
     </nav>
   );
 }

--- a/lib/activeQuartet.ts
+++ b/lib/activeQuartet.ts
@@ -1,4 +1,5 @@
 const ACTIVE_QUARTET_STORAGE_KEY = "active-quartet";
+export const ACTIVE_QUARTET_CHANGED_EVENT = "active-quartet-changed";
 
 type StorageLike = Pick<Storage, "getItem" | "removeItem" | "setItem">;
 
@@ -11,6 +12,12 @@ export type ActiveQuartet = {
 function getBrowserStorage(): StorageLike | null {
   if (typeof window === "undefined") return null;
   return window.localStorage;
+}
+
+function notifyActiveQuartetChanged() {
+  if (typeof window === "undefined") return;
+
+  window.dispatchEvent(new Event(ACTIVE_QUARTET_CHANGED_EVENT));
 }
 
 export function getActiveQuartet(
@@ -42,12 +49,14 @@ export function setActiveQuartet(
   if (!storage) return;
 
   storage.setItem(ACTIVE_QUARTET_STORAGE_KEY, JSON.stringify(activeQuartet));
+  notifyActiveQuartetChanged();
 }
 
 export function clearActiveQuartet(storage = getBrowserStorage()) {
   if (!storage) return;
 
   storage.removeItem(ACTIVE_QUARTET_STORAGE_KEY);
+  notifyActiveQuartetChanged();
 }
 
 export function clearActiveQuartetIfMatches(


### PR DESCRIPTION
Closes #83.

## Summary
- Add a persistent active-quartet indicator to the main app navigation.
- Include one-tap actions to return to the quartet or leave it.
- Remove the participant row and clear active quartet state when leaving from the indicator.
- Emit same-tab active-quartet change events so the indicator updates immediately.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.