### PR TITLE
Track recently sung match results

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The Supabase project should have the current production schema applied:
 - `session_participants` stores participant repertoire snapshots and is keyed by
   `(session_id, user_id)` so one singer can refresh without creating duplicate
   rows.
+- `sung_song_events` stores each user's private "marked as sung" events for
+  recent-use indicators.
 
 One-time migration SQL is intentionally not kept in this README after it has
 been applied. Add any future schema change to the PR that introduces it, then
@@ -43,3 +45,6 @@ remove the one-time instructions after production is updated.
 
 For the private repertoire notes feature, apply the one-time SQL in
 [docs/private-repertoire-notes.md](docs/private-repertoire-notes.md).
+
+For the recently sung feature, apply the one-time SQL in
+[docs/recently-sung-events.md](docs/recently-sung-events.md).

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -28,6 +28,11 @@ import {
 } from "@/lib/activeQuartet";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
+import {
+  getRecentSungSongs,
+  markSongAsSung,
+  type SungSongEvent,
+} from "@/lib/sungSongStore";
 
 const matchSections = [
   {
@@ -63,6 +68,10 @@ function normalizeSongTitle(title: string) {
   return title.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
+function normalizeOptionalText(value: string | null | undefined) {
+  return value?.toLowerCase().replace(/[^a-z0-9]/g, "") ?? "";
+}
+
 export default function JoinSessionPage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
@@ -78,6 +87,8 @@ export default function JoinSessionPage() {
   const [personalSongNotes, setPersonalSongNotes] = useState<PersonalSongNote[]>(
     []
   );
+  const [recentSungSongs, setRecentSungSongs] = useState<SungSongEvent[]>([]);
+  const [markingSungKey, setMarkingSungKey] = useState("");
   const [message, setMessage] = useState("");
   const [copyMessage, setCopyMessage] = useState("");
   const [qrUrl, setQrUrl] = useState("");
@@ -255,6 +266,42 @@ export default function JoinSessionPage() {
     }
   }
 
+  async function refreshRecentSungSongs() {
+    const events = await getRecentSungSongs();
+    setRecentSungSongs(events);
+  }
+
+  function matchKey(match: MatchResult) {
+    return `${normalizeSongTitle(match.songTitle)}:${match.voicing}`;
+  }
+
+  async function markMatchAsSung(match: MatchResult) {
+    if (!sessionId) {
+      setMessage("Could not mark that yet. Wait for the quartet to finish loading.");
+      return;
+    }
+
+    const key = matchKey(match);
+    setMarkingSungKey(key);
+    setMessage("");
+
+    try {
+      await markSongAsSung({
+        sessionId,
+        songTitle: match.songTitle,
+        voicing: match.voicing,
+        arrangerName: match.arrangerNames.join(", ") || undefined,
+      });
+      await refreshRecentSungSongs();
+      setMessage(`Marked "${match.songTitle}" as sung.`);
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not mark that song as sung. Check your connection and try again.");
+    } finally {
+      setMarkingSungKey("");
+    }
+  }
+
   useEffect(() => {
     let unsubscribe: undefined | (() => void);
     const timer = window.setInterval(() => {
@@ -297,6 +344,7 @@ export default function JoinSessionPage() {
         setDisplayName(profile.display_name);
         setSessionId(session.id);
         setSession(session);
+        await refreshRecentSungSongs();
 
         const joinUrl = `${window.location.origin}/join/${code}`;
         const qr = await QRCode.toDataURL(joinUrl);
@@ -389,6 +437,23 @@ export default function JoinSessionPage() {
           normalizeSongTitle(note.songTitle) === matchTitle
       )
       .map((note) => note.notes);
+  }
+
+  function wasRecentlySung(match: MatchResult) {
+    const matchTitle = normalizeSongTitle(match.songTitle);
+    const matchArrangers = match.arrangerNames.map(normalizeOptionalText);
+
+    return recentSungSongs.some(
+      (event) => {
+        if (event.voicing !== match.voicing) return false;
+        if (normalizeSongTitle(event.song_title) !== matchTitle) return false;
+
+        const eventArranger = normalizeOptionalText(event.arranger_name);
+        if (!eventArranger || matchArrangers.length === 0) return true;
+
+        return matchArrangers.includes(eventArranger);
+      }
+    );
   }
 
   if (loading) {
@@ -687,6 +752,9 @@ export default function JoinSessionPage() {
                               key={match.songTitle + match.voicing}
                               match={match}
                               personalNotes={notesForMatch(match)}
+                              isRecentlySung={wasRecentlySung(match)}
+                              isMarkingSung={markingSungKey === matchKey(match)}
+                              onMarkAsSung={() => markMatchAsSung(match)}
                             />
                           ))}
                         </div>

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -8,6 +8,9 @@ import {
 type MatchCardProps = {
   match: MatchResult;
   personalNotes?: string[];
+  isRecentlySung?: boolean;
+  isMarkingSung?: boolean;
+  onMarkAsSung?: () => void;
 };
 
 const categoryStyles: Record<
@@ -54,13 +57,20 @@ function partAbbreviation(voicing: Voicing, part: Part): string {
   return part;
 }
 
-export function MatchCard({ match, personalNotes = [] }: MatchCardProps) {
+export function MatchCard({
+  match,
+  personalNotes = [],
+  isRecentlySung = false,
+  isMarkingSung = false,
+  onMarkAsSung,
+}: MatchCardProps) {
   const styles = categoryStyles[match.category];
   const parts = requiredPartsForVoicing(match.voicing);
   const hasDetails =
     match.warnings.length > 0 ||
     match.arrangerNames.length > 0 ||
-    personalNotes.length > 0;
+    personalNotes.length > 0 ||
+    isRecentlySung;
 
   return (
     <details
@@ -72,9 +82,16 @@ export function MatchCard({ match, personalNotes = [] }: MatchCardProps) {
             <h3 className="truncate text-base font-semibold text-white">
               {match.songTitle}
             </h3>
-            <p className="mt-0.5 text-xs font-semibold uppercase tracking-normal text-slate-400">
-              {match.voicing}
-            </p>
+            <div className="mt-0.5 flex flex-wrap items-center gap-2">
+              <p className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                {match.voicing}
+              </p>
+              {isRecentlySung && (
+                <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs font-semibold text-slate-200">
+                  Sung recently
+                </span>
+              )}
+            </div>
           </div>
           <span className="shrink-0 rounded-full bg-slate-950/80 px-2 py-1 text-xs font-semibold text-slate-300 group-open:hidden">
             Details
@@ -151,6 +168,19 @@ export function MatchCard({ match, personalNotes = [] }: MatchCardProps) {
                 {note}
               </p>
             ))}
+          </div>
+        )}
+
+        {onMarkAsSung && (
+          <div className="mt-3">
+            <button
+              type="button"
+              onClick={onMarkAsSung}
+              disabled={isMarkingSung}
+              className="rounded-lg bg-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/20 disabled:opacity-40"
+            >
+              {isMarkingSung ? "Marking..." : "Mark as sung"}
+            </button>
           </div>
         )}
 

--- a/docs/recently-sung-events.md
+++ b/docs/recently-sung-events.md
@@ -1,0 +1,36 @@
+# Recently Sung Events
+
+Issue #88 adds a private event log for songs a user marks as sung from quartet
+results.
+
+Apply this SQL once in the Supabase SQL editor before deploying the feature:
+
+```sql
+create table if not exists public.sung_song_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  session_id uuid not null references public.sessions(id) on delete cascade,
+  song_title text not null,
+  voicing text not null,
+  arranger_name text,
+  sung_at timestamptz not null default now()
+);
+
+alter table public.sung_song_events enable row level security;
+
+create policy "Users can read their sung song events"
+on public.sung_song_events
+for select
+using (auth.uid() = user_id);
+
+create policy "Users can insert their sung song events"
+on public.sung_song_events
+for insert
+with check (auth.uid() = user_id);
+
+create index if not exists sung_song_events_user_sung_at_idx
+on public.sung_song_events (user_id, sung_at desc);
+```
+
+Events are private to the user who marked the song. They are not copied into
+quartet participant snapshots and do not affect matching rank yet.

--- a/lib/sungSongStore.ts
+++ b/lib/sungSongStore.ts
@@ -1,0 +1,60 @@
+import { supabase } from "@/lib/supabase";
+import type { Voicing } from "@/lib/matching";
+import { getCurrentUser } from "@/lib/profileStore";
+
+export type SungSongEvent = {
+  id: string;
+  user_id: string;
+  session_id: string;
+  song_title: string;
+  voicing: Voicing;
+  arranger_name: string | null;
+  sung_at: string;
+};
+
+type RawSungSongEvent = Omit<SungSongEvent, "voicing"> & {
+  voicing: string;
+};
+
+export async function getRecentSungSongs(days = 30) {
+  const user = await getCurrentUser();
+  if (!user) return [];
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+
+  const { data, error } = await supabase
+    .from("sung_song_events")
+    .select("*")
+    .eq("user_id", user.id)
+    .gte("sung_at", since.toISOString())
+    .order("sung_at", { ascending: false });
+
+  if (error) throw error;
+  return data as RawSungSongEvent[] as SungSongEvent[];
+}
+
+export async function markSongAsSung(input: {
+  sessionId: string;
+  songTitle: string;
+  voicing: Voicing;
+  arrangerName?: string;
+}) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const { data, error } = await supabase
+    .from("sung_song_events")
+    .insert({
+      user_id: user.id,
+      session_id: input.sessionId,
+      song_title: input.songTitle,
+      voicing: input.voicing,
+      arranger_name: input.arrangerName || null,
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as RawSungSongEvent as SungSongEvent;
+}


### PR DESCRIPTION
Closes #88

## Summary
- Add a private `sung_song_events` store for current-user "Mark as sung" events.
- Add a lightweight Mark as sung action to each match card and a subtle Sung recently badge for current-user recent events.
- Record user, song title, voicing, optional arranger, quartet/session id, and timestamp.
- Leave matching and ranking logic unchanged.

## Manual Supabase step
Apply this once in the Supabase SQL editor before deploying:

```sql
create table if not exists public.sung_song_events (
  id uuid primary key default gen_random_uuid(),
  user_id uuid not null references auth.users(id) on delete cascade,
  session_id uuid not null references public.sessions(id) on delete cascade,
  song_title text not null,
  voicing text not null,
  arranger_name text,
  sung_at timestamptz not null default now()
);

alter table public.sung_song_events enable row level security;

create policy "Users can read their sung song events"
on public.sung_song_events
for select
using (auth.uid() = user_id);

create policy "Users can insert their sung song events"
on public.sung_song_events
for insert
with check (auth.uid() = user_id);

create index if not exists sung_song_events_user_sung_at_idx
on public.sung_song_events (user_id, sung_at desc);
```

## Verification
- npm run test:run
- npm run build