### PR TITLE
Add PostHog product analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # Production example: https://what-can-we-sing.vercel.app
 # Leave blank for local development; localhost falls back to window.location.origin.
 NEXT_PUBLIC_SITE_URL=
+
+# Optional product analytics. Leave blank to disable PostHog locally.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Copy `.env.example` to `.env.local` for local development.
 NEXT_PUBLIC_SUPABASE_URL=your Supabase project URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your Supabase anon key
 NEXT_PUBLIC_SITE_URL=https://your-production-app-url
+NEXT_PUBLIC_POSTHOG_KEY=your PostHog project API key
+NEXT_PUBLIC_POSTHOG_HOST=your PostHog host URL
 ```
 
 `NEXT_PUBLIC_SITE_URL` is used for Supabase magic-link redirects in production. Set it to the deployed Vercel app URL, without a trailing path. If it is blank during local development, login links fall back to the current localhost origin.
+
+`NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` enable optional product analytics. Leave them blank to disable analytics in local development. Analytics events use counts, IDs, and booleans only; free-text repertoire notes, feedback text, song titles, arranger names, names, and email addresses should not be sent to PostHog.
 
 Magic links redirect through `/auth/callback`, where the app exchanges the Supabase code for a session before sending the user to the intended page. In Supabase Auth URL configuration, add the production callback URL and any required local development callback URL to the allowed redirect URLs, such as:
 

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
+import { trackEvent } from "@/lib/analytics";
 import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
 import {
   type DbSession,
@@ -78,6 +79,7 @@ export default function JoinSessionPage() {
   const code = params.code;
 
   const hasAutoJoined = useRef(false);
+  const lastTrackedMatchesKey = useRef("");
 
   const [loading, setLoading] = useState(true);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -192,7 +194,7 @@ export default function JoinSessionPage() {
       setSession((current) =>
         current ? { ...current, last_activity_at: lastActivityAt } : current
       );
-      await refreshParticipants(id);
+      const updatedParticipants = await refreshParticipants(id);
 
       if (existingParticipant) {
         setMessage(
@@ -202,6 +204,11 @@ export default function JoinSessionPage() {
         return;
       }
 
+      trackEvent("quartet_joined", {
+        session_id: id,
+        participant_count: updatedParticipants.length,
+        song_count: entries.length,
+      });
       setMessage(`Joined as ${name} with ${entries.length} songs.`);
     } catch (err) {
       console.error(err);
@@ -270,7 +277,11 @@ export default function JoinSessionPage() {
       await removeParticipant(sessionId, currentUserId);
       clearActiveQuartetIfMatches(sessionId);
       window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
-      await refreshParticipants(sessionId);
+      const updatedParticipants = await refreshParticipants(sessionId);
+      trackEvent("quartet_left", {
+        session_id: sessionId,
+        participant_count: updatedParticipants.length,
+      });
       window.location.href = "/?leftQuartet=1";
     } catch (err) {
       console.error(err);
@@ -318,6 +329,9 @@ export default function JoinSessionPage() {
 
     try {
       await removeParticipant(pendingActiveQuartet.sessionId, currentUserId);
+      trackEvent("quartet_left", {
+        session_id: pendingActiveQuartet.sessionId,
+      });
       clearActiveQuartet();
       setPendingActiveQuartet(null);
       await joinSession(sessionId, displayName, currentUserId, {
@@ -487,6 +501,15 @@ export default function JoinSessionPage() {
     ...section,
     matches: matches.filter((match) => match.category === section.category),
   }));
+  const readyMatchCount = groupedMatches.find(
+    (section) => section.category === "ready"
+  )?.matches.length ?? 0;
+  const possibleMatchCount = groupedMatches.find(
+    (section) => section.category === "possible"
+  )?.matches.length ?? 0;
+  const onePartMissingCount = groupedMatches.find(
+    (section) => section.category === "one_part_missing"
+  )?.matches.length ?? 0;
   const quartetExpired = session ? isSessionExpired(session, now) : false;
   const expirationLabel = session ? sessionExpirationLabel(session, now) : "";
   const openSingerSlots = Math.max(
@@ -503,6 +526,50 @@ export default function JoinSessionPage() {
     !quartetExpired &&
     !pendingActiveQuartet &&
     participants.length >= MAX_QUARTET_PARTICIPANTS;
+
+  useEffect(() => {
+    if (
+      loading ||
+      !sessionId ||
+      loadError ||
+      quartetExpired ||
+      pendingActiveQuartet
+    ) {
+      return;
+    }
+
+    const trackingKey = [
+      sessionId,
+      participants.length,
+      matches.length,
+      readyMatchCount,
+      possibleMatchCount,
+      onePartMissingCount,
+    ].join(":");
+
+    if (lastTrackedMatchesKey.current === trackingKey) return;
+
+    lastTrackedMatchesKey.current = trackingKey;
+    trackEvent("quartet_matches_viewed", {
+      session_id: sessionId,
+      participant_count: participants.length,
+      match_count: matches.length,
+      ready_match_count: readyMatchCount,
+      possible_match_count: possibleMatchCount,
+      one_part_missing_count: onePartMissingCount,
+    });
+  }, [
+    loading,
+    loadError,
+    matches.length,
+    onePartMissingCount,
+    participants.length,
+    pendingActiveQuartet,
+    possibleMatchCount,
+    quartetExpired,
+    readyMatchCount,
+    sessionId,
+  ]);
 
   function notesForMatch(match: MatchResult) {
     const matchTitle = normalizeSongTitle(match.songTitle);

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/activeQuartet";
 import { parseJoinCode } from "@/lib/joinCode";
 import { getCurrentUser } from "@/lib/profileStore";
+import { trackEvent } from "@/lib/analytics";
 import { removeParticipant } from "@/lib/sessionStore";
 import { useEffect, useRef, useState } from "react";
 
@@ -70,6 +71,9 @@ export default function JoinPage() {
       const user = await getCurrentUser();
       if (user) {
         await removeParticipant(activeQuartet.sessionId, user.id);
+        trackEvent("quartet_left", {
+          session_id: activeQuartet.sessionId,
+        });
       }
       clearActiveQuartet();
       window.location.href = `/join/${encodeURIComponent(pendingCode)}`;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { AnalyticsIdentity } from "@/components/AnalyticsIdentity";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,10 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <AnalyticsIdentity />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -8,6 +8,7 @@ import {
   type ActiveQuartet,
 } from "@/lib/activeQuartet";
 import { getCurrentUser } from "@/lib/profileStore";
+import { trackEvent } from "@/lib/analytics";
 import { createSession, removeParticipant } from "@/lib/sessionStore";
 
 function makeJoinCode() {
@@ -40,7 +41,11 @@ export default function SessionPage() {
       const code = makeJoinCode();
 
       try {
-        await createSession(code);
+        const session = await createSession(code);
+        trackEvent("quartet_started", {
+          session_id: session.id,
+          participant_count: 0,
+        });
         window.location.href = `/join/${code}`;
       } catch (err) {
         console.error("Failed to create session", err);
@@ -65,6 +70,9 @@ export default function SessionPage() {
       const user = await getCurrentUser();
       if (user) {
         await removeParticipant(activeQuartet.sessionId, user.id);
+        trackEvent("quartet_left", {
+          session_id: activeQuartet.sessionId,
+        });
       }
       clearActiveQuartet();
       setActiveQuartet(null);

--- a/components/ActiveQuartetIndicator.tsx
+++ b/components/ActiveQuartetIndicator.tsx
@@ -9,6 +9,7 @@ import {
   type ActiveQuartet,
 } from "@/lib/activeQuartet";
 import { getCurrentUser } from "@/lib/profileStore";
+import { trackEvent } from "@/lib/analytics";
 import { removeParticipant } from "@/lib/sessionStore";
 
 function isViewingActiveQuartet(pathname: string, code: string) {
@@ -48,6 +49,9 @@ export function ActiveQuartetIndicator() {
 
       if (user) {
         await removeParticipant(activeQuartet.sessionId, user.id);
+        trackEvent("quartet_left", {
+          session_id: activeQuartet.sessionId,
+        });
       }
 
       clearActiveQuartet();

--- a/components/AnalyticsIdentity.tsx
+++ b/components/AnalyticsIdentity.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { identifyAnalyticsUser, trackEvent } from "@/lib/analytics";
+import { getCurrentUser } from "@/lib/profileStore";
+
+function loggedInStorageKey(userId: string) {
+  return `analytics:user_logged_in:${userId}`;
+}
+
+export function AnalyticsIdentity() {
+  useEffect(() => {
+    async function identifyUser() {
+      try {
+        const user = await getCurrentUser();
+
+        if (!user) return;
+
+        identifyAnalyticsUser(user.id);
+
+        const storageKey = loggedInStorageKey(user.id);
+        if (window.sessionStorage.getItem(storageKey)) return;
+
+        trackEvent("user_logged_in");
+        window.sessionStorage.setItem(storageKey, "true");
+      } catch (err) {
+        console.error("Could not identify analytics user", err);
+      }
+    }
+
+    identifyUser();
+  }, []);
+
+  return null;
+}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
 import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
+import { trackEvent } from "@/lib/analytics";
 import {
   addRepertoireItem,
   deleteRepertoireItem,
@@ -207,6 +208,10 @@ export default function RepertoireManager() {
       resetAddForm();
       setIsAddOpen(false);
       setMessage("Song added.");
+      trackEvent("repertoire_song_added", {
+        song_count: items.length + 1,
+        parts_known_count: partsKnown.length,
+      });
 
       await loadRepertoire();
     } catch (err) {
@@ -222,6 +227,9 @@ export default function RepertoireManager() {
         cancelEditing();
       }
       setMessage("Song deleted.");
+      trackEvent("repertoire_song_deleted", {
+        song_count: Math.max(0, items.length - 1),
+      });
       await loadRepertoire();
     } catch (err) {
       console.error(err);
@@ -256,6 +264,10 @@ export default function RepertoireManager() {
 
       cancelEditing();
       setMessage("Song updated.");
+      trackEvent("repertoire_song_edited", {
+        song_count: items.length,
+        parts_known_count: editForm.partsKnown.length,
+      });
       await loadRepertoire();
     } catch (err) {
       console.error(err);

--- a/components/SignOutButton.tsx
+++ b/components/SignOutButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getCurrentUser, signOut } from "@/lib/profileStore";
+import { resetAnalytics } from "@/lib/analytics";
 import { useEffect, useState } from "react";
 
 export function SignOutButton({ className = "" }: { className?: string }) {
@@ -29,6 +30,7 @@ export function SignOutButton({ className = "" }: { className?: string }) {
 
     try {
       await signOut();
+      resetAnalytics();
       window.location.href = "/login";
     } catch (err) {
       console.error(err);

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,19 @@
+import posthog from "posthog-js";
+
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+if (posthogKey && posthogHost) {
+  posthog.init(posthogKey, {
+    api_host: posthogHost,
+    autocapture: false,
+    capture_exceptions: true,
+    capture_pageview: false,
+    defaults: "2025-05-24",
+    loaded: (posthogInstance) => {
+      if (process.env.NODE_ENV === "development") {
+        posthogInstance.debug();
+      }
+    },
+  });
+}

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeAnalyticsProperties } from "../analytics";
+
+describe("sanitizeAnalyticsProperties", () => {
+  it("keeps safe primitive analytics properties", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        session_id: "session-123",
+        participant_count: 4,
+        ready_match_count: 2,
+        empty_value: null,
+      })
+    ).toEqual({
+      session_id: "session-123",
+      participant_count: 4,
+      ready_match_count: 2,
+      empty_value: null,
+    });
+  });
+
+  it("drops free-text and identifying property keys", () => {
+    expect(
+      sanitizeAnalyticsProperties({
+        song_title: "Hello, Mary Lou!",
+        arranger_name: "Arranger",
+        feedback_text: "Please add this",
+        display_name: "Singer",
+        notes: "Private note",
+        email: "singer@example.com",
+        song_count: 12,
+      })
+    ).toEqual({
+      song_count: 12,
+    });
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,92 @@
+import posthog from "posthog-js";
+
+export type AnalyticsEventName =
+  | "user_logged_in"
+  | "repertoire_song_added"
+  | "repertoire_song_edited"
+  | "repertoire_song_deleted"
+  | "quartet_started"
+  | "quartet_joined"
+  | "quartet_left"
+  | "quartet_member_removed"
+  | "quartet_matches_viewed"
+  | "feedback_submitted";
+
+type AnalyticsPropertyValue = string | number | boolean | null | undefined;
+type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
+
+const blockedPropertyFragments = [
+  "arranger",
+  "email",
+  "feedback",
+  "message",
+  "name",
+  "note",
+  "text",
+  "title",
+];
+
+function hasPostHogConfig() {
+  return Boolean(
+    process.env.NEXT_PUBLIC_POSTHOG_KEY && process.env.NEXT_PUBLIC_POSTHOG_HOST
+  );
+}
+
+function canUsePostHog() {
+  return typeof window !== "undefined" && hasPostHogConfig();
+}
+
+export function sanitizeAnalyticsProperties(
+  properties: AnalyticsProperties = {}
+) {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([key, value]) => {
+      const normalizedKey = key.toLowerCase();
+      const hasBlockedKey = blockedPropertyFragments.some((fragment) =>
+        normalizedKey.includes(fragment)
+      );
+
+      if (hasBlockedKey || value === undefined) return false;
+
+      return (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean" ||
+        value === null
+      );
+    })
+  );
+}
+
+export function trackEvent(
+  eventName: AnalyticsEventName,
+  properties?: AnalyticsProperties
+) {
+  try {
+    if (!canUsePostHog()) return;
+
+    posthog.capture(eventName, sanitizeAnalyticsProperties(properties));
+  } catch (err) {
+    console.error("Analytics event failed", err);
+  }
+}
+
+export function identifyAnalyticsUser(userId: string | null | undefined) {
+  try {
+    if (!canUsePostHog() || !userId) return;
+
+    posthog.identify(userId);
+  } catch (err) {
+    console.error("Analytics identify failed", err);
+  }
+}
+
+export function resetAnalytics() {
+  try {
+    if (!canUsePostHog()) return;
+
+    posthog.reset();
+  } catch (err) {
+    console.error("Analytics reset failed", err);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.1",
         "next": "^16.2.4",
+        "posthog-js": "^1.372.3",
         "qrcode": "^1.5.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1306,6 +1307,252 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -1315,6 +1562,85 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.27.7",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.7.tgz",
+      "integrity": "sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.372.3"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.372.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.3.tgz",
+      "integrity": "sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -2109,6 +2435,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3379,6 +3712,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3559,6 +3903,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4297,6 +4650,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5673,6 +6032,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6242,6 +6607,37 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.372.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.3.tgz",
+      "integrity": "sha512-CpKWMt6RkgY4lPpyvYzKcilKKB5VhL2gmS8HgibxmXZkEk/2rUxrEtRMScH8xi4n5WDaNSluCo87dh9yo9zArQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.27.7",
+        "@posthog/types": "1.372.3",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6262,6 +6658,30 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -6290,6 +6710,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7640,6 +8066,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.1",
     "next": "^16.2.4",
+    "posthog-js": "^1.372.3",
     "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary
- Add PostHog App Router initialization using `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST`.
- Identify authenticated users by Supabase user id and reset analytics identity on sign out.
- Track repertoire and quartet product events with safe count/id/boolean properties only.
- Disable automatic PostHog pageview/autocapture and filter free-text/identifying property keys.
- Document optional PostHog environment variables.

## Notes
- No Supabase dashboard or database migration is required.
- The current app does not have a feedback form or member-removal UI, so those event hooks are not attached to nonexistent flows.

## Verification
- `npm run test:run`
- `npm run build`

Fixes #111