### PR TITLE
Sync participant snapshot display names

### DIFF
--- a/lib/__tests__/sessionParticipantDisplayName.test.ts
+++ b/lib/__tests__/sessionParticipantDisplayName.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { applyParticipantDisplayName } from "../sessionParticipantDisplayName";
+import type { DbParticipant } from "../sessionStore";
+
+function participant(): DbParticipant {
+  return {
+    id: "participant-1",
+    session_id: "session-1",
+    user_id: "user-1",
+    display_name: "Old Name",
+    joined_at: "2026-04-27T00:00:00Z",
+    repertoire: [
+      {
+        userId: "user-1",
+        displayName: "Old Name",
+        songTitle: "Test Song",
+        voicing: "TTBB",
+        partsKnown: ["Lead"],
+        confidence: "Good to Go",
+      },
+      {
+        userId: "user-1",
+        displayName: "Old Name",
+        songTitle: "Another Song",
+        voicing: "SATB",
+        partsKnown: ["Tenor"],
+        confidence: "A Little Rusty",
+      },
+    ],
+  };
+}
+
+describe("session participant display name sync", () => {
+  it("updates both the participant row name and repertoire snapshot names", () => {
+    const result = applyParticipantDisplayName(participant(), "New Name");
+
+    expect(result.display_name).toBe("New Name");
+    expect(result.repertoire.map((entry) => entry.displayName)).toEqual([
+      "New Name",
+      "New Name",
+    ]);
+  });
+
+  it("does not change participant identity or repertoire song details", () => {
+    const original = participant();
+    const result = applyParticipantDisplayName(original, "New Name");
+
+    expect(result.id).toBe("participant-1");
+    expect(result.session_id).toBe("session-1");
+    expect(result.user_id).toBe("user-1");
+    expect(result.repertoire[0]).toMatchObject({
+      userId: "user-1",
+      songTitle: "Test Song",
+      voicing: "TTBB",
+      partsKnown: ["Lead"],
+      confidence: "Good to Go",
+    });
+  });
+});

--- a/lib/sessionParticipantDisplayName.ts
+++ b/lib/sessionParticipantDisplayName.ts
@@ -1,0 +1,15 @@
+import type { DbParticipant } from "@/lib/sessionStore";
+
+export function applyParticipantDisplayName(
+  participant: DbParticipant,
+  displayName: string
+): DbParticipant {
+  return {
+    ...participant,
+    display_name: displayName,
+    repertoire: participant.repertoire.map((entry) => ({
+      ...entry,
+      displayName,
+    })),
+  };
+}

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -1,5 +1,6 @@
 import { supabase } from "@/lib/supabase";
 import type { SingerEntry } from "@/lib/matching";
+import { applyParticipantDisplayName } from "@/lib/sessionParticipantDisplayName";
 import type { ParticipantChangePayload } from "@/lib/sessionParticipantChanges";
 
 export type DbSession = {
@@ -107,21 +108,37 @@ export async function updateParticipantDisplayName(
   displayName: string,
   lastActivityAt = new Date().toISOString()
 ) {
-  const { data, error } = await supabase
+  const { data: currentParticipant, error: selectError } = await supabase
     .from("session_participants")
-    .update({ display_name: displayName })
+    .select("*")
     .eq("session_id", sessionId)
     .eq("user_id", userId)
-    .select()
     .maybeSingle();
+
+  if (selectError) throw selectError;
+  if (!currentParticipant) return null;
+
+  const participant = applyParticipantDisplayName(
+    currentParticipant as DbParticipant,
+    displayName
+  );
+
+  const { data, error } = await supabase
+    .from("session_participants")
+    .update({
+      display_name: participant.display_name,
+      repertoire: participant.repertoire,
+    })
+    .eq("id", participant.id)
+    .eq("user_id", userId)
+    .select()
+    .single();
 
   if (error) throw error;
 
-  if (data) {
-    await updateSessionActivity(sessionId, lastActivityAt);
-  }
+  await updateSessionActivity(sessionId, lastActivityAt);
 
-  return data as DbParticipant | null;
+  return data as DbParticipant;
 }
 
 export async function getParticipants(sessionId: string) {


### PR DESCRIPTION
## Summary
- Update active quartet participant display-name sync to rewrite the participant repertoire snapshot names too
- Keep the update scoped to the existing `session_participants` row by `session_id`, row `id`, and authenticated `user_id`
- Add regression coverage that row-level and snapshot-level names both change without altering participant identity or song details

Follow-up for #125.

## Why
The previous fix only updated `session_participants.display_name`. Match/result UI can still render singer names from the participant repertoire snapshot, where each entry also carries `displayName`, so stale names could survive realtime and refresh.

## Manual steps
None. No database migration or Supabase dashboard change required.

## Verification
- `npm run test:run`
- `npm run build`