### PR TITLE
Normalize malformed auth callback links

### DIFF
--- a/docs/auth-email-template.md
+++ b/docs/auth-email-template.md
@@ -1,6 +1,8 @@
-# Supabase Magic Link Email Template
+# Supabase Auth Email Templates
 
 This project does not include a checked-in Supabase `config.toml`, so the hosted Supabase Auth email template must be configured in the Supabase dashboard.
+
+## Magic Link
 
 In Supabase, go to **Authentication > Email Templates > Magic Link** and use this template.
 
@@ -36,3 +38,37 @@ Body:
 ```
 
 Supabase's server-side auth guidance recommends sending `{{ .TokenHash }}` to an app callback route for PKCE/SSR flows. This template uses `{{ .RedirectTo }}` so the app's `emailRedirectTo` value, including any intended `next` path, is preserved. Keep the `token_hash={{ .TokenHash }}` and `type=email` query parameters in both links.
+
+## Confirm Signup
+
+New-user signup confirmation uses a different template and usually does not
+include the app-generated `next` query parameter. In Supabase, go to
+**Authentication > Email Templates > Confirm signup** and use `?` before the
+first query parameter:
+
+```html
+<div style="font-family: Arial, sans-serif; color: #0f172a; line-height: 1.5;">
+  <h2 style="margin: 0 0 16px;">What Can We Sing</h2>
+  <p style="margin: 0 0 16px;">
+    Click the button below to confirm your account and get started.
+  </p>
+  <p style="margin: 0 0 24px;">
+    <a
+      href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup"
+      style="display: inline-block; border-radius: 8px; background: #67e8f9; color: #0f172a; font-weight: 700; padding: 12px 18px; text-decoration: none;"
+    >
+      Confirm your account
+    </a>
+  </p>
+  <p style="margin: 0 0 8px; font-size: 14px; color: #475569;">
+    If the button does not work, copy and paste this link into your browser.
+  </p>
+  <p style="margin: 0; font-size: 14px; word-break: break-all;">
+    <a href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup" style="color: #0369a1;">{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup</a>
+  </p>
+</div>
+```
+
+Do not use `&token_hash=...` immediately after `/auth/callback` in this
+template. Without the `?`, the browser requests
+`/auth/callback&token_hash=...`, which is not the real callback route.

--- a/docs/auth-manual-test-checklist.md
+++ b/docs/auth-manual-test-checklist.md
@@ -13,6 +13,11 @@ or the login/callback flow.
   - Button and fallback links use:
     `{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=email`
   - The template does not use `/login` as the link target.
+- Authentication > Email Templates > Confirm signup:
+  - Button and fallback links use:
+    `{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=signup`
+  - The template uses `?token_hash`, not `&token_hash`, immediately after
+    `/auth/callback`.
 
 ## Local flow
 
@@ -34,6 +39,8 @@ or the login/callback flow.
 ## Failure checks
 
 - Opening `/auth/callback` without `code` or `token_hash` returns to `/login`.
+- Opening `/auth/callback&token_hash=REDACTED&type=signup` normalizes to the
+  real `/auth/callback?token_hash=REDACTED&type=signup` route.
 - Opening a magic link twice should fail gracefully and not create a loop.
 - If a profile has no display name, the app redirects to `/settings`, not
   `/login`.

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   allowsMissingDisplayName,
   getLoginRedirectUrl,
+  getNormalizedAuthCallbackUrl,
   getSettingsRedirectUrl,
   isPublicAuthPath,
 } from "../authRoute";
@@ -15,6 +16,12 @@ describe("isPublicAuthPath", () => {
     expect(isPublicAuthPath("/auth/callback")).toBe(true);
   });
 
+  it("allows malformed auth callback paths so proxy can normalize them", () => {
+    expect(isPublicAuthPath("/auth/callback&token_hash=abc&type=signup")).toBe(
+      true
+    );
+  });
+
   it("allows the privacy route without an auth redirect", () => {
     expect(isPublicAuthPath("/privacy")).toBe(true);
   });
@@ -22,6 +29,36 @@ describe("isPublicAuthPath", () => {
   it("protects app routes", () => {
     expect(isPublicAuthPath("/repertoire")).toBe(false);
     expect(isPublicAuthPath("/join/ABC123")).toBe(false);
+  });
+});
+
+describe("getNormalizedAuthCallbackUrl", () => {
+  it("normalizes callback links that used & before the first query parameter", () => {
+    const url = getNormalizedAuthCallbackUrl(
+      new URL("https://example.com/auth/callback&token_hash=abc&type=signup")
+    );
+
+    expect(url?.toString()).toBe(
+      "https://example.com/auth/callback?token_hash=abc&type=signup"
+    );
+  });
+
+  it("preserves any existing query string while normalizing", () => {
+    const url = getNormalizedAuthCallbackUrl(
+      new URL("https://example.com/auth/callback&token_hash=abc?type=signup")
+    );
+
+    expect(url?.toString()).toBe(
+      "https://example.com/auth/callback?token_hash=abc&type=signup"
+    );
+  });
+
+  it("ignores normal callback paths", () => {
+    expect(
+      getNormalizedAuthCallbackUrl(
+        new URL("https://example.com/auth/callback?token_hash=abc&type=signup")
+      )
+    ).toBeNull();
   });
 });
 

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -3,8 +3,25 @@ export function isPublicAuthPath(pathname: string): boolean {
     pathname === "/login" ||
     pathname.startsWith("/login/") ||
     pathname === "/auth/callback" ||
+    pathname.startsWith("/auth/callback&") ||
     pathname === "/privacy"
   );
+}
+
+export function getNormalizedAuthCallbackUrl(requestUrl: URL): URL | null {
+  if (!requestUrl.pathname.startsWith("/auth/callback&")) {
+    return null;
+  }
+
+  const normalizedUrl = new URL(requestUrl);
+  const malformedQuery = normalizedUrl.pathname.slice("/auth/callback&".length);
+  const existingSearch = normalizedUrl.search.replace(/^\?/, "");
+  const search = [malformedQuery, existingSearch].filter(Boolean).join("&");
+
+  normalizedUrl.pathname = "/auth/callback";
+  normalizedUrl.search = search ? `?${search}` : "";
+
+  return normalizedUrl;
 }
 
 export function allowsMissingDisplayName(pathname: string): boolean {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,11 +3,17 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   allowsMissingDisplayName,
   getLoginRedirectUrl,
+  getNormalizedAuthCallbackUrl,
   getSettingsRedirectUrl,
   isPublicAuthPath,
 } from "@/lib/authRoute";
 
 export async function proxy(request: NextRequest) {
+  const normalizedAuthCallbackUrl = getNormalizedAuthCallbackUrl(request.nextUrl);
+  if (normalizedAuthCallbackUrl) {
+    return NextResponse.redirect(normalizedAuthCallbackUrl);
+  }
+
   if (isPublicAuthPath(request.nextUrl.pathname)) {
     return NextResponse.next();
   }


### PR DESCRIPTION
## Summary
- Defensively normalize malformed `/auth/callback&token_hash=...` links to `/auth/callback?token_hash=...` in the proxy before auth guards run.
- Treat malformed callback paths as public so they do not become `/login?redirect=...` loops.
- Add regression tests for the exact malformed signup callback URL shape.
- Document the different Supabase template separators for Magic Link vs Confirm signup.

## Verification
- `npm run test:run`
- `npm run build`

Follow-up to #121.