### PR TITLE
Add fuzzy repertoire title suggestions

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
+import {
+  findFuzzySongTitleSuggestions,
+  type FuzzySongTitleSuggestion,
+} from "@/lib/fuzzySongTitles";
 import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -58,6 +62,10 @@ export default function RepertoireManager() {
   const [isAdding, setIsAdding] = useState(false);
   const [savingEditId, setSavingEditId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [dismissedSuggestionIds, setDismissedSuggestionIds] = useState<string[]>(
+    []
+  );
+  const [updatingSuggestionId, setUpdatingSuggestionId] = useState("");
 
   async function loadRepertoire() {
     try {
@@ -358,6 +366,53 @@ export default function RepertoireManager() {
     }
   }
 
+  function dismissSuggestion(suggestionId: string) {
+    setDismissedSuggestionIds((current) =>
+      current.includes(suggestionId) ? current : [...current, suggestionId]
+    );
+  }
+
+  async function applyTitleSuggestion(suggestion: FuzzySongTitleSuggestion) {
+    if (updatingSuggestionId) return;
+
+    const item = items.find((candidate) => candidate.id === suggestion.itemId);
+    if (!item) {
+      setMessage("Could not find that song. Refresh and try again.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Update "${suggestion.itemTitle}" to "${suggestion.suggestedTitle}"?`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      setUpdatingSuggestionId(suggestion.id);
+      await updateRepertoireItem(item.id, {
+        songTitle: suggestion.suggestedTitle,
+        voicing: item.voicing,
+        arrangerName: item.arranger_name ?? undefined,
+        partsKnown: item.parts_known,
+        confidence: item.confidence,
+        notes: item.notes ?? undefined,
+      });
+      dismissSuggestion(suggestion.id);
+      setMessage("Song title updated.");
+      try {
+        await refreshActiveQuartetSnapshot();
+      } catch (err) {
+        console.error("Could not update active quartet snapshot", err);
+      }
+      await loadRepertoire();
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not update that song title. Please try again.");
+    } finally {
+      setUpdatingSuggestionId("");
+    }
+  }
+
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
@@ -380,6 +435,13 @@ export default function RepertoireManager() {
         sensitivity: "base",
       })
     );
+  const titleSuggestions = findFuzzySongTitleSuggestions(
+    items.map((item) => ({
+      id: item.id,
+      songTitle: item.song_title,
+      voicing: item.voicing,
+    }))
+  ).filter((suggestion) => !dismissedSuggestionIds.includes(suggestion.id));
 
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
@@ -432,6 +494,64 @@ export default function RepertoireManager() {
             Add song
           </button>
         </section>
+
+        {titleSuggestions.length > 0 && (
+          <section className="mt-8 rounded-2xl border border-amber-300/25 bg-amber-300/10 p-4">
+            <div>
+              <h2 className="text-xl font-semibold text-amber-100">
+                Possible duplicate titles
+              </h2>
+              <p className="mt-1 text-sm text-amber-50/80">
+                These are not used as confirmed matches unless you update your
+                own repertoire.
+              </p>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {titleSuggestions.map((suggestion) => (
+                <div
+                  key={suggestion.id}
+                  className="rounded-xl border border-amber-200/20 bg-slate-950/50 p-3"
+                >
+                  <p className="text-sm text-amber-50">
+                    Possible same song: Is{" "}
+                    <span className="font-semibold">
+                      "{suggestion.itemTitle}"
+                    </span>{" "}
+                    the same as{" "}
+                    <span className="font-semibold">
+                      "{suggestion.suggestedTitle}"
+                    </span>
+                    ?
+                  </p>
+                  <p className="mt-1 text-xs font-semibold text-amber-100/80">
+                    {suggestion.voicing}
+                  </p>
+                  <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => applyTitleSuggestion(suggestion)}
+                      disabled={Boolean(updatingSuggestionId)}
+                      className="rounded-lg bg-amber-200 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-100 disabled:opacity-40"
+                    >
+                      {updatingSuggestionId === suggestion.id
+                        ? "Updating..."
+                        : "Update my title"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => dismissSuggestion(suggestion.id)}
+                      disabled={Boolean(updatingSuggestionId)}
+                      className="rounded-lg bg-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/20 disabled:opacity-40"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         <section className="mt-8">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">

--- a/lib/__tests__/fuzzySongTitles.test.ts
+++ b/lib/__tests__/fuzzySongTitles.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { findFuzzySongTitleSuggestions } from "../fuzzySongTitles";
+
+describe("findFuzzySongTitleSuggestions", () => {
+  it("suggests conservative same-voicing typo matches", () => {
+    const suggestions = findFuzzySongTitleSuggestions([
+      { id: "1", songTitle: "Hello Mary Lu", voicing: "TTBB" },
+      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
+    ]);
+
+    expect(suggestions).toEqual([
+      {
+        id: "1:2",
+        itemId: "1",
+        itemTitle: "Hello Mary Lu",
+        suggestedItemId: "2",
+        suggestedTitle: "Hello, Mary Lou!",
+        voicing: "TTBB",
+      },
+    ]);
+  });
+
+  it("suggests likely partial title matches", () => {
+    const suggestions = findFuzzySongTitleSuggestions([
+      { id: "1", songTitle: "Mary Lou", voicing: "TTBB" },
+      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      itemTitle: "Mary Lou",
+      suggestedTitle: "Hello, Mary Lou!",
+      voicing: "TTBB",
+    });
+  });
+
+  it("does not suggest exact normalized matches", () => {
+    const suggestions = findFuzzySongTitleSuggestions([
+      { id: "1", songTitle: "Hello Mary Lou", voicing: "TTBB" },
+      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
+    ]);
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it("does not compare titles across different voicings", () => {
+    const suggestions = findFuzzySongTitleSuggestions([
+      { id: "1", songTitle: "Hello Mary Lu", voicing: "TTBB" },
+      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "SSAA" },
+    ]);
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it("avoids obvious false positives", () => {
+    const suggestions = findFuzzySongTitleSuggestions([
+      { id: "1", songTitle: "Hello Mary Lou", voicing: "TTBB" },
+      { id: "2", songTitle: "Goodbye My Coney Island Baby", voicing: "TTBB" },
+      { id: "3", songTitle: "Sweet Adeline", voicing: "TTBB" },
+    ]);
+
+    expect(suggestions).toEqual([]);
+  });
+});

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -3,6 +3,7 @@ import {
   arrangementCheckNote,
   findMatches,
   normalizeConfidence,
+  possibleSameSongNote,
   SingerEntry,
 } from "../matching";
 
@@ -148,6 +149,60 @@ describe("findMatches", () => {
 
     expect(matches.length).toBe(1);
     expect(matches[0].songTitle).toBe("Hello, Mary Lou!");
+  });
+
+  it("suggests a possible match for conservative near-duplicate titles", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "T", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "L", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "Bari", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "Bass", songTitle: "Why Try To Change Me Now", voicing: "TTBB", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toMatchObject({
+      songTitle: "Why Try To Change Me Now",
+      category: "possible",
+      missingParts: [],
+    });
+    expect(matches[0].warnings).toContain(
+      possibleSameSongNote("Why Try to Change Me", "Why Try To Change Me Now")
+    );
+    expect(matches[1]).toMatchObject({
+      songTitle: "Why Try to Change Me",
+      category: "one_part_missing",
+      missingParts: ["Bass"],
+    });
+  });
+
+  it("does not make fuzzy title suggestions ready-to-sing matches", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "T", songTitle: "Hello Mary Lu", voicing: "TTBB", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "L", songTitle: "Hello Mary Lu", voicing: "TTBB", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "Bari", songTitle: "Hello Mary Lu", voicing: "TTBB", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "Bass", songTitle: "Hello, Mary Lou!", voicing: "TTBB", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches.some((match) => match.category === "ready")).toBe(false);
+    expect(matches[0].category).toBe("possible");
+  });
+
+  it("does not suggest fuzzy title matches across different voicings", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "T", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "L", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "Bari", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "Bass", songTitle: "Why Try To Change Me Now", voicing: "SATB", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].category).toBe("one_part_missing");
   });
 
   it("returns one_part_missing when three distinct singers cover three TTBB parts", () => {

--- a/lib/fuzzySongTitles.ts
+++ b/lib/fuzzySongTitles.ts
@@ -1,0 +1,161 @@
+import type { Voicing } from "@/lib/matching";
+
+export type FuzzySongTitleItem = {
+  id: string;
+  songTitle: string;
+  voicing: Voicing;
+};
+
+export type FuzzySongTitleSuggestion = {
+  id: string;
+  itemId: string;
+  itemTitle: string;
+  suggestedItemId: string;
+  suggestedTitle: string;
+  voicing: Voicing;
+};
+
+function normalizeTitleForExactMatch(title: string) {
+  return title.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function titleTokens(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+function levenshteinDistance(a: string, b: string) {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: b.length + 1 }, () => 0);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + cost
+      );
+    }
+
+    for (let j = 0; j <= b.length; j += 1) {
+      previous[j] = current[j];
+    }
+  }
+
+  return previous[b.length];
+}
+
+function characterSimilarity(a: string, b: string) {
+  const longerLength = Math.max(a.length, b.length);
+  if (longerLength === 0) return 1;
+
+  return 1 - levenshteinDistance(a, b) / longerLength;
+}
+
+function tokenOverlap(aTokens: string[], bTokens: string[]) {
+  const a = new Set(aTokens);
+  const b = new Set(bTokens);
+  const shared = [...a].filter((token) => b.has(token)).length;
+  const total = new Set([...a, ...b]).size;
+
+  if (total === 0) return 1;
+  return shared / total;
+}
+
+function isTokenSubset(shorterTokens: string[], longerTokens: string[]) {
+  const longer = new Set(longerTokens);
+  return shorterTokens.every((token) => longer.has(token));
+}
+
+function isLikelySameSongTitle(a: string, b: string) {
+  const aCompact = normalizeTitleForExactMatch(a);
+  const bCompact = normalizeTitleForExactMatch(b);
+
+  if (!aCompact || !bCompact) return false;
+  if (aCompact === bCompact) return false;
+
+  const shorterLength = Math.min(aCompact.length, bCompact.length);
+  const longerLength = Math.max(aCompact.length, bCompact.length);
+  if (shorterLength < 6) return false;
+
+  if (
+    longerLength >= 9 &&
+    characterSimilarity(aCompact, bCompact) >= 0.9
+  ) {
+    return true;
+  }
+
+  const aTokens = titleTokens(a);
+  const bTokens = titleTokens(b);
+  const shorterTokens =
+    aTokens.length <= bTokens.length ? aTokens : bTokens;
+  const longerTokens = aTokens.length > bTokens.length ? aTokens : bTokens;
+
+  if (
+    shorterTokens.length >= 2 &&
+    isTokenSubset(shorterTokens, longerTokens) &&
+    longerTokens.length - shorterTokens.length <= 2
+  ) {
+    return true;
+  }
+
+  return (
+    aTokens.length >= 3 &&
+    bTokens.length >= 3 &&
+    tokenOverlap(aTokens, bTokens) >= 0.75
+  );
+}
+
+function canonicalFirstTitle(
+  a: FuzzySongTitleItem,
+  b: FuzzySongTitleItem
+): [FuzzySongTitleItem, FuzzySongTitleItem] {
+  if (b.songTitle.length > a.songTitle.length) return [b, a];
+  if (a.songTitle.length > b.songTitle.length) return [a, b];
+
+  return a.songTitle.localeCompare(b.songTitle, undefined, {
+    sensitivity: "base",
+  }) <= 0
+    ? [a, b]
+    : [b, a];
+}
+
+export function findFuzzySongTitleSuggestions(
+  items: FuzzySongTitleItem[]
+): FuzzySongTitleSuggestion[] {
+  const suggestions: FuzzySongTitleSuggestion[] = [];
+
+  for (let i = 0; i < items.length; i += 1) {
+    for (let j = i + 1; j < items.length; j += 1) {
+      const first = items[i];
+      const second = items[j];
+
+      if (first.voicing !== second.voicing) continue;
+      if (!isLikelySameSongTitle(first.songTitle, second.songTitle)) continue;
+
+      const [canonical, variant] = canonicalFirstTitle(first, second);
+
+      suggestions.push({
+        id: [variant.id, canonical.id].sort().join(":"),
+        itemId: variant.id,
+        itemTitle: variant.songTitle,
+        suggestedItemId: canonical.id,
+        suggestedTitle: canonical.songTitle,
+        voicing: variant.voicing,
+      });
+    }
+  }
+
+  return suggestions.sort((a, b) =>
+    a.suggestedTitle.localeCompare(b.suggestedTitle, undefined, {
+      sensitivity: "base",
+    })
+  );
+}

--- a/lib/fuzzySongTitles.ts
+++ b/lib/fuzzySongTitles.ts
@@ -74,7 +74,7 @@ function isTokenSubset(shorterTokens: string[], longerTokens: string[]) {
   return shorterTokens.every((token) => longer.has(token));
 }
 
-function isLikelySameSongTitle(a: string, b: string) {
+export function isLikelySameSongTitle(a: string, b: string) {
   const aCompact = normalizeTitleForExactMatch(a);
   const bCompact = normalizeTitleForExactMatch(b);
 

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -1,3 +1,5 @@
+import { isLikelySameSongTitle } from "./fuzzySongTitles";
+
 export type Voicing = "TTBB" | "SATB" | "SSAA";
 
 export type Part =
@@ -40,6 +42,10 @@ export type MatchResult = {
 
 export const arrangementCheckNote =
   "Consider double-checking that everyone is singing the same arrangement.";
+
+export function possibleSameSongNote(firstTitle: string, secondTitle: string) {
+  return `Possible same song: Is "${firstTitle}" the same as "${secondTitle}"?`;
+}
 
 export function requiredPartsForVoicing(voicing: Voicing): Part[] {
   if (voicing === "TTBB") return ["Tenor", "Lead", "Baritone", "Bass"];
@@ -179,6 +185,40 @@ function scoreMatch(
   return categoryBase + assignedConfidence * 20 + flexibility * 2 - warningPenalty;
 }
 
+function knownArrangersForGroup(group: SingerEntry[]) {
+  return Array.from(
+    new Set(
+      group
+        .map((e) => e.arrangerName?.trim())
+        .filter((name): name is string => Boolean(name))
+    )
+  );
+}
+
+function arrangementWarningsForGroup(
+  group: SingerEntry[],
+  knownArrangers: string[]
+) {
+  const hasSomeMissingArranger =
+    knownArrangers.length > 0 && group.some((e) => !e.arrangerName?.trim());
+  const hasMultipleArrangers = knownArrangers.length > 1;
+
+  return hasSomeMissingArranger || hasMultipleArrangers
+    ? [arrangementCheckNote]
+    : [];
+}
+
+function preferredSuggestionTitle(firstTitle: string, secondTitle: string) {
+  if (secondTitle.length > firstTitle.length) return secondTitle;
+  if (firstTitle.length > secondTitle.length) return firstTitle;
+
+  return firstTitle.localeCompare(secondTitle, undefined, {
+    sensitivity: "base",
+  }) <= 0
+    ? firstTitle
+    : secondTitle;
+}
+
 export function findMatches(entries: SingerEntry[]): MatchResult[] {
   const groups = new Map<string, SingerEntry[]>();
 
@@ -194,24 +234,8 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     const requiredParts = requiredPartsForVoicing(voicing);
 
     const fullAssignment = findDistinctAssignment(requiredParts, group);
-
-    const knownArrangers = Array.from(
-      new Set(
-        group
-          .map((e) => e.arrangerName?.trim())
-          .filter((name): name is string => Boolean(name))
-      )
-    );
-
-    const hasSomeMissingArranger =
-      knownArrangers.length > 0 && group.some((e) => !e.arrangerName?.trim());
-    const hasMultipleArrangers = knownArrangers.length > 1;
-
-    const warnings: string[] = [];
-
-    if (hasSomeMissingArranger || hasMultipleArrangers) {
-      warnings.push(arrangementCheckNote);
-    }
+    const knownArrangers = knownArrangersForGroup(group);
+    const warnings = arrangementWarningsForGroup(group, knownArrangers);
 
     const confidence = confidenceWarning(group);
     if (confidence) warnings.push(confidence);
@@ -267,6 +291,57 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
           requiredParts,
           warnings
         ),
+      });
+    }
+  }
+
+  const exactGroups = Array.from(groups.values());
+  const possibleSuggestionKeys = new Set<string>();
+
+  for (let i = 0; i < exactGroups.length; i += 1) {
+    for (let j = i + 1; j < exactGroups.length; j += 1) {
+      const firstGroup = exactGroups[i];
+      const secondGroup = exactGroups[j];
+      const first = firstGroup[0];
+      const second = secondGroup[0];
+
+      if (first.voicing !== second.voicing) continue;
+      if (!isLikelySameSongTitle(first.songTitle, second.songTitle)) continue;
+
+      const group = [...firstGroup, ...secondGroup];
+      const requiredParts = requiredPartsForVoicing(first.voicing);
+      const fullAssignment = findDistinctAssignment(requiredParts, group);
+
+      if (!fullAssignment) continue;
+
+      const suggestionKey = [
+        first.voicing,
+        normalizeTitle(first.songTitle),
+        normalizeTitle(second.songTitle),
+      ]
+        .sort()
+        .join(":");
+
+      if (possibleSuggestionKeys.has(suggestionKey)) continue;
+      possibleSuggestionKeys.add(suggestionKey);
+
+      const knownArrangers = knownArrangersForGroup(group);
+      const warnings = [
+        possibleSameSongNote(first.songTitle, second.songTitle),
+        ...arrangementWarningsForGroup(group, knownArrangers),
+      ];
+      const confidence = confidenceWarning(group);
+      if (confidence) warnings.push(confidence);
+
+      results.push({
+        songTitle: preferredSuggestionTitle(first.songTitle, second.songTitle),
+        voicing: first.voicing,
+        arrangerNames: knownArrangers,
+        category: "possible",
+        missingParts: [],
+        assignments: buildAssignments(fullAssignment),
+        warnings,
+        score: scoreMatch("possible", fullAssignment, group, requiredParts, warnings),
       });
     }
   }


### PR DESCRIPTION
Closes #90

## Summary
- Added conservative same-voicing fuzzy song-title detection.
- Added `Possible` quartet results when near-duplicate title groups together cover all required parts, such as three singers on `Why Try to Change Me` and one singer on `Why Try To Change Me Now`.
- Added a lightweight repertoire cleanup panel that lets a user confirm an update to their own title or dismiss the suggestion.
- Kept fuzzy suggestions separate from confirmed `Ready to Sing` results, so near matches are never silently treated as ready.

## Notes
- Suggestions are not generated across different voicings.
- Exact normalized title matches are left to the existing matching behavior.
- No Supabase migration or dashboard change is required.

## Verification
- `npm run test:run` passed
- `npm run build` passed