### PR TITLE
Fix feedback destination email privacy

### DIFF
--- a/app/api/feedback/route.test.ts
+++ b/app/api/feedback/route.test.ts
@@ -1,0 +1,138 @@
+import { createServerClient } from "@supabase/ssr";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+const privateDestinationEmail = "owner-private@example.com";
+
+function feedbackRequest(body: unknown) {
+  return {
+    json: async () => body,
+    cookies: {
+      getAll: () => [],
+    },
+  } as never;
+}
+
+async function responseBody(response: Response) {
+  return JSON.stringify(await response.json());
+}
+
+describe("feedback API", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon-key",
+    };
+
+    vi.mocked(createServerClient).mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+    } as never);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not expose the feedback destination when email is not configured", async () => {
+    process.env.FEEDBACK_TO_EMAIL = privateDestinationEmail;
+    delete process.env.FEEDBACK_FROM_EMAIL;
+    delete process.env.RESEND_API_KEY;
+
+    const response = await POST(
+      feedbackRequest({
+        type: "Bug report",
+        message: "The feedback form broke.",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(await responseBody(response)).not.toContain(privateDestinationEmail);
+  });
+
+  it("does not expose the feedback destination when Resend fails", async () => {
+    process.env.FEEDBACK_TO_EMAIL = privateDestinationEmail;
+    process.env.FEEDBACK_FROM_EMAIL = "What Can We Sing <feedback@example.com>";
+    process.env.RESEND_API_KEY = "resend-key";
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(`Could not deliver to ${privateDestinationEmail}`, {
+        status: 422,
+        statusText: "Unprocessable Entity",
+      })
+    );
+
+    const response = await POST(
+      feedbackRequest({
+        type: "Bug report",
+        message: "The feedback form broke.",
+      })
+    );
+
+    expect(response.status).toBe(502);
+    expect(await responseBody(response)).not.toContain(privateDestinationEmail);
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      privateDestinationEmail
+    );
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      "Could not deliver"
+    );
+  });
+
+  it("uses the server-only destination email when sending feedback", async () => {
+    process.env.FEEDBACK_TO_EMAIL = privateDestinationEmail;
+    process.env.FEEDBACK_FROM_EMAIL = "What Can We Sing <feedback@example.com>";
+    process.env.RESEND_API_KEY = "resend-key";
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+    const response = await POST(
+      feedbackRequest({
+        type: "Feature idea",
+        message: "Add a pitch pipe.",
+        contactEmail: "singer@example.com",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({
+        body: expect.stringContaining(`"to":"${privateDestinationEmail}"`),
+      })
+    );
+    expect(await responseBody(response)).not.toContain(privateDestinationEmail);
+  });
+
+  it("ignores non-form fields in the feedback request body", async () => {
+    process.env.FEEDBACK_TO_EMAIL = privateDestinationEmail;
+    process.env.FEEDBACK_FROM_EMAIL = "What Can We Sing <feedback@example.com>";
+    process.env.RESEND_API_KEY = "resend-key";
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+
+    await POST(
+      feedbackRequest({
+        type: "General feedback",
+        message: "Nice and simple.",
+        contactEmail: "singer@example.com",
+        path: "https://example.com/feedback",
+      })
+    );
+
+    const emailRequest = JSON.parse(
+      vi.mocked(fetch).mock.calls[0][1]?.body as string
+    );
+
+    expect(emailRequest.text).not.toContain("https://example.com/feedback");
+  });
+});

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   formatFeedbackEmailText,
   validateFeedbackSubmission,
-} from "@/lib/feedback";
+} from "../../../lib/feedback";
 
 const resendApiUrl = "https://api.resend.com/emails";
 
@@ -15,7 +15,13 @@ export async function POST(request: NextRequest) {
   let submission;
 
   try {
-    submission = validateFeedbackSubmission(await request.json());
+    const body = await request.json();
+
+    submission = validateFeedbackSubmission({
+      type: body?.type,
+      message: body?.message,
+      contactEmail: body?.contactEmail,
+    });
   } catch (err) {
     return jsonResponse(
       err instanceof Error ? err.message : "Could not read feedback.",
@@ -95,7 +101,10 @@ export async function POST(request: NextRequest) {
     });
 
     if (!response.ok) {
-      console.error("Feedback email failed", await response.text());
+      console.error("Feedback email failed", {
+        status: response.status,
+        statusText: response.statusText,
+      });
       return jsonResponse("Could not send feedback. Please try again.", 502);
     }
 

--- a/app/feedback/page.tsx
+++ b/app/feedback/page.tsx
@@ -54,7 +54,6 @@ export default function FeedbackPage() {
           type,
           message,
           contactEmail,
-          path: window.location.href,
         }),
       });
       const data = (await response.json()) as { message?: string };

--- a/lib/__tests__/feedback.test.ts
+++ b/lib/__tests__/feedback.test.ts
@@ -11,13 +11,11 @@ describe("feedback helpers", () => {
         type: "Bug report",
         message: "  Something broke.  ",
         contactEmail: "  singer@example.com  ",
-        path: "  /settings  ",
       })
     ).toEqual({
       type: "Bug report",
       message: "Something broke.",
       contactEmail: "singer@example.com",
-      path: "/settings",
     });
   });
 
@@ -37,7 +35,6 @@ describe("feedback helpers", () => {
           type: "Feature idea",
           message: "Add a pitch pipe.",
           contactEmail: "singer@example.com",
-          path: "/join/ABC123",
         },
         {
           userId: "user-1",

--- a/lib/feedback.ts
+++ b/lib/feedback.ts
@@ -10,7 +10,6 @@ export type FeedbackSubmission = {
   type: FeedbackType;
   message: string;
   contactEmail?: string;
-  path?: string;
 };
 
 export type FeedbackContext = {
@@ -32,7 +31,6 @@ export function validateFeedbackSubmission(
   const message = typeof value.message === "string" ? value.message.trim() : "";
   const contactEmail =
     typeof value.contactEmail === "string" ? value.contactEmail.trim() : "";
-  const path = typeof value.path === "string" ? value.path.trim() : "";
 
   if (!isFeedbackType(type)) {
     throw new Error("Choose a feedback type.");
@@ -50,7 +48,6 @@ export function validateFeedbackSubmission(
     type,
     message,
     ...(contactEmail ? { contactEmail } : {}),
-    ...(path ? { path } : {}),
   };
 }
 
@@ -61,7 +58,6 @@ export function formatFeedbackEmailText(
   return [
     `Type: ${submission.type}`,
     `Submitted: ${context.timestamp}`,
-    `Path: ${submission.path ?? "Unknown"}`,
     `User ID: ${context.userId ?? "Unknown"}`,
     `Display name: ${context.displayName ?? "Unknown"}`,
     `Contact email: ${submission.contactEmail ?? "Not provided"}`,


### PR DESCRIPTION
## Summary
- keep feedback submissions to form data only: type, message, optional contact email
- keep `FEEDBACK_TO_EMAIL` server-only in the API route and avoid logging raw Resend provider responses
- add feedback API regression tests that verify the destination email is not exposed in public responses or logs

Closes #138.

## Verification
- `npm run test:run`
- `npm run build`