### PR TITLE
Add QR scanner to join page

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -6,33 +6,58 @@ import {
   getActiveQuartet,
   type ActiveQuartet,
 } from "@/lib/activeQuartet";
+import { parseJoinCode } from "@/lib/joinCode";
 import { getCurrentUser } from "@/lib/profileStore";
 import { removeParticipant } from "@/lib/sessionStore";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+type BarcodeDetectorResult = {
+  rawValue?: string;
+};
+
+type BarcodeDetectorLike = {
+  detect(source: CanvasImageSource): Promise<BarcodeDetectorResult[]>;
+};
+
+type BarcodeDetectorConstructor = new (options: {
+  formats: string[];
+}) => BarcodeDetectorLike;
 
 export default function JoinPage() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const scanFrameRef = useRef<number | null>(null);
   const [joinCode, setJoinCode] = useState("");
   const [pendingCode, setPendingCode] = useState("");
   const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
   const [leavingCurrent, setLeavingCurrent] = useState(false);
   const [message, setMessage] = useState("");
+  const [scannerOpen, setScannerOpen] = useState(false);
+  const [scannerMessage, setScannerMessage] = useState("");
+
+  function goToQuartet(code: string) {
+    const currentQuartet = getActiveQuartet();
+
+    if (currentQuartet && currentQuartet.code !== code) {
+      setPendingCode(code);
+      setActiveQuartet(currentQuartet);
+      setMessage("");
+      setScannerOpen(false);
+      return;
+    }
+
+    window.location.href = `/join/${encodeURIComponent(code)}`;
+  }
 
   function joinQuartet() {
-    const code = joinCode.trim().toUpperCase();
+    const code = parseJoinCode(joinCode);
+
     if (!code) {
       setMessage("Enter the quartet code another singer shared with you.");
       return;
     }
 
-    const currentQuartet = getActiveQuartet();
-    if (currentQuartet && currentQuartet.code !== code) {
-      setPendingCode(code);
-      setActiveQuartet(currentQuartet);
-      setMessage("");
-      return;
-    }
-
-    window.location.href = `/join/${encodeURIComponent(code)}`;
+    goToQuartet(code);
   }
 
   async function leaveCurrentAndContinue() {
@@ -56,6 +81,102 @@ export default function JoinPage() {
       setLeavingCurrent(false);
     }
   }
+
+  function closeScanner() {
+    setScannerOpen(false);
+  }
+
+  useEffect(() => {
+    if (!scannerOpen) return;
+
+    let cancelled = false;
+
+    async function startScanner() {
+      setScannerMessage("Opening camera...");
+
+      const BarcodeDetectorConstructor = (
+        window as typeof window & {
+          BarcodeDetector?: BarcodeDetectorConstructor;
+        }
+      ).BarcodeDetector;
+
+      if (!BarcodeDetectorConstructor) {
+        setScannerMessage(
+          "This browser does not support in-app QR scanning. Use your camera app or enter the code manually."
+        );
+        return;
+      }
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: { ideal: "environment" } },
+          audio: false,
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        streamRef.current = stream;
+
+        const video = videoRef.current;
+        if (!video) return;
+
+        video.srcObject = stream;
+        await video.play();
+
+        const detector = new BarcodeDetectorConstructor({
+          formats: ["qr_code"],
+        });
+
+        setScannerMessage("Point your camera at the quartet QR code.");
+
+        async function scanFrame() {
+          if (cancelled || !videoRef.current) return;
+
+          try {
+            const results = await detector.detect(videoRef.current);
+            const rawValue = results[0]?.rawValue;
+            const code = rawValue ? parseJoinCode(rawValue) : null;
+
+            if (code) {
+              goToQuartet(code);
+              return;
+            }
+          } catch (err) {
+            console.error("QR scan failed", err);
+            setScannerMessage(
+              "Could not read a QR code yet. Try holding the camera steady."
+            );
+          }
+
+          scanFrameRef.current = window.requestAnimationFrame(scanFrame);
+        }
+
+        scanFrameRef.current = window.requestAnimationFrame(scanFrame);
+      } catch (err) {
+        console.error("Camera permission failed", err);
+        setScannerMessage(
+          "Could not open the camera. Check browser permission or enter the code manually."
+        );
+      }
+    }
+
+    startScanner();
+
+    return () => {
+      cancelled = true;
+
+      if (scanFrameRef.current) {
+        window.cancelAnimationFrame(scanFrameRef.current);
+        scanFrameRef.current = null;
+      }
+
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    };
+  }, [scannerOpen]);
 
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
@@ -93,8 +214,64 @@ export default function JoinPage() {
             Join quartet
           </button>
 
+          <button
+            type="button"
+            onClick={() => {
+              setScannerMessage("");
+              setScannerOpen(true);
+            }}
+            className="mt-3 w-full rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Scan QR code
+          </button>
+
           {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
         </section>
+
+        {scannerOpen && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qr-scanner-title"
+            className="fixed inset-0 z-50 flex bg-slate-950 text-white"
+          >
+            <div className="flex min-h-full w-full flex-col">
+              <div className="flex items-center justify-between gap-4 border-b border-white/10 p-4">
+                <div>
+                  <h2 id="qr-scanner-title" className="text-xl font-semibold">
+                    Scan QR code
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-300">
+                    Scan the quartet QR code from another singer&apos;s screen.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeScanner}
+                  className="rounded-xl bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+                >
+                  Cancel
+                </button>
+              </div>
+
+              <div className="relative flex flex-1 items-center justify-center overflow-hidden bg-black">
+                <video
+                  ref={videoRef}
+                  playsInline
+                  muted
+                  className="h-full w-full object-cover"
+                />
+                <div className="pointer-events-none absolute inset-x-8 top-1/2 aspect-square max-h-[70vw] -translate-y-1/2 rounded-3xl border-4 border-cyan-300/80 shadow-[0_0_0_9999px_rgba(2,6,23,0.55)] sm:inset-x-auto sm:h-80 sm:w-80" />
+              </div>
+
+              <div className="border-t border-white/10 p-4">
+                <p className="text-sm text-slate-300">
+                  {scannerMessage || "Camera preview will appear here."}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
 
         {activeQuartet && (
           <div

--- a/lib/__tests__/joinCode.test.ts
+++ b/lib/__tests__/joinCode.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseJoinCode } from "../joinCode";
+
+describe("parseJoinCode", () => {
+  it("accepts a raw quartet code", () => {
+    expect(parseJoinCode(" 93567t ")).toBe("93567T");
+  });
+
+  it("extracts the code from a join URL", () => {
+    expect(parseJoinCode("https://what-can-we-sing.vercel.app/join/93567T")).toBe(
+      "93567T"
+    );
+  });
+
+  it("extracts the code from a local join URL", () => {
+    expect(parseJoinCode("http://localhost:3000/join/abc123")).toBe("ABC123");
+  });
+
+  it("rejects URLs that are not join links", () => {
+    expect(parseJoinCode("https://what-can-we-sing.vercel.app/repertoire")).toBeNull();
+  });
+
+  it("rejects unsafe or malformed values", () => {
+    expect(parseJoinCode("")).toBeNull();
+    expect(parseJoinCode("https://example.com/join/has spaces")).toBeNull();
+    expect(parseJoinCode("DROP TABLE")).toBeNull();
+  });
+});

--- a/lib/joinCode.ts
+++ b/lib/joinCode.ts
@@ -1,0 +1,25 @@
+const JOIN_CODE_PATTERN = /^[A-Z0-9]{4,12}$/;
+
+function normalizeJoinCode(value: string) {
+  return value.trim().toUpperCase();
+}
+
+export function parseJoinCode(value: string): string | null {
+  const normalized = normalizeJoinCode(value);
+
+  if (JOIN_CODE_PATTERN.test(normalized)) {
+    return normalized;
+  }
+
+  try {
+    const url = new URL(value);
+    const [, route, code] = url.pathname.split("/");
+
+    if (route !== "join" || !code) return null;
+
+    const parsedCode = normalizeJoinCode(decodeURIComponent(code));
+    return JOIN_CODE_PATTERN.test(parsedCode) ? parsedCode : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #89

## Summary
- Add a Scan QR code action to `/join` that opens a full-screen camera scanner modal.
- Parse scanned QR contents as either a raw quartet code or a `/join/[code]` URL, then redirect to the matching quartet route.
- Keep manual code entry and active-quartet conflict handling intact.
- Add unit coverage for join code parsing.

## Verification
- npm run test:run
- npm run build

No database migration or Supabase dashboard changes required.