### PR TITLE
Add repertoire sorting and filters

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -13,6 +13,11 @@ import {
   type FuzzySongTitleSuggestion,
 } from "@/lib/fuzzySongTitles";
 import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
+import {
+  filterAndSortRepertoire,
+  hasActiveRepertoireFilters,
+  type RepertoireSortOption,
+} from "@/lib/repertoireView";
 import { trackEvent } from "@/lib/analytics";
 import {
   addRepertoireItem,
@@ -61,6 +66,11 @@ export default function RepertoireManager() {
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<RepertoireRow[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortOption, setSortOption] =
+    useState<RepertoireSortOption>("title_asc");
+  const [voicingFilter, setVoicingFilter] = useState<Voicing | "">("");
+  const [partFilter, setPartFilter] = useState<Part | "">("");
+  const [neverSungOnly, setNeverSungOnly] = useState(false);
   const [songTitle, setSongTitle] = useState("");
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
@@ -213,6 +223,21 @@ export default function RepertoireManager() {
   function cancelEditing() {
     setEditingId(null);
     setEditForm(null);
+  }
+
+  function updateVoicingFilter(nextVoicing: Voicing | "") {
+    setVoicingFilter(nextVoicing);
+    setPartFilter((currentPart) => {
+      if (!nextVoicing || !currentPart) return currentPart;
+      return partsByVoicing[nextVoicing].includes(currentPart) ? currentPart : "";
+    });
+  }
+
+  function clearRepertoireFilters() {
+    setSearchQuery("");
+    setVoicingFilter("");
+    setPartFilter("");
+    setNeverSungOnly(false);
   }
 
   function updateEditForm(patch: Partial<RepertoireForm>) {
@@ -507,15 +532,29 @@ export default function RepertoireManager() {
     Boolean(voicing) &&
     !rowHasMissingPartOrConfidence(partRows) &&
     !hasDuplicateParts(partRows);
-  const visibleItems = items
-    .filter((item) =>
-      item.song_title.toLowerCase().includes(searchQuery.trim().toLowerCase())
-    )
-    .sort((a, b) =>
-      a.song_title.localeCompare(b.song_title, undefined, {
-        sensitivity: "base",
-      })
-    );
+  const repertoireFilters = {
+    searchQuery,
+    voicing: voicingFilter,
+    part: partFilter,
+    neverSungOnly,
+    sort: sortOption,
+  };
+  const visibleItems = filterAndSortRepertoire(items, repertoireFilters);
+  const hasActiveFilters = hasActiveRepertoireFilters(repertoireFilters);
+  const partFilterOptions = voicingFilter
+    ? partsByVoicing[voicingFilter]
+    : Array.from(new Set(voicings.flatMap((v) => partsByVoicing[v])));
+  const filteredEmptyDescription = [
+    voicingFilter,
+    partFilter
+      ? voicingFilter
+        ? partButtonLabel(voicingFilter, partFilter)
+        : partFilter
+      : "",
+    neverSungOnly ? "never sung" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   const titleSuggestions = findFuzzySongTitleSuggestions(
     items.map((item) => ({
       id: item.id,
@@ -639,12 +678,14 @@ export default function RepertoireManager() {
             <div>
               <h2 className="text-2xl font-semibold">Songs I know</h2>
               <p className="mt-1 text-sm text-slate-400">
-                {items.length} {items.length === 1 ? "song" : "songs"} saved
+                {visibleItems.length === items.length
+                  ? `${items.length} ${items.length === 1 ? "song" : "songs"} saved`
+                  : `${visibleItems.length} of ${items.length} songs shown`}
               </p>
             </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-              <label className="block sm:w-72">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(12rem,18rem)_11rem_11rem_11rem]">
+              <label className="block">
                 <span className="text-sm font-medium text-slate-300">
                   Search by title
                 </span>
@@ -654,7 +695,109 @@ export default function RepertoireManager() {
                   className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                 />
               </label>
+              <label className="block">
+                <span className="text-sm font-medium text-slate-300">
+                  Sort
+                </span>
+                <select
+                  value={sortOption}
+                  onChange={(e) =>
+                    setSortOption(e.target.value as RepertoireSortOption)
+                  }
+                  className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                >
+                  <option value="title_asc">Title A-Z</option>
+                  <option value="created_desc">Added newest</option>
+                  <option value="created_asc">Added oldest</option>
+                  <option value="last_sung_desc">Sung recently</option>
+                  <option value="last_sung_asc">Least recently sung</option>
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-slate-300">
+                  Voicing
+                </span>
+                <select
+                  value={voicingFilter}
+                  onChange={(e) =>
+                    updateVoicingFilter(e.target.value as Voicing | "")
+                  }
+                  className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                >
+                  <option value="">All voicings</option>
+                  {voicings.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-slate-300">
+                  Part
+                </span>
+                <select
+                  value={partFilter}
+                  onChange={(e) => setPartFilter(e.target.value as Part | "")}
+                  className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                >
+                  <option value="">All parts</option>
+                  {partFilterOptions.map((part) => (
+                    <option key={part} value={part}>
+                      {voicingFilter ? partButtonLabel(voicingFilter, part) : part}
+                    </option>
+                  ))}
+                </select>
+              </label>
             </div>
+          </div>
+
+          <div className="mt-3 flex flex-col gap-3 rounded-xl border border-white/10 bg-white/5 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <label className="flex items-center gap-3 text-sm font-semibold text-slate-200">
+              <input
+                type="checkbox"
+                checked={neverSungOnly}
+                onChange={(e) => setNeverSungOnly(e.target.checked)}
+                className="h-4 w-4 rounded border-white/20 bg-slate-900 text-cyan-300"
+              />
+              Never sung
+            </label>
+
+            {hasActiveFilters ? (
+              <div className="flex flex-wrap items-center gap-2">
+                {searchQuery.trim() && (
+                  <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
+                    Title: {searchQuery.trim()}
+                  </span>
+                )}
+                {voicingFilter && (
+                  <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
+                    {voicingFilter}
+                  </span>
+                )}
+                {partFilter && (
+                  <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
+                    {voicingFilter
+                      ? partButtonLabel(voicingFilter, partFilter)
+                      : partFilter}
+                  </span>
+                )}
+                {neverSungOnly && (
+                  <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
+                    Never sung
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={clearRepertoireFilters}
+                  className="rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 hover:bg-slate-700"
+                >
+                  Clear filters
+                </button>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-400">No filters active</p>
+            )}
           </div>
 
           <div className="mt-4 space-y-2">
@@ -670,7 +813,9 @@ export default function RepertoireManager() {
 
             {items.length > 0 && visibleItems.length === 0 && (
               <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-slate-300">
-                No songs match that title.
+                {filteredEmptyDescription
+                  ? `No ${filteredEmptyDescription} songs match these filters.`
+                  : "No songs match these filters."}
               </div>
             )}
 

--- a/lib/__tests__/repertoireView.test.ts
+++ b/lib/__tests__/repertoireView.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { RepertoireRow } from "../repertoireStore";
+import {
+  filterAndSortRepertoire,
+  hasActiveRepertoireFilters,
+  type RepertoireFilters,
+} from "../repertoireView";
+
+function row(patch: Partial<RepertoireRow> & Pick<RepertoireRow, "id" | "song_title">): RepertoireRow {
+  return {
+    id: patch.id,
+    user_id: "user-1",
+    song_title: patch.song_title,
+    voicing: patch.voicing ?? "TTBB",
+    arranger_name: patch.arranger_name ?? null,
+    parts_known: patch.parts_known ?? ["Lead"],
+    part_confidences:
+      patch.part_confidences ?? [{ part: "Lead", confidence: "Good to Go" }],
+    confidence: patch.confidence ?? "Good to Go",
+    notes: patch.notes ?? null,
+    last_sung_at: patch.last_sung_at ?? null,
+    times_sung_count: patch.times_sung_count ?? 0,
+    created_at: patch.created_at ?? "2026-04-01T00:00:00.000Z",
+    updated_at: patch.updated_at ?? "2026-04-01T00:00:00.000Z",
+  };
+}
+
+const defaultFilters: RepertoireFilters = {
+  searchQuery: "",
+  voicing: "",
+  part: "",
+  neverSungOnly: false,
+  sort: "title_asc",
+};
+
+describe("filterAndSortRepertoire", () => {
+  it("sorts alphabetically by title", () => {
+    const result = filterAndSortRepertoire(
+      [row({ id: "2", song_title: "Zulu" }), row({ id: "1", song_title: "Alpha" })],
+      defaultFilters
+    );
+
+    expect(result.map((item) => item.song_title)).toEqual(["Alpha", "Zulu"]);
+  });
+
+  it("sorts by date added newest and oldest", () => {
+    const items = [
+      row({ id: "old", song_title: "Old", created_at: "2026-01-01T00:00:00.000Z" }),
+      row({ id: "new", song_title: "New", created_at: "2026-04-01T00:00:00.000Z" }),
+    ];
+
+    expect(
+      filterAndSortRepertoire(items, {
+        ...defaultFilters,
+        sort: "created_desc",
+      }).map((item) => item.id)
+    ).toEqual(["new", "old"]);
+    expect(
+      filterAndSortRepertoire(items, {
+        ...defaultFilters,
+        sort: "created_asc",
+      }).map((item) => item.id)
+    ).toEqual(["old", "new"]);
+  });
+
+  it("sorts by last sung with never-sung placement", () => {
+    const items = [
+      row({ id: "never", song_title: "Never", last_sung_at: null }),
+      row({ id: "old", song_title: "Old", last_sung_at: "2026-01-01T00:00:00.000Z" }),
+      row({ id: "recent", song_title: "Recent", last_sung_at: "2026-04-01T00:00:00.000Z" }),
+    ];
+
+    expect(
+      filterAndSortRepertoire(items, {
+        ...defaultFilters,
+        sort: "last_sung_desc",
+      }).map((item) => item.id)
+    ).toEqual(["recent", "old", "never"]);
+    expect(
+      filterAndSortRepertoire(items, {
+        ...defaultFilters,
+        sort: "last_sung_asc",
+      }).map((item) => item.id)
+    ).toEqual(["never", "old", "recent"]);
+  });
+
+  it("filters by search, voicing, part, and never sung", () => {
+    const result = filterAndSortRepertoire(
+      [
+        row({
+          id: "match",
+          song_title: "Bright Was The Night",
+          voicing: "TTBB",
+          parts_known: ["Lead", "Baritone"],
+          part_confidences: [
+            { part: "Lead", confidence: "Good to Go" },
+            { part: "Baritone", confidence: "A Little Rusty" },
+          ],
+          last_sung_at: null,
+        }),
+        row({
+          id: "wrong-part",
+          song_title: "Bright Morning",
+          voicing: "TTBB",
+          parts_known: ["Bass"],
+          part_confidences: [{ part: "Bass", confidence: "Good to Go" }],
+          last_sung_at: null,
+        }),
+        row({
+          id: "wrong-voicing",
+          song_title: "Bright Was The Night",
+          voicing: "SATB",
+          parts_known: ["Alto"],
+          part_confidences: [{ part: "Alto", confidence: "Good to Go" }],
+          last_sung_at: null,
+        }),
+        row({
+          id: "already-sung",
+          song_title: "Bright Was The Night",
+          voicing: "TTBB",
+          parts_known: ["Baritone"],
+          part_confidences: [{ part: "Baritone", confidence: "Good to Go" }],
+          last_sung_at: "2026-04-01T00:00:00.000Z",
+        }),
+      ],
+      {
+        searchQuery: "bright",
+        voicing: "TTBB",
+        part: "Baritone",
+        neverSungOnly: true,
+        sort: "title_asc",
+      }
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["match"]);
+  });
+});
+
+describe("hasActiveRepertoireFilters", () => {
+  it("ignores sorting and detects only active filters", () => {
+    expect(
+      hasActiveRepertoireFilters({ ...defaultFilters, sort: "created_desc" })
+    ).toBe(false);
+    expect(
+      hasActiveRepertoireFilters({ ...defaultFilters, searchQuery: "hello" })
+    ).toBe(true);
+  });
+});

--- a/lib/repertoireView.ts
+++ b/lib/repertoireView.ts
@@ -1,0 +1,118 @@
+import type { Part, Voicing } from "@/lib/matching";
+import type { RepertoireRow } from "@/lib/repertoireStore";
+
+export type RepertoireSortOption =
+  | "title_asc"
+  | "created_desc"
+  | "created_asc"
+  | "last_sung_desc"
+  | "last_sung_asc";
+
+export type RepertoireFilters = {
+  searchQuery: string;
+  voicing: Voicing | "";
+  part: Part | "";
+  neverSungOnly: boolean;
+  sort: RepertoireSortOption;
+};
+
+function normalizedText(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function compareTitles(a: RepertoireRow, b: RepertoireRow) {
+  return a.song_title.localeCompare(b.song_title, undefined, {
+    sensitivity: "base",
+  });
+}
+
+function timestampValue(value: string | null | undefined) {
+  return value ? new Date(value).getTime() : null;
+}
+
+function compareNullableDates(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  direction: "asc" | "desc",
+  nulls: "first" | "last"
+) {
+  const aTime = timestampValue(a);
+  const bTime = timestampValue(b);
+
+  if (aTime === null && bTime === null) return 0;
+  if (aTime === null) return nulls === "first" ? -1 : 1;
+  if (bTime === null) return nulls === "first" ? 1 : -1;
+
+  return direction === "asc" ? aTime - bTime : bTime - aTime;
+}
+
+export function filterAndSortRepertoire(
+  items: RepertoireRow[],
+  filters: RepertoireFilters
+) {
+  const query = normalizedText(filters.searchQuery);
+
+  return items
+    .filter((item) => {
+      if (query && !normalizedText(item.song_title).includes(query)) {
+        return false;
+      }
+
+      if (filters.voicing && item.voicing !== filters.voicing) {
+        return false;
+      }
+
+      if (
+        filters.part &&
+        !item.part_confidences.some(({ part }) => part === filters.part)
+      ) {
+        return false;
+      }
+
+      if (filters.neverSungOnly && item.last_sung_at) {
+        return false;
+      }
+
+      return true;
+    })
+    .sort((a, b) => {
+      if (filters.sort === "created_desc") {
+        return (
+          compareNullableDates(a.created_at, b.created_at, "desc", "last") ||
+          compareTitles(a, b)
+        );
+      }
+
+      if (filters.sort === "created_asc") {
+        return (
+          compareNullableDates(a.created_at, b.created_at, "asc", "last") ||
+          compareTitles(a, b)
+        );
+      }
+
+      if (filters.sort === "last_sung_desc") {
+        return (
+          compareNullableDates(a.last_sung_at, b.last_sung_at, "desc", "last") ||
+          compareTitles(a, b)
+        );
+      }
+
+      if (filters.sort === "last_sung_asc") {
+        return (
+          compareNullableDates(a.last_sung_at, b.last_sung_at, "asc", "first") ||
+          compareTitles(a, b)
+        );
+      }
+
+      return compareTitles(a, b);
+    });
+}
+
+export function hasActiveRepertoireFilters(filters: RepertoireFilters) {
+  return Boolean(
+    filters.searchQuery.trim() ||
+      filters.voicing ||
+      filters.part ||
+      filters.neverSungOnly
+  );
+}


### PR DESCRIPTION
## Summary

- add repertoire controls for title search, sort order, voicing filter, part filter, and never-sung filtering
- include last-sung sort options now that repertoire metadata exists
- show active filters with a clear-filters action and more specific empty filtered states
- extract sorting/filtering into a pure helper with unit coverage

Closes #180.

## Verification

- `npm run test:run`
- `npm run build`

## Supabase

No new Supabase migration or dashboard change is required for this PR; it uses the existing `user_repertoire` fields, including `last_sung_at` when present.