### PR TITLE
Fix quartet return after display name change

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -7,6 +7,10 @@ import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { trackEvent } from "@/lib/analytics";
 import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
+import {
+  findParticipantByUserId,
+  resolveParticipantForJoin,
+} from "@/lib/sessionParticipantResolution";
 import { applyParticipantChange } from "@/lib/sessionParticipantChanges";
 import {
   type DbSession,
@@ -164,14 +168,13 @@ export default function JoinSessionPage() {
 
       const existingParticipants = await refreshParticipants(id);
 
-      const existingParticipant = existingParticipants.find(
-        (participant) => participant.user_id === userId
+      const participantResolution = resolveParticipantForJoin(
+        existingParticipants,
+        userId,
+        MAX_QUARTET_PARTICIPANTS
       );
 
-      if (
-        !existingParticipant &&
-        existingParticipants.length >= MAX_QUARTET_PARTICIPANTS
-      ) {
+      if (participantResolution.status === "full") {
         setMessage("This quartet already has four singers.");
         return;
       }
@@ -179,9 +182,9 @@ export default function JoinSessionPage() {
       const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();
 
-      if (existingParticipant) {
+      if (participantResolution.status === "existing") {
         await updateParticipantSnapshot(
-          existingParticipant.id,
+          participantResolution.participant.id,
           userId,
           name,
           entries,
@@ -197,7 +200,7 @@ export default function JoinSessionPage() {
       );
       const updatedParticipants = await refreshParticipants(id);
 
-      if (existingParticipant) {
+      if (participantResolution.status === "existing") {
         setMessage(
           options.successMessage ??
             `Updated ${name}'s repertoire with ${entries.length} songs.`
@@ -228,8 +231,9 @@ export default function JoinSessionPage() {
 
     try {
       const currentParticipants = await refreshParticipants(sessionId);
-      const existingParticipant = currentParticipants.find(
-        (participant) => participant.user_id === currentUserId
+      const existingParticipant = findParticipantByUserId(
+        currentParticipants,
+        currentUserId
       );
 
       if (!existingParticipant) {
@@ -447,9 +451,11 @@ export default function JoinSessionPage() {
 
         const currentParticipants = await refreshParticipants(session.id);
 
-        const alreadyJoined = currentParticipants.some(
-          (participant) => participant.user_id === user.id
+        const existingParticipant = findParticipantByUserId(
+          currentParticipants,
+          user.id
         );
+        const alreadyJoined = Boolean(existingParticipant);
 
         const activeQuartet = getActiveQuartet();
         if (
@@ -469,21 +475,25 @@ export default function JoinSessionPage() {
             setLeftQuartet(false);
           }
 
-          const existingParticipant = currentParticipants.find(
-            (participant) => participant.user_id === user.id
-          );
           const entries = await getMyEntries(profile.display_name);
           const lastActivityAt = new Date().toISOString();
 
           if (existingParticipant) {
-            await updateParticipantSnapshot(
-              existingParticipant.id,
-              user.id,
-              profile.display_name,
-              entries,
-              lastActivityAt
-            );
-            await refreshParticipants(session.id);
+            try {
+              await updateParticipantSnapshot(
+                existingParticipant.id,
+                user.id,
+                profile.display_name,
+                entries,
+                lastActivityAt
+              );
+              await refreshParticipants(session.id);
+            } catch (err) {
+              console.error("Could not refresh returning participant", err);
+              setMessage(
+                "You are in this quartet. Refresh my songs if your latest changes do not appear."
+              );
+            }
           }
 
           setActiveQuartet({
@@ -491,7 +501,9 @@ export default function JoinSessionPage() {
             code,
             joinedAt: lastActivityAt,
           });
-          setMessage(`You are in this quartet as ${profile.display_name}.`);
+          setMessage((current) =>
+            current || `You are in this quartet as ${profile.display_name}.`
+          );
         } else if (!hasAutoJoined.current && !hasLeftQuartet) {
           hasAutoJoined.current = true;
           await joinSession(session.id, profile.display_name, user.id);

--- a/lib/__tests__/sessionParticipantResolution.test.ts
+++ b/lib/__tests__/sessionParticipantResolution.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  findParticipantByUserId,
+  resolveParticipantForJoin,
+} from "../sessionParticipantResolution";
+import type { DbParticipant } from "../sessionStore";
+
+function participant(
+  id: string,
+  userId: string,
+  displayName: string
+): DbParticipant {
+  return {
+    id,
+    session_id: "session-1",
+    user_id: userId,
+    display_name: displayName,
+    repertoire: [],
+    joined_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("session participant resolution", () => {
+  it("finds an existing participant by user_id", () => {
+    const existingParticipant = participant("participant-1", "user-1", "Tim");
+
+    expect(
+      findParticipantByUserId([existingParticipant], "user-1")
+    ).toBe(existingParticipant);
+  });
+
+  it("recognizes the same participant after display_name changes", () => {
+    const existingParticipant = participant(
+      "participant-1",
+      "user-1",
+      "New Name"
+    );
+
+    const result = resolveParticipantForJoin(
+      [existingParticipant],
+      "user-1",
+      4
+    );
+
+    expect(result).toEqual({
+      status: "existing",
+      participant: existingParticipant,
+    });
+  });
+
+  it("does not treat an existing user as a new participant when full", () => {
+    const existingParticipant = participant(
+      "participant-1",
+      "user-1",
+      "New Name"
+    );
+    const participants = [
+      existingParticipant,
+      participant("participant-2", "user-2", "Singer 2"),
+      participant("participant-3", "user-3", "Singer 3"),
+      participant("participant-4", "user-4", "Singer 4"),
+    ];
+
+    expect(resolveParticipantForJoin(participants, "user-1", 4)).toEqual({
+      status: "existing",
+      participant: existingParticipant,
+    });
+  });
+});

--- a/lib/sessionParticipantResolution.ts
+++ b/lib/sessionParticipantResolution.ts
@@ -1,0 +1,31 @@
+import type { DbParticipant } from "./sessionStore";
+
+export type ParticipantResolution =
+  | { status: "existing"; participant: DbParticipant }
+  | { status: "full" }
+  | { status: "can_join" };
+
+export function findParticipantByUserId(
+  participants: DbParticipant[],
+  userId: string
+) {
+  return participants.find((participant) => participant.user_id === userId);
+}
+
+export function resolveParticipantForJoin(
+  participants: DbParticipant[],
+  userId: string,
+  maxParticipants: number
+): ParticipantResolution {
+  const existingParticipant = findParticipantByUserId(participants, userId);
+
+  if (existingParticipant) {
+    return { status: "existing", participant: existingParticipant };
+  }
+
+  if (participants.length >= maxParticipants) {
+    return { status: "full" };
+  }
+
+  return { status: "can_join" };
+}


### PR DESCRIPTION
## Summary
- Extract participant resolution so quartet membership is explicitly matched by authenticated `user_id`.
- Use that helper in join/refresh/return flows to avoid treating display-name changes as new participants.
- Keep the quartet page load non-fatal if the automatic returning-user song/name refresh fails, avoiding the false generic load error.
- Add regression tests for recognizing existing participants by `user_id`, including changed display names and full quartets.

## Verification
- `npm run test:run`
- `npm run build`

Fixes #117