### PR TITLE
Refresh active quartet snapshots from repertoire

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -120,7 +120,6 @@ export default function JoinSessionPage() {
   const [leftQuartet, setLeftQuartet] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [joiningQuartet, setJoiningQuartet] = useState(false);
-  const [realtimeMessage, setRealtimeMessage] = useState("");
   const [pendingActiveQuartet, setPendingActiveQuartet] =
     useState<ActiveQuartet | null>(null);
   const [leavingCurrentQuartet, setLeavingCurrentQuartet] = useState(false);
@@ -139,7 +138,10 @@ export default function JoinSessionPage() {
     }
   }
 
-  async function refreshParticipants(id: string) {
+  async function refreshParticipants(
+    id: string,
+    options: { showErrorMessage?: boolean } = {}
+  ) {
     try {
       const data = await getParticipants(id);
       setParticipants(data);
@@ -147,7 +149,9 @@ export default function JoinSessionPage() {
       return data;
     } catch (err) {
       console.error(err);
-      setMessage("Could not refresh singers. Please try again.");
+      if (options.showErrorMessage ?? true) {
+        setMessage("Could not refresh singers. Please try again.");
+      }
       throw err;
     }
   }
@@ -266,9 +270,6 @@ export default function JoinSessionPage() {
     if (isRefreshingCurrentParticipant.current) return;
 
     if (!id || !userId || !name) {
-      setMessage(
-        "Could not update your songs yet. Wait for the quartet to finish loading."
-      );
       return;
     }
 
@@ -295,9 +296,6 @@ export default function JoinSessionPage() {
       );
     } catch (err) {
       console.error("Could not update returning participant repertoire", err);
-      setMessage(
-        "Could not update your songs. Check your connection and come back to this quartet again."
-      );
     } finally {
       isRefreshingCurrentParticipant.current = false;
     }
@@ -436,7 +434,6 @@ export default function JoinSessionPage() {
     if (!sessionId) return;
 
     return subscribeToSessionParticipants(sessionId, (payload) => {
-      setRealtimeMessage("");
       setParticipants((currentParticipants) => {
         const updatedParticipants = applyParticipantChange(
           currentParticipants,
@@ -446,10 +443,8 @@ export default function JoinSessionPage() {
         void refreshParticipantProfileNames(updatedParticipants);
         return updatedParticipants;
       });
-      void refreshParticipants(sessionId).catch(() => undefined);
-    }, () => {
-      setRealtimeMessage(
-        "Live updates are having trouble. You can still use the current results or refresh singers."
+      void refreshParticipants(sessionId, { showErrorMessage: false }).catch(
+        () => undefined
       );
     });
   }, [sessionId]);
@@ -463,7 +458,6 @@ export default function JoinSessionPage() {
     if (!participantUserIdsKey) return;
 
     return subscribeToProfileDisplayNames(participantUserIds, (payload) => {
-      setRealtimeMessage("");
       setProfileDisplayNamesByUserId((currentProfileDisplayNames) =>
         applyProfileDisplayNameChange(
           currentProfileDisplayNames,
@@ -645,6 +639,18 @@ export default function JoinSessionPage() {
     !isQuartetFull;
 
   useEffect(() => {
+    if (!sessionId || loading || loadError || quartetExpired) return;
+
+    const timer = window.setInterval(() => {
+      void refreshParticipants(sessionId, { showErrorMessage: false }).catch(
+        () => undefined
+      );
+    }, 5000);
+
+    return () => window.clearInterval(timer);
+  }, [loading, loadError, quartetExpired, sessionId]);
+
+  useEffect(() => {
     if (
       loading ||
       !sessionId ||
@@ -810,23 +816,6 @@ export default function JoinSessionPage() {
           <p className="mt-4 rounded-xl bg-white/10 p-4 text-slate-200">
             {message}
           </p>
-        )}
-
-        {!loadError && !quartetExpired && realtimeMessage && (
-          <div className="mt-4 rounded-xl border border-amber-200/20 bg-amber-200/10 p-4 text-sm text-amber-50">
-            <p>{realtimeMessage}</p>
-            {sessionId && (
-              <button
-                type="button"
-                onClick={() => {
-                  void refreshParticipants(sessionId).catch(() => undefined);
-                }}
-                className="mt-3 rounded-xl bg-amber-100 px-4 py-2 font-semibold text-slate-950 hover:bg-white"
-              >
-                Refresh singers
-              </button>
-            )}
-          </div>
         )}
 
         {!loadError && !quartetExpired && pendingActiveQuartet && (

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -13,6 +13,7 @@ import {
   type RepertoireRow,
 } from "@/lib/repertoireStore";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
+import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
 
 const voicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
 
@@ -234,6 +235,11 @@ export default function RepertoireManager() {
         song_count: items.length + 1,
         parts_known_count: partsKnown.length,
       });
+      try {
+        await refreshActiveQuartetSnapshot();
+      } catch (err) {
+        console.error("Could not refresh active quartet snapshot", err);
+      }
 
       try {
         await loadRepertoire();
@@ -261,6 +267,11 @@ export default function RepertoireManager() {
       trackEvent("repertoire_song_deleted", {
         song_count: Math.max(0, items.length - 1),
       });
+      try {
+        await refreshActiveQuartetSnapshot();
+      } catch (err) {
+        console.error("Could not refresh active quartet snapshot", err);
+      }
       try {
         await loadRepertoire();
       } catch {
@@ -308,6 +319,11 @@ export default function RepertoireManager() {
         song_count: items.length,
         parts_known_count: editForm.partsKnown.length,
       });
+      try {
+        await refreshActiveQuartetSnapshot();
+      } catch (err) {
+        console.error("Could not refresh active quartet snapshot", err);
+      }
       try {
         await loadRepertoire();
       } catch {

--- a/lib/activeQuartetSnapshot.ts
+++ b/lib/activeQuartetSnapshot.ts
@@ -1,0 +1,51 @@
+import { getActiveQuartet, clearActiveQuartetIfMatches, setActiveQuartet } from "@/lib/activeQuartet";
+import { type SingerEntry } from "@/lib/matching";
+import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
+import { getMyRepertoire } from "@/lib/repertoireStore";
+import { getParticipants, upsertParticipant } from "@/lib/sessionStore";
+import { findParticipantByUserId } from "@/lib/sessionParticipantResolution";
+
+export async function refreshActiveQuartetSnapshot() {
+  const activeQuartet = getActiveQuartet();
+  if (!activeQuartet) return { status: "no_active_quartet" as const };
+
+  const user = await getCurrentUser();
+  if (!user) return { status: "no_user" as const };
+
+  const participants = await getParticipants(activeQuartet.sessionId);
+  const currentParticipant = findParticipantByUserId(participants, user.id);
+
+  if (!currentParticipant) {
+    clearActiveQuartetIfMatches(activeQuartet.sessionId);
+    return { status: "not_participant" as const };
+  }
+
+  const profile = await getMyProfile();
+  if (!profile?.display_name) return { status: "missing_profile" as const };
+
+  const repertoire = await getMyRepertoire();
+  const entries: SingerEntry[] = repertoire.map((item) => ({
+    userId: item.user_id,
+    displayName: profile.display_name,
+    songTitle: item.song_title,
+    voicing: item.voicing,
+    arrangerName: item.arranger_name,
+    partsKnown: item.parts_known,
+    confidence: item.confidence,
+  }));
+  const lastActivityAt = new Date().toISOString();
+
+  await upsertParticipant(
+    activeQuartet.sessionId,
+    user.id,
+    profile.display_name,
+    entries,
+    lastActivityAt
+  );
+  setActiveQuartet({
+    ...activeQuartet,
+    joinedAt: lastActivityAt,
+  });
+
+  return { status: "updated" as const, songCount: entries.length };
+}


### PR DESCRIPTION
## Summary
- Refresh the active quartet `session_participants` snapshot immediately after repertoire add/edit/delete, instead of waiting for the join page return flow.
- Confirm the current user still has a `session_participants` row before syncing, so repertoire edits do not recreate a participant after leaving.
- Add silent participant reconciliation on the quartet page so missed realtime DELETE/UPDATE events are corrected from fresh Supabase data.
- Remove the non-actionable “Could not update your songs” and “Live updates are having trouble” messages from the quartet UI.

## Verification
- `npm run test:run`
- `npm run build`

Follow-up for #151