### PR TITLE
Always sync active quartet participant display name

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -18,7 +18,6 @@ export default function SettingsPage() {
   const [userId, setUserId] = useState("");
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
-  const [savedDisplayName, setSavedDisplayName] = useState("");
   const [message, setMessage] = useState("");
   const [displayNameError, setDisplayNameError] = useState("");
   const [showRepertoireNextStep, setShowRepertoireNextStep] = useState(false);
@@ -42,7 +41,6 @@ export default function SettingsPage() {
 
         if (profile) {
           setDisplayName(profile.display_name ?? "");
-          setSavedDisplayName(profile.display_name ?? "");
         } else {
           setMessage(
             "Add a display name before joining a quartet so other singers know who you are."
@@ -77,7 +75,6 @@ export default function SettingsPage() {
       const activeQuartetDisplayNameSync = getActiveQuartetDisplayNameSync({
         activeQuartet: getActiveQuartet(),
         userId,
-        previousDisplayName: savedDisplayName,
         nextDisplayName: trimmedDisplayName,
       });
       let activeQuartetSyncFailed = false;
@@ -93,10 +90,6 @@ export default function SettingsPage() {
           activeQuartetSyncFailed = true;
           console.error(err);
         }
-      }
-
-      if (!activeQuartetSyncFailed) {
-        setSavedDisplayName(trimmedDisplayName);
       }
 
       let repertoireCount: number | null = null;

--- a/lib/__tests__/activeQuartetDisplayNameSync.test.ts
+++ b/lib/__tests__/activeQuartetDisplayNameSync.test.ts
@@ -13,7 +13,6 @@ describe("active quartet display name sync", () => {
       getActiveQuartetDisplayNameSync({
         activeQuartet,
         userId: "user-1",
-        previousDisplayName: "Old Name",
         nextDisplayName: "New Name",
       })
     ).toEqual({
@@ -28,7 +27,6 @@ describe("active quartet display name sync", () => {
       getActiveQuartetDisplayNameSync({
         activeQuartet,
         userId: "user-1",
-        previousDisplayName: "Old Name",
         nextDisplayName: "  New Name  ",
       })
     ).toMatchObject({ displayName: "New Name" });
@@ -39,19 +37,31 @@ describe("active quartet display name sync", () => {
       getActiveQuartetDisplayNameSync({
         activeQuartet: null,
         userId: "user-1",
-        previousDisplayName: "Old Name",
         nextDisplayName: "New Name",
       })
     ).toBeNull();
   });
 
-  it("does not sync unchanged display names", () => {
+  it("still syncs when the profile display name did not change", () => {
     expect(
       getActiveQuartetDisplayNameSync({
         activeQuartet,
         userId: "user-1",
-        previousDisplayName: "New Name",
-        nextDisplayName: " New Name ",
+        nextDisplayName: "Tim - new name",
+      })
+    ).toEqual({
+      sessionId: "session-1",
+      userId: "user-1",
+      displayName: "Tim - new name",
+    });
+  });
+
+  it("does not sync blank display names", () => {
+    expect(
+      getActiveQuartetDisplayNameSync({
+        activeQuartet,
+        userId: "user-1",
+        nextDisplayName: "   ",
       })
     ).toBeNull();
   });

--- a/lib/activeQuartetDisplayNameSync.ts
+++ b/lib/activeQuartetDisplayNameSync.ts
@@ -3,7 +3,6 @@ import type { ActiveQuartet } from "@/lib/activeQuartet";
 type ActiveQuartetDisplayNameSyncInput = {
   activeQuartet: ActiveQuartet | null;
   userId: string;
-  previousDisplayName: string;
   nextDisplayName: string;
 };
 
@@ -16,16 +15,11 @@ export type ActiveQuartetDisplayNameSync = {
 export function getActiveQuartetDisplayNameSync({
   activeQuartet,
   userId,
-  previousDisplayName,
   nextDisplayName,
 }: ActiveQuartetDisplayNameSyncInput): ActiveQuartetDisplayNameSync | null {
   const displayName = nextDisplayName.trim();
 
   if (!activeQuartet || !userId || !displayName) {
-    return null;
-  }
-
-  if (previousDisplayName.trim() === displayName) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Always sync the active quartet participant row when settings saves a nonblank display name
- Keep the update scoped to the active quartet `session_id` and authenticated `user_id`
- Update regression coverage so an already-stale participant row can be repaired even when the profile name itself is unchanged

Closes #125.

## Manual steps
None. No database migration or Supabase dashboard change required.

## Verification
- `npm run test:run`
- `npm run build`