### PR TITLE
Add session participants RLS migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,19 @@ The Supabase project should have the current production schema applied:
 - `sung_song_events` stores each user's private "marked as sung" events for
   recent-use indicators.
 
-One-time migration SQL is intentionally not kept in this README after it has
-been applied. Add any future schema change to the PR that introduces it, then
-remove the one-time instructions after production is updated.
+Database migrations live in `supabase/migrations`. Apply unapplied migrations
+to the linked Supabase project with:
+
+```bash
+supabase db push
+```
+
+If the project is not linked locally, run `supabase link --project-ref <project-ref>`
+first, then `supabase db push`. The migration
+`20260428051000_fix_session_participants_rls.sql` updates
+`session_participants` row-level security so authenticated users can read
+session participants and insert, update, or delete only their own participant
+row.
 
 For the private repertoire notes feature, apply the one-time SQL in
 [docs/private-repertoire-notes.md](docs/private-repertoire-notes.md).

--- a/supabase/migrations/20260428051000_fix_session_participants_rls.sql
+++ b/supabase/migrations/20260428051000_fix_session_participants_rls.sql
@@ -1,0 +1,45 @@
+alter table public.session_participants enable row level security;
+
+grant select, insert, update, delete on public.session_participants to authenticated;
+
+do $$
+declare
+  policy_record record;
+begin
+  for policy_record in
+    select policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'session_participants'
+  loop
+    execute format(
+      'drop policy if exists %I on public.session_participants',
+      policy_record.policyname
+    );
+  end loop;
+end $$;
+
+create policy "Authenticated users can read session participants"
+on public.session_participants
+for select
+to authenticated
+using (true);
+
+create policy "Users can insert their own session participant row"
+on public.session_participants
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+create policy "Users can update their own session participant row"
+on public.session_participants
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "Users can delete their own session participant row"
+on public.session_participants
+for delete
+to authenticated
+using (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- Add a Supabase migration that enables RLS on `session_participants` and grants authenticated table access.
- Replace existing `session_participants` policies idempotently, then create authenticated select/insert/update/delete policies.
- Document `supabase db push` as the deployment step for unapplied migrations.

## Behavior
- Authenticated users can select session participants.
- Authenticated users can insert/update/delete only rows where `user_id = auth.uid()`.
- No UI workaround or matching logic changes.

## Stale upsert check
- After successful leave, the app clears the active quartet and redirects.
- I do not see a post-leave code path that upserts `session_participants` again; upsert paths are join/rejoin, return-to-quartet refresh, and active repertoire snapshot refresh.

## Deployment note
- Apply with `supabase db push` after linking the project if needed: `supabase link --project-ref <project-ref>`.

## Verification
- `npm run test:run`
- `npm run build`