### PR TITLE
Fix participant removal from quartet

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -341,13 +341,23 @@ export default function JoinSessionPage() {
     }
   }
 
+  async function confirmLeaveQuartet() {
+    const confirmed = window.confirm("Remove yourself from this quartet?");
+    if (!confirmed) return;
+
+    await leaveQuartet();
+  }
+
   async function removeQuartetParticipant(participant: DbParticipant) {
     if (!sessionId || !currentUserId) {
       setMessage("Could not remove that singer yet. Wait for the quartet to finish loading.");
       return;
     }
 
-    if (participant.user_id === currentUserId) return;
+    if (participant.user_id === currentUserId) {
+      await confirmLeaveQuartet();
+      return;
+    }
 
     const participantName = getParticipantDisplayName(
       participant,
@@ -364,11 +374,14 @@ export default function JoinSessionPage() {
 
     try {
       await removeParticipantById(sessionId, participant.id);
-      await refreshParticipants(sessionId, { showErrorMessage: false });
+      const updatedParticipants = await refreshParticipants(sessionId, {
+        showErrorMessage: false,
+      });
       trackEvent("quartet_member_removed", {
         session_id: sessionId,
-        participant_count: Math.max(0, participants.length - 1),
+        participant_count: updatedParticipants.length,
       });
+      setMessage(`${participantName} was removed from the quartet.`);
     } catch (err) {
       console.error(err);
       setMessage("Could not remove that singer. Check your connection and try again.");
@@ -869,25 +882,30 @@ export default function JoinSessionPage() {
           </div>
 
           {canManageParticipants && (
-            isCurrentParticipant ? (
-              <a
-                href="/settings"
-                className="w-fit rounded-lg border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-cyan-300/10"
-              >
-                Change my display name
-              </a>
-            ) : (
+            <div className="flex flex-wrap gap-2">
+              {isCurrentParticipant && (
+                <a
+                  href="/settings"
+                  className="w-fit rounded-lg border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-cyan-300/10"
+                >
+                  Change my display name
+                </a>
+              )}
               <button
                 type="button"
                 onClick={() => removeQuartetParticipant(participant)}
-                disabled={Boolean(removingParticipantId)}
+                disabled={
+                  leaving ||
+                  !sessionId ||
+                  Boolean(removingParticipantId)
+                }
                 className="w-fit rounded-lg bg-rose-400/10 px-3 py-2 text-sm font-semibold text-rose-200 hover:bg-rose-400/20 disabled:opacity-40"
               >
-                {removingParticipantId === participant.id
+                {leaving || removingParticipantId === participant.id
                   ? "Removing..."
                   : "Remove from quartet"}
               </button>
-            )
+            </div>
           )}
         </div>
       </div>
@@ -1066,7 +1084,7 @@ export default function JoinSessionPage() {
                         Edit repertoire
                       </a>
                       <button
-                        onClick={leaveQuartet}
+                        onClick={confirmLeaveQuartet}
                         disabled={leaving || !sessionId}
                         className="rounded-xl bg-rose-200 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-40"
                       >
@@ -1109,7 +1127,7 @@ export default function JoinSessionPage() {
 
                       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                         <button
-                          onClick={leaveQuartet}
+                          onClick={confirmLeaveQuartet}
                           disabled={leaving || !sessionId}
                           className="rounded-xl bg-rose-200 px-5 py-3 font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-40"
                         >

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -127,7 +127,8 @@ Code:
 - Read participants: `lib/sessionStore.ts#getParticipants`
 - Insert/update own snapshot: `lib/sessionStore.ts#upsertParticipant`
 - Delete own row: `lib/sessionStore.ts#removeParticipant`
-- Remove selected row by id: `lib/sessionStore.ts#removeParticipantById`
+- Remove selected row by id: `lib/sessionStore.ts#removeParticipantById`,
+  through `public.remove_session_participant_by_id`
 - Realtime participant subscription:
   `lib/sessionStore.ts#subscribeToSessionParticipants`
 - Repertoire snapshot refresh:
@@ -152,11 +153,15 @@ Required database contract:
 - Authenticated users can select session participants.
 - Authenticated users can insert/update/delete only their own row where
   `user_id = auth.uid()`.
+- Authenticated users who are current participants in a session can call
+  `public.remove_session_participant_by_id(p_session_id, p_participant_id)` to
+  remove another participant from that same session.
 - Table is in the Supabase Realtime publication.
 
 Established by migrations:
 - `20260428051000_fix_session_participants_rls.sql`
 - `20260428060000_supabase_contract_alignment.sql`
+- `20260428151000_add_participant_removal_function.sql`
 
 ### `sung_song_events`
 

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -28,6 +28,13 @@ const sungMetadataMigration = readFileSync(
   ),
   "utf8"
 );
+const participantRemovalMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260428151000_add_participant_removal_function.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -68,6 +75,17 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("leave");
     expect(contract).toContain("repertoire snapshot");
     expect(contract).toContain("Match calculation source");
+  });
+
+  it("documents and migrates participant removal by quartet members", () => {
+    expect(contract).toContain("remove_session_participant_by_id");
+    expect(participantRemovalMigration).toContain(
+      "remove_session_participant_by_id"
+    );
+    expect(participantRemovalMigration).toContain("auth.uid()");
+    expect(participantRemovalMigration).toContain("requester.session_id");
+    expect(participantRemovalMigration).toContain("delete from public.session_participants");
+    expect(participantRemovalMigration).toContain("to authenticated");
   });
 
   it("documents and migrates per-part repertoire confidence", () => {

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -172,27 +172,30 @@ export async function removeParticipantById(
   sessionId: string,
   participantId: string
 ) {
-  const participant = await getParticipantForDelete({
-    sessionId,
-    participantId,
-  });
+  const { data, error } = await supabase.rpc(
+    "remove_session_participant_by_id",
+    {
+      p_session_id: sessionId,
+      p_participant_id: participantId,
+    }
+  );
 
-  if (!participant) {
+  if (error) throw error;
+  const participant = Array.isArray(data) ? data[0] : data;
+
+  if (
+    !participant ||
+    participant.session_id !== sessionId ||
+    participant.id !== participantId
+  ) {
     throw new SessionParticipantWriteError(
-      "Could not find the selected quartet participant row to delete."
+      "Could not verify that the selected quartet participant row was deleted."
     );
   }
 
-  const { error } = await supabase
-    .from("session_participants")
-    .delete()
-    .eq("session_id", sessionId)
-    .eq("id", participantId);
-
-  if (error) throw error;
   await verifyParticipantDeleted({ sessionId, participantId });
 
-  return participant;
+  return participant as Pick<DbParticipant, "id" | "session_id" | "user_id">;
 }
 
 export function subscribeToSessionParticipants(

--- a/supabase/migrations/20260428151000_add_participant_removal_function.sql
+++ b/supabase/migrations/20260428151000_add_participant_removal_function.sql
@@ -1,0 +1,54 @@
+create or replace function public.remove_session_participant_by_id(
+  p_session_id uuid,
+  p_participant_id uuid
+)
+returns table (
+  id uuid,
+  session_id uuid,
+  user_id uuid
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  requester_id uuid := auth.uid();
+  removed_participant record;
+begin
+  if requester_id is null then
+    raise exception 'You must be logged in to remove a quartet participant.'
+      using errcode = '42501';
+  end if;
+
+  if not exists (
+    select 1
+    from public.session_participants requester
+    where requester.session_id = p_session_id
+      and requester.user_id = requester_id
+  ) then
+    raise exception 'You must be in the quartet to remove a participant.'
+      using errcode = '42501';
+  end if;
+
+  delete from public.session_participants target
+  where target.session_id = p_session_id
+    and target.id = p_participant_id
+  returning target.id, target.session_id, target.user_id
+  into removed_participant;
+
+  if removed_participant.id is null then
+    raise exception 'Could not find the selected quartet participant row to delete.'
+      using errcode = 'P0002';
+  end if;
+
+  id := removed_participant.id;
+  session_id := removed_participant.session_id;
+  user_id := removed_participant.user_id;
+  return next;
+end;
+$$;
+
+revoke all on function public.remove_session_participant_by_id(uuid, uuid)
+from public;
+grant execute on function public.remove_session_participant_by_id(uuid, uuid)
+to authenticated;


### PR DESCRIPTION
## Summary

- restore the participant-list `Remove from quartet` action for other singers
- route other-singer removal through a Supabase function that verifies the requester is currently in the same quartet before deleting the selected participant row
- keep self-removal on the shared leave flow with confirmation
- refresh participants only after the database delete succeeds and show confirmation/error feedback
- update the Supabase contract and guardrail test for the new participant-removal capability

Closes #166.

## Verification

- `npm run test:run`
- `npm run build`

## Supabase deployment step

This PR adds migration `20260428151000_add_participant_removal_function.sql`. Apply it to Supabase before relying on participant removal in production:

```bash
supabase db push
```

No dashboard-only change is required.