### PR TITLE
Add private notes to repertoire entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Supabase project should have the current production schema applied:
 
 - `profiles` stores each user's required `display_name`.
 - `user_repertoire` stores each user's songs, voicing, parts known, confidence,
-  and optional arranger name.
+  optional arranger name, and private notes.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by
@@ -40,3 +40,6 @@ The Supabase project should have the current production schema applied:
 One-time migration SQL is intentionally not kept in this README after it has
 been applied. Add any future schema change to the PR that introduces it, then
 remove the one-time instructions after production is updated.
+
+For the private repertoire notes feature, apply the one-time SQL in
+[docs/private-repertoire-notes.md](docs/private-repertoire-notes.md).

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
-import { findMatches, SingerEntry } from "@/lib/matching";
+import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
 import {
   type DbSession,
   type DbParticipant,
@@ -49,8 +49,18 @@ const matchSections = [
 
 const MAX_QUARTET_PARTICIPANTS = 4;
 
+type PersonalSongNote = {
+  songTitle: string;
+  voicing: SingerEntry["voicing"];
+  notes: string;
+};
+
 function leftQuartetStorageKey(code: string) {
   return `left-quartet:${code}`;
+}
+
+function normalizeSongTitle(title: string) {
+  return title.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
 export default function JoinSessionPage() {
@@ -65,6 +75,9 @@ export default function JoinSessionPage() {
   const [currentUserId, setCurrentUserId] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [participants, setParticipants] = useState<DbParticipant[]>([]);
+  const [personalSongNotes, setPersonalSongNotes] = useState<PersonalSongNote[]>(
+    []
+  );
   const [message, setMessage] = useState("");
   const [copyMessage, setCopyMessage] = useState("");
   const [qrUrl, setQrUrl] = useState("");
@@ -84,6 +97,15 @@ export default function JoinSessionPage() {
 
   async function getMyEntries(name: string): Promise<SingerEntry[]> {
     const repertoire = await getMyRepertoire();
+    setPersonalSongNotes(
+      repertoire
+        .filter((item) => item.notes?.trim())
+        .map((item) => ({
+          songTitle: item.song_title,
+          voicing: item.voicing,
+          notes: item.notes?.trim() ?? "",
+        }))
+    );
 
     return repertoire.map((item) => ({
       userId: item.user_id,
@@ -356,6 +378,18 @@ export default function JoinSessionPage() {
     !quartetExpired &&
     !pendingActiveQuartet &&
     participants.length >= MAX_QUARTET_PARTICIPANTS;
+
+  function notesForMatch(match: MatchResult) {
+    const matchTitle = normalizeSongTitle(match.songTitle);
+
+    return personalSongNotes
+      .filter(
+        (note) =>
+          note.voicing === match.voicing &&
+          normalizeSongTitle(note.songTitle) === matchTitle
+      )
+      .map((note) => note.notes);
+  }
 
   if (loading) {
     return (
@@ -652,6 +686,7 @@ export default function JoinSessionPage() {
                             <MatchCard
                               key={match.songTitle + match.voicing}
                               match={match}
+                              personalNotes={notesForMatch(match)}
                             />
                           ))}
                         </div>

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -7,6 +7,7 @@ import {
 
 type MatchCardProps = {
   match: MatchResult;
+  personalNotes?: string[];
 };
 
 const categoryStyles: Record<
@@ -53,10 +54,13 @@ function partAbbreviation(voicing: Voicing, part: Part): string {
   return part;
 }
 
-export function MatchCard({ match }: MatchCardProps) {
+export function MatchCard({ match, personalNotes = [] }: MatchCardProps) {
   const styles = categoryStyles[match.category];
   const parts = requiredPartsForVoicing(match.voicing);
-  const hasDetails = match.warnings.length > 0 || match.arrangerNames.length > 0;
+  const hasDetails =
+    match.warnings.length > 0 ||
+    match.arrangerNames.length > 0 ||
+    personalNotes.length > 0;
 
   return (
     <details
@@ -135,6 +139,17 @@ export function MatchCard({ match }: MatchCardProps) {
           >
             {match.warnings.map((warning) => (
               <p key={warning}>{warning}</p>
+            ))}
+          </div>
+        )}
+
+        {personalNotes.length > 0 && (
+          <div className="mt-3 rounded-lg bg-white/5 p-2 text-xs text-slate-300">
+            <p className="font-semibold text-slate-200">My notes</p>
+            {personalNotes.map((note, index) => (
+              <p key={`${note}-${index}`} className="mt-1 whitespace-pre-wrap">
+                {note}
+              </p>
             ))}
           </div>
         )}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -32,6 +32,7 @@ type RepertoireForm = {
   arrangerName: string;
   partsKnown: Part[];
   confidence: Confidence;
+  notes: string;
 };
 
 function partAbbreviation(voicing: Voicing, part: Part): string {
@@ -72,6 +73,7 @@ export default function RepertoireManager() {
   const [songTitle, setSongTitle] = useState("");
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
+  const [notes, setNotes] = useState("");
   const [partsKnown, setPartsKnown] = useState<Part[]>([]);
   const [confidence, setConfidence] = useState<Confidence | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -140,6 +142,7 @@ export default function RepertoireManager() {
     setSongTitle("");
     setVoicing("");
     setArrangerName("");
+    setNotes("");
     setPartsKnown([]);
     setConfidence("");
     setShowArranger(false);
@@ -172,6 +175,7 @@ export default function RepertoireManager() {
       arrangerName: item.arranger_name ?? "",
       partsKnown: item.parts_known,
       confidence: item.confidence,
+      notes: item.notes ?? "",
     });
     setMessage("");
   }
@@ -226,6 +230,7 @@ export default function RepertoireManager() {
         arrangerName: arrangerName.trim() || undefined,
         partsKnown,
         confidence,
+        notes: notes.trim() || undefined,
       });
 
       resetAddForm();
@@ -275,6 +280,7 @@ export default function RepertoireManager() {
         arrangerName: editForm.arrangerName.trim() || undefined,
         partsKnown: editForm.partsKnown,
         confidence: editForm.confidence,
+        notes: editForm.notes.trim() || undefined,
       });
 
       cancelEditing();
@@ -475,6 +481,20 @@ export default function RepertoireManager() {
                           ))}
                         </select>
                       </label>
+
+                      <label className="block md:col-span-2">
+                        <span className="text-sm font-medium text-slate-300">
+                          Notes (optional)
+                        </span>
+                        <textarea
+                          value={editForm.notes}
+                          onChange={(e) =>
+                            updateEditForm({ notes: e.target.value })
+                          }
+                          rows={3}
+                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        />
+                      </label>
                     </div>
 
                     <div className="mt-5">
@@ -550,6 +570,11 @@ export default function RepertoireManager() {
                           </span>
                         )}
                       </div>
+                      {item.notes && (
+                        <p className="mt-1 line-clamp-2 text-xs text-slate-400">
+                          Notes: {item.notes}
+                        </p>
+                      )}
                     </div>
 
                     <div className="flex shrink-0 gap-1">
@@ -717,6 +742,19 @@ export default function RepertoireManager() {
                     </button>
                   )}
                 </div>
+
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-300">
+                    Notes (optional)
+                  </span>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    rows={3}
+                    placeholder="Key, first words, or tricky spots"
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                  />
+                </label>
               </div>
 
               <div className="mt-6 flex flex-col gap-3 sm:flex-row">

--- a/docs/private-repertoire-notes.md
+++ b/docs/private-repertoire-notes.md
@@ -1,0 +1,13 @@
+# Private Repertoire Notes
+
+Issue #87 adds optional private notes to each `user_repertoire` row.
+
+Apply this SQL once in the Supabase SQL editor before deploying the feature:
+
+```sql
+alter table public.user_repertoire
+add column if not exists notes text;
+```
+
+No changes are needed to session participant data. Notes stay in
+`user_repertoire` and are not copied into quartet snapshots.

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -10,6 +10,7 @@ export type RepertoireRow = {
   arranger_name: string | null;
   parts_known: Part[];
   confidence: Confidence;
+  notes: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -45,6 +46,7 @@ export async function addRepertoireItem(input: {
   arrangerName?: string;
   partsKnown: Part[];
   confidence: Confidence;
+  notes?: string;
 }) {
   const user = await getCurrentUser();
   if (!user) throw new Error("You must be logged in.");
@@ -58,6 +60,7 @@ export async function addRepertoireItem(input: {
       arranger_name: input.arrangerName || null,
       parts_known: input.partsKnown,
       confidence: input.confidence,
+      notes: input.notes || null,
     })
     .select()
     .single();
@@ -74,6 +77,7 @@ export async function updateRepertoireItem(
     arrangerName?: string;
     partsKnown: Part[];
     confidence: Confidence;
+    notes?: string;
   }
 ) {
   const user = await getCurrentUser();
@@ -87,6 +91,7 @@ export async function updateRepertoireItem(
       arranger_name: input.arrangerName || null,
       parts_known: input.partsKnown,
       confidence: input.confidence,
+      notes: input.notes || null,
     })
     .eq("id", id)
     .eq("user_id", user.id)


### PR DESCRIPTION
Closes #87

## Summary
- Add optional private notes to repertoire add/edit flows and saved repertoire rows.
- Keep notes out of shared session participant snapshots used for matching.
- Show the current user's notes subtly in quartet match details as "My notes".
- Document the required one-time Supabase column migration.

## Manual Supabase step
Apply this once in the Supabase SQL editor before deploying:

```sql
alter table public.user_repertoire
add column if not exists notes text;
```

## Verification
- npm run test:run
- npm run build