### PR TITLE
Improve network failure handling

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -105,14 +105,22 @@ export default function JoinSessionPage() {
   const [leftQuartet, setLeftQuartet] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [refreshingSongs, setRefreshingSongs] = useState(false);
+  const [joiningQuartet, setJoiningQuartet] = useState(false);
+  const [realtimeMessage, setRealtimeMessage] = useState("");
   const [pendingActiveQuartet, setPendingActiveQuartet] =
     useState<ActiveQuartet | null>(null);
   const [leavingCurrentQuartet, setLeavingCurrentQuartet] = useState(false);
 
   async function refreshParticipants(id: string) {
-    const data = await getParticipants(id);
-    setParticipants(data);
-    return data;
+    try {
+      const data = await getParticipants(id);
+      setParticipants(data);
+      return data;
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not refresh singers. Please try again.");
+      throw err;
+    }
   }
 
   async function loadMyRepertoire() {
@@ -150,6 +158,8 @@ export default function JoinSessionPage() {
     userId = currentUserId,
     options: { clearLeftFlag?: boolean; successMessage?: string } = {}
   ) {
+    if (joiningQuartet) return;
+
     if (session && isSessionExpired(session)) {
       setLoadError("This quartet has expired.");
       return;
@@ -161,6 +171,7 @@ export default function JoinSessionPage() {
     }
 
     try {
+      setJoiningQuartet(true);
       if (options.clearLeftFlag) {
         window.sessionStorage.removeItem(leftQuartetStorageKey(code));
         setLeftQuartet(false);
@@ -216,7 +227,9 @@ export default function JoinSessionPage() {
       setMessage(`Joined as ${name} with ${entries.length} songs.`);
     } catch (err) {
       console.error(err);
-      setMessage("Could not join quartet. Check your connection and try again.");
+      setMessage("Could not join quartet. Please try again.");
+    } finally {
+      setJoiningQuartet(false);
     }
   }
 
@@ -353,8 +366,13 @@ export default function JoinSessionPage() {
   }
 
   async function refreshRecentSungSongs() {
-    const events = await getRecentSungSongs();
-    setRecentSungSongs(events);
+    try {
+      const events = await getRecentSungSongs();
+      setRecentSungSongs(events);
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not refresh recent songs. Matches still work.");
+    }
   }
 
   function matchKey(match: MatchResult) {
@@ -392,8 +410,13 @@ export default function JoinSessionPage() {
     if (!sessionId) return;
 
     return subscribeToSessionParticipants(sessionId, (payload) => {
+      setRealtimeMessage("");
       setParticipants((currentParticipants) =>
         applyParticipantChange(currentParticipants, payload, sessionId)
+      );
+    }, () => {
+      setRealtimeMessage(
+        "Live updates are having trouble. You can still use the current results or refresh singers."
       );
     });
   }, [sessionId]);
@@ -439,11 +462,20 @@ export default function JoinSessionPage() {
         setDisplayName(profile.display_name);
         setSessionId(session.id);
         setSession(session);
-        await refreshRecentSungSongs();
+        try {
+          await refreshRecentSungSongs();
+        } catch {
+          // refreshRecentSungSongs handles its own message.
+        }
 
         const joinUrl = `${window.location.origin}/join/${code}`;
-        const qr = await QRCode.toDataURL(joinUrl);
-        setQrUrl(qr);
+        try {
+          const qr = await QRCode.toDataURL(joinUrl);
+          setQrUrl(qr);
+        } catch (err) {
+          console.error(err);
+          setCopyMessage("QR code unavailable. Share the code or link instead.");
+        }
 
         const hasLeftQuartet =
           window.sessionStorage.getItem(leftQuartetStorageKey(code)) === "true";
@@ -475,11 +507,11 @@ export default function JoinSessionPage() {
             setLeftQuartet(false);
           }
 
-          const entries = await getMyEntries(profile.display_name);
           const lastActivityAt = new Date().toISOString();
 
           if (existingParticipant) {
             try {
+              const entries = await getMyEntries(profile.display_name);
               await updateParticipantSnapshot(
                 existingParticipant.id,
                 user.id,
@@ -671,6 +703,15 @@ export default function JoinSessionPage() {
             >
               {quartetExpired ? "Start a new quartet" : "Enter a different code"}
             </a>
+            {!quartetExpired && (
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="ml-0 mt-3 rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700 sm:ml-3"
+              >
+                Try again
+              </button>
+            )}
           </div>
         )}
 
@@ -678,6 +719,23 @@ export default function JoinSessionPage() {
           <p className="mt-4 rounded-xl bg-white/10 p-4 text-slate-200">
             {message}
           </p>
+        )}
+
+        {!loadError && !quartetExpired && realtimeMessage && (
+          <div className="mt-4 rounded-xl border border-amber-200/20 bg-amber-200/10 p-4 text-sm text-amber-50">
+            <p>{realtimeMessage}</p>
+            {sessionId && (
+              <button
+                type="button"
+                onClick={() => {
+                  void refreshParticipants(sessionId).catch(() => undefined);
+                }}
+                className="mt-3 rounded-xl bg-amber-100 px-4 py-2 font-semibold text-slate-950 hover:bg-white"
+              >
+                Refresh singers
+              </button>
+            )}
+          </div>
         )}
 
         {!loadError && !quartetExpired && pendingActiveQuartet && (
@@ -810,6 +868,7 @@ export default function JoinSessionPage() {
                   <button
                     onClick={rejoinQuartet}
                     disabled={
+                      joiningQuartet ||
                       !sessionId ||
                       !displayName ||
                       !currentUserId ||
@@ -817,7 +876,7 @@ export default function JoinSessionPage() {
                     }
                     className="mt-4 rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                   >
-                    Join this quartet again
+                    {joiningQuartet ? "Joining..." : "Join this quartet again"}
                   </button>
                 </>
               ) : (

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -30,23 +30,28 @@ export default function LoginPage() {
       return;
     }
 
-    const { error } = await supabase.auth.signInWithOtp({
-      email: email.trim(),
-      options: {
-        emailRedirectTo,
-      },
-    });
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email: email.trim(),
+        options: {
+          emailRedirectTo,
+        },
+      });
 
-    if (error) {
-      setMessage(`${error.message} Check the email address and try again.`);
+      if (error) {
+        setMessage(`${error.message} Check the email address and try again.`);
+        return;
+      }
+
+      setMessage(
+        "Check your email for a What Can We Sing login link. Open it in this browser to continue."
+      );
+    } catch (err) {
+      console.error(err);
+      setMessage("Network unavailable. Try again when you have a connection.");
+    } finally {
       setIsSending(false);
-      return;
     }
-
-    setMessage(
-      "Check your email for a What Can We Sing login link. Open it in this browser to continue."
-    );
-    setIsSending(false);
   }
 
   return (

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,6 +17,7 @@ export default function SettingsPage() {
   const [message, setMessage] = useState("");
   const [displayNameError, setDisplayNameError] = useState("");
   const [showRepertoireNextStep, setShowRepertoireNextStep] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -52,6 +53,8 @@ export default function SettingsPage() {
   }, []);
 
   async function saveSettings() {
+    if (isSaving) return;
+
     if (!displayName.trim()) {
       setDisplayNameError("Display name is required.");
       setMessage("");
@@ -59,21 +62,35 @@ export default function SettingsPage() {
     }
 
     try {
+      setIsSaving(true);
       setDisplayNameError("");
       await upsertMyProfile(displayName.trim());
-      const repertoire = await getMyRepertoire();
 
-      if (repertoire.length === 0) {
+      let repertoireCount: number | null = null;
+      try {
+        const repertoire = await getMyRepertoire();
+        repertoireCount = repertoire.length;
+      } catch (err) {
+        console.error(err);
+      }
+
+      if (repertoireCount === 0) {
         setMessage("Settings saved. Next, add a few songs you know.");
         setShowRepertoireNextStep(true);
         return;
       }
 
-      setMessage("Settings saved.");
+      setMessage(
+        repertoireCount === null
+          ? "Settings saved. Could not check your songs yet."
+          : "Settings saved."
+      );
       setShowRepertoireNextStep(false);
     } catch (err) {
       console.error(err);
-      setMessage("Could not save settings. Check your connection and try again.");
+      setMessage("Could not save changes. Please try again.");
+    } finally {
+      setIsSaving(false);
     }
   }
 
@@ -131,9 +148,10 @@ export default function SettingsPage() {
 
           <button
             onClick={saveSettings}
+            disabled={isSaving}
             className="mt-6 rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
           >
-            Save settings
+            {isSaving ? "Saving..." : "Save settings"}
           </button>
 
           {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -54,19 +54,38 @@ export default function RepertoireManager() {
   const [editForm, setEditForm] = useState<RepertoireForm | null>(null);
   const [message, setMessage] = useState("");
   const [loadError, setLoadError] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [savingEditId, setSavingEditId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   async function loadRepertoire() {
-    setLoadError("");
-    const user = await getCurrentUser();
+    try {
+      setLoadError("");
+      const user = await getCurrentUser();
 
-    if (!user) {
-      window.location.href = "/login";
-      return;
+      if (!user) {
+        window.location.href = "/login";
+        return;
+      }
+
+      const data = await getMyRepertoire();
+      setItems(data);
+      setLoadError("");
+    } catch (err) {
+      console.error(err);
+      setLoadError(
+        "Could not load your repertoire. Check your connection and try again."
+      );
+      throw err;
     }
+  }
 
-    const data = await getMyRepertoire();
-    setItems(data);
-    setLoadError("");
+  async function retryLoadRepertoire() {
+    try {
+      await loadRepertoire();
+    } catch {
+      // loadRepertoire already shows the retry message.
+    }
   }
 
   useEffect(() => {
@@ -175,6 +194,8 @@ export default function RepertoireManager() {
   }
 
   async function addItem() {
+    if (isAdding) return;
+
     if (!songTitle.trim()) {
       setMessage("Add a song title before saving.");
       return;
@@ -196,6 +217,7 @@ export default function RepertoireManager() {
     }
 
     try {
+      setIsAdding(true);
       await addRepertoireItem({
         songTitle: songTitle.trim(),
         voicing,
@@ -213,15 +235,24 @@ export default function RepertoireManager() {
         parts_known_count: partsKnown.length,
       });
 
-      await loadRepertoire();
+      try {
+        await loadRepertoire();
+      } catch {
+        setMessage("Song added. Could not refresh the list yet.");
+      }
     } catch (err) {
       console.error(err);
-      setMessage("Could not add song. Check your connection and try again.");
+      setMessage("Could not add song. Please try again.");
+    } finally {
+      setIsAdding(false);
     }
   }
 
   async function deleteItem(id: string) {
+    if (deletingId) return;
+
     try {
+      setDeletingId(id);
       await deleteRepertoireItem(id);
       if (editingId === id) {
         cancelEditing();
@@ -230,14 +261,22 @@ export default function RepertoireManager() {
       trackEvent("repertoire_song_deleted", {
         song_count: Math.max(0, items.length - 1),
       });
-      await loadRepertoire();
+      try {
+        await loadRepertoire();
+      } catch {
+        setMessage("Song deleted. Could not refresh the list yet.");
+      }
     } catch (err) {
       console.error(err);
-      setMessage("Could not delete song. Check your connection and try again.");
+      setMessage("Could not delete song. Please try again.");
+    } finally {
+      setDeletingId(null);
     }
   }
 
   async function saveEdit(id: string) {
+    if (savingEditId) return;
+
     if (!editForm) {
       return;
     }
@@ -253,6 +292,7 @@ export default function RepertoireManager() {
     }
 
     try {
+      setSavingEditId(id);
       await updateRepertoireItem(id, {
         songTitle: editForm.songTitle.trim(),
         voicing: editForm.voicing,
@@ -268,10 +308,16 @@ export default function RepertoireManager() {
         song_count: items.length,
         parts_known_count: editForm.partsKnown.length,
       });
-      await loadRepertoire();
+      try {
+        await loadRepertoire();
+      } catch {
+        setMessage("Song updated. Could not refresh the list yet.");
+      }
     } catch (err) {
       console.error(err);
-      setMessage("Could not update song. Check your connection and try again.");
+      setMessage("Could not save changes. Please try again.");
+    } finally {
+      setSavingEditId(null);
     }
   }
 
@@ -323,7 +369,7 @@ export default function RepertoireManager() {
             <p>{loadError}</p>
             <button
               type="button"
-              onClick={loadRepertoire}
+              onClick={retryLoadRepertoire}
               className="mt-3 rounded-xl bg-rose-100 px-4 py-2 font-semibold text-slate-950 hover:bg-white"
             >
               Try again
@@ -505,21 +551,24 @@ export default function RepertoireManager() {
                     <div className="mt-6 flex flex-col gap-3 sm:flex-row">
                       <button
                         onClick={() => saveEdit(item.id)}
+                        disabled={savingEditId === item.id || deletingId === item.id}
                         className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                       >
-                        Save changes
+                        {savingEditId === item.id ? "Saving..." : "Save changes"}
                       </button>
                       <button
                         onClick={cancelEditing}
+                        disabled={savingEditId === item.id || deletingId === item.id}
                         className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-200 hover:bg-slate-700"
                       >
                         Cancel
                       </button>
                       <button
                         onClick={() => deleteItem(item.id)}
-                        className="rounded-xl bg-rose-400/10 px-5 py-3 font-semibold text-rose-200 hover:bg-rose-400/20"
+                        disabled={savingEditId === item.id || deletingId === item.id}
+                        className="rounded-xl bg-rose-400/10 px-5 py-3 font-semibold text-rose-200 hover:bg-rose-400/20 disabled:opacity-40"
                       >
-                        Delete
+                        {deletingId === item.id ? "Deleting..." : "Delete"}
                       </button>
                     </div>
                   </div>
@@ -563,15 +612,17 @@ export default function RepertoireManager() {
                     <div className="flex shrink-0 gap-1">
                       <button
                         onClick={() => startEditing(item)}
+                        disabled={Boolean(deletingId)}
                         className="rounded-lg bg-cyan-300/10 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-cyan-300/20"
                       >
                         Edit
                       </button>
                       <button
                         onClick={() => deleteItem(item.id)}
-                        className="rounded-lg bg-rose-400/10 px-3 py-2 text-sm font-semibold text-rose-200 hover:bg-rose-400/20"
+                        disabled={deletingId === item.id}
+                        className="rounded-lg bg-rose-400/10 px-3 py-2 text-sm font-semibold text-rose-200 hover:bg-rose-400/20 disabled:opacity-40"
                       >
-                        Delete
+                        {deletingId === item.id ? "Deleting..." : "Delete"}
                       </button>
                     </div>
                   </div>
@@ -744,10 +795,10 @@ export default function RepertoireManager() {
                 <button
                   type="button"
                   onClick={addItem}
-                  disabled={!canAddSong}
+                  disabled={!canAddSong || isAdding}
                   className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                 >
-                  Add to repertoire
+                  {isAdding ? "Adding..." : "Add to repertoire"}
                 </button>
                 <button
                   type="button"

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -124,7 +124,8 @@ export async function removeParticipant(sessionId: string, userId: string) {
 
 export function subscribeToSessionParticipants(
   sessionId: string,
-  onChange: (payload: ParticipantChangePayload) => void
+  onChange: (payload: ParticipantChangePayload) => void,
+  onStatusChange?: (status: string) => void
 ) {
   const channel = supabase
     .channel(`session-participants-${sessionId}`)
@@ -140,7 +141,15 @@ export function subscribeToSessionParticipants(
         onChange(payload as ParticipantChangePayload);
       }
     )
-    .subscribe();
+    .subscribe((status) => {
+      if (
+        status === "CHANNEL_ERROR" ||
+        status === "TIMED_OUT" ||
+        status === "CLOSED"
+      ) {
+        onStatusChange?.(status);
+      }
+    });
 
   return () => {
     supabase.removeChannel(channel);


### PR DESCRIPTION
## Summary
- Add safer login error handling for unavailable network calls.
- Disable settings and repertoire save/delete buttons while requests are in flight to prevent duplicate submissions.
- Preserve repertoire form state on failed saves and show clearer retry-oriented messages.
- Make post-save refresh failures non-destructive where the save itself succeeded.
- Keep quartet pages usable when optional recent-song/QR/realtime work fails, with manual retry affordances for loading and participant refresh.
- Report realtime subscription trouble without clearing already-loaded quartet data.

## Verification
- `npm run test:run`
- `npm run build`

Fixes #92