### PR TITLE
Reject nested auth callback redirects

### DIFF
--- a/lib/__tests__/authRedirect.test.ts
+++ b/lib/__tests__/authRedirect.test.ts
@@ -28,6 +28,11 @@ describe("getPostLoginRedirectPath", () => {
     expect(getPostLoginRedirectPath("?redirect=/login")).toBe("/");
     expect(getPostLoginRedirectPath("?redirect=/login?redirect=/join/ABC123")).toBe("/");
     expect(getPostLoginRedirectPath("?redirect=/auth/callback?code=abc")).toBe("/");
+    expect(
+      getPostLoginRedirectPath(
+        "?redirect=/auth/callback&token_hash=abc&type=email"
+      )
+    ).toBe("/");
   });
 });
 
@@ -48,6 +53,11 @@ describe("getAuthCallbackNextPath", () => {
   it("does not redirect successful callbacks back to auth routes", () => {
     expect(getAuthCallbackNextPath("?next=/login")).toBe("/");
     expect(getAuthCallbackNextPath("?next=/auth/callback")).toBe("/");
+    expect(
+      getAuthCallbackNextPath(
+        "?next=%2Fauth%2Fcallback%26token_hash%3Dabc%26type%3Demail"
+      )
+    ).toBe("/");
   });
 });
 

--- a/lib/authRedirect.ts
+++ b/lib/authRedirect.ts
@@ -2,6 +2,7 @@ const DEFAULT_AUTH_REDIRECT_PATH = "/";
 const AUTH_CALLBACK_PATH = "/auth/callback";
 
 const disallowedAuthRedirectPaths = ["/login", "/auth/callback"];
+const disallowedMalformedAuthRedirectPathPrefixes = ["/auth/callback&"];
 
 function normalizeSiteUrl(siteUrl: string | undefined): string | null {
   if (!siteUrl?.trim()) return null;
@@ -47,6 +48,14 @@ export function isSafeAppRedirectPath(path: string | null): path is string {
   if (!path || !path.startsWith("/") || path.startsWith("//")) return false;
 
   const { pathname } = new URL(path, "https://example.com");
+
+  if (
+    disallowedMalformedAuthRedirectPathPrefixes.some((disallowedPrefix) =>
+      pathname.startsWith(disallowedPrefix)
+    )
+  ) {
+    return false;
+  }
 
   return !disallowedAuthRedirectPaths.some(
     (disallowedPath) =>


### PR DESCRIPTION
## Summary
- Treat malformed auth callback paths like `/auth/callback&token_hash=...` as unsafe redirect destinations
- Prevent magic-link callbacks from redirecting into a nested stale callback after successful OTP verification
- Add regression coverage for the nested callback shape seen in mobile email links

## Why
A received login link had `next=/auth/callback&token_hash=...&type=email` plus a fresh outer `token_hash`. The outer callback could verify successfully, then redirect to the nested stale callback, which sends the user back to login. The redirect sanitizer already rejected `/auth/callback`, but not malformed `/auth/callback&...` paths.

## Verification
- `npm run test:run`
- `npm run build`