### PR TITLE
Implement Mark as Sung for repertoire rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Supabase project should have the current production schema applied:
 
 - `profiles` stores each user's required `display_name`.
 - `user_repertoire` stores each user's songs, voicing, part/confidence pairs,
-  optional arranger name, and private notes.
+  optional arranger name, private notes, and personal sung-count metadata.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by
@@ -51,7 +51,9 @@ The Supabase project should have the current production schema applied:
   rows. Supabase Realtime must be enabled for this table so joined clients see
   participant insert, update, and delete changes immediately.
 - `sung_song_events` stores each user's private "marked as sung" events for
-  recent-use indicators.
+  recent-use indicators. Marking a song as sung is performed through the
+  `mark_repertoire_sung` database function so repertoire metadata and the event
+  log stay in sync.
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { trackEvent } from "@/lib/analytics";
+import { resolveCurrentUserRepertoireForMarkAsSung } from "@/lib/markAsSung";
 import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
 import {
   findParticipantByUserId,
@@ -46,10 +47,12 @@ import {
   getProfilesByIds,
   subscribeToProfileDisplayNames,
 } from "@/lib/profileStore";
-import { getMyRepertoire } from "@/lib/repertoireStore";
+import {
+  getMyRepertoire,
+  markRepertoireItemAsSung,
+} from "@/lib/repertoireStore";
 import {
   getRecentSungSongs,
-  markSongAsSung,
   type SungSongEvent,
 } from "@/lib/sungSongStore";
 
@@ -177,6 +180,7 @@ export default function JoinSessionPage() {
     const repertoire = await loadMyRepertoire();
 
     return repertoire.map((item) => ({
+      repertoireId: item.id,
       userId: item.user_id,
       displayName: name,
       songTitle: item.song_title,
@@ -467,16 +471,43 @@ export default function JoinSessionPage() {
     setMessage("");
 
     try {
-      await markSongAsSung({
-        sessionId,
-        songTitle: match.songTitle,
+      const resolution = resolveCurrentUserRepertoireForMarkAsSung(
+        match,
+        currentUserId
+      );
+
+      if (resolution.status === "no_matching_entry") {
+        setMessage("This match does not include one of your assigned song parts.");
+        return;
+      }
+
+      if (resolution.status === "missing_repertoire_id") {
+        setMessage("Refresh your quartet songs before marking this as sung.");
+        return;
+      }
+
+      if (resolution.status === "ambiguous") {
+        setMessage(
+          "This match includes more than one of your repertoire entries. Update the exact song from your repertoire."
+        );
+        return;
+      }
+
+      await markRepertoireItemAsSung(resolution.repertoireId, sessionId);
+      trackEvent("song_marked_sung", {
+        session_id: sessionId,
+        match_category: match.category,
         voicing: match.voicing,
-        arrangerName: match.arrangerNames.join(", ") || undefined,
       });
       await refreshRecentSungSongs();
-      setMessage(`Marked "${match.songTitle}" as sung.`);
+      setMessage(`Marked "${resolution.entry.songTitle}" as sung.`);
     } catch (err) {
       console.error(err);
+      trackEvent("song_mark_sung_failed", {
+        session_id: sessionId,
+        match_category: match.category,
+        voicing: match.voicing,
+      });
       setMessage("Could not mark that song as sung. Check your connection and try again.");
     } finally {
       setMarkingSungKey("");

--- a/docs/recently-sung-events.md
+++ b/docs/recently-sung-events.md
@@ -1,11 +1,15 @@
 # Recently Sung Events
 
-Issue #88 adds a private event log for songs a user marks as sung from quartet
-results.
+Issue #88 added a private event log for songs a user marks as sung from quartet
+results. Issue #179 also stores personal sung metadata on `user_repertoire`.
 
-This schema and RLS requirement is now captured in
-`supabase/migrations/20260428060000_supabase_contract_alignment.sql`. Apply
+The event schema and RLS requirement is captured in
+`supabase/migrations/20260428060000_supabase_contract_alignment.sql`. The
+repertoire metadata and `mark_repertoire_sung` database function are captured in
+`supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql`. Apply
 unapplied migrations with `supabase db push`.
 
 Events are private to the user who marked the song. They are not copied into
-quartet participant snapshots and do not affect matching rank yet.
+quartet participant snapshots and do not affect matching rank yet. The database
+function updates only the authenticated user's selected repertoire row and then
+records the private event.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -53,6 +53,9 @@ Code:
 - Insert own song: `lib/repertoireStore.ts#addRepertoireItem`
 - Update own song: `lib/repertoireStore.ts#updateRepertoireItem`
 - Delete own song: `lib/repertoireStore.ts#deleteRepertoireItem`
+- Mark own song as sung:
+  `lib/repertoireStore.ts#markRepertoireItemAsSung`, through
+  `public.mark_repertoire_sung`
 - Used by `lib/activeQuartetSnapshot.ts` to refresh the current user's
   `session_participants.repertoire` snapshot.
 
@@ -71,14 +74,22 @@ Required database contract:
   per-part confidence in `part_confidences` and keeps this set to the first
   row's confidence.
 - `notes text`
+- `last_sung_at timestamptz`
+- `times_sung_count integer not null default 0`
 - RLS enabled.
 - Authenticated users can select/insert/update/delete only rows where
   `user_id = auth.uid()`.
 - Index on `(user_id, song_title)` for repertoire listing.
+- Index on `(user_id, last_sung_at desc)` for future sung-history sorting.
+- `public.mark_repertoire_sung(p_repertoire_id uuid, p_session_id uuid)`
+  updates only the authenticated user's matching `user_repertoire` row,
+  increments `times_sung_count`, sets `last_sung_at`, and records the matching
+  private `sung_song_events` row in one database operation.
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
 - `20260428142000_add_part_confidences_to_repertoire.sql`
+- `20260428145000_add_repertoire_sung_metadata.sql`
 
 ### `sessions`
 
@@ -153,7 +164,8 @@ Purpose: private per-user log for songs marked as recently sung.
 
 Code:
 - Read recent events: `lib/sungSongStore.ts#getRecentSungSongs`
-- Insert event: `lib/sungSongStore.ts#markSongAsSung`
+- Insert event as part of marking repertoire metadata:
+  `public.mark_repertoire_sung`
 
 Expected context:
 - Browser authenticated user.

--- a/lib/__tests__/markAsSung.test.ts
+++ b/lib/__tests__/markAsSung.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { MatchResult } from "../matching";
+import { resolveCurrentUserRepertoireForMarkAsSung } from "../markAsSung";
+
+function match(assignments: MatchResult["assignments"]): MatchResult {
+  return {
+    songTitle: "Test Song",
+    voicing: "TTBB",
+    arrangerNames: [],
+    category: "ready",
+    missingParts: [],
+    assignments,
+    warnings: [],
+    score: 1,
+  };
+}
+
+describe("resolveCurrentUserRepertoireForMarkAsSung", () => {
+  it("resolves the current user's assigned repertoire row", () => {
+    const result = resolveCurrentUserRepertoireForMarkAsSung(
+      match({
+        Tenor: [
+          {
+            repertoireId: "rep-1",
+            userId: "current-user",
+            displayName: "Current",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Tenor"],
+          },
+        ],
+        Lead: [
+          {
+            repertoireId: "rep-2",
+            userId: "other-user",
+            displayName: "Other",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Lead"],
+          },
+        ],
+      }),
+      "current-user"
+    );
+
+    expect(result).toMatchObject({
+      status: "ready",
+      repertoireId: "rep-1",
+    });
+  });
+
+  it("does not resolve another singer's repertoire row", () => {
+    const result = resolveCurrentUserRepertoireForMarkAsSung(
+      match({
+        Lead: [
+          {
+            repertoireId: "rep-2",
+            userId: "other-user",
+            displayName: "Other",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Lead"],
+          },
+        ],
+      }),
+      "current-user"
+    );
+
+    expect(result).toEqual({ status: "no_matching_entry" });
+  });
+
+  it("does not mark ambiguous current-user entries", () => {
+    const result = resolveCurrentUserRepertoireForMarkAsSung(
+      match({
+        Tenor: [
+          {
+            repertoireId: "rep-1",
+            userId: "current-user",
+            displayName: "Current",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Tenor"],
+          },
+        ],
+        Lead: [
+          {
+            repertoireId: "rep-2",
+            userId: "current-user",
+            displayName: "Current",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Lead"],
+          },
+        ],
+      }),
+      "current-user"
+    );
+
+    expect(result).toEqual({
+      status: "ambiguous",
+      repertoireIds: ["rep-1", "rep-2"],
+    });
+  });
+
+  it("requires a repertoire row id before updating", () => {
+    const result = resolveCurrentUserRepertoireForMarkAsSung(
+      match({
+        Bass: [
+          {
+            userId: "current-user",
+            displayName: "Current",
+            songTitle: "Test Song",
+            voicing: "TTBB",
+            partsKnown: ["Bass"],
+          },
+        ],
+      }),
+      "current-user"
+    );
+
+    expect(result).toEqual({ status: "missing_repertoire_id" });
+  });
+});

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -21,6 +21,13 @@ const partConfidenceMigration = readFileSync(
   ),
   "utf8"
 );
+const sungMetadataMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -68,5 +75,16 @@ describe("Supabase contract guardrails", () => {
     expect(partConfidenceMigration).toContain("part_confidences jsonb");
     expect(partConfidenceMigration).toContain("unnest(parts_known)");
     expect(partConfidenceMigration).toContain("confidence");
+  });
+
+  it("documents and migrates personal sung repertoire metadata", () => {
+    expect(contract).toContain("last_sung_at");
+    expect(contract).toContain("times_sung_count");
+    expect(contract).toContain("mark_repertoire_sung");
+    expect(sungMetadataMigration).toContain("last_sung_at timestamptz");
+    expect(sungMetadataMigration).toContain("times_sung_count integer");
+    expect(sungMetadataMigration).toContain("times_sung_count + 1");
+    expect(sungMetadataMigration).toContain("user_id = auth.uid()");
+    expect(sungMetadataMigration).toContain("sung_song_events");
   });
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -10,6 +10,8 @@ export type AnalyticsEventName =
   | "quartet_left"
   | "quartet_member_removed"
   | "quartet_matches_viewed"
+  | "song_marked_sung"
+  | "song_mark_sung_failed"
   | "feedback_submitted";
 
 type AnalyticsPropertyValue = string | number | boolean | null | undefined;

--- a/lib/markAsSung.ts
+++ b/lib/markAsSung.ts
@@ -1,0 +1,57 @@
+import type { MatchResult, SingerEntry } from "@/lib/matching";
+
+export type MarkAsSungResolution =
+  | {
+      status: "ready";
+      repertoireId: string;
+      entry: SingerEntry;
+    }
+  | {
+      status: "no_matching_entry";
+    }
+  | {
+      status: "missing_repertoire_id";
+    }
+  | {
+      status: "ambiguous";
+      repertoireIds: string[];
+    };
+
+export function resolveCurrentUserRepertoireForMarkAsSung(
+  match: MatchResult,
+  currentUserId: string
+): MarkAsSungResolution {
+  const userEntries = Object.values(match.assignments)
+    .flat()
+    .filter((entry) => entry.userId === currentUserId);
+
+  if (userEntries.length === 0) {
+    return { status: "no_matching_entry" };
+  }
+
+  const entriesByRepertoireId = new Map<string, SingerEntry>();
+  let hasMissingRepertoireId = false;
+
+  for (const entry of userEntries) {
+    if (!entry.repertoireId) {
+      hasMissingRepertoireId = true;
+      continue;
+    }
+
+    entriesByRepertoireId.set(entry.repertoireId, entry);
+  }
+
+  if (entriesByRepertoireId.size === 1 && !hasMissingRepertoireId) {
+    const [repertoireId, entry] = Array.from(entriesByRepertoireId.entries())[0];
+    return { status: "ready", repertoireId, entry };
+  }
+
+  if (entriesByRepertoireId.size > 1) {
+    return {
+      status: "ambiguous",
+      repertoireIds: Array.from(entriesByRepertoireId.keys()).sort(),
+    };
+  }
+
+  return { status: "missing_repertoire_id" };
+}

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -27,6 +27,7 @@ export type PartConfidence = {
 export type PartConfidenceMap = Partial<Record<Part, Confidence>>;
 
 export type SingerEntry = {
+  repertoireId?: string;
   userId: string;
   displayName: string;
   songTitle: string;

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -18,6 +18,8 @@ export type RepertoireRow = {
   part_confidences: PartConfidence[];
   confidence: Confidence;
   notes: string | null;
+  last_sung_at: string | null;
+  times_sung_count: number;
   created_at: string;
   updated_at: string;
 };
@@ -83,6 +85,8 @@ function normalizeRepertoireRow(row: RawRepertoireRow): RepertoireRow {
     parts_known: partConfidences.map((item) => item.part),
     part_confidences: partConfidences,
     confidence: partConfidences[0]?.confidence ?? "Music Required",
+    last_sung_at: row.last_sung_at ?? null,
+    times_sung_count: row.times_sung_count ?? 0,
   };
 }
 
@@ -98,6 +102,25 @@ export async function getMyRepertoire() {
 
   if (error) throw error;
   return (data as RawRepertoireRow[]).map(normalizeRepertoireRow);
+}
+
+export async function markRepertoireItemAsSung(id: string, sessionId: string) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const { data, error } = await supabase.rpc("mark_repertoire_sung", {
+    p_repertoire_id: id,
+    p_session_id: sessionId,
+  });
+
+  if (error) throw error;
+
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || row.user_id !== user.id || row.id !== id) {
+    throw new Error("Could not verify that your repertoire row was marked as sung.");
+  }
+
+  return normalizeRepertoireRow(row as RawRepertoireRow);
 }
 
 export async function addRepertoireItem(input: {

--- a/lib/sungSongStore.ts
+++ b/lib/sungSongStore.ts
@@ -33,28 +33,3 @@ export async function getRecentSungSongs(days = 30) {
   if (error) throw error;
   return data as RawSungSongEvent[] as SungSongEvent[];
 }
-
-export async function markSongAsSung(input: {
-  sessionId: string;
-  songTitle: string;
-  voicing: Voicing;
-  arrangerName?: string;
-}) {
-  const user = await getCurrentUser();
-  if (!user) throw new Error("You must be logged in.");
-
-  const { data, error } = await supabase
-    .from("sung_song_events")
-    .insert({
-      user_id: user.id,
-      session_id: input.sessionId,
-      song_title: input.songTitle,
-      voicing: input.voicing,
-      arranger_name: input.arrangerName || null,
-    })
-    .select()
-    .single();
-
-  if (error) throw error;
-  return data as RawSungSongEvent as SungSongEvent;
-}

--- a/supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql
+++ b/supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql
@@ -1,0 +1,53 @@
+alter table public.user_repertoire
+  add column if not exists last_sung_at timestamptz,
+  add column if not exists times_sung_count integer not null default 0;
+
+create index if not exists user_repertoire_user_last_sung_idx
+on public.user_repertoire (user_id, last_sung_at desc);
+
+create or replace function public.mark_repertoire_sung(
+  p_repertoire_id uuid,
+  p_session_id uuid
+)
+returns public.user_repertoire
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  updated_repertoire public.user_repertoire;
+begin
+  update public.user_repertoire
+  set
+    last_sung_at = now(),
+    times_sung_count = times_sung_count + 1,
+    updated_at = now()
+  where id = p_repertoire_id
+    and user_id = auth.uid()
+  returning * into updated_repertoire;
+
+  if updated_repertoire.id is null then
+    raise exception 'Could not mark repertoire song as sung'
+      using errcode = 'P0002';
+  end if;
+
+  insert into public.sung_song_events (
+    user_id,
+    session_id,
+    song_title,
+    voicing,
+    arranger_name
+  )
+  values (
+    updated_repertoire.user_id,
+    p_session_id,
+    updated_repertoire.song_title,
+    updated_repertoire.voicing,
+    updated_repertoire.arranger_name
+  );
+
+  return updated_repertoire;
+end;
+$$;
+
+grant execute on function public.mark_repertoire_sung(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary

- carry `user_repertoire.id` through quartet repertoire snapshots so Mark as Sung can update by row id instead of title text
- add a safe resolver for the current user's assigned repertoire row, including ambiguous/missing-id handling for fuzzy matches
- add `last_sung_at` and `times_sung_count` metadata plus a `mark_repertoire_sung` database function that updates the user's row and records the private recent-sung event together
- update Supabase docs/contract and guardrail tests

Closes #179.

## Verification

- `npm run test:run`
- `npm run build`

## Supabase deployment step

This PR adds migration `20260428145000_add_repertoire_sung_metadata.sql`. Apply it to Supabase before relying on Mark as Sung in production:

```bash
supabase db push
```

No dashboard-only change is required.