### PR TITLE
Simplify quartet start flow

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import QRCode from "qrcode";
 import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
@@ -65,6 +66,8 @@ export default function JoinSessionPage() {
   const [displayName, setDisplayName] = useState("");
   const [participants, setParticipants] = useState<DbParticipant[]>([]);
   const [message, setMessage] = useState("");
+  const [copyMessage, setCopyMessage] = useState("");
+  const [qrUrl, setQrUrl] = useState("");
   const [loadError, setLoadError] = useState("");
   const [now, setNow] = useState(() => new Date());
   const [leftQuartet, setLeftQuartet] = useState(false);
@@ -179,6 +182,28 @@ export default function JoinSessionPage() {
     });
   }
 
+  async function copyJoinLink() {
+    const joinUrl = `${window.location.origin}/join/${code}`;
+
+    try {
+      await window.navigator.clipboard.writeText(joinUrl);
+      setCopyMessage("Join link copied.");
+    } catch (err) {
+      console.error(err);
+      setCopyMessage("Could not copy automatically. Share the code instead.");
+    }
+  }
+
+  async function copyJoinCode() {
+    try {
+      await window.navigator.clipboard.writeText(code);
+      setCopyMessage("Quartet code copied.");
+    } catch (err) {
+      console.error(err);
+      setCopyMessage("Could not copy automatically. You can still share the code.");
+    }
+  }
+
   async function leaveCurrentAndJoinThisQuartet() {
     if (!pendingActiveQuartet || !currentUserId || !sessionId) {
       setMessage("Could not continue yet. Wait for this quartet to finish loading.");
@@ -247,6 +272,11 @@ export default function JoinSessionPage() {
         setDisplayName(profile.display_name);
         setSessionId(session.id);
         setSession(session);
+
+        const joinUrl = `${window.location.origin}/join/${code}`;
+        const qr = await QRCode.toDataURL(joinUrl);
+        setQrUrl(qr);
+
         const hasLeftQuartet =
           window.sessionStorage.getItem(leftQuartetStorageKey(code)) === "true";
         setLeftQuartet(hasLeftQuartet);
@@ -312,6 +342,12 @@ export default function JoinSessionPage() {
   }));
   const quartetExpired = session ? isSessionExpired(session, now) : false;
   const expirationLabel = session ? sessionExpirationLabel(session, now) : "";
+  const openSingerSlots = Math.max(0, MAX_QUARTET_PARTICIPANTS - participants.length);
+  const showJoinInfo =
+    Boolean(session) &&
+    !quartetExpired &&
+    !pendingActiveQuartet &&
+    participants.length < MAX_QUARTET_PARTICIPANTS;
 
   if (loading) {
     return (
@@ -397,6 +433,54 @@ export default function JoinSessionPage() {
 
         {!loadError && !quartetExpired && !pendingActiveQuartet && (
           <>
+            {showJoinInfo && (
+              <section className="mt-6 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5">
+                <div className="flex flex-col gap-5 md:flex-row md:items-center">
+                  {qrUrl && (
+                    <img
+                      src={qrUrl}
+                      alt="QR code for joining this quartet"
+                      className="mx-auto w-44 rounded-xl bg-white p-3 md:mx-0"
+                    />
+                  )}
+
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold uppercase text-cyan-200">
+                      Waiting for singers
+                    </p>
+                    <p className="mt-2 text-5xl font-bold tracking-widest text-white">
+                      {code}
+                    </p>
+                    <p className="mt-2 text-sm text-slate-200">
+                      {openSingerSlots} {openSingerSlots === 1 ? "spot" : "spots"} open.
+                      Share this code or QR link with singers nearby.
+                    </p>
+
+                    <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                      <button
+                        type="button"
+                        onClick={copyJoinCode}
+                        className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
+                      >
+                        Copy code
+                      </button>
+                      <button
+                        type="button"
+                        onClick={copyJoinLink}
+                        className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700"
+                      >
+                        Copy join link
+                      </button>
+                    </div>
+
+                    {copyMessage && (
+                      <p className="mt-2 text-sm text-cyan-100">{copyMessage}</p>
+                    )}
+                  </div>
+                </div>
+              </section>
+            )}
+
             <div className="mt-6 rounded-2xl border border-white/10 bg-white/10 p-6">
               {leftQuartet ? (
                 <>

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import {
@@ -16,8 +15,6 @@ function makeJoinCode() {
 }
 
 export default function SessionPage() {
-  const [joinCode, setJoinCode] = useState("");
-  const [qrUrl, setQrUrl] = useState("");
   const [loading, setLoading] = useState(true);
   const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
   const [leavingCurrent, setLeavingCurrent] = useState(false);
@@ -44,11 +41,7 @@ export default function SessionPage() {
 
       try {
         await createSession(code);
-        setJoinCode(code);
-
-        const joinUrl = `${window.location.origin}/join/${code}`;
-        const qr = await QRCode.toDataURL(joinUrl);
-        setQrUrl(qr);
+        window.location.href = `/join/${code}`;
       } catch (err) {
         console.error("Failed to create session", err);
         setErrorMessage(
@@ -149,26 +142,8 @@ export default function SessionPage() {
         )}
 
         {!activeQuartet && !errorMessage && (
-          <div className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-6 text-center">
-            {qrUrl && (
-              <img
-                src={qrUrl}
-                alt="QR code"
-                className="mx-auto rounded-xl bg-white p-4"
-              />
-            )}
-
-            <p className="mt-6 text-sm text-slate-400">Quartet code</p>
-            <p className="text-5xl font-bold tracking-widest text-cyan-300">
-              {joinCode}
-            </p>
-
-            <a
-              href={`/join/${joinCode}`}
-              className="mt-6 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
-            >
-              Join this quartet
-            </a>
+          <div className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-6">
+            <p className="text-slate-300">Creating your quartet...</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes #84.

## Summary
- Redirect newly-created quartets from `/session` straight to the quartet page.
- Let the quartet page auto-join the creator through the existing join flow.
- Move QR code and join-code sharing onto the active quartet page while fewer than four singers are present.
- Add copy actions for the quartet code and join link.
- Hide the share surface once the quartet is full so match results take focus.

## Testing
- npm run test:run
- npm run build

## Manual steps
- None. No database migration or Supabase dashboard change required.