### PR TITLE
Update quartet profile names in realtime

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -23,6 +23,7 @@ import {
   upsertParticipant,
 } from "@/lib/sessionStore";
 import {
+  applyProfileDisplayNameChange,
   getCurrentParticipantDisplayName,
   getParticipantDisplayName,
   getParticipantEntriesWithProfileNames,
@@ -43,6 +44,7 @@ import {
   getCurrentUser,
   getMyProfile,
   getProfilesByIds,
+  subscribeToProfileDisplayNames,
 } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 import {
@@ -451,6 +453,30 @@ export default function JoinSessionPage() {
       );
     });
   }, [sessionId]);
+
+  const participantUserIds = Array.from(
+    new Set(participants.map((participant) => participant.user_id))
+  ).sort();
+  const participantUserIdsKey = participantUserIds.join(":");
+
+  useEffect(() => {
+    if (!participantUserIdsKey) return;
+
+    return subscribeToProfileDisplayNames(participantUserIds, (payload) => {
+      setRealtimeMessage("");
+      setProfileDisplayNamesByUserId((currentProfileDisplayNames) =>
+        applyProfileDisplayNameChange(
+          currentProfileDisplayNames,
+          payload,
+          participantUserIds
+        )
+      );
+    }, () => {
+      setRealtimeMessage(
+        "Live profile updates are having trouble. You can still refresh singers."
+      );
+    });
+  }, [participantUserIdsKey]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {

--- a/lib/__tests__/sessionParticipantDisplayName.test.ts
+++ b/lib/__tests__/sessionParticipantDisplayName.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyProfileDisplayNameChange,
   getCurrentParticipantDisplayName,
   getParticipantDisplayName,
   getParticipantEntriesWithProfileNames,
@@ -90,5 +91,35 @@ describe("session participant display name sync", () => {
       partsKnown: ["Lead"],
       confidence: "Good to Go",
     });
+  });
+
+  it("applies realtime profile display name changes for relevant participants", () => {
+    expect(
+      applyProfileDisplayNameChange(
+        { "user-1": "Old Name" },
+        {
+          eventType: "UPDATE",
+          new: { id: "user-1", display_name: "New Name" },
+          old: { id: "user-1" },
+        },
+        ["user-1"]
+      )
+    ).toEqual({ "user-1": "New Name" });
+  });
+
+  it("ignores realtime profile changes for users outside the quartet", () => {
+    const currentNames = { "user-1": "Singer One" };
+
+    expect(
+      applyProfileDisplayNameChange(
+        currentNames,
+        {
+          eventType: "UPDATE",
+          new: { id: "user-2", display_name: "Singer Two" },
+          old: { id: "user-2" },
+        },
+        ["user-1"]
+      )
+    ).toBe(currentNames);
   });
 });

--- a/lib/profileStore.ts
+++ b/lib/profileStore.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/lib/supabase";
+import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 
 export type Profile = {
   id: string;
@@ -6,6 +7,11 @@ export type Profile = {
   created_at: string;
   updated_at: string;
 };
+
+export type ProfileDisplayName = Pick<Profile, "id" | "display_name">;
+
+export type ProfileChangePayload =
+  RealtimePostgresChangesPayload<ProfileDisplayName>;
 
 export async function getCurrentUser() {
   const { data, error } = await supabase.auth.getUser();
@@ -42,11 +48,51 @@ export async function getProfilesByIds(userIds: string[]) {
   if (error) throw error;
 
   return Object.fromEntries(
-    (data as Pick<Profile, "id" | "display_name">[]).map((profile) => [
+    (data as ProfileDisplayName[]).map((profile) => [
       profile.id,
       profile.display_name,
     ])
   );
+}
+
+export function subscribeToProfileDisplayNames(
+  userIds: string[],
+  onChange: (payload: ProfileChangePayload) => void,
+  onStatusChange?: (status: string) => void
+) {
+  const uniqueUserIds = Array.from(new Set(userIds)).filter(Boolean).sort();
+
+  if (uniqueUserIds.length === 0) {
+    return () => undefined;
+  }
+
+  const channel = supabase
+    .channel(`profiles-display-names-${uniqueUserIds.join("-")}`)
+    .on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "profiles",
+        filter: `id=in.(${uniqueUserIds.join(",")})`,
+      },
+      (payload) => {
+        onChange(payload as ProfileChangePayload);
+      }
+    )
+    .subscribe((status) => {
+      if (
+        status === "CHANNEL_ERROR" ||
+        status === "TIMED_OUT" ||
+        status === "CLOSED"
+      ) {
+        onStatusChange?.(status);
+      }
+    });
+
+  return () => {
+    supabase.removeChannel(channel);
+  };
 }
 
 export async function upsertMyProfile(displayName: string) {

--- a/lib/sessionParticipantDisplayName.ts
+++ b/lib/sessionParticipantDisplayName.ts
@@ -1,5 +1,6 @@
 import type { DbParticipant } from "@/lib/sessionStore";
 import type { SingerEntry } from "@/lib/matching";
+import type { ProfileChangePayload } from "@/lib/profileStore";
 
 export type ProfileDisplayNamesByUserId = Record<string, string>;
 
@@ -48,4 +49,36 @@ export function getParticipantEntriesWithProfileNames(
       displayName,
     }));
   });
+}
+
+export function applyProfileDisplayNameChange(
+  profileDisplayNamesByUserId: ProfileDisplayNamesByUserId,
+  payload: ProfileChangePayload,
+  relevantUserIds: string[]
+): ProfileDisplayNamesByUserId {
+  if (payload.eventType === "DELETE") {
+    const deletedProfileId = payload.old.id;
+
+    if (!deletedProfileId || !relevantUserIds.includes(deletedProfileId)) {
+      return profileDisplayNamesByUserId;
+    }
+
+    const { [deletedProfileId]: _deleted, ...remainingProfiles } =
+      profileDisplayNamesByUserId;
+    return remainingProfiles;
+  }
+
+  const changedProfile = payload.new;
+
+  if (
+    !changedProfile?.id ||
+    !relevantUserIds.includes(changedProfile.id)
+  ) {
+    return profileDisplayNamesByUserId;
+  }
+
+  return {
+    ...profileDisplayNamesByUserId,
+    [changedProfile.id]: changedProfile.display_name,
+  };
 }


### PR DESCRIPTION
## Summary
- Subscribe quartet pages to realtime `profiles` changes for the current participant `user_id` set
- Update the local profile-name map on profile change events so participant list and match-card names rerender without refresh
- Keep the subscription scoped to current quartet participants and clean it up when the participant set changes or the page unmounts
- Add regression coverage for applying relevant profile-name changes and ignoring unrelated users

Closes #134.

## Manual steps
No migration required. Supabase Realtime must be enabled for `profiles`; the reporter noted this has already been configured.

## Verification
- `npm run test:run`
- `npm run build`