### PR TITLE
Allow match rows to collapse

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -111,6 +111,7 @@ export default function JoinSessionPage() {
   );
   const [recentSungSongs, setRecentSungSongs] = useState<SungSongEvent[]>([]);
   const [markingSungKey, setMarkingSungKey] = useState("");
+  const [expandedMatchId, setExpandedMatchId] = useState<string | null>(null);
   const [message, setMessage] = useState("");
   const [copyMessage, setCopyMessage] = useState("");
   const [qrUrl, setQrUrl] = useState("");
@@ -404,6 +405,12 @@ export default function JoinSessionPage() {
 
   function matchKey(match: MatchResult) {
     return `${normalizeSongTitle(match.songTitle)}:${match.voicing}`;
+  }
+
+  function toggleExpandedMatch(matchId: string) {
+    setExpandedMatchId((currentMatchId) =>
+      currentMatchId === matchId ? null : matchId
+    );
   }
 
   async function markMatchAsSung(match: MatchResult) {
@@ -1071,16 +1078,22 @@ export default function JoinSessionPage() {
                         </div>
 
                         <div className="mt-3 space-y-2">
-                          {section.matches.map((match) => (
-                            <MatchCard
-                              key={match.songTitle + match.voicing}
-                              match={match}
-                              personalNotes={notesForMatch(match)}
-                              isRecentlySung={wasRecentlySung(match)}
-                              isMarkingSung={markingSungKey === matchKey(match)}
-                              onMarkAsSung={() => markMatchAsSung(match)}
-                            />
-                          ))}
+                          {section.matches.map((match) => {
+                            const id = matchKey(match);
+
+                            return (
+                              <MatchCard
+                                key={id}
+                                match={match}
+                                personalNotes={notesForMatch(match)}
+                                isExpanded={expandedMatchId === id}
+                                isRecentlySung={wasRecentlySung(match)}
+                                isMarkingSung={markingSungKey === id}
+                                onToggle={() => toggleExpandedMatch(id)}
+                                onMarkAsSung={() => markMatchAsSung(match)}
+                              />
+                            );
+                          })}
                         </div>
                       </section>
                     )

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -7,8 +7,10 @@ import { partAbbreviation } from "@/lib/partAbbreviations";
 type MatchCardProps = {
   match: MatchResult;
   personalNotes?: string[];
+  isExpanded: boolean;
   isRecentlySung?: boolean;
   isMarkingSung?: boolean;
+  onToggle: () => void;
   onMarkAsSung?: () => void;
 };
 
@@ -36,8 +38,10 @@ const categoryStyles: Record<
 export function MatchCard({
   match,
   personalNotes = [],
+  isExpanded,
   isRecentlySung = false,
   isMarkingSung = false,
+  onToggle,
   onMarkAsSung,
 }: MatchCardProps) {
   const styles = categoryStyles[match.category];
@@ -50,9 +54,17 @@ export function MatchCard({
 
   return (
     <details
+      open={isExpanded}
       className={`group rounded-xl border px-3 py-2 shadow-lg open:pb-3 ${styles.row}`}
     >
-      <summary className="cursor-pointer list-none">
+      <summary
+        aria-expanded={isExpanded}
+        onClick={(event) => {
+          event.preventDefault();
+          onToggle();
+        }}
+        className="cursor-pointer list-none"
+      >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <h3 className="truncate text-base font-semibold text-white">


### PR DESCRIPTION
## Summary
- track a single `expandedMatchId` on the quartet results page
- make match cards controlled so tapping the expanded row closes it
- expanding a different match now collapses the previous one

Closes #143.

## Verification
- `npm run test:run`
- `npm run build`