### PR TITLE
Fix realtime participant updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The Supabase project should have the current production schema applied:
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by
   `(session_id, user_id)` so one singer can refresh without creating duplicate
-  rows.
+  rows. Supabase Realtime must be enabled for this table so joined clients see
+  participant insert, update, and delete changes immediately.
 - `sung_song_events` stores each user's private "marked as sung" events for
   recent-use indicators.
 

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -7,6 +7,7 @@ import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { trackEvent } from "@/lib/analytics";
 import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
+import { applyParticipantChange } from "@/lib/sessionParticipantChanges";
 import {
   type DbSession,
   type DbParticipant,
@@ -384,7 +385,16 @@ export default function JoinSessionPage() {
   }
 
   useEffect(() => {
-    let unsubscribe: undefined | (() => void);
+    if (!sessionId) return;
+
+    return subscribeToSessionParticipants(sessionId, (payload) => {
+      setParticipants((currentParticipants) =>
+        applyParticipantChange(currentParticipants, payload, sessionId)
+      );
+    });
+  }, [sessionId]);
+
+  useEffect(() => {
     const timer = window.setInterval(() => {
       setNow(new Date());
     }, 60 * 1000);
@@ -437,10 +447,6 @@ export default function JoinSessionPage() {
 
         const currentParticipants = await refreshParticipants(session.id);
 
-        unsubscribe = subscribeToSessionParticipants(session.id, () => {
-          refreshParticipants(session.id);
-        });
-
         const alreadyJoined = currentParticipants.some(
           (participant) => participant.user_id === user.id
         );
@@ -491,7 +497,6 @@ export default function JoinSessionPage() {
 
     return () => {
       window.clearInterval(timer);
-      if (unsubscribe) unsubscribe();
     };
   }, [code]);
 

--- a/lib/__tests__/sessionParticipantChanges.test.ts
+++ b/lib/__tests__/sessionParticipantChanges.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { applyParticipantChange } from "../sessionParticipantChanges";
+import type { DbParticipant } from "../sessionStore";
+
+function participant(
+  id: string,
+  sessionId: string,
+  joinedAt: string,
+  displayName = id
+): DbParticipant {
+  return {
+    id,
+    session_id: sessionId,
+    user_id: `user-${id}`,
+    display_name: displayName,
+    repertoire: [],
+    joined_at: joinedAt,
+  };
+}
+
+describe("applyParticipantChange", () => {
+  it("adds inserted participants for the current session", () => {
+    const existing = participant("one", "session-1", "2026-01-01T00:00:00Z");
+    const inserted = participant("two", "session-1", "2026-01-01T00:01:00Z");
+
+    const result = applyParticipantChange(
+      [existing],
+      {
+        eventType: "INSERT",
+        new: inserted,
+        old: {},
+      },
+      "session-1"
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["one", "two"]);
+  });
+
+  it("updates existing participants without duplicating them", () => {
+    const existing = participant("one", "session-1", "2026-01-01T00:00:00Z");
+    const updated = participant(
+      "one",
+      "session-1",
+      "2026-01-01T00:00:00Z",
+      "Updated Singer"
+    );
+
+    const result = applyParticipantChange(
+      [existing],
+      {
+        eventType: "UPDATE",
+        new: updated,
+        old: existing,
+      },
+      "session-1"
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].display_name).toBe("Updated Singer");
+  });
+
+  it("removes deleted participants for the current session", () => {
+    const first = participant("one", "session-1", "2026-01-01T00:00:00Z");
+    const second = participant("two", "session-1", "2026-01-01T00:01:00Z");
+
+    const result = applyParticipantChange(
+      [first, second],
+      {
+        eventType: "DELETE",
+        new: {},
+        old: { id: "one", session_id: "session-1" },
+      },
+      "session-1"
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["two"]);
+  });
+
+  it("ignores changes from other sessions", () => {
+    const existing = participant("one", "session-1", "2026-01-01T00:00:00Z");
+    const otherSession = participant(
+      "two",
+      "session-2",
+      "2026-01-01T00:01:00Z"
+    );
+
+    const result = applyParticipantChange(
+      [existing],
+      {
+        eventType: "INSERT",
+        new: otherSession,
+        old: {},
+      },
+      "session-1"
+    );
+
+    expect(result).toEqual([existing]);
+  });
+});

--- a/lib/sessionParticipantChanges.ts
+++ b/lib/sessionParticipantChanges.ts
@@ -1,0 +1,51 @@
+import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import type { DbParticipant } from "./sessionStore";
+
+export type ParticipantChangePayload =
+  RealtimePostgresChangesPayload<DbParticipant>;
+
+function sortParticipants(participants: DbParticipant[]) {
+  return [...participants].sort(
+    (a, b) =>
+      new Date(a.joined_at).getTime() - new Date(b.joined_at).getTime()
+  );
+}
+
+export function applyParticipantChange(
+  participants: DbParticipant[],
+  payload: ParticipantChangePayload,
+  sessionId: string
+) {
+  if (payload.eventType === "DELETE") {
+    const deletedParticipant = payload.old;
+
+    if (
+      deletedParticipant.session_id &&
+      deletedParticipant.session_id !== sessionId
+    ) {
+      return participants;
+    }
+
+    if (!deletedParticipant.id) return participants;
+
+    return participants.filter(
+      (participant) => participant.id !== deletedParticipant.id
+    );
+  }
+
+  const changedParticipant = payload.new;
+
+  if (
+    !changedParticipant?.id ||
+    changedParticipant.session_id !== sessionId
+  ) {
+    return participants;
+  }
+
+  return sortParticipants([
+    ...participants.filter(
+      (participant) => participant.id !== changedParticipant.id
+    ),
+    changedParticipant,
+  ]);
+}

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabase";
 import type { SingerEntry } from "@/lib/matching";
+import type { ParticipantChangePayload } from "@/lib/sessionParticipantChanges";
 
 export type DbSession = {
   id: string;
@@ -123,7 +124,7 @@ export async function removeParticipant(sessionId: string, userId: string) {
 
 export function subscribeToSessionParticipants(
   sessionId: string,
-  onChange: () => void
+  onChange: (payload: ParticipantChangePayload) => void
 ) {
   const channel = supabase
     .channel(`session-participants-${sessionId}`)
@@ -135,8 +136,8 @@ export function subscribeToSessionParticipants(
         table: "session_participants",
         filter: `session_id=eq.${sessionId}`,
       },
-      () => {
-        onChange();
+      (payload) => {
+        onChange(payload as ParticipantChangePayload);
       }
     )
     .subscribe();


### PR DESCRIPTION
## Summary
- Scope `/join/[code]` realtime subscriptions to the active quartet session id.
- Apply Supabase realtime insert/update/delete payloads directly to local participant state.
- Move subscription setup into a session-id keyed effect so cleanup happens on unmount/session changes and duplicate subscriptions are avoided.
- Add unit tests for participant insert/update/delete/other-session realtime state handling.
- Document that Supabase Realtime must be enabled for `session_participants`.

## Manual step
- Verify Supabase Realtime is enabled for the `session_participants` table in the project dashboard.

## Verification
- `npm run test:run`
- `npm run build`

Fixes #114