### PR TITLE
Fix returning to active quartet

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -13,6 +13,7 @@ import {
   getSessionByCode,
   removeParticipant,
   subscribeToSessionParticipants,
+  updateParticipantSnapshot,
   upsertParticipant,
 } from "@/lib/sessionStore";
 import {
@@ -168,7 +169,18 @@ export default function JoinSessionPage() {
       const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();
 
-      await upsertParticipant(id, userId, name, entries, lastActivityAt);
+      if (existingParticipant) {
+        await updateParticipantSnapshot(
+          existingParticipant.id,
+          userId,
+          name,
+          entries,
+          lastActivityAt
+        );
+      } else {
+        await upsertParticipant(id, userId, name, entries, lastActivityAt);
+      }
+
       setActiveQuartet({ sessionId: id, code, joinedAt: lastActivityAt });
       setSession((current) =>
         current ? { ...current, last_activity_at: lastActivityAt } : current

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -77,6 +77,29 @@ export async function upsertParticipant(
   return data as DbParticipant;
 }
 
+export async function updateParticipantSnapshot(
+  participantId: string,
+  userId: string,
+  displayName: string,
+  repertoire: SingerEntry[],
+  lastActivityAt = new Date().toISOString()
+) {
+  const { data, error } = await supabase
+    .from("session_participants")
+    .update({
+      display_name: displayName,
+      repertoire,
+    })
+    .eq("id", participantId)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  await updateSessionActivity(data.session_id, lastActivityAt);
+  return data as DbParticipant;
+}
+
 export async function getParticipants(sessionId: string) {
   const { data, error } = await supabase
     .from("session_participants")


### PR DESCRIPTION
Closes #103

## Summary
- Recognize already-joined quartet participants by authenticated `user_id` before refreshing their snapshot.
- Update an existing participant row directly instead of running the fresh join/upsert path again.
- Preserve repertoire snapshot refresh for returning users while keeping active quartet state consistent.
- Leave matching logic unchanged.

## Verification
- npm run test:run
- npm run build

No database migration or Supabase dashboard changes required.