### PR TITLE
Resolve active participant before display name sync

### DIFF
--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -53,29 +53,6 @@ async function tryUpdateSessionActivity(
   }
 }
 
-async function tryUpdateParticipantSnapshotDisplayName(
-  participant: DbParticipant,
-  userId: string,
-  displayName: string
-) {
-  const updatedParticipant = applyParticipantDisplayName(
-    participant,
-    displayName
-  );
-
-  try {
-    const { error } = await supabase
-      .from("session_participants")
-      .update({ repertoire: updatedParticipant.repertoire })
-      .eq("id", participant.id)
-      .eq("user_id", userId);
-
-    if (error) throw error;
-  } catch (err) {
-    console.warn("Could not update participant repertoire display names", err);
-  }
-}
-
 export async function getSessionByCode(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
@@ -142,22 +119,32 @@ export async function updateParticipantDisplayName(
   displayName: string,
   lastActivityAt = new Date().toISOString()
 ) {
-  const { data, error } = await supabase
-    .from("session_participants")
-    .update({ display_name: displayName })
-    .eq("session_id", sessionId)
-    .eq("user_id", userId)
-    .select()
-    .maybeSingle();
+  const currentParticipants = await getParticipants(sessionId);
+  const currentParticipant = currentParticipants.find(
+    (participant) => participant.user_id === userId
+  );
 
-  if (error) throw error;
-  if (!data) return null;
+  if (!currentParticipant) {
+    throw new Error("Active quartet participant was not found.");
+  }
 
-  await tryUpdateParticipantSnapshotDisplayName(
-    data as DbParticipant,
-    userId,
+  const updatedParticipant = applyParticipantDisplayName(
+    currentParticipant,
     displayName
   );
+
+  const { data, error } = await supabase
+    .from("session_participants")
+    .update({
+      display_name: updatedParticipant.display_name,
+      repertoire: updatedParticipant.repertoire,
+    })
+    .eq("id", currentParticipant.id)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  if (error) throw error;
   await tryUpdateSessionActivity(sessionId, lastActivityAt);
 
   return data as DbParticipant;


### PR DESCRIPTION
## Summary
- Resolve the active session participant through the same participant-list query used by the quartet page
- Find the current participant by authenticated `user_id`, then update that exact row by participant `id`
- Update both `session_participants.display_name` and the participant repertoire snapshot names in the same required row update
- Throw when no active participant row is found instead of silently treating a no-op as success

## Why
The previous Settings sync could no-op when the active quartet state and participant row did not line up, while still letting Settings report success. This version first proves the current user's row exists in the active session, then updates that exact row.

## Verification
- `npm run test:run`
- `npm run build`