### PR TITLE
Fix magic link auth callback flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NEXT_PUBLIC_POSTHOG_HOST=your PostHog host URL
 
 `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` enable optional product analytics. Leave them blank to disable analytics in local development. Analytics events use counts, IDs, and booleans only; free-text repertoire notes, feedback text, song titles, arranger names, names, and email addresses should not be sent to PostHog.
 
-Magic links redirect through `/auth/callback`, where the app exchanges the Supabase code for a session before sending the user to the intended page. In Supabase Auth URL configuration, add the production callback URL and any required local development callback URL to the allowed redirect URLs, such as:
+Magic links redirect through `/auth/callback`, where the app exchanges the Supabase code or token hash for a session before sending the user to the intended page. In Supabase Auth URL configuration, add the production callback URL and any required local development callback URL to the allowed redirect URLs, such as:
 
 ```text
 https://your-production-app-url/auth/callback
@@ -27,6 +27,9 @@ http://localhost:3000/auth/callback
 ## Supabase auth email
 
 Hosted Supabase projects configure Auth email templates in the Supabase dashboard, not in this repo. Use the recommended Magic Link template in [docs/auth-email-template.md](docs/auth-email-template.md) so login emails are clearly branded as What Can We Sing and include a button plus fallback link.
+
+After changing auth settings or email templates, run the manual checklist in
+[docs/auth-manual-test-checklist.md](docs/auth-manual-test-checklist.md).
 
 ## Supabase database
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,16 +1,36 @@
+import type { EmailOtpType } from "@supabase/supabase-js";
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { getAuthCallbackNextPath } from "@/lib/authRedirect";
 
+const allowedEmailOtpTypes = new Set([
+  "email",
+  "magiclink",
+  "signup",
+  "invite",
+  "recovery",
+  "email_change",
+]);
+
+function getEmailOtpType(type: string | null): EmailOtpType | null {
+  return type && allowedEmailOtpTypes.has(type)
+    ? (type as EmailOtpType)
+    : null;
+}
+
 export async function GET(request: NextRequest) {
   const nextPath = getAuthCallbackNextPath(request.nextUrl.search);
   const code = request.nextUrl.searchParams.get("code");
+  const tokenHash = request.nextUrl.searchParams.get("token_hash");
+  const type = getEmailOtpType(request.nextUrl.searchParams.get("type"));
   const successUrl = new URL(nextPath, request.url);
   const loginUrl = new URL("/login", request.url);
 
-  loginUrl.searchParams.set("redirect", nextPath);
+  if (nextPath !== "/") {
+    loginUrl.searchParams.set("redirect", nextPath);
+  }
 
-  if (!code) {
+  if (!code && (!tokenHash || !type)) {
     return NextResponse.redirect(loginUrl);
   }
 
@@ -24,7 +44,7 @@ export async function GET(request: NextRequest) {
         getAll() {
           return request.cookies.getAll();
         },
-        setAll(cookiesToSet, headersToSet) {
+        setAll(cookiesToSet, headersToSet = {}) {
           response = NextResponse.redirect(successUrl);
 
           cookiesToSet.forEach(({ name, value, options }) => {
@@ -39,7 +59,13 @@ export async function GET(request: NextRequest) {
     }
   );
 
-  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  const { error } =
+    tokenHash && type
+      ? await supabase.auth.verifyOtp({
+          token_hash: tokenHash,
+          type,
+        })
+      : await supabase.auth.exchangeCodeForSession(code!);
 
   if (error) {
     return NextResponse.redirect(loginUrl);

--- a/docs/auth-email-template.md
+++ b/docs/auth-email-template.md
@@ -20,7 +20,7 @@ Body:
   </p>
   <p style="margin: 0 0 24px;">
     <a
-      href="{{ .ConfirmationURL }}"
+      href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email"
       style="display: inline-block; border-radius: 8px; background: #67e8f9; color: #0f172a; font-weight: 700; padding: 12px 18px; text-decoration: none;"
     >
       Log in to What Can We Sing
@@ -30,9 +30,9 @@ Body:
     If the button does not work, copy and paste this link into your browser.
   </p>
   <p style="margin: 0; font-size: 14px; word-break: break-all;">
-    <a href="{{ .ConfirmationURL }}" style="color: #0369a1;">{{ .ConfirmationURL }}</a>
+    <a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email" style="color: #0369a1;">{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email</a>
   </p>
 </div>
 ```
 
-Supabase provides `{{ .ConfirmationURL }}` for the one-time login URL. Keep that variable in both links.
+Supabase's server-side auth guidance recommends sending `{{ .TokenHash }}` to an app callback route for PKCE/SSR flows. This template uses `{{ .RedirectTo }}` so the app's `emailRedirectTo` value, including any intended `next` path, is preserved. Keep the `token_hash={{ .TokenHash }}` and `type=email` query parameters in both links.

--- a/docs/auth-manual-test-checklist.md
+++ b/docs/auth-manual-test-checklist.md
@@ -1,0 +1,39 @@
+# Magic Link Auth Manual Test Checklist
+
+Run this checklist after changing Supabase Auth settings, auth email templates,
+or the login/callback flow.
+
+## Supabase dashboard setup
+
+- Authentication > URL Configuration:
+  - Site URL is the production app URL.
+  - Redirect URLs include `https://your-production-app-url/auth/callback`.
+  - Redirect URLs include `http://localhost:3000/auth/callback` for local tests.
+- Authentication > Email Templates > Magic Link:
+  - Button and fallback links use:
+    `{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email`
+  - The template does not use `/login` as the link target.
+
+## Local flow
+
+1. Start the app locally.
+2. Visit `/login`.
+3. Request a magic link.
+4. Open the link in the same browser.
+5. Confirm the URL goes through `/auth/callback`.
+6. Confirm the app lands on `/` by default.
+7. Confirm refreshing `/` does not redirect back to `/login`.
+
+## Protected route flow
+
+1. In a signed-out browser, visit `/join/TEST12`.
+2. Confirm the app redirects to `/login?redirect=/join/TEST12`.
+3. Request and open a magic link.
+4. Confirm the app lands back on `/join/TEST12`, not `/login`.
+
+## Failure checks
+
+- Opening `/auth/callback` without `code` or `token_hash` returns to `/login`.
+- Opening a magic link twice should fail gracefully and not create a loop.
+- If a profile has no display name, the app redirects to `/settings`, not
+  `/login`.

--- a/lib/__tests__/authRedirect.test.ts
+++ b/lib/__tests__/authRedirect.test.ts
@@ -23,6 +23,12 @@ describe("getPostLoginRedirectPath", () => {
   it("ignores protocol-relative redirect URLs", () => {
     expect(getPostLoginRedirectPath("?redirect=//example.com")).toBe("/");
   });
+
+  it("does not preserve auth routes as post-login destinations", () => {
+    expect(getPostLoginRedirectPath("?redirect=/login")).toBe("/");
+    expect(getPostLoginRedirectPath("?redirect=/login?redirect=/join/ABC123")).toBe("/");
+    expect(getPostLoginRedirectPath("?redirect=/auth/callback?code=abc")).toBe("/");
+  });
 });
 
 describe("getAuthCallbackNextPath", () => {
@@ -38,6 +44,11 @@ describe("getAuthCallbackNextPath", () => {
     expect(getAuthCallbackNextPath("?next=https://example.com")).toBe("/");
     expect(getAuthCallbackNextPath("?next=//example.com")).toBe("/");
   });
+
+  it("does not redirect successful callbacks back to auth routes", () => {
+    expect(getAuthCallbackNextPath("?next=/login")).toBe("/");
+    expect(getAuthCallbackNextPath("?next=/auth/callback")).toBe("/");
+  });
 });
 
 describe("getMagicLinkRedirectUrl", () => {
@@ -48,7 +59,7 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "",
       })
-    ).toBe("https://what-can-we-sing.vercel.app/auth/callback");
+    ).toBe("https://what-can-we-sing.vercel.app/auth/callback?next=%2F");
   });
 
   it("passes a safe redirect parameter through the auth callback", () => {
@@ -70,7 +81,7 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "",
       })
-    ).toBe("http://localhost:3000/auth/callback");
+    ).toBe("http://localhost:3000/auth/callback?next=%2F");
   });
 
   it("does not fall back to a production browser origin", () => {
@@ -90,6 +101,6 @@ describe("getMagicLinkRedirectUrl", () => {
         origin: "http://localhost:3000",
         search: "?redirect=https://example.com",
       })
-    ).toBe("https://what-can-we-sing.vercel.app/auth/callback");
+    ).toBe("https://what-can-we-sing.vercel.app/auth/callback?next=%2F");
   });
 });

--- a/lib/authRedirect.ts
+++ b/lib/authRedirect.ts
@@ -1,6 +1,8 @@
 const DEFAULT_AUTH_REDIRECT_PATH = "/";
 const AUTH_CALLBACK_PATH = "/auth/callback";
 
+const disallowedAuthRedirectPaths = ["/login", "/auth/callback"];
+
 function normalizeSiteUrl(siteUrl: string | undefined): string | null {
   if (!siteUrl?.trim()) return null;
 
@@ -24,7 +26,7 @@ function isLocalOrigin(origin: string): boolean {
 export function getPostLoginRedirectPath(search: string): string {
   const redirect = new URLSearchParams(search).get("redirect");
 
-  if (!redirect || !redirect.startsWith("/") || redirect.startsWith("//")) {
+  if (!isSafeAppRedirectPath(redirect)) {
     return DEFAULT_AUTH_REDIRECT_PATH;
   }
 
@@ -34,11 +36,22 @@ export function getPostLoginRedirectPath(search: string): string {
 export function getAuthCallbackNextPath(search: string): string {
   const next = new URLSearchParams(search).get("next");
 
-  if (!next || !next.startsWith("/") || next.startsWith("//")) {
+  if (!isSafeAppRedirectPath(next)) {
     return DEFAULT_AUTH_REDIRECT_PATH;
   }
 
   return next;
+}
+
+export function isSafeAppRedirectPath(path: string | null): path is string {
+  if (!path || !path.startsWith("/") || path.startsWith("//")) return false;
+
+  const { pathname } = new URL(path, "https://example.com");
+
+  return !disallowedAuthRedirectPaths.some(
+    (disallowedPath) =>
+      pathname === disallowedPath || pathname.startsWith(`${disallowedPath}/`)
+  );
 }
 
 export function getMagicLinkRedirectUrl({
@@ -57,9 +70,7 @@ export function getMagicLinkRedirectUrl({
 
   const callbackUrl = new URL(AUTH_CALLBACK_PATH, baseUrl);
 
-  if (redirectPath !== DEFAULT_AUTH_REDIRECT_PATH) {
-    callbackUrl.searchParams.set("next", redirectPath);
-  }
+  callbackUrl.searchParams.set("next", redirectPath);
 
   return callbackUrl.toString();
 }


### PR DESCRIPTION
## Summary
- Support both Supabase magic-link callback shapes: PKCE `code` exchange and SSR-safe `token_hash` + `type` verification.
- Prevent post-login redirects from preserving `/login` or `/auth/callback`, which can create the observed loop back to the login page.
- Always include a `next` parameter in generated callback URLs so the dashboard token-hash email template can safely append `token_hash` with `&`.
- Make the callback cookie writer tolerant of the current `@supabase/ssr` `setAll` arguments.
- Update the recommended Supabase Magic Link template to use `{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email`.
- Add a manual magic-link auth checklist for production/local/mobile regression checks.

## Manual Supabase step
Update **Authentication > Email Templates > Magic Link** in the Supabase dashboard to match `docs/auth-email-template.md`, especially the link target:

```html
{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email
```

Also confirm Auth URL Configuration allows the production and local `/auth/callback` URLs.

## Verification
- `npm run test:run`
- `npm run build`

Fixes #121