### PR TITLE
Handle participant leave realtime updates

### DIFF
--- a/lib/__tests__/sessionParticipantChanges.test.ts
+++ b/lib/__tests__/sessionParticipantChanges.test.ts
@@ -76,6 +76,39 @@ describe("applyParticipantChange", () => {
     expect(result.map((item) => item.id)).toEqual(["two"]);
   });
 
+  it("removes deleted participants when realtime only sends the primary key", () => {
+    const first = participant("one", "session-1", "2026-01-01T00:00:00Z");
+    const second = participant("two", "session-1", "2026-01-01T00:01:00Z");
+
+    const result = applyParticipantChange(
+      [first, second],
+      {
+        eventType: "DELETE",
+        new: {},
+        old: { id: "one" },
+      },
+      "session-1"
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["two"]);
+  });
+
+  it("ignores unscoped delete events for participants not in local state", () => {
+    const existing = participant("one", "session-1", "2026-01-01T00:00:00Z");
+
+    const result = applyParticipantChange(
+      [existing],
+      {
+        eventType: "DELETE",
+        new: {},
+        old: { id: "other-session-participant" },
+      },
+      "session-1"
+    );
+
+    expect(result).toEqual([existing]);
+  });
+
   it("ignores changes from other sessions", () => {
     const existing = participant("one", "session-1", "2026-01-01T00:00:00Z");
     const otherSession = participant(

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -128,10 +128,33 @@ export function subscribeToSessionParticipants(
     .on(
       "postgres_changes",
       {
-        event: "*",
+        event: "INSERT",
         schema: "public",
         table: "session_participants",
         filter: `session_id=eq.${sessionId}`,
+      },
+      (payload) => {
+        onChange(payload as ParticipantChangePayload);
+      }
+    )
+    .on(
+      "postgres_changes",
+      {
+        event: "UPDATE",
+        schema: "public",
+        table: "session_participants",
+        filter: `session_id=eq.${sessionId}`,
+      },
+      (payload) => {
+        onChange(payload as ParticipantChangePayload);
+      }
+    )
+    .on(
+      "postgres_changes",
+      {
+        event: "DELETE",
+        schema: "public",
+        table: "session_participants",
       },
       (payload) => {
         onChange(payload as ParticipantChangePayload);


### PR DESCRIPTION
## Summary
- keep session participant INSERT and UPDATE realtime subscriptions scoped to the current quartet
- listen for session participant DELETE events without the session filter so primary-key-only delete payloads still reach connected clients
- rely on local participant IDs to ignore unrelated unscoped deletes safely
- add regression coverage for primary-key-only delete payloads and unrelated delete events

Closes #146.

## Supabase check
No schema migration is required. Please verify `session_participants` is enabled for Supabase Realtime so INSERT, UPDATE, and DELETE events are published.

## Verification
- `npm run test:run`
- `npm run build`