### PR TITLE
Add in-app feedback form

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,19 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your Supabase anon key
 NEXT_PUBLIC_SITE_URL=https://your-production-app-url
 NEXT_PUBLIC_POSTHOG_KEY=your PostHog project API key
 NEXT_PUBLIC_POSTHOG_HOST=your PostHog host URL
+RESEND_API_KEY=your Resend API key for server-side feedback email
+FEEDBACK_FROM_EMAIL=What Can We Sing <feedback@your-verified-domain>
+FEEDBACK_TO_EMAIL=feedback destination address
 ```
 
 `NEXT_PUBLIC_SITE_URL` is used for Supabase magic-link redirects in production. Set it to the deployed Vercel app URL, without a trailing path. If it is blank during local development, login links fall back to the current localhost origin.
 
 `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` enable optional product analytics. Leave them blank to disable analytics in local development. Analytics events use counts, IDs, and booleans only; free-text repertoire notes, feedback text, song titles, arranger names, names, and email addresses should not be sent to PostHog.
+
+`RESEND_API_KEY`, `FEEDBACK_FROM_EMAIL`, and `FEEDBACK_TO_EMAIL` are server-only
+settings for the in-app feedback form. Configure them in Vercel, not as
+`NEXT_PUBLIC_*` variables. For the current deployment, set
+`FEEDBACK_TO_EMAIL` to the app owner address.
 
 Magic links redirect through `/auth/callback`, where the app exchanges the Supabase code or token hash for a session before sending the user to the intended page. In Supabase Auth URL configuration, add the production callback URL and any required local development callback URL to the allowed redirect URLs, such as:
 

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,107 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  formatFeedbackEmailText,
+  validateFeedbackSubmission,
+} from "@/lib/feedback";
+
+const resendApiUrl = "https://api.resend.com/emails";
+
+function jsonResponse(message: string, status: number) {
+  return NextResponse.json({ message }, { status });
+}
+
+export async function POST(request: NextRequest) {
+  let submission;
+
+  try {
+    submission = validateFeedbackSubmission(await request.json());
+  } catch (err) {
+    return jsonResponse(
+      err instanceof Error ? err.message : "Could not read feedback.",
+      400
+    );
+  }
+
+  const feedbackToEmail = process.env.FEEDBACK_TO_EMAIL;
+  const feedbackFromEmail = process.env.FEEDBACK_FROM_EMAIL;
+  const resendApiKey = process.env.RESEND_API_KEY;
+
+  if (!feedbackToEmail || !feedbackFromEmail || !resendApiKey) {
+    return jsonResponse("Feedback email is not configured yet.", 503);
+  }
+
+  let userId: string | undefined;
+  let displayName: string | undefined;
+
+  try {
+    const response = NextResponse.next();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return request.cookies.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              response.cookies.set(name, value, options);
+            });
+          },
+        },
+      }
+    );
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    userId = user?.id;
+
+    if (user) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("display_name")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      displayName = profile?.display_name;
+    }
+  } catch (err) {
+    console.error("Could not load feedback user context", err);
+  }
+
+  const emailText = formatFeedbackEmailText(submission, {
+    userId,
+    displayName,
+    timestamp: new Date().toISOString(),
+  });
+
+  try {
+    const response = await fetch(resendApiUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: feedbackFromEmail,
+        to: feedbackToEmail,
+        subject: `What Can We Sing feedback: ${submission.type}`,
+        text: emailText,
+        reply_to: submission.contactEmail,
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("Feedback email failed", await response.text());
+      return jsonResponse("Could not send feedback. Please try again.", 502);
+    }
+
+    return jsonResponse("Feedback sent. Thank you!", 200);
+  } catch (err) {
+    console.error("Feedback email request failed", err);
+    return jsonResponse("Could not send feedback. Please try again.", 502);
+  }
+}

--- a/app/feedback/page.tsx
+++ b/app/feedback/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { AppNav } from "@/components/AppNav";
+import {
+  feedbackTypes,
+  maxFeedbackMessageLength,
+  type FeedbackType,
+} from "@/lib/feedback";
+import { getCurrentUser } from "@/lib/profileStore";
+import { useEffect, useState } from "react";
+
+export default function FeedbackPage() {
+  const [type, setType] = useState<FeedbackType>("Bug report");
+  const [message, setMessage] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [statusTone, setStatusTone] = useState<"info" | "success" | "error">(
+    "info"
+  );
+  const [isSending, setIsSending] = useState(false);
+
+  useEffect(() => {
+    async function loadUserEmail() {
+      try {
+        const user = await getCurrentUser();
+        setContactEmail(user?.email ?? "");
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    loadUserEmail();
+  }, []);
+
+  async function sendFeedback() {
+    if (isSending) return;
+
+    if (!message.trim()) {
+      setStatusTone("error");
+      setStatusMessage("Add a message before sending feedback.");
+      return;
+    }
+
+    setIsSending(true);
+    setStatusMessage("");
+
+    try {
+      const response = await fetch("/api/feedback", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          type,
+          message,
+          contactEmail,
+          path: window.location.href,
+        }),
+      });
+      const data = (await response.json()) as { message?: string };
+
+      if (!response.ok) {
+        setStatusTone("error");
+        setStatusMessage(data.message ?? "Could not send feedback.");
+        return;
+      }
+
+      setStatusTone("success");
+      setStatusMessage(data.message ?? "Feedback sent. Thank you!");
+      setMessage("");
+    } catch (err) {
+      console.error(err);
+      setStatusTone("error");
+      setStatusMessage("Network unavailable. Try again when you have a connection.");
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
+      <div className="mx-auto max-w-2xl">
+        <AppNav />
+
+        <h1 className="mt-4 text-4xl font-bold">Send feedback</h1>
+
+        <section className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-5">
+          <label className="block">
+            <span className="text-sm font-medium text-slate-300">
+              Feedback type
+            </span>
+            <select
+              value={type}
+              onChange={(event) => setType(event.target.value as FeedbackType)}
+              className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+            >
+              {feedbackTypes.map((feedbackType) => (
+                <option key={feedbackType}>{feedbackType}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="mt-5 block">
+            <span className="text-sm font-medium text-slate-300">Message</span>
+            <textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              maxLength={maxFeedbackMessageLength}
+              rows={7}
+              className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+            />
+          </label>
+
+          <label className="mt-5 block">
+            <span className="text-sm font-medium text-slate-300">
+              Contact email
+            </span>
+            <input
+              value={contactEmail}
+              onChange={(event) => setContactEmail(event.target.value)}
+              type="email"
+              className="mt-1 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={sendFeedback}
+            disabled={isSending}
+            className="mt-6 w-full rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+          >
+            {isSending ? "Sending..." : "Send feedback"}
+          </button>
+
+          {statusMessage && (
+            <p
+              className={`mt-4 text-sm ${
+                statusTone === "success"
+                  ? "text-cyan-200"
+                  : statusTone === "error"
+                  ? "text-rose-200"
+                  : "text-slate-300"
+              }`}
+            >
+              {statusMessage}
+            </p>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -30,6 +30,11 @@ const navItems = [
     label: "Settings",
     isActive: (pathname: string) => pathname === "/settings",
   },
+  {
+    href: "/feedback",
+    label: "Send feedback",
+    isActive: (pathname: string) => pathname === "/feedback",
+  },
 ];
 
 export function AppNav() {

--- a/lib/__tests__/feedback.test.ts
+++ b/lib/__tests__/feedback.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatFeedbackEmailText,
+  validateFeedbackSubmission,
+} from "../feedback";
+
+describe("feedback helpers", () => {
+  it("validates and trims feedback submissions", () => {
+    expect(
+      validateFeedbackSubmission({
+        type: "Bug report",
+        message: "  Something broke.  ",
+        contactEmail: "  singer@example.com  ",
+        path: "  /settings  ",
+      })
+    ).toEqual({
+      type: "Bug report",
+      message: "Something broke.",
+      contactEmail: "singer@example.com",
+      path: "/settings",
+    });
+  });
+
+  it("rejects blank messages", () => {
+    expect(() =>
+      validateFeedbackSubmission({
+        type: "General feedback",
+        message: " ",
+      })
+    ).toThrow("Add a message before sending feedback.");
+  });
+
+  it("formats useful app context for the feedback email", () => {
+    expect(
+      formatFeedbackEmailText(
+        {
+          type: "Feature idea",
+          message: "Add a pitch pipe.",
+          contactEmail: "singer@example.com",
+          path: "/join/ABC123",
+        },
+        {
+          userId: "user-1",
+          displayName: "Tim",
+          timestamp: "2026-04-27T00:00:00.000Z",
+        }
+      )
+    ).toContain("Display name: Tim");
+  });
+});

--- a/lib/feedback.ts
+++ b/lib/feedback.ts
@@ -1,0 +1,72 @@
+export const feedbackTypes = [
+  "Bug report",
+  "Feature idea",
+  "General feedback",
+] as const;
+
+export type FeedbackType = (typeof feedbackTypes)[number];
+
+export type FeedbackSubmission = {
+  type: FeedbackType;
+  message: string;
+  contactEmail?: string;
+  path?: string;
+};
+
+export type FeedbackContext = {
+  userId?: string;
+  displayName?: string;
+  timestamp: string;
+};
+
+export const maxFeedbackMessageLength = 5000;
+
+export function isFeedbackType(value: string): value is FeedbackType {
+  return feedbackTypes.includes(value as FeedbackType);
+}
+
+export function validateFeedbackSubmission(
+  value: Partial<FeedbackSubmission>
+): FeedbackSubmission {
+  const type = typeof value.type === "string" ? value.type : "";
+  const message = typeof value.message === "string" ? value.message.trim() : "";
+  const contactEmail =
+    typeof value.contactEmail === "string" ? value.contactEmail.trim() : "";
+  const path = typeof value.path === "string" ? value.path.trim() : "";
+
+  if (!isFeedbackType(type)) {
+    throw new Error("Choose a feedback type.");
+  }
+
+  if (!message) {
+    throw new Error("Add a message before sending feedback.");
+  }
+
+  if (message.length > maxFeedbackMessageLength) {
+    throw new Error("Keep feedback under 5000 characters.");
+  }
+
+  return {
+    type,
+    message,
+    ...(contactEmail ? { contactEmail } : {}),
+    ...(path ? { path } : {}),
+  };
+}
+
+export function formatFeedbackEmailText(
+  submission: FeedbackSubmission,
+  context: FeedbackContext
+) {
+  return [
+    `Type: ${submission.type}`,
+    `Submitted: ${context.timestamp}`,
+    `Path: ${submission.path ?? "Unknown"}`,
+    `User ID: ${context.userId ?? "Unknown"}`,
+    `Display name: ${context.displayName ?? "Unknown"}`,
+    `Contact email: ${submission.contactEmail ?? "Not provided"}`,
+    "",
+    "Message:",
+    submission.message,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- Add a visible `Send feedback` navigation item and mobile-friendly feedback form
- Add a server-side `/api/feedback` route that sends submissions through Resend without exposing the destination email in frontend code
- Include feedback type, message, optional contact email, current path, authenticated user id, display name, and timestamp in the email body
- Add validation/formatting helper tests

Closes #73.

## Manual steps
Configure these server-only Vercel environment variables before using the form in production:
- `RESEND_API_KEY`: Resend API key for server-side feedback email
- `FEEDBACK_FROM_EMAIL`: verified sender, for example `What Can We Sing <feedback@your-domain>`
- `FEEDBACK_TO_EMAIL`: app owner destination address; for current deployment set this to `cubuff98@gmail.com`

No database migration required.

## Verification
- `npm run test:run`
- `npm run build`