### PR TITLE
Show fuzzy title details in match cards

### DIFF
--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -47,6 +47,7 @@ export function MatchCard({
   const styles = categoryStyles[match.category];
   const parts = requiredPartsForVoicing(match.voicing);
   const hasDetails =
+    Boolean(match.titleVariants?.length) ||
     match.warnings.length > 0 ||
     match.arrangerNames.length > 0 ||
     personalNotes.length > 0 ||
@@ -137,6 +138,46 @@ export function MatchCard({
             {match.arrangerNames.join(", ")}
           </p>
         )}
+
+        {match.titleMatchType === "fuzzy" && match.titleVariants?.length ? (
+          <div className="mt-3 rounded-lg bg-amber-300/10 p-3 text-sm text-amber-50">
+            <p className="font-semibold text-amber-100">
+              Potential title match
+            </p>
+            <p className="mt-1 text-xs text-amber-50/80">
+              These repertoire entries may refer to the same song.
+            </p>
+            <p className="mt-2 text-xs text-amber-50/70">
+              Comparison key:{" "}
+              {match.titleVariants
+                .map((variant) => variant.normalizedTitle)
+                .join(" / ")}
+            </p>
+            <div className="mt-3 space-y-3">
+              {match.titleVariants.map((variant) => (
+                <div key={variant.title}>
+                  <p className="font-semibold text-white">"{variant.title}"</p>
+                  <ul className="mt-1 space-y-1">
+                    {variant.singers.map((singer) => (
+                      <li
+                        key={`${variant.title}-${singer.displayName}-${singer.part}`}
+                        className="text-xs text-amber-50/90"
+                      >
+                        {singer.displayName} -{" "}
+                        {partAbbreviation(match.voicing, singer.part)}
+                        {singer.confidence ? ` - ${singer.confidence}` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-xs text-amber-50/80">
+              If these are the same song, consider updating repertoire titles
+              so future matches are clearer.
+            </p>
+          </div>
+        ) : null}
 
         {match.warnings.length > 0 && (
           <div

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -170,6 +170,25 @@ describe("findMatches", () => {
     expect(matches[0].warnings).toContain(
       possibleSameSongNote("Why Try to Change Me", "Why Try To Change Me Now")
     );
+    expect(matches[0].titleMatchType).toBe("fuzzy");
+    expect(matches[0].titleVariants).toEqual([
+      {
+        title: "Why Try to Change Me",
+        normalizedTitle: "whytrytochangeme",
+        singers: [
+          { displayName: "T", part: "Tenor", confidence: null },
+          { displayName: "L", part: "Lead", confidence: null },
+          { displayName: "Bari", part: "Baritone", confidence: null },
+        ],
+      },
+      {
+        title: "Why Try To Change Me Now",
+        normalizedTitle: "whytrytochangemenow",
+        singers: [
+          { displayName: "Bass", part: "Bass", confidence: null },
+        ],
+      },
+    ]);
     expect(matches[1]).toMatchObject({
       songTitle: "Why Try to Change Me",
       category: "one_part_missing",

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -46,6 +46,20 @@ export type MatchResult = {
   assignments: Partial<Record<Part, SingerEntry[]>>;
   warnings: string[];
   score: number;
+  titleMatchType?: "exact" | "fuzzy";
+  titleVariants?: MatchTitleVariant[];
+};
+
+export type MatchTitleVariant = {
+  title: string;
+  normalizedTitle: string;
+  singers: MatchTitleVariantSinger[];
+};
+
+export type MatchTitleVariantSinger = {
+  displayName: string;
+  part: Part;
+  confidence: Confidence | null;
 };
 
 export const arrangementCheckNote =
@@ -257,6 +271,37 @@ function preferredSuggestionTitle(firstTitle: string, secondTitle: string) {
     : secondTitle;
 }
 
+function buildTitleVariants(
+  assignment: Record<Part, SingerEntry>
+): MatchTitleVariant[] {
+  const variants = new Map<string, MatchTitleVariant>();
+
+  for (const [part, entry] of Object.entries(assignment)) {
+    const assignedPart = part as Part;
+    const existing = variants.get(entry.songTitle);
+    const singer = {
+      displayName: entry.displayName,
+      part: assignedPart,
+      confidence: confidenceForPart(entry, assignedPart),
+    };
+
+    if (existing) {
+      existing.singers.push(singer);
+      continue;
+    }
+
+    variants.set(entry.songTitle, {
+      title: entry.songTitle,
+      normalizedTitle: normalizeTitle(entry.songTitle),
+      singers: [singer],
+    });
+  }
+
+  return Array.from(variants.values()).sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: "base" })
+  );
+}
+
 export function findMatches(entries: SingerEntry[]): MatchResult[] {
   const groups = new Map<string, SingerEntry[]>();
 
@@ -383,6 +428,8 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         assignments: buildAssignments(fullAssignment),
         warnings,
         score: scoreMatch("possible", fullAssignment, group, requiredParts, warnings),
+        titleMatchType: "fuzzy",
+        titleVariants: buildTitleVariants(fullAssignment),
       });
     }
   }


### PR DESCRIPTION
Closes #175

## Summary
- Added structured title-variant metadata to fuzzy `possible` match results.
- Expanded fuzzy match details now show each submitted title, its normalized comparison key, and the singer/part/confidence assigned from that title.
- Added a clear note that singers should manually update repertoire titles if the variants are the same song.

## Notes
- This does not change the automatic matching decision or rewrite repertoire entries.
- Exact matches are not made noisier; the extra section renders only for fuzzy title matches.
- No Supabase migration or dashboard change is required.

## Verification
- `npm run test:run` passed
- `npm run build` passed