### PR TITLE
Make active quartet name sync robust

### DIFF
--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -53,6 +53,29 @@ async function tryUpdateSessionActivity(
   }
 }
 
+async function tryUpdateParticipantSnapshotDisplayName(
+  participant: DbParticipant,
+  userId: string,
+  displayName: string
+) {
+  const updatedParticipant = applyParticipantDisplayName(
+    participant,
+    displayName
+  );
+
+  try {
+    const { error } = await supabase
+      .from("session_participants")
+      .update({ repertoire: updatedParticipant.repertoire })
+      .eq("id", participant.id)
+      .eq("user_id", userId);
+
+    if (error) throw error;
+  } catch (err) {
+    console.warn("Could not update participant repertoire display names", err);
+  }
+}
+
 export async function getSessionByCode(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
@@ -119,34 +142,22 @@ export async function updateParticipantDisplayName(
   displayName: string,
   lastActivityAt = new Date().toISOString()
 ) {
-  const { data: currentParticipant, error: selectError } = await supabase
-    .from("session_participants")
-    .select("*")
-    .eq("session_id", sessionId)
-    .eq("user_id", userId)
-    .maybeSingle();
-
-  if (selectError) throw selectError;
-  if (!currentParticipant) return null;
-
-  const participant = applyParticipantDisplayName(
-    currentParticipant as DbParticipant,
-    displayName
-  );
-
   const { data, error } = await supabase
     .from("session_participants")
-    .update({
-      display_name: participant.display_name,
-      repertoire: participant.repertoire,
-    })
-    .eq("id", participant.id)
+    .update({ display_name: displayName })
+    .eq("session_id", sessionId)
     .eq("user_id", userId)
     .select()
-    .single();
+    .maybeSingle();
 
   if (error) throw error;
+  if (!data) return null;
 
+  await tryUpdateParticipantSnapshotDisplayName(
+    data as DbParticipant,
+    userId,
+    displayName
+  );
   await tryUpdateSessionActivity(sessionId, lastActivityAt);
 
   return data as DbParticipant;


### PR DESCRIPTION
## Summary
- Make Settings update `session_participants.display_name` directly as the required operation
- Keep repertoire snapshot name rewriting best-effort so it cannot cause the visible active-quartet name update to fail
- Keep session activity timestamp updates best-effort so they cannot produce a false "Could not update your active quartet name yet" message

## Why
The previous implementation made the visible participant name update depend on extra follow-up work: selecting the full participant row, rewriting `repertoire` JSON, and touching the parent session timestamp. If any optional step failed, Settings showed a failure and could leave the participant row unchanged. This change makes the row display-name update happen first and isolates optional sync work afterward.

## Verification
- `npm run test:run`
- `npm run build`