### PR TITLE
Verify session participant writes

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -235,16 +235,23 @@ export default function RepertoireManager() {
         song_count: items.length + 1,
         parts_known_count: partsKnown.length,
       });
+      let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
       } catch (err) {
-        console.error("Could not refresh active quartet snapshot", err);
+        snapshotUpdated = false;
+        console.error("Could not update active quartet snapshot", err);
+        setMessage("Song added, but quartet matches could not be updated yet.");
       }
 
       try {
         await loadRepertoire();
       } catch {
-        setMessage("Song added. Could not refresh the list yet.");
+        setMessage(
+          snapshotUpdated
+            ? "Song added. Could not refresh the list yet."
+            : "Song added, but quartet matches could not be updated yet."
+        );
       }
     } catch (err) {
       console.error(err);
@@ -267,15 +274,22 @@ export default function RepertoireManager() {
       trackEvent("repertoire_song_deleted", {
         song_count: Math.max(0, items.length - 1),
       });
+      let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
       } catch (err) {
-        console.error("Could not refresh active quartet snapshot", err);
+        snapshotUpdated = false;
+        console.error("Could not update active quartet snapshot", err);
+        setMessage("Song deleted, but quartet matches could not be updated yet.");
       }
       try {
         await loadRepertoire();
       } catch {
-        setMessage("Song deleted. Could not refresh the list yet.");
+        setMessage(
+          snapshotUpdated
+            ? "Song deleted. Could not refresh the list yet."
+            : "Song deleted, but quartet matches could not be updated yet."
+        );
       }
     } catch (err) {
       console.error(err);
@@ -319,15 +333,22 @@ export default function RepertoireManager() {
         song_count: items.length,
         parts_known_count: editForm.partsKnown.length,
       });
+      let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
       } catch (err) {
-        console.error("Could not refresh active quartet snapshot", err);
+        snapshotUpdated = false;
+        console.error("Could not update active quartet snapshot", err);
+        setMessage("Song saved, but quartet matches could not be updated yet.");
       }
       try {
         await loadRepertoire();
       } catch {
-        setMessage("Song updated. Could not refresh the list yet.");
+        setMessage(
+          snapshotUpdated
+            ? "Song updated. Could not refresh the list yet."
+            : "Song saved, but quartet matches could not be updated yet."
+        );
       }
     } catch (err) {
       console.error(err);

--- a/lib/activeQuartetSnapshot.ts
+++ b/lib/activeQuartetSnapshot.ts
@@ -5,6 +5,13 @@ import { getMyRepertoire } from "@/lib/repertoireStore";
 import { getParticipants, upsertParticipant } from "@/lib/sessionStore";
 import { findParticipantByUserId } from "@/lib/sessionParticipantResolution";
 
+export class ActiveQuartetSnapshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ActiveQuartetSnapshotError";
+  }
+}
+
 export async function refreshActiveQuartetSnapshot() {
   const activeQuartet = getActiveQuartet();
   if (!activeQuartet) return { status: "no_active_quartet" as const };
@@ -21,7 +28,11 @@ export async function refreshActiveQuartetSnapshot() {
   }
 
   const profile = await getMyProfile();
-  if (!profile?.display_name) return { status: "missing_profile" as const };
+  if (!profile?.display_name) {
+    throw new ActiveQuartetSnapshotError(
+      "Could not update quartet matches because your profile is missing a display name."
+    );
+  }
 
   const repertoire = await getMyRepertoire();
   const entries: SingerEntry[] = repertoire.map((item) => ({
@@ -35,17 +46,31 @@ export async function refreshActiveQuartetSnapshot() {
   }));
   const lastActivityAt = new Date().toISOString();
 
-  await upsertParticipant(
+  const updatedParticipant = await upsertParticipant(
     activeQuartet.sessionId,
     user.id,
     profile.display_name,
     entries,
     lastActivityAt
   );
+
+  if (
+    updatedParticipant.session_id !== activeQuartet.sessionId ||
+    updatedParticipant.user_id !== user.id
+  ) {
+    throw new ActiveQuartetSnapshotError(
+      "Could not verify that the active quartet snapshot was updated."
+    );
+  }
+
   setActiveQuartet({
     ...activeQuartet,
     joinedAt: lastActivityAt,
   });
 
-  return { status: "updated" as const, songCount: entries.length };
+  return {
+    status: "updated" as const,
+    participant: updatedParticipant,
+    songCount: entries.length,
+  };
 }

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -18,6 +18,13 @@ export type DbParticipant = {
   joined_at: string;
 };
 
+export class SessionParticipantWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionParticipantWriteError";
+  }
+}
+
 export async function createSession(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
@@ -74,6 +81,12 @@ export async function upsertParticipant(
     .single();
 
   if (error) throw error;
+  if (!data || data.session_id !== sessionId || data.user_id !== userId) {
+    throw new SessionParticipantWriteError(
+      "Could not verify the quartet participant snapshot was saved."
+    );
+  }
+
   await updateSessionActivity(sessionId, lastActivityAt);
   return data as DbParticipant;
 }
@@ -89,7 +102,60 @@ export async function getParticipants(sessionId: string) {
   return data as DbParticipant[];
 }
 
+async function getParticipantForDelete({
+  sessionId,
+  userId,
+  participantId,
+}: {
+  sessionId: string;
+  userId?: string;
+  participantId?: string;
+}) {
+  let query = supabase
+    .from("session_participants")
+    .select("id, session_id, user_id")
+    .eq("session_id", sessionId);
+
+  if (userId) query = query.eq("user_id", userId);
+  if (participantId) query = query.eq("id", participantId);
+
+  const { data, error } = await query.maybeSingle();
+
+  if (error) throw error;
+  return data as Pick<DbParticipant, "id" | "session_id" | "user_id"> | null;
+}
+
+async function verifyParticipantDeleted({
+  sessionId,
+  userId,
+  participantId,
+}: {
+  sessionId: string;
+  userId?: string;
+  participantId?: string;
+}) {
+  const remainingParticipant = await getParticipantForDelete({
+    sessionId,
+    userId,
+    participantId,
+  });
+
+  if (remainingParticipant) {
+    throw new SessionParticipantWriteError(
+      "Could not verify that the quartet participant row was deleted."
+    );
+  }
+}
+
 export async function removeParticipant(sessionId: string, userId: string) {
+  const participant = await getParticipantForDelete({ sessionId, userId });
+
+  if (!participant) {
+    throw new SessionParticipantWriteError(
+      "Could not find your quartet participant row to delete."
+    );
+  }
+
   const { error } = await supabase
     .from("session_participants")
     .delete()
@@ -97,12 +163,26 @@ export async function removeParticipant(sessionId: string, userId: string) {
     .eq("user_id", userId);
 
   if (error) throw error;
+  await verifyParticipantDeleted({ sessionId, userId });
+
+  return participant;
 }
 
 export async function removeParticipantById(
   sessionId: string,
   participantId: string
 ) {
+  const participant = await getParticipantForDelete({
+    sessionId,
+    participantId,
+  });
+
+  if (!participant) {
+    throw new SessionParticipantWriteError(
+      "Could not find the selected quartet participant row to delete."
+    );
+  }
+
   const { error } = await supabase
     .from("session_participants")
     .delete()
@@ -110,6 +190,9 @@ export async function removeParticipantById(
     .eq("id", participantId);
 
   if (error) throw error;
+  await verifyParticipantDeleted({ sessionId, participantId });
+
+  return participant;
 }
 
 export function subscribeToSessionParticipants(


### PR DESCRIPTION
## Summary
- Verify `session_participants` upserts return the intended `session_id` + `user_id` row before treating snapshot updates as successful.
- Verify leave/remove flows find the intended participant row before delete and confirm the row is gone after delete.
- Stop swallowing active quartet snapshot errors during repertoire add/edit/delete; show a clear saved-but-not-synced message when quartet matches could not be updated.

## Notes
- No Supabase migration or dashboard change is required.
- Realtime behavior and matching logic were not changed.

## Verification
- `npm run test:run`
- `npm run build`

Closes #158