### PR TITLE
Support part-specific repertoire confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After changing auth settings or email templates, run the manual checklist in
 The Supabase project should have the current production schema applied:
 
 - `profiles` stores each user's required `display_name`.
-- `user_repertoire` stores each user's songs, voicing, parts known, confidence,
+- `user_repertoire` stores each user's songs, voicing, part/confidence pairs,
   optional arranger name, and private notes.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -184,6 +184,9 @@ export default function JoinSessionPage() {
       arrangerName: item.arranger_name,
       partsKnown: item.parts_known,
       confidence: item.confidence,
+      partConfidences: Object.fromEntries(
+        item.part_confidences.map(({ part, confidence }) => [part, confidence])
+      ),
     }));
   }
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -19,7 +19,7 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">What is stored</h2>
             <p className="mt-2 text-slate-300">
               What Can We Sing stores your display name and your repertoire:
-              song titles, parts you know, confidence level, and optional
+              song titles, parts you know, confidence for each part, and optional
               arranger names.
             </p>
           </div>

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
-import type { Confidence, Part, Voicing } from "@/lib/matching";
+import type {
+  Confidence,
+  Part,
+  PartConfidence,
+  Voicing,
+} from "@/lib/matching";
 import {
   findFuzzySongTitleSuggestions,
   type FuzzySongTitleSuggestion,
@@ -33,13 +38,22 @@ const confidenceLevels: Confidence[] = [
   "Music Required",
 ];
 
+const emptyPartRow = (): PartConfidenceFormRow => ({
+  part: "",
+  confidence: "",
+});
+
 type RepertoireForm = {
   songTitle: string;
   voicing: Voicing;
   arrangerName: string;
-  partsKnown: Part[];
-  confidence: Confidence;
+  partRows: PartConfidenceFormRow[];
   notes: string;
+};
+
+type PartConfidenceFormRow = {
+  part: Part | "";
+  confidence: Confidence | "";
 };
 
 export default function RepertoireManager() {
@@ -51,8 +65,9 @@ export default function RepertoireManager() {
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
   const [notes, setNotes] = useState("");
-  const [partsKnown, setPartsKnown] = useState<Part[]>([]);
-  const [confidence, setConfidence] = useState<Confidence | "">("");
+  const [partRows, setPartRows] = useState<PartConfidenceFormRow[]>([
+    { part: "", confidence: "" },
+  ]);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [showArranger, setShowArranger] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -66,6 +81,31 @@ export default function RepertoireManager() {
     []
   );
   const [updatingSuggestionId, setUpdatingSuggestionId] = useState("");
+
+  function completePartConfidences(
+    rows: PartConfidenceFormRow[]
+  ): PartConfidence[] {
+    return rows
+      .filter(
+        (row): row is PartConfidence =>
+          Boolean(row.part) && Boolean(row.confidence)
+      )
+      .map((row) => ({
+        part: row.part,
+        confidence: row.confidence,
+      }));
+  }
+
+  function hasDuplicateParts(rows: PartConfidenceFormRow[]) {
+    const selectedParts = rows
+      .map((row) => row.part)
+      .filter((part): part is Part => Boolean(part));
+    return new Set(selectedParts).size !== selectedParts.length;
+  }
+
+  function rowHasMissingPartOrConfidence(rows: PartConfidenceFormRow[]) {
+    return rows.some((row) => !row.part || !row.confidence);
+  }
 
   async function loadRepertoire() {
     try {
@@ -143,8 +183,7 @@ export default function RepertoireManager() {
     setVoicing("");
     setArrangerName("");
     setNotes("");
-    setPartsKnown([]);
-    setConfidence("");
+    setPartRows([emptyPartRow()]);
     setShowArranger(false);
   }
 
@@ -159,22 +198,13 @@ export default function RepertoireManager() {
     setMessage("");
   }
 
-  function togglePart(part: Part) {
-    setPartsKnown((current) =>
-      current.includes(part)
-        ? current.filter((p) => p !== part)
-        : [...current, part]
-    );
-  }
-
   function startEditing(item: RepertoireRow) {
     setEditingId(item.id);
     setEditForm({
       songTitle: item.song_title,
       voicing: item.voicing,
       arrangerName: item.arranger_name ?? "",
-      partsKnown: item.parts_known,
-      confidence: item.confidence,
+      partRows: item.part_confidences,
       notes: item.notes ?? "",
     });
     setMessage("");
@@ -185,21 +215,66 @@ export default function RepertoireManager() {
     setEditForm(null);
   }
 
-  function toggleEditPart(part: Part) {
+  function updateEditForm(patch: Partial<RepertoireForm>) {
+    setEditForm((current) => (current ? { ...current, ...patch } : current));
+  }
+
+  function updatePartRow(
+    rowIndex: number,
+    patch: Partial<PartConfidenceFormRow>
+  ) {
+    setPartRows((current) =>
+      current.map((row, index) =>
+        index === rowIndex ? { ...row, ...patch } : row
+      )
+    );
+  }
+
+  function addPartRow() {
+    setPartRows((current) => [...current, emptyPartRow()]);
+  }
+
+  function removePartRow(rowIndex: number) {
+    setPartRows((current) =>
+      current.length <= 1
+        ? current
+        : current.filter((_, index) => index !== rowIndex)
+    );
+  }
+
+  function updateEditPartRow(
+    rowIndex: number,
+    patch: Partial<PartConfidenceFormRow>
+  ) {
     setEditForm((current) => {
       if (!current) return current;
 
       return {
         ...current,
-        partsKnown: current.partsKnown.includes(part)
-          ? current.partsKnown.filter((p) => p !== part)
-          : [...current.partsKnown, part],
+        partRows: current.partRows.map((row, index) =>
+          index === rowIndex ? { ...row, ...patch } : row
+        ),
       };
     });
   }
 
-  function updateEditForm(patch: Partial<RepertoireForm>) {
-    setEditForm((current) => (current ? { ...current, ...patch } : current));
+  function addEditPartRow() {
+    setEditForm((current) =>
+      current
+        ? { ...current, partRows: [...current.partRows, emptyPartRow()] }
+        : current
+    );
+  }
+
+  function removeEditPartRow(rowIndex: number) {
+    setEditForm((current) => {
+      if (!current || current.partRows.length <= 1) return current;
+
+      return {
+        ...current,
+        partRows: current.partRows.filter((_, index) => index !== rowIndex),
+      };
+    });
   }
 
   async function addItem() {
@@ -215,24 +290,24 @@ export default function RepertoireManager() {
       return;
     }
 
-    if (!confidence) {
-      setMessage("Choose a confidence level before saving.");
+    if (rowHasMissingPartOrConfidence(partRows)) {
+      setMessage("Choose a part and confidence for each row before saving.");
       return;
     }
 
-    if (partsKnown.length === 0) {
-      setMessage("Choose at least one part you know before saving.");
+    if (hasDuplicateParts(partRows)) {
+      setMessage("Use each part only once for this song.");
       return;
     }
 
     try {
       setIsAdding(true);
+      const partConfidences = completePartConfidences(partRows);
       await addRepertoireItem({
         songTitle: songTitle.trim(),
         voicing,
         arrangerName: arrangerName.trim() || undefined,
-        partsKnown,
-        confidence,
+        partConfidences,
         notes: notes.trim() || undefined,
       });
 
@@ -241,7 +316,7 @@ export default function RepertoireManager() {
       setMessage("Song added.");
       trackEvent("repertoire_song_added", {
         song_count: items.length + 1,
-        parts_known_count: partsKnown.length,
+        parts_known_count: partConfidences.length,
       });
       let snapshotUpdated = true;
       try {
@@ -319,19 +394,26 @@ export default function RepertoireManager() {
       return;
     }
 
-    if (editForm.partsKnown.length === 0) {
-      setMessage("Choose at least one part you know before saving changes.");
+    if (rowHasMissingPartOrConfidence(editForm.partRows)) {
+      setMessage(
+        "Choose a part and confidence for each row before saving changes."
+      );
+      return;
+    }
+
+    if (hasDuplicateParts(editForm.partRows)) {
+      setMessage("Use each part only once for this song.");
       return;
     }
 
     try {
       setSavingEditId(id);
+      const partConfidences = completePartConfidences(editForm.partRows);
       await updateRepertoireItem(id, {
         songTitle: editForm.songTitle.trim(),
         voicing: editForm.voicing,
         arrangerName: editForm.arrangerName.trim() || undefined,
-        partsKnown: editForm.partsKnown,
-        confidence: editForm.confidence,
+        partConfidences,
         notes: editForm.notes.trim() || undefined,
       });
 
@@ -339,7 +421,7 @@ export default function RepertoireManager() {
       setMessage("Song updated.");
       trackEvent("repertoire_song_edited", {
         song_count: items.length,
-        parts_known_count: editForm.partsKnown.length,
+        parts_known_count: partConfidences.length,
       });
       let snapshotUpdated = true;
       try {
@@ -393,8 +475,7 @@ export default function RepertoireManager() {
         songTitle: suggestion.suggestedTitle,
         voicing: item.voicing,
         arrangerName: item.arranger_name ?? undefined,
-        partsKnown: item.parts_known,
-        confidence: item.confidence,
+        partConfidences: item.part_confidences,
         notes: item.notes ?? undefined,
       });
       dismissSuggestion(suggestion.id);
@@ -424,8 +505,8 @@ export default function RepertoireManager() {
   const canAddSong =
     Boolean(songTitle.trim()) &&
     Boolean(voicing) &&
-    Boolean(confidence) &&
-    partsKnown.length > 0;
+    !rowHasMissingPartOrConfidence(partRows) &&
+    !hasDuplicateParts(partRows);
   const visibleItems = items
     .filter((item) =>
       item.song_title.toLowerCase().includes(searchQuery.trim().toLowerCase())
@@ -636,34 +717,13 @@ export default function RepertoireManager() {
                           onChange={(e) =>
                             updateEditForm({
                               voicing: e.target.value as Voicing,
-                              partsKnown: [],
+                              partRows: [emptyPartRow()],
                             })
                           }
                           className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                         >
                           {voicings.map((v) => (
                             <option key={v}>{v}</option>
-                          ))}
-                        </select>
-                      </label>
-
-                      <label className="block">
-                        <span className="text-sm font-medium text-slate-300">
-                          Confidence
-                        </span>
-                        <select
-                          value={editForm.confidence}
-                          onChange={(e) =>
-                            updateEditForm({
-                              confidence: e.target.value as Confidence,
-                            })
-                          }
-                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                        >
-                          {confidenceLevels.map((level) => (
-                            <option key={level} value={level}>
-                              {level}
-                            </option>
                           ))}
                         </select>
                       </label>
@@ -685,24 +745,86 @@ export default function RepertoireManager() {
 
                     <div className="mt-5">
                       <p className="text-sm font-medium text-slate-300">
-                        Parts you know
+                        Parts and confidence
                       </p>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {partsByVoicing[editForm.voicing].map((part) => (
-                          <button
-                            key={part}
-                            type="button"
-                            onClick={() => toggleEditPart(part)}
-                            className={`min-h-12 rounded-xl px-4 py-3 text-sm font-semibold ring-1 ${
-                              editForm.partsKnown.includes(part)
-                                ? "bg-cyan-300 text-slate-950 ring-cyan-200"
-                                : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
-                            }`}
+                      <div className="mt-2 space-y-3">
+                        {editForm.partRows.map((row, rowIndex) => (
+                          <div
+                            key={rowIndex}
+                            className="grid gap-2 rounded-xl border border-white/10 bg-slate-950/60 p-3 sm:grid-cols-[1fr_1fr_auto]"
                           >
-                            {partButtonLabel(editForm.voicing, part)}
-                          </button>
+                            <label className="block">
+                              <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                                Part
+                              </span>
+                              <select
+                                value={row.part}
+                                onChange={(e) =>
+                                  updateEditPartRow(rowIndex, {
+                                    part: e.target.value as Part | "",
+                                  })
+                                }
+                                className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                              >
+                                <option value="">Choose part</option>
+                                {partsByVoicing[editForm.voicing].map((part) => (
+                                  <option
+                                    key={part}
+                                    value={part}
+                                    disabled={editForm.partRows.some(
+                                      (candidate, candidateIndex) =>
+                                        candidateIndex !== rowIndex &&
+                                        candidate.part === part
+                                    )}
+                                  >
+                                    {partButtonLabel(editForm.voicing, part)}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label className="block">
+                              <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                                Confidence
+                              </span>
+                              <select
+                                value={row.confidence}
+                                onChange={(e) =>
+                                  updateEditPartRow(rowIndex, {
+                                    confidence: e.target.value as Confidence | "",
+                                  })
+                                }
+                                className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                              >
+                                <option value="">Choose confidence</option>
+                                {confidenceLevels.map((level) => (
+                                  <option key={level} value={level}>
+                                    {level}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <button
+                              type="button"
+                              onClick={() => removeEditPartRow(rowIndex)}
+                              disabled={editForm.partRows.length <= 1}
+                              className="min-h-12 rounded-xl bg-slate-800 px-3 py-3 text-sm font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40 sm:self-end"
+                            >
+                              Remove
+                            </button>
+                          </div>
                         ))}
                       </div>
+                      <button
+                        type="button"
+                        onClick={addEditPartRow}
+                        disabled={
+                          editForm.partRows.length >=
+                          partsByVoicing[editForm.voicing].length
+                        }
+                        className="mt-3 rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold text-cyan-200 hover:bg-white/20 disabled:opacity-40"
+                      >
+                        Add another part
+                      </button>
                     </div>
 
                     <div className="mt-6 flex flex-col gap-3 sm:flex-row">
@@ -742,17 +864,14 @@ export default function RepertoireManager() {
                       </div>
 
                       <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-slate-300">
-                        {item.parts_known.map((part) => (
+                        {item.part_confidences.map(({ part, confidence }) => (
                           <span
                             key={part}
                             className="rounded-full bg-cyan-300/10 px-2 py-0.5 font-semibold text-cyan-100 ring-1 ring-cyan-300/20"
                           >
-                            {partAbbreviation(item.voicing, part)}
+                            {partAbbreviation(item.voicing, part)} · {confidence}
                           </span>
                         ))}
-                        <span className="rounded-full bg-slate-900 px-2 py-0.5 font-medium text-slate-300">
-                          {item.confidence}
-                        </span>
                         {item.arranger_name && (
                           <span className="truncate text-slate-400">
                             Arr. {item.arranger_name}
@@ -847,7 +966,7 @@ export default function RepertoireManager() {
                         type="button"
                         onClick={() => {
                           setVoicing(v);
-                          setPartsKnown([]);
+                          setPartRows([emptyPartRow()]);
                         }}
                         className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
                           voicing === v
@@ -863,52 +982,91 @@ export default function RepertoireManager() {
 
                 <div>
                   <p className="text-sm font-medium text-slate-300">
-                    Parts you know
+                    Parts and confidence
                   </p>
-                  <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  <div className="mt-2 space-y-3">
                     {voicing ? (
-                      partsByVoicing[voicing].map((part) => (
-                        <button
-                          key={part}
-                          type="button"
-                          onClick={() => togglePart(part)}
-                          className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
-                            partsKnown.includes(part)
-                              ? "bg-cyan-300 text-slate-950 ring-cyan-200"
-                              : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
-                          }`}
+                      partRows.map((row, rowIndex) => (
+                        <div
+                          key={rowIndex}
+                          className="grid gap-2 rounded-xl border border-white/10 bg-slate-950/60 p-3 sm:grid-cols-[1fr_1fr_auto]"
                         >
-                          {partButtonLabel(voicing, part)}
-                        </button>
+                          <label className="block">
+                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                              Part
+                            </span>
+                            <select
+                              value={row.part}
+                              onChange={(e) =>
+                                updatePartRow(rowIndex, {
+                                  part: e.target.value as Part | "",
+                                })
+                              }
+                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                            >
+                              <option value="">Choose part</option>
+                              {partsByVoicing[voicing].map((part) => (
+                                <option
+                                  key={part}
+                                  value={part}
+                                  disabled={partRows.some(
+                                    (candidate, candidateIndex) =>
+                                      candidateIndex !== rowIndex &&
+                                      candidate.part === part
+                                  )}
+                                >
+                                  {partButtonLabel(voicing, part)}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="block">
+                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                              Confidence
+                            </span>
+                            <select
+                              value={row.confidence}
+                              onChange={(e) =>
+                                updatePartRow(rowIndex, {
+                                  confidence: e.target.value as Confidence | "",
+                                })
+                              }
+                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                            >
+                              <option value="">Choose confidence</option>
+                              {confidenceLevels.map((level) => (
+                                <option key={level} value={level}>
+                                  {level}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => removePartRow(rowIndex)}
+                            disabled={partRows.length <= 1}
+                            className="min-h-12 rounded-xl bg-slate-800 px-3 py-3 text-sm font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40 sm:self-end"
+                          >
+                            Remove
+                          </button>
+                        </div>
                       ))
                     ) : (
-                      <p className="col-span-2 text-sm text-slate-400 sm:col-span-4">
+                      <p className="text-sm text-slate-400">
                         Choose a voicing first.
                       </p>
                     )}
                   </div>
-                </div>
-
-                <div>
-                  <p className="text-sm font-medium text-slate-300">
-                    Confidence
-                  </p>
-                  <div className="mt-2 grid gap-2 sm:grid-cols-3">
-                    {confidenceLevels.map((level) => (
-                      <button
-                        key={level}
-                        type="button"
-                        onClick={() => setConfidence(level)}
-                        className={`min-h-12 rounded-xl px-3 py-3 text-sm font-semibold ring-1 ${
-                          confidence === level
-                            ? "bg-cyan-300 text-slate-950 ring-cyan-200"
-                            : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
-                        }`}
-                      >
-                        {level}
-                      </button>
-                    ))}
-                  </div>
+                  {voicing && (
+                    <button
+                      type="button"
+                      onClick={addPartRow}
+                      disabled={partRows.length >= partsByVoicing[voicing].length}
+                      className="mt-3 rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold text-cyan-200 hover:bg-white/20 disabled:opacity-40"
+                    >
+                      Add another part
+                    </button>
+                  )}
                 </div>
 
                 <div>

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -66,7 +66,10 @@ Required database contract:
 - `voicing text not null`
 - `arranger_name text`
 - `parts_known text[] not null`
-- `confidence text`
+- `part_confidences jsonb not null default '[]'::jsonb`
+- `confidence text` remains for legacy rows and compatibility; new code stores
+  per-part confidence in `part_confidences` and keeps this set to the first
+  row's confidence.
 - `notes text`
 - RLS enabled.
 - Authenticated users can select/insert/update/delete only rows where
@@ -75,6 +78,7 @@ Required database contract:
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
+- `20260428142000_add_part_confidences_to_repertoire.sql`
 
 ### `sessions`
 
@@ -129,7 +133,8 @@ Required database contract:
 - `session_id uuid not null references public.sessions(id) on delete cascade`
 - `user_id uuid not null references auth.users(id) on delete cascade`
 - `display_name text not null`
-- `repertoire jsonb not null default '[]'::jsonb`
+- `repertoire jsonb not null default '[]'::jsonb`; snapshot entries include
+  `partsKnown` and, for current snapshots, `partConfidences`
 - `joined_at timestamptz not null default now()`
 - Unique index on `(session_id, user_id)` for upserts.
 - RLS enabled.

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -35,7 +35,7 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].warnings).toContain(
-      "Confidence warning: Rusty marked A Little Rusty, Music marked Music Required"
+      "Confidence warning: Rusty marked A Little Rusty on Lead, Music marked Music Required on Baritone"
     );
   });
 
@@ -350,6 +350,41 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].assignments.Tenor?.[0].displayName).toBe("Ready Tenor");
+  });
+
+  it("uses confidence for the assigned part when choosing flexible singers", () => {
+    const entries: SingerEntry[] = [
+      {
+        userId: "1",
+        displayName: "Flexible",
+        songTitle: "Part Confidence Song",
+        voicing: "TTBB",
+        partsKnown: ["Tenor", "Lead"],
+        confidence: "Music Required",
+        partConfidences: {
+          Tenor: "Music Required",
+          Lead: "Good to Go",
+        },
+      },
+      {
+        userId: "2",
+        displayName: "Tenor Only",
+        songTitle: "Part Confidence Song",
+        voicing: "TTBB",
+        partsKnown: ["Tenor"],
+        confidence: "Music Required",
+        partConfidences: {
+          Tenor: "Good to Go",
+        },
+      },
+      { userId: "3", displayName: "Bari", songTitle: "Part Confidence Song", voicing: "TTBB", partsKnown: ["Baritone"], confidence: "Good to Go" },
+      { userId: "4", displayName: "Bass", songTitle: "Part Confidence Song", voicing: "TTBB", partsKnown: ["Bass"], confidence: "Good to Go" },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].assignments.Tenor?.[0].displayName).toBe("Tenor Only");
+    expect(matches[0].assignments.Lead?.[0].displayName).toBe("Flexible");
   });
 
   it("uses extra part coverage as a modest tie-breaker", () => {

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -14,6 +14,13 @@ const migration = readFileSync(
   ),
   "utf8"
 );
+const partConfidenceMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260428142000_add_part_confidences_to_repertoire.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -54,5 +61,12 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("leave");
     expect(contract).toContain("repertoire snapshot");
     expect(contract).toContain("Match calculation source");
+  });
+
+  it("documents and migrates per-part repertoire confidence", () => {
+    expect(contract).toContain("part_confidences");
+    expect(partConfidenceMigration).toContain("part_confidences jsonb");
+    expect(partConfidenceMigration).toContain("unnest(parts_known)");
+    expect(partConfidenceMigration).toContain("confidence");
   });
 });

--- a/lib/activeQuartetSnapshot.ts
+++ b/lib/activeQuartetSnapshot.ts
@@ -43,6 +43,9 @@ export async function refreshActiveQuartetSnapshot() {
     arrangerName: item.arranger_name,
     partsKnown: item.parts_known,
     confidence: item.confidence,
+    partConfidences: Object.fromEntries(
+      item.part_confidences.map(({ part, confidence }) => [part, confidence])
+    ),
   }));
   const lastActivityAt = new Date().toISOString();
 

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -19,6 +19,13 @@ export type Confidence =
   | "A Little Rusty"
   | "Music Required";
 
+export type PartConfidence = {
+  part: Part;
+  confidence: Confidence;
+};
+
+export type PartConfidenceMap = Partial<Record<Part, Confidence>>;
+
 export type SingerEntry = {
   userId: string;
   displayName: string;
@@ -27,6 +34,7 @@ export type SingerEntry = {
   arrangerName?: string | null;
   partsKnown: Part[];
   confidence?: Confidence | null;
+  partConfidences?: PartConfidenceMap | null;
 };
 
 export type MatchResult = {
@@ -84,9 +92,25 @@ function confidenceValue(confidence?: string | null): number {
   return 3;
 }
 
-function confidenceWarning(entries: SingerEntry[]): string | null {
-  const weak = entries.filter((e) => {
-    const normalizedConfidence = normalizeConfidence(e.confidence);
+export function confidenceForPart(
+  entry: SingerEntry,
+  part: Part
+): Confidence | null {
+  return (
+    normalizeConfidence(entry.partConfidences?.[part]) ??
+    normalizeConfidence(entry.confidence)
+  );
+}
+
+function confidenceValueForPart(entry: SingerEntry, part: Part): number {
+  return confidenceValue(confidenceForPart(entry, part));
+}
+
+function confidenceWarning(
+  assignment: Record<Part, SingerEntry>
+): string | null {
+  const weak = Object.entries(assignment).filter(([part, entry]) => {
+    const normalizedConfidence = confidenceForPart(entry, part as Part);
     return (
       normalizedConfidence === "A Little Rusty" ||
       normalizedConfidence === "Music Required"
@@ -96,7 +120,10 @@ function confidenceWarning(entries: SingerEntry[]): string | null {
   if (!weak.length) return null;
 
   return `Confidence warning: ${weak
-    .map((e) => `${e.displayName} marked ${normalizeConfidence(e.confidence)}`)
+    .map(([part, entry]) => {
+      const normalizedConfidence = confidenceForPart(entry, part as Part);
+      return `${entry.displayName} marked ${normalizedConfidence} on ${part}`;
+    })
     .join(", ")}`;
 }
 
@@ -120,7 +147,10 @@ function findDistinctAssignment(
 
     const candidates = entries
       .filter((entry) => entry.partsKnown.includes(part) && !usedSingerIds.has(entry.userId))
-      .sort((a, b) => confidenceValue(b.confidence) - confidenceValue(a.confidence));
+      .sort(
+        (a, b) =>
+          confidenceValueForPart(b, part) - confidenceValueForPart(a, part)
+      );
 
     for (const candidate of candidates) {
       assignment[part] = candidate;
@@ -166,7 +196,15 @@ function scoreMatch(
   }[category];
 
   const assignedConfidence = Object.values(assignment).reduce(
-    (sum, entry) => sum + confidenceValue(entry.confidence),
+    (sum, entry) => {
+      const assignedPart = Object.entries(assignment).find(
+        ([, assignedEntry]) => assignedEntry === entry
+      )?.[0] as Part | undefined;
+
+      return assignedPart
+        ? sum + confidenceValueForPart(entry, assignedPart)
+        : sum;
+    },
     0
   );
 
@@ -237,10 +275,10 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     const knownArrangers = knownArrangersForGroup(group);
     const warnings = arrangementWarningsForGroup(group, knownArrangers);
 
-    const confidence = confidenceWarning(group);
-    if (confidence) warnings.push(confidence);
-
     if (fullAssignment) {
+      const confidence = confidenceWarning(fullAssignment);
+      if (confidence) warnings.push(confidence);
+
       results.push({
         songTitle,
         voicing,
@@ -276,6 +314,9 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     }
 
     if (bestNearMatch) {
+      const confidence = confidenceWarning(bestNearMatch.assignment);
+      if (confidence) warnings.push(confidence);
+
       results.push({
         songTitle,
         voicing,
@@ -330,7 +371,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         possibleSameSongNote(first.songTitle, second.songTitle),
         ...arrangementWarningsForGroup(group, knownArrangers),
       ];
-      const confidence = confidenceWarning(group);
+      const confidence = confidenceWarning(fullAssignment);
       if (confidence) warnings.push(confidence);
 
       results.push({

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -1,5 +1,11 @@
 import { supabase } from "@/lib/supabase";
-import { normalizeConfidence, type Confidence, type Part, type Voicing } from "@/lib/matching";
+import {
+  normalizeConfidence,
+  type Confidence,
+  type Part,
+  type PartConfidence,
+  type Voicing,
+} from "@/lib/matching";
 import { getCurrentUser } from "@/lib/profileStore";
 
 export type RepertoireRow = {
@@ -9,20 +15,74 @@ export type RepertoireRow = {
   voicing: Voicing;
   arranger_name: string | null;
   parts_known: Part[];
+  part_confidences: PartConfidence[];
   confidence: Confidence;
   notes: string | null;
   created_at: string;
   updated_at: string;
 };
 
-type RawRepertoireRow = Omit<RepertoireRow, "confidence"> & {
+type RawRepertoireRow = Omit<RepertoireRow, "confidence" | "part_confidences"> & {
   confidence: string | null;
+  part_confidences?: unknown;
 };
 
+const validParts: Part[] = [
+  "Tenor",
+  "Lead",
+  "Baritone",
+  "Bass",
+  "Soprano",
+  "Alto",
+  "Soprano 1",
+  "Soprano 2",
+  "Alto 1",
+  "Alto 2",
+];
+
+function isPart(value: unknown): value is Part {
+  return typeof value === "string" && validParts.includes(value as Part);
+}
+
+function normalizePartConfidences(row: RawRepertoireRow): PartConfidence[] {
+  if (Array.isArray(row.part_confidences)) {
+    const seen = new Set<Part>();
+    const normalized = row.part_confidences
+      .map((item) => {
+        if (!item || typeof item !== "object") return null;
+        const candidate = item as { part?: unknown; confidence?: unknown };
+        const confidence =
+          typeof candidate.confidence === "string"
+            ? normalizeConfidence(candidate.confidence)
+            : null;
+
+        if (!isPart(candidate.part) || !confidence || seen.has(candidate.part)) {
+          return null;
+        }
+
+        seen.add(candidate.part);
+        return { part: candidate.part, confidence };
+      })
+      .filter((item): item is PartConfidence => Boolean(item));
+
+    if (normalized.length > 0) return normalized;
+  }
+
+  const fallbackConfidence = normalizeConfidence(row.confidence) ?? "Music Required";
+  return row.parts_known.map((part) => ({
+    part,
+    confidence: fallbackConfidence,
+  }));
+}
+
 function normalizeRepertoireRow(row: RawRepertoireRow): RepertoireRow {
+  const partConfidences = normalizePartConfidences(row);
+
   return {
     ...row,
-    confidence: normalizeConfidence(row.confidence) ?? "Music Required",
+    parts_known: partConfidences.map((item) => item.part),
+    part_confidences: partConfidences,
+    confidence: partConfidences[0]?.confidence ?? "Music Required",
   };
 }
 
@@ -44,12 +104,12 @@ export async function addRepertoireItem(input: {
   songTitle: string;
   voicing: Voicing;
   arrangerName?: string;
-  partsKnown: Part[];
-  confidence: Confidence;
+  partConfidences: PartConfidence[];
   notes?: string;
 }) {
   const user = await getCurrentUser();
   if (!user) throw new Error("You must be logged in.");
+  const primaryConfidence = input.partConfidences[0]?.confidence ?? "Music Required";
 
   const { data, error } = await supabase
     .from("user_repertoire")
@@ -58,8 +118,9 @@ export async function addRepertoireItem(input: {
       song_title: input.songTitle,
       voicing: input.voicing,
       arranger_name: input.arrangerName || null,
-      parts_known: input.partsKnown,
-      confidence: input.confidence,
+      parts_known: input.partConfidences.map((item) => item.part),
+      part_confidences: input.partConfidences,
+      confidence: primaryConfidence,
       notes: input.notes || null,
     })
     .select()
@@ -75,13 +136,13 @@ export async function updateRepertoireItem(
     songTitle: string;
     voicing: Voicing;
     arrangerName?: string;
-    partsKnown: Part[];
-    confidence: Confidence;
+    partConfidences: PartConfidence[];
     notes?: string;
   }
 ) {
   const user = await getCurrentUser();
   if (!user) throw new Error("You must be logged in.");
+  const primaryConfidence = input.partConfidences[0]?.confidence ?? "Music Required";
 
   const { data, error } = await supabase
     .from("user_repertoire")
@@ -89,8 +150,9 @@ export async function updateRepertoireItem(
       song_title: input.songTitle,
       voicing: input.voicing,
       arranger_name: input.arrangerName || null,
-      parts_known: input.partsKnown,
-      confidence: input.confidence,
+      parts_known: input.partConfidences.map((item) => item.part),
+      part_confidences: input.partConfidences,
+      confidence: primaryConfidence,
       notes: input.notes || null,
     })
     .eq("id", id)

--- a/supabase/migrations/20260428142000_add_part_confidences_to_repertoire.sql
+++ b/supabase/migrations/20260428142000_add_part_confidences_to_repertoire.sql
@@ -1,0 +1,19 @@
+alter table public.user_repertoire
+  add column if not exists part_confidences jsonb not null default '[]'::jsonb;
+
+update public.user_repertoire
+set part_confidences = coalesce(
+  (
+    select jsonb_agg(
+      jsonb_build_object(
+        'part',
+        part_name,
+        'confidence',
+        coalesce(confidence, 'Music Required')
+      )
+    )
+    from unnest(parts_known) as part_name
+  ),
+  '[]'::jsonb
+)
+where part_confidences = '[]'::jsonb;


### PR DESCRIPTION
Closes #155

## Summary
- Replaced the repertoire multi-part picker plus single confidence with repeatable part/confidence rows for add and edit flows.
- Prevented duplicate part rows in the UI and validation.
- Added `part_confidences` to repertoire rows while continuing to write legacy `parts_known` and `confidence` for compatibility.
- Updated quartet snapshots so new session participant repertoire entries include per-part confidence.
- Updated matching to rank and warn using the confidence for the specific assigned part, with fallback to legacy entry confidence for older snapshots.

## Migration / Supabase step
- Added `supabase/migrations/20260428142000_add_part_confidences_to_repertoire.sql`.
- After merge, run `supabase db push` to add/backfill `user_repertoire.part_confidences`.
- No dashboard-only Supabase change is required.

## Tests
- Added/updated matching tests for assigned-part confidence behavior.
- Added a Supabase contract guardrail for the new migration/column.

## Verification
- `npm run test:run` passed
- `npm run build` passed