### PR TITLE
Sync active quartet display name changes

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { AppNav } from "@/components/AppNav";
+import { getActiveQuartet } from "@/lib/activeQuartet";
+import { getActiveQuartetDisplayNameSync } from "@/lib/activeQuartetDisplayNameSync";
 import {
   getCurrentUser,
   getMyProfile,
   upsertMyProfile,
 } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
+import { updateParticipantDisplayName } from "@/lib/sessionStore";
 import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [userId, setUserId] = useState("");
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
+  const [savedDisplayName, setSavedDisplayName] = useState("");
   const [message, setMessage] = useState("");
   const [displayNameError, setDisplayNameError] = useState("");
   const [showRepertoireNextStep, setShowRepertoireNextStep] = useState(false);
@@ -30,12 +35,14 @@ export default function SettingsPage() {
         }
 
         setIsLoggedIn(true);
+        setUserId(user.id);
         setEmail(user.email ?? "");
 
         const profile = await getMyProfile();
 
         if (profile) {
           setDisplayName(profile.display_name ?? "");
+          setSavedDisplayName(profile.display_name ?? "");
         } else {
           setMessage(
             "Add a display name before joining a quartet so other singers know who you are."
@@ -64,7 +71,33 @@ export default function SettingsPage() {
     try {
       setIsSaving(true);
       setDisplayNameError("");
-      await upsertMyProfile(displayName.trim());
+      const trimmedDisplayName = displayName.trim();
+      await upsertMyProfile(trimmedDisplayName);
+
+      const activeQuartetDisplayNameSync = getActiveQuartetDisplayNameSync({
+        activeQuartet: getActiveQuartet(),
+        userId,
+        previousDisplayName: savedDisplayName,
+        nextDisplayName: trimmedDisplayName,
+      });
+      let activeQuartetSyncFailed = false;
+
+      if (activeQuartetDisplayNameSync) {
+        try {
+          await updateParticipantDisplayName(
+            activeQuartetDisplayNameSync.sessionId,
+            activeQuartetDisplayNameSync.userId,
+            activeQuartetDisplayNameSync.displayName
+          );
+        } catch (err) {
+          activeQuartetSyncFailed = true;
+          console.error(err);
+        }
+      }
+
+      if (!activeQuartetSyncFailed) {
+        setSavedDisplayName(trimmedDisplayName);
+      }
 
       let repertoireCount: number | null = null;
       try {
@@ -75,13 +108,19 @@ export default function SettingsPage() {
       }
 
       if (repertoireCount === 0) {
-        setMessage("Settings saved. Next, add a few songs you know.");
+        setMessage(
+          activeQuartetSyncFailed
+            ? "Settings saved. Could not update your active quartet name yet."
+            : "Settings saved. Next, add a few songs you know."
+        );
         setShowRepertoireNextStep(true);
         return;
       }
 
       setMessage(
-        repertoireCount === null
+        activeQuartetSyncFailed
+          ? "Settings saved. Could not update your active quartet name yet."
+          : repertoireCount === null
           ? "Settings saved. Could not check your songs yet."
           : "Settings saved."
       );

--- a/lib/__tests__/activeQuartetDisplayNameSync.test.ts
+++ b/lib/__tests__/activeQuartetDisplayNameSync.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { getActiveQuartetDisplayNameSync } from "../activeQuartetDisplayNameSync";
+
+describe("active quartet display name sync", () => {
+  const activeQuartet = {
+    sessionId: "session-1",
+    code: "ABC123",
+    joinedAt: "2026-04-27T00:00:00Z",
+  };
+
+  it("returns a participant update keyed by session and user id", () => {
+    expect(
+      getActiveQuartetDisplayNameSync({
+        activeQuartet,
+        userId: "user-1",
+        previousDisplayName: "Old Name",
+        nextDisplayName: "New Name",
+      })
+    ).toEqual({
+      sessionId: "session-1",
+      userId: "user-1",
+      displayName: "New Name",
+    });
+  });
+
+  it("trims the saved display name before syncing", () => {
+    expect(
+      getActiveQuartetDisplayNameSync({
+        activeQuartet,
+        userId: "user-1",
+        previousDisplayName: "Old Name",
+        nextDisplayName: "  New Name  ",
+      })
+    ).toMatchObject({ displayName: "New Name" });
+  });
+
+  it("does not sync when there is no active quartet", () => {
+    expect(
+      getActiveQuartetDisplayNameSync({
+        activeQuartet: null,
+        userId: "user-1",
+        previousDisplayName: "Old Name",
+        nextDisplayName: "New Name",
+      })
+    ).toBeNull();
+  });
+
+  it("does not sync unchanged display names", () => {
+    expect(
+      getActiveQuartetDisplayNameSync({
+        activeQuartet,
+        userId: "user-1",
+        previousDisplayName: "New Name",
+        nextDisplayName: " New Name ",
+      })
+    ).toBeNull();
+  });
+});

--- a/lib/activeQuartetDisplayNameSync.ts
+++ b/lib/activeQuartetDisplayNameSync.ts
@@ -1,0 +1,37 @@
+import type { ActiveQuartet } from "@/lib/activeQuartet";
+
+type ActiveQuartetDisplayNameSyncInput = {
+  activeQuartet: ActiveQuartet | null;
+  userId: string;
+  previousDisplayName: string;
+  nextDisplayName: string;
+};
+
+export type ActiveQuartetDisplayNameSync = {
+  sessionId: string;
+  userId: string;
+  displayName: string;
+};
+
+export function getActiveQuartetDisplayNameSync({
+  activeQuartet,
+  userId,
+  previousDisplayName,
+  nextDisplayName,
+}: ActiveQuartetDisplayNameSyncInput): ActiveQuartetDisplayNameSync | null {
+  const displayName = nextDisplayName.trim();
+
+  if (!activeQuartet || !userId || !displayName) {
+    return null;
+  }
+
+  if (previousDisplayName.trim() === displayName) {
+    return null;
+  }
+
+  return {
+    sessionId: activeQuartet.sessionId,
+    userId,
+    displayName,
+  };
+}

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -101,6 +101,29 @@ export async function updateParticipantSnapshot(
   return data as DbParticipant;
 }
 
+export async function updateParticipantDisplayName(
+  sessionId: string,
+  userId: string,
+  displayName: string,
+  lastActivityAt = new Date().toISOString()
+) {
+  const { data, error } = await supabase
+    .from("session_participants")
+    .update({ display_name: displayName })
+    .eq("session_id", sessionId)
+    .eq("user_id", userId)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+
+  if (data) {
+    await updateSessionActivity(sessionId, lastActivityAt);
+  }
+
+  return data as DbParticipant | null;
+}
+
 export async function getParticipants(sessionId: string) {
   const { data, error } = await supabase
     .from("session_participants")


### PR DESCRIPTION
## Summary
- Sync active quartet participant display names after settings profile saves
- Update the participant row by `session_id` and authenticated `user_id`, avoiding duplicate participants
- Add unit coverage for deciding when active quartet name sync should run

Closes #119.

## Manual steps
None. No database migration or Supabase dashboard change required.

## Verification
- `npm run test:run`
- `npm run build`