### PR TITLE
Reconcile active quartet display names

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -22,6 +22,7 @@ import {
   updateParticipantSnapshot,
   upsertParticipant,
 } from "@/lib/sessionStore";
+import { getCurrentParticipantDisplayName } from "@/lib/sessionParticipantDisplayName";
 import {
   isSessionExpired,
   sessionExpirationLabel,
@@ -234,7 +235,9 @@ export default function JoinSessionPage() {
   }
 
   async function refreshMySongs() {
-    if (!sessionId || !currentUserId || !displayName) {
+    const name = currentParticipantDisplayName;
+
+    if (!sessionId || !currentUserId || !name) {
       setMessage("Could not refresh yet. Wait for the quartet to finish loading.");
       return;
     }
@@ -250,17 +253,17 @@ export default function JoinSessionPage() {
       );
 
       if (!existingParticipant) {
-        await joinSession(sessionId, displayName, currentUserId);
+        await joinSession(sessionId, name, currentUserId);
         return;
       }
 
-      const entries = await getMyEntries(displayName);
+      const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();
 
       await updateParticipantSnapshot(
         existingParticipant.id,
         currentUserId,
-        displayName,
+        name,
         entries,
         lastActivityAt
       );
@@ -269,9 +272,7 @@ export default function JoinSessionPage() {
         current ? { ...current, last_activity_at: lastActivityAt } : current
       );
       await refreshParticipants(sessionId);
-      setMessage(
-        `Updated ${displayName}'s repertoire with ${entries.length} songs.`
-      );
+      setMessage(`Updated ${name}'s repertoire with ${entries.length} songs.`);
     } catch (err) {
       console.error(err);
       setMessage(
@@ -309,7 +310,7 @@ export default function JoinSessionPage() {
   }
 
   async function rejoinQuartet() {
-    await joinSession(sessionId, displayName, currentUserId, {
+    await joinSession(sessionId, currentParticipantDisplayName, currentUserId, {
       clearLeftFlag: true,
     });
   }
@@ -577,6 +578,11 @@ export default function JoinSessionPage() {
   )?.matches.length ?? 0;
   const quartetExpired = session ? isSessionExpired(session, now) : false;
   const expirationLabel = session ? sessionExpirationLabel(session, now) : "";
+  const currentParticipantDisplayName = getCurrentParticipantDisplayName(
+    participants,
+    currentUserId,
+    displayName
+  );
   const openSingerSlots = Math.max(
     0,
     MAX_QUARTET_PARTICIPANTS - participants.length
@@ -883,7 +889,7 @@ export default function JoinSessionPage() {
                 <>
                   <p className="text-slate-300">You are in this quartet as:</p>
                   <p className="mt-1 text-2xl font-bold text-cyan-300">
-                    {displayName}
+                    {currentParticipantDisplayName}
                   </p>
 
                   <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -902,7 +908,7 @@ export default function JoinSessionPage() {
                         disabled={
                           refreshingSongs ||
                           !sessionId ||
-                          !displayName ||
+                          !currentParticipantDisplayName ||
                           !currentUserId
                         }
                         className="text-sm font-semibold text-cyan-300 hover:text-cyan-200 disabled:opacity-40"

--- a/lib/__tests__/sessionParticipantDisplayName.test.ts
+++ b/lib/__tests__/sessionParticipantDisplayName.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { applyParticipantDisplayName } from "../sessionParticipantDisplayName";
+import {
+  applyParticipantDisplayName,
+  getCurrentParticipantDisplayName,
+} from "../sessionParticipantDisplayName";
 import type { DbParticipant } from "../sessionStore";
 
 function participant(): DbParticipant {
@@ -31,6 +34,22 @@ function participant(): DbParticipant {
 }
 
 describe("session participant display name sync", () => {
+  it("uses the current participant row name ahead of stale profile state", () => {
+    expect(
+      getCurrentParticipantDisplayName(
+        [applyParticipantDisplayName(participant(), "New Name")],
+        "user-1",
+        "Old Name"
+      )
+    ).toBe("New Name");
+  });
+
+  it("falls back to profile state when the current participant is not loaded", () => {
+    expect(getCurrentParticipantDisplayName([], "user-1", "Profile Name")).toBe(
+      "Profile Name"
+    );
+  });
+
   it("updates both the participant row name and repertoire snapshot names", () => {
     const result = applyParticipantDisplayName(participant(), "New Name");
 

--- a/lib/sessionParticipantDisplayName.ts
+++ b/lib/sessionParticipantDisplayName.ts
@@ -1,5 +1,16 @@
 import type { DbParticipant } from "@/lib/sessionStore";
 
+export function getCurrentParticipantDisplayName(
+  participants: DbParticipant[],
+  userId: string,
+  fallbackDisplayName: string
+) {
+  return (
+    participants.find((participant) => participant.user_id === userId)
+      ?.display_name ?? fallbackDisplayName
+  );
+}
+
 export function applyParticipantDisplayName(
   participant: DbParticipant,
   displayName: string

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -42,6 +42,17 @@ async function updateSessionActivity(sessionId: string, lastActivityAt: string) 
   if (error) throw error;
 }
 
+async function tryUpdateSessionActivity(
+  sessionId: string,
+  lastActivityAt: string
+) {
+  try {
+    await updateSessionActivity(sessionId, lastActivityAt);
+  } catch (err) {
+    console.warn("Could not update session activity", err);
+  }
+}
+
 export async function getSessionByCode(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
@@ -136,7 +147,7 @@ export async function updateParticipantDisplayName(
 
   if (error) throw error;
 
-  await updateSessionActivity(sessionId, lastActivityAt);
+  await tryUpdateSessionActivity(sessionId, lastActivityAt);
 
   return data as DbParticipant;
 }


### PR DESCRIPTION
## Summary
- Make the quartet page derive the current singer name from the authenticated user's participant row when it exists
- Use that reconciled name for the header, refresh action, and rejoin action so stale profile/page state cannot overwrite the participant row
- Treat session activity timestamp failures as non-fatal after `session_participants` display-name sync succeeds
- Add regression coverage for preferring the participant row name over stale profile state

## Why
The broken state had two separate name sources: the participant list read `session_participants.display_name`, while the header read local profile-derived state. Browser history/realtime could update the participant list while leaving the header stale. Also, Settings could show "Could not update your active quartet name yet" after the participant row had already updated if the follow-up session activity timestamp write failed.

## Verification
- `npm run test:run`
- `npm run build`