### PR TITLE
Add Supabase alignment contract and guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ Before finishing any change:
 - do not change app behavior unless requested
 - prefer small PRs
 - preserve existing tests and add tests for matching logic changes
+- when adding or changing Supabase operations, update migrations/RLS,
+  `docs/supabase-contract.md`, and related tests or test notes
 
 ## Important files
 - `lib/matching.ts`: core matching/ranking logic

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The Supabase project should have the current production schema applied:
 - `sung_song_events` stores each user's private "marked as sung" events for
   recent-use indicators.
 
+The app/database contract is documented in
+[docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes
+Supabase usage must update that contract, migrations, and tests or test notes.
+
 Database migrations live in `supabase/migrations`. Apply unapplied migrations
 to the linked Supabase project with:
 
@@ -61,14 +65,4 @@ supabase db push
 ```
 
 If the project is not linked locally, run `supabase link --project-ref <project-ref>`
-first, then `supabase db push`. The migration
-`20260428051000_fix_session_participants_rls.sql` updates
-`session_participants` row-level security so authenticated users can read
-session participants and insert, update, or delete only their own participant
-row.
-
-For the private repertoire notes feature, apply the one-time SQL in
-[docs/private-repertoire-notes.md](docs/private-repertoire-notes.md).
-
-For the recently sung feature, apply the one-time SQL in
-[docs/recently-sung-events.md](docs/recently-sung-events.md).
+first, then `supabase db push`.

--- a/docs/private-repertoire-notes.md
+++ b/docs/private-repertoire-notes.md
@@ -2,12 +2,9 @@
 
 Issue #87 adds optional private notes to each `user_repertoire` row.
 
-Apply this SQL once in the Supabase SQL editor before deploying the feature:
-
-```sql
-alter table public.user_repertoire
-add column if not exists notes text;
-```
+This schema requirement is now captured in
+`supabase/migrations/20260428060000_supabase_contract_alignment.sql`. Apply
+unapplied migrations with `supabase db push`.
 
 No changes are needed to session participant data. Notes stay in
 `user_repertoire` and are not copied into quartet snapshots.

--- a/docs/recently-sung-events.md
+++ b/docs/recently-sung-events.md
@@ -3,34 +3,9 @@
 Issue #88 adds a private event log for songs a user marks as sung from quartet
 results.
 
-Apply this SQL once in the Supabase SQL editor before deploying the feature:
-
-```sql
-create table if not exists public.sung_song_events (
-  id uuid primary key default gen_random_uuid(),
-  user_id uuid not null references auth.users(id) on delete cascade,
-  session_id uuid not null references public.sessions(id) on delete cascade,
-  song_title text not null,
-  voicing text not null,
-  arranger_name text,
-  sung_at timestamptz not null default now()
-);
-
-alter table public.sung_song_events enable row level security;
-
-create policy "Users can read their sung song events"
-on public.sung_song_events
-for select
-using (auth.uid() = user_id);
-
-create policy "Users can insert their sung song events"
-on public.sung_song_events
-for insert
-with check (auth.uid() = user_id);
-
-create index if not exists sung_song_events_user_sung_at_idx
-on public.sung_song_events (user_id, sung_at desc);
-```
+This schema and RLS requirement is now captured in
+`supabase/migrations/20260428060000_supabase_contract_alignment.sql`. Apply
+unapplied migrations with `supabase db push`.
 
 Events are private to the user who marked the song. They are not copied into
 quartet participant snapshots and do not affect matching rank yet.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -1,0 +1,236 @@
+# Supabase Contract
+
+This document is the source of truth for how the app uses Supabase. Any code
+change that adds or changes a Supabase operation must update this contract, the
+migrations in `supabase/migrations`, and tests or test documentation.
+
+## Client Model
+
+- Browser code uses `NEXT_PUBLIC_SUPABASE_URL` and
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY`.
+- Browser writes run as the authenticated user. Service-role keys must never be
+  used in browser code.
+- Feedback email delivery runs on the server through the `/api/feedback` route.
+  It uses Supabase Auth only to identify the current user and read their profile.
+- Realtime is required for `profiles` and `session_participants`.
+
+## Tables And Objects
+
+### `profiles`
+
+Purpose: source of truth for display names.
+
+Code:
+- Read current profile: `lib/profileStore.ts#getMyProfile`
+- Read participant names by id: `lib/profileStore.ts#getProfilesByIds`
+- Read profile for feedback email context: `app/api/feedback/route.ts`
+- Insert/update own profile: `lib/profileStore.ts#upsertMyProfile`
+- Realtime profile display-name subscription:
+  `lib/profileStore.ts#subscribeToProfileDisplayNames`
+
+Expected context:
+- Browser authenticated user for reads and own upsert.
+- Server route with user session for feedback profile read.
+
+Required database contract:
+- `id uuid primary key references auth.users(id) on delete cascade`
+- `display_name text not null`
+- RLS enabled.
+- Authenticated users can read profiles.
+- Authenticated users can insert/update only their own profile where
+  `id = auth.uid()`.
+- Table is in the Supabase Realtime publication.
+
+Established by migrations:
+- `20260428060000_supabase_contract_alignment.sql`
+
+### `user_repertoire`
+
+Purpose: source of truth for each user's saved songs.
+
+Code:
+- Read own repertoire: `lib/repertoireStore.ts#getMyRepertoire`
+- Insert own song: `lib/repertoireStore.ts#addRepertoireItem`
+- Update own song: `lib/repertoireStore.ts#updateRepertoireItem`
+- Delete own song: `lib/repertoireStore.ts#deleteRepertoireItem`
+- Used by `lib/activeQuartetSnapshot.ts` to refresh the current user's
+  `session_participants.repertoire` snapshot.
+
+Expected context:
+- Browser authenticated user.
+
+Required database contract:
+- `id uuid primary key`
+- `user_id uuid not null references auth.users(id) on delete cascade`
+- `song_title text not null`
+- `voicing text not null`
+- `arranger_name text`
+- `parts_known text[] not null`
+- `confidence text`
+- `notes text`
+- RLS enabled.
+- Authenticated users can select/insert/update/delete only rows where
+  `user_id = auth.uid()`.
+- Index on `(user_id, song_title)` for repertoire listing.
+
+Established by migrations:
+- `20260428060000_supabase_contract_alignment.sql`
+
+### `sessions`
+
+Purpose: source of truth for quartet join codes and session activity.
+
+Code:
+- Insert new session: `lib/sessionStore.ts#createSession`
+- Read by join code: `lib/sessionStore.ts#getSessionByCode`
+- Update `last_activity_at`: internal helper in `lib/sessionStore.ts`, called
+  after participant snapshot upserts.
+
+Expected context:
+- Browser authenticated user.
+
+Required database contract:
+- `id uuid primary key`
+- `join_code text not null`
+- `created_at timestamptz not null default now()`
+- `last_activity_at timestamptz`
+- Unique index on `join_code`.
+- RLS enabled.
+- Authenticated users can select sessions, create sessions, and update session
+  activity.
+
+Established by migrations:
+- `20260428060000_supabase_contract_alignment.sql`
+
+### `session_participants`
+
+Purpose: source of truth for active quartet membership and each participant's
+repertoire snapshot. Quartet participant lists and match results must derive
+from this table, not local-only state.
+
+Code:
+- Read participants: `lib/sessionStore.ts#getParticipants`
+- Insert/update own snapshot: `lib/sessionStore.ts#upsertParticipant`
+- Delete own row: `lib/sessionStore.ts#removeParticipant`
+- Remove selected row by id: `lib/sessionStore.ts#removeParticipantById`
+- Realtime participant subscription:
+  `lib/sessionStore.ts#subscribeToSessionParticipants`
+- Repertoire snapshot refresh:
+  `lib/activeQuartetSnapshot.ts#refreshActiveQuartetSnapshot`
+- Match calculation source:
+  `app/join/[code]/page.tsx` builds entries from current participants and calls
+  `findMatches`.
+
+Expected context:
+- Browser authenticated user.
+
+Required database contract:
+- `id uuid primary key`
+- `session_id uuid not null references public.sessions(id) on delete cascade`
+- `user_id uuid not null references auth.users(id) on delete cascade`
+- `display_name text not null`
+- `repertoire jsonb not null default '[]'::jsonb`
+- `joined_at timestamptz not null default now()`
+- Unique index on `(session_id, user_id)` for upserts.
+- RLS enabled.
+- Authenticated users can select session participants.
+- Authenticated users can insert/update/delete only their own row where
+  `user_id = auth.uid()`.
+- Table is in the Supabase Realtime publication.
+
+Established by migrations:
+- `20260428051000_fix_session_participants_rls.sql`
+- `20260428060000_supabase_contract_alignment.sql`
+
+### `sung_song_events`
+
+Purpose: private per-user log for songs marked as recently sung.
+
+Code:
+- Read recent events: `lib/sungSongStore.ts#getRecentSungSongs`
+- Insert event: `lib/sungSongStore.ts#markSongAsSung`
+
+Expected context:
+- Browser authenticated user.
+
+Required database contract:
+- `id uuid primary key`
+- `user_id uuid not null references auth.users(id) on delete cascade`
+- `session_id uuid not null references public.sessions(id) on delete cascade`
+- `song_title text not null`
+- `voicing text not null`
+- `arranger_name text`
+- `sung_at timestamptz not null default now()`
+- RLS enabled.
+- Authenticated users can select/insert only rows where
+  `user_id = auth.uid()`.
+- Index on `(user_id, sung_at desc)`.
+
+Established by migrations:
+- `20260428060000_supabase_contract_alignment.sql`
+
+### Feedback Email
+
+Purpose: send user feedback email through Resend.
+
+Supabase usage:
+- `app/api/feedback/route.ts` calls `supabase.auth.getUser()`.
+- If a user is authenticated, it reads `profiles.display_name`.
+- No feedback table, RPC, storage bucket, or Supabase function is used.
+
+Expected context:
+- Server route with user cookies.
+- Resend credentials are server-only environment variables.
+
+## Auth Assumptions
+
+- Users sign in with Supabase Auth OTP from `app/login/page.tsx`.
+- Most app pages require an authenticated user before reading or writing app
+  tables.
+- RLS policies are written for the `authenticated` role and `auth.uid()`.
+
+## Realtime Assumptions
+
+- `profiles` must be in the Supabase Realtime publication for live display-name
+  updates.
+- `session_participants` must be in the Supabase Realtime publication for live
+  join, leave, and snapshot updates.
+- The quartet screen also refetches `session_participants`, so the database is
+  the source of truth even if a realtime event is missed.
+
+## Coverage
+
+Automated tests currently cover:
+- Matching rules and ranking in `lib/__tests__/matching.test.ts`
+- Participant realtime payload application in
+  `lib/__tests__/sessionParticipantChanges.test.ts`
+- Existing participant/rejoin recognition by `user_id` in
+  `lib/__tests__/sessionParticipantResolution.test.ts`
+- Display names derived from `profiles` instead of stale participant names in
+  `lib/__tests__/sessionParticipantDisplayName.test.ts`
+- Active quartet local-storage behavior in `lib/__tests__/activeQuartet.test.ts`
+- Supabase contract/migration text in
+  `lib/__tests__/supabaseContract.test.ts`
+
+True RLS execution tests are not currently automated because this repo does not
+start an isolated Supabase database in CI and does not have fixture auth users
+for policy assertions. The smallest follow-up is to add Supabase CLI-backed
+integration tests that run migrations against a local Supabase instance, create
+two auth users, and assert:
+- join/rejoin behavior is backed by `session_participants`
+- user A can join, update their snapshot, leave, and rejoin
+- user A cannot update/delete user B's participant row
+- repertoire edits update only user A's `session_participants` snapshot
+- quartet matches derive from refreshed `session_participants` data
+
+## Supabase Alignment Checklist
+
+For any PR that adds or changes a Supabase operation, update all applicable
+items:
+
+- Code path using `.from(...)`, `.rpc(...)`, Auth, Realtime, or Storage
+- Migration/schema, including tables, columns, constraints, indexes, grants,
+  RLS, and Realtime publication
+- Tests, or a documented reason automated coverage is not practical yet
+- This `docs/supabase-contract.md` file
+- User-facing or operator docs for required deployment commands

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const contract = readFileSync(
+  join(repoRoot, "docs/supabase-contract.md"),
+  "utf8"
+);
+const migration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260428060000_supabase_contract_alignment.sql"
+  ),
+  "utf8"
+);
+
+describe("Supabase contract guardrails", () => {
+  const tables = [
+    "profiles",
+    "user_repertoire",
+    "sessions",
+    "session_participants",
+    "sung_song_events",
+  ];
+
+  it("documents every app-owned Supabase table", () => {
+    for (const table of tables) {
+      expect(contract).toContain(table);
+    }
+  });
+
+  it("keeps schema and RLS policies in migrations for browser-written tables", () => {
+    for (const table of tables) {
+      expect(migration).toContain(`public.${table}`);
+      expect(migration).toContain(
+        `alter table public.${table} enable row level security`
+      );
+    }
+
+    expect(migration).toContain("for insert");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("for delete");
+    expect(migration).toContain("auth.uid()");
+  });
+
+  it("protects the session participant upsert and realtime contract", () => {
+    expect(migration).toContain(
+      "session_participants_session_user_key"
+    );
+    expect(migration).toContain("(session_id, user_id)");
+    expect(migration).toContain("supabase_realtime");
+    expect(contract).toContain("join/rejoin");
+    expect(contract).toContain("leave");
+    expect(contract).toContain("repertoire snapshot");
+    expect(contract).toContain("Match calculation source");
+  });
+});

--- a/supabase/migrations/20260428060000_supabase_contract_alignment.sql
+++ b/supabase/migrations/20260428060000_supabase_contract_alignment.sql
@@ -1,0 +1,222 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.user_repertoire (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  song_title text not null,
+  voicing text not null,
+  arranger_name text,
+  parts_known text[] not null,
+  confidence text,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.sessions (
+  id uuid primary key default gen_random_uuid(),
+  join_code text not null,
+  created_at timestamptz not null default now(),
+  last_activity_at timestamptz
+);
+
+create table if not exists public.session_participants (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.sessions(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  display_name text not null,
+  repertoire jsonb not null default '[]'::jsonb,
+  joined_at timestamptz not null default now()
+);
+
+create table if not exists public.sung_song_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  session_id uuid not null references public.sessions(id) on delete cascade,
+  song_title text not null,
+  voicing text not null,
+  arranger_name text,
+  sung_at timestamptz not null default now()
+);
+
+alter table public.user_repertoire
+  add column if not exists notes text;
+
+alter table public.sessions
+  add column if not exists last_activity_at timestamptz;
+
+create unique index if not exists sessions_join_code_key
+on public.sessions (join_code);
+
+create unique index if not exists session_participants_session_user_key
+on public.session_participants (session_id, user_id);
+
+create index if not exists user_repertoire_user_title_idx
+on public.user_repertoire (user_id, song_title);
+
+create index if not exists session_participants_session_joined_idx
+on public.session_participants (session_id, joined_at);
+
+create index if not exists sung_song_events_user_sung_at_idx
+on public.sung_song_events (user_id, sung_at desc);
+
+alter table public.profiles enable row level security;
+alter table public.user_repertoire enable row level security;
+alter table public.sessions enable row level security;
+alter table public.session_participants enable row level security;
+alter table public.sung_song_events enable row level security;
+
+grant select, insert, update on public.profiles to authenticated;
+grant select, insert, update, delete on public.user_repertoire to authenticated;
+grant select, insert, update on public.sessions to authenticated;
+grant select, insert, update, delete on public.session_participants to authenticated;
+grant select, insert on public.sung_song_events to authenticated;
+
+drop policy if exists "Authenticated users can read profiles" on public.profiles;
+drop policy if exists "Users can insert their own profile" on public.profiles;
+drop policy if exists "Users can update their own profile" on public.profiles;
+drop policy if exists "Users can read their own repertoire" on public.user_repertoire;
+drop policy if exists "Users can insert their own repertoire" on public.user_repertoire;
+drop policy if exists "Users can update their own repertoire" on public.user_repertoire;
+drop policy if exists "Users can delete their own repertoire" on public.user_repertoire;
+drop policy if exists "Authenticated users can read sessions" on public.sessions;
+drop policy if exists "Authenticated users can create sessions" on public.sessions;
+drop policy if exists "Authenticated users can update session activity" on public.sessions;
+drop policy if exists "Authenticated users can read session participants" on public.session_participants;
+drop policy if exists "Users can insert their own session participant row" on public.session_participants;
+drop policy if exists "Users can update their own session participant row" on public.session_participants;
+drop policy if exists "Users can delete their own session participant row" on public.session_participants;
+drop policy if exists "Users can read their sung song events" on public.sung_song_events;
+drop policy if exists "Users can insert their sung song events" on public.sung_song_events;
+
+create policy "Authenticated users can read profiles"
+on public.profiles
+for select
+to authenticated
+using (true);
+
+create policy "Users can insert their own profile"
+on public.profiles
+for insert
+to authenticated
+with check (id = auth.uid());
+
+create policy "Users can update their own profile"
+on public.profiles
+for update
+to authenticated
+using (id = auth.uid())
+with check (id = auth.uid());
+
+create policy "Users can read their own repertoire"
+on public.user_repertoire
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Users can insert their own repertoire"
+on public.user_repertoire
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+create policy "Users can update their own repertoire"
+on public.user_repertoire
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "Users can delete their own repertoire"
+on public.user_repertoire
+for delete
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Authenticated users can read sessions"
+on public.sessions
+for select
+to authenticated
+using (true);
+
+create policy "Authenticated users can create sessions"
+on public.sessions
+for insert
+to authenticated
+with check (true);
+
+create policy "Authenticated users can update session activity"
+on public.sessions
+for update
+to authenticated
+using (true)
+with check (true);
+
+create policy "Authenticated users can read session participants"
+on public.session_participants
+for select
+to authenticated
+using (true);
+
+create policy "Users can insert their own session participant row"
+on public.session_participants
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+create policy "Users can update their own session participant row"
+on public.session_participants
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "Users can delete their own session participant row"
+on public.session_participants
+for delete
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Users can read their sung song events"
+on public.sung_song_events
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Users can insert their sung song events"
+on public.sung_song_events
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    if not exists (
+      select 1
+      from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'profiles'
+    ) then
+      alter publication supabase_realtime add table public.profiles;
+    end if;
+
+    if not exists (
+      select 1
+      from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'session_participants'
+    ) then
+      alter publication supabase_realtime add table public.session_participants;
+    end if;
+  end if;
+end $$;


### PR DESCRIPTION
## Audit summary
- Audited app Supabase usage across `.from(...)`, Auth, Realtime subscriptions, migration SQL, and existing docs.
- No `.rpc(...)` or Supabase Storage usage was found.
- Feedback delivery uses the server `/api/feedback` route, Supabase Auth for identity, and `profiles` for display-name context; it does not use a feedback table/function.

## Tables/objects reviewed
- `profiles`
- `user_repertoire`
- `sessions`
- `session_participants`
- `sung_song_events`
- Supabase Auth assumptions
- Realtime publication assumptions for `profiles` and `session_participants`
- Feedback email route behavior

## Mismatches found
- The repo did not have a single source-of-truth Supabase contract tying code paths to schema, RLS, indexes, grants, and realtime requirements.
- Some Supabase setup requirements lived as dashboard/manual SQL docs instead of migration-backed docs.
- `session_participants` had a focused RLS migration, but the broader app contract for browser writes across app tables was not documented or guarded.
- Realtime requirements were implicit in code/docs rather than captured alongside schema/RLS expectations.
- True RLS execution tests are not currently automated because the repo does not start an isolated Supabase DB in CI with fixture auth users.

## Migrations added or changed
- Added `supabase/migrations/20260428060000_supabase_contract_alignment.sql` to establish app-owned schema assumptions, grants, RLS policies, indexes, and realtime publication entries for `profiles` and `session_participants`.
- Existing `20260428051000_fix_session_participants_rls.sql` remains in place; the new migration broadens the durable contract rather than patching around RLS in UI.

## Tests added or changed
- Added `lib/__tests__/supabaseContract.test.ts` as a lightweight guardrail that verifies the contract doc and migration cover app-owned Supabase tables, RLS, session participant upsert uniqueness, and realtime assumptions.
- Updated docs to remove one-off dashboard SQL instructions in favor of migrations.

## Required Supabase deployment/manual steps
- After merge, apply migrations to Supabase with `supabase db push` from a machine with the Supabase CLI installed and linked to the project.
- If the project is not linked locally, run `supabase link --project-ref <project-ref>` first.
- No dashboard-only RLS policy change is required by this PR.

## Issue #161/#162 style flow coverage
- Covered in the contract and migration guardrails: join/rejoin, leave/delete, repertoire snapshot refresh, participant source-of-truth, and match calculation from database-backed `session_participants` data.
- The remaining gap is true policy execution testing against a local Supabase instance; this PR documents the smallest follow-up to add Supabase CLI-backed integration tests for those flows.

## Verification
- `npm run test:run` passed
- `npm run build` passed