### PR TITLE
Fix quartet participant state flow

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -19,7 +19,6 @@ import {
   getSessionByCode,
   removeParticipant,
   subscribeToSessionParticipants,
-  updateParticipantSnapshot,
   upsertParticipant,
 } from "@/lib/sessionStore";
 import {
@@ -223,16 +222,7 @@ export default function JoinSessionPage() {
       const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();
 
-      if (participantResolution.status === "existing") {
-        await updateParticipantSnapshot(
-          participantResolution.participant.id,
-          userId,
-          entries,
-          lastActivityAt
-        );
-      } else {
-        await upsertParticipant(id, userId, name, entries, lastActivityAt);
-      }
+      await upsertParticipant(id, userId, name, entries, lastActivityAt);
 
       setActiveQuartet({ sessionId: id, code, joinedAt: lastActivityAt });
       setSession((current) =>
@@ -296,20 +286,9 @@ export default function JoinSessionPage() {
 
       const entries = await getMyEntries(name);
       const lastActivityAt = new Date().toISOString();
-      const updatedParticipant = await updateParticipantSnapshot(
-        existingParticipant.id,
-        userId,
-        entries,
-        lastActivityAt
-      );
+      await upsertParticipant(id, userId, name, entries, lastActivityAt);
 
-      setParticipants((currentParticipants) =>
-        currentParticipants.map((participant) =>
-          participant.id === updatedParticipant.id
-            ? updatedParticipant
-            : participant
-        )
-      );
+      await refreshParticipants(id);
       setActiveQuartet({ sessionId: id, code, joinedAt: lastActivityAt });
       setSession((current) =>
         current ? { ...current, last_activity_at: lastActivityAt } : current
@@ -337,10 +316,9 @@ export default function JoinSessionPage() {
       await removeParticipant(sessionId, currentUserId);
       clearActiveQuartetIfMatches(sessionId);
       window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
-      const updatedParticipants = await refreshParticipants(sessionId);
       trackEvent("quartet_left", {
         session_id: sessionId,
-        participant_count: updatedParticipants.length,
+        participant_count: Math.max(0, participants.length - 1),
       });
       window.location.href = "/?leftQuartet=1";
     } catch (err) {
@@ -468,6 +446,7 @@ export default function JoinSessionPage() {
         void refreshParticipantProfileNames(updatedParticipants);
         return updatedParticipants;
       });
+      void refreshParticipants(sessionId).catch(() => undefined);
     }, () => {
       setRealtimeMessage(
         "Live updates are having trouble. You can still use the current results or refresh singers."
@@ -491,10 +470,6 @@ export default function JoinSessionPage() {
           payload,
           participantUserIds
         )
-      );
-    }, () => {
-      setRealtimeMessage(
-        "Live profile updates are having trouble. You can still refresh singers."
       );
     });
   }, [participantUserIdsKey]);

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -78,25 +78,6 @@ export async function upsertParticipant(
   return data as DbParticipant;
 }
 
-export async function updateParticipantSnapshot(
-  participantId: string,
-  userId: string,
-  repertoire: SingerEntry[],
-  lastActivityAt = new Date().toISOString()
-) {
-  const { data, error } = await supabase
-    .from("session_participants")
-    .update({ repertoire })
-    .eq("id", participantId)
-    .eq("user_id", userId)
-    .select()
-    .single();
-
-  if (error) throw error;
-  await updateSessionActivity(data.session_id, lastActivityAt);
-  return data as DbParticipant;
-}
-
 export async function getParticipants(sessionId: string) {
   const { data, error } = await supabase
     .from("session_participants")


### PR DESCRIPTION
## Summary
- Use the `session_participants` upsert path for both joining and refreshing a returning participant's repertoire snapshot, keyed by `session_id,user_id`.
- Refetch fresh `session_participants` after participant realtime events so rendered participants, fullness, and matches are grounded in current Supabase rows.
- Remove the stale participant-id snapshot update path and avoid treating a successful leave as failed just because a follow-up refresh fails.
- Stop surfacing the optional profile realtime warning as a quartet state problem.

## Data-flow audit
- Fetch: `getParticipants(sessionId)` in `lib/sessionStore.ts`, called by `/join/[code]` on page load, join/rejoin, snapshot refresh, manual refresh, and realtime events.
- Update: `upsertParticipant(sessionId, userId, displayName, repertoire)` in `lib/sessionStore.ts`; this now covers joins and repertoire snapshot refreshes using the unique `(session_id,user_id)` key.
- Delete: `removeParticipant(sessionId, userId)` in `lib/sessionStore.ts`, used by the join page and active quartet indicator.
- Realtime: `subscribeToSessionParticipants(sessionId)` subscribes to INSERT, UPDATE, and DELETE for `session_participants`; `/join/[code]` applies the event immediately and then refetches fresh participants.

## Manual setup
- No new migration is required.
- Supabase Realtime still needs to be enabled for `session_participants`, as documented in `README.md`.

## Verification
- `npm run test:run`
- `npm run build`

Closes #151