### PR TITLE
Add high-value unit test coverage

### DIFF
--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -1,9 +1,8 @@
 import {
   requiredPartsForVoicing,
   type MatchResult,
-  type Part,
-  type Voicing,
 } from "@/lib/matching";
+import { partAbbreviation } from "@/lib/partAbbreviations";
 
 type MatchCardProps = {
   match: MatchResult;
@@ -33,29 +32,6 @@ const categoryStyles: Record<
     part: "bg-slate-900/80 text-slate-100 ring-white/10",
   },
 };
-
-function partAbbreviation(voicing: Voicing, part: Part): string {
-  if (voicing === "TTBB") {
-    if (part === "Tenor") return "T";
-    if (part === "Lead") return "L";
-    if (part === "Baritone") return "Bari";
-    if (part === "Bass") return "Bass";
-  }
-
-  if (voicing === "SATB") {
-    if (part === "Soprano") return "S";
-    if (part === "Alto") return "A";
-    if (part === "Tenor") return "T";
-    if (part === "Bass") return "Bass";
-  }
-
-  if (part === "Soprano 1") return "S1";
-  if (part === "Soprano 2") return "S2";
-  if (part === "Alto 1") return "A1";
-  if (part === "Alto 2") return "A2";
-
-  return part;
-}
 
 export function MatchCard({
   match,

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
+import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
 import {
   addRepertoireItem,
   deleteRepertoireItem,
@@ -34,36 +35,6 @@ type RepertoireForm = {
   confidence: Confidence;
   notes: string;
 };
-
-function partAbbreviation(voicing: Voicing, part: Part): string {
-  if (voicing === "TTBB") {
-    if (part === "Tenor") return "T";
-    if (part === "Lead") return "L";
-    if (part === "Baritone") return "Bari";
-    if (part === "Bass") return "Bass";
-  }
-
-  if (voicing === "SATB") {
-    if (part === "Soprano") return "S";
-    if (part === "Alto") return "A";
-    if (part === "Tenor") return "T";
-    if (part === "Bass") return "Bass";
-  }
-
-  if (part === "Soprano 1") return "S1";
-  if (part === "Soprano 2") return "S2";
-  if (part === "Alto 1") return "A1";
-  if (part === "Alto 2") return "A2";
-
-  return part;
-}
-
-function partButtonLabel(voicing: Voicing, part: Part): string {
-  const abbreviation = partAbbreviation(voicing, part);
-
-  if (abbreviation === part) return part;
-  return `${abbreviation} ${part}`;
-}
 
 export default function RepertoireManager() {
   const songTitleInputRef = useRef<HTMLInputElement>(null);

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -10,6 +10,29 @@ describe("findMatches", () => {
     expect(normalizeConfidence("Learning")).toBe("Music Required");
   });
 
+  it("keeps current confidence values and rejects unknown values", () => {
+    expect(normalizeConfidence("Good to Go")).toBe("Good to Go");
+    expect(normalizeConfidence("A Little Rusty")).toBe("A Little Rusty");
+    expect(normalizeConfidence("Music Required")).toBe("Music Required");
+    expect(normalizeConfidence("Unknown")).toBeNull();
+    expect(normalizeConfidence(null)).toBeNull();
+  });
+
+  it("adds confidence warnings for rusty or music-required singers", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "Ready", songTitle: "Warning Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "2", displayName: "Rusty", songTitle: "Warning Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "A Little Rusty" },
+      { userId: "3", displayName: "Music", songTitle: "Warning Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Music Required" },
+      { userId: "4", displayName: "Ready Bass", songTitle: "Warning Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].warnings).toContain(
+      "Confidence warning: Rusty marked A Little Rusty, Music marked Music Required"
+    );
+  });
+
   it("does not let one singer cover multiple quartet parts", () => {
     const entries: SingerEntry[] = [
       {
@@ -232,6 +255,39 @@ describe("findMatches", () => {
 
     expect(matches[0].songTitle).toBe("Strong Song");
     expect(matches[0].score).toBeGreaterThan(matches[1].score);
+  });
+
+  it("ranks a little rusty above music required within the same category", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Music Required Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Music Required" },
+      { userId: "2", displayName: "B", songTitle: "Music Required Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Music Required" },
+      { userId: "3", displayName: "C", songTitle: "Music Required Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Music Required" },
+      { userId: "4", displayName: "D", songTitle: "Music Required Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Music Required" },
+
+      { userId: "1", displayName: "A", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "A Little Rusty" },
+      { userId: "2", displayName: "B", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "A Little Rusty" },
+      { userId: "3", displayName: "C", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "A Little Rusty" },
+      { userId: "4", displayName: "D", songTitle: "Rusty Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "A Little Rusty" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].songTitle).toBe("Rusty Song");
+    expect(matches[0].score).toBeGreaterThan(matches[1].score);
+  });
+
+  it("prefers the stronger singer when multiple singers can cover the same part", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "Rusty Tenor", songTitle: "Choice Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Music Required" },
+      { userId: "2", displayName: "Ready Tenor", songTitle: "Choice Song", voicing: "TTBB", partsKnown: ["Tenor"], confidence: "Good to Go" },
+      { userId: "3", displayName: "Lead", songTitle: "Choice Song", voicing: "TTBB", partsKnown: ["Lead"], confidence: "Good to Go" },
+      { userId: "4", displayName: "Bari", songTitle: "Choice Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "5", displayName: "Bass", songTitle: "Choice Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].assignments.Tenor?.[0].displayName).toBe("Ready Tenor");
   });
 
   it("uses extra part coverage as a modest tie-breaker", () => {

--- a/lib/__tests__/partAbbreviations.test.ts
+++ b/lib/__tests__/partAbbreviations.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { partAbbreviation, partButtonLabel } from "../partAbbreviations";
+
+describe("partAbbreviation", () => {
+  it("uses the standard TTBB abbreviations", () => {
+    expect(partAbbreviation("TTBB", "Tenor")).toBe("T");
+    expect(partAbbreviation("TTBB", "Lead")).toBe("L");
+    expect(partAbbreviation("TTBB", "Baritone")).toBe("Bari");
+    expect(partAbbreviation("TTBB", "Bass")).toBe("Bass");
+  });
+
+  it("uses the standard SATB abbreviations", () => {
+    expect(partAbbreviation("SATB", "Soprano")).toBe("S");
+    expect(partAbbreviation("SATB", "Alto")).toBe("A");
+    expect(partAbbreviation("SATB", "Tenor")).toBe("T");
+    expect(partAbbreviation("SATB", "Bass")).toBe("Bass");
+  });
+
+  it("uses the standard SSAA abbreviations", () => {
+    expect(partAbbreviation("SSAA", "Soprano 1")).toBe("S1");
+    expect(partAbbreviation("SSAA", "Soprano 2")).toBe("S2");
+    expect(partAbbreviation("SSAA", "Alto 1")).toBe("A1");
+    expect(partAbbreviation("SSAA", "Alto 2")).toBe("A2");
+  });
+
+  it("includes full part names in button labels only when abbreviated", () => {
+    expect(partButtonLabel("TTBB", "Lead")).toBe("L Lead");
+    expect(partButtonLabel("TTBB", "Bass")).toBe("Bass");
+    expect(partButtonLabel("SSAA", "Alto 2")).toBe("A2 Alto 2");
+  });
+});

--- a/lib/partAbbreviations.ts
+++ b/lib/partAbbreviations.ts
@@ -1,0 +1,31 @@
+import type { Part, Voicing } from "@/lib/matching";
+
+export function partAbbreviation(voicing: Voicing, part: Part): string {
+  if (voicing === "TTBB") {
+    if (part === "Tenor") return "T";
+    if (part === "Lead") return "L";
+    if (part === "Baritone") return "Bari";
+    if (part === "Bass") return "Bass";
+  }
+
+  if (voicing === "SATB") {
+    if (part === "Soprano") return "S";
+    if (part === "Alto") return "A";
+    if (part === "Tenor") return "T";
+    if (part === "Bass") return "Bass";
+  }
+
+  if (part === "Soprano 1") return "S1";
+  if (part === "Soprano 2") return "S2";
+  if (part === "Alto 1") return "A1";
+  if (part === "Alto 2") return "A2";
+
+  return part;
+}
+
+export function partButtonLabel(voicing: Voicing, part: Part): string {
+  const abbreviation = partAbbreviation(voicing, part);
+
+  if (abbreviation === part) return part;
+  return `${abbreviation} ${part}`;
+}


### PR DESCRIPTION
## Summary
- Add pure unit coverage for the standard part abbreviation and button-label helpers.
- Reuse the shared part abbreviation helper in match and repertoire UI code without changing behavior.
- Add matching tests for current confidence values, confidence warnings, rusty-vs-music-required ranking, and stronger singer assignment.

## Verification
- npm run test:run
- npm run build