### PR TITLE
Handle removed participant state in quartet UI

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -13,6 +13,7 @@ import {
   resolveParticipantForJoin,
 } from "@/lib/sessionParticipantResolution";
 import { applyParticipantChange } from "@/lib/sessionParticipantChanges";
+import { didCurrentParticipantGetRemoved } from "@/lib/sessionParticipantRemoval";
 import {
   type DbSession,
   type DbParticipant,
@@ -101,6 +102,7 @@ export default function JoinSessionPage() {
   const hasAutoJoined = useRef(false);
   const isRefreshingCurrentParticipant = useRef(false);
   const lastTrackedMatchesKey = useRef("");
+  const participantsRef = useRef<DbParticipant[]>([]);
 
   const [loading, setLoading] = useState(true);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -129,6 +131,25 @@ export default function JoinSessionPage() {
     useState<ActiveQuartet | null>(null);
   const [leavingCurrentQuartet, setLeavingCurrentQuartet] = useState(false);
 
+  function setTrackedParticipants(data: DbParticipant[]) {
+    participantsRef.current = data;
+    setParticipants(data);
+  }
+
+  function markCurrentUserRemovedFromQuartet(id: string) {
+    if (
+      window.sessionStorage.getItem(leftQuartetStorageKey(code)) === "true"
+    ) {
+      return;
+    }
+
+    window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
+    clearActiveQuartetIfMatches(id);
+    setLeftQuartet(true);
+    setPendingActiveQuartet(null);
+    setMessage("You were removed from this quartet.");
+  }
+
   async function refreshParticipantProfileNames(data: DbParticipant[]) {
     try {
       const profileDisplayNames = await getProfilesByIds(
@@ -149,7 +170,18 @@ export default function JoinSessionPage() {
   ) {
     try {
       const data = await getParticipants(id);
-      setParticipants(data);
+      const previousParticipants = participantsRef.current;
+      setTrackedParticipants(data);
+      if (
+        id === sessionId &&
+        didCurrentParticipantGetRemoved(
+          previousParticipants,
+          data,
+          currentUserId
+        )
+      ) {
+        markCurrentUserRemovedFromQuartet(id);
+      }
       await refreshParticipantProfileNames(data);
       return data;
     } catch (err) {
@@ -381,7 +413,13 @@ export default function JoinSessionPage() {
         session_id: sessionId,
         participant_count: updatedParticipants.length,
       });
-      setMessage(`${participantName} was removed from the quartet.`);
+      const removedMessage = `${participantName} was removed from the quartet.`;
+      setMessage(removedMessage);
+      window.setTimeout(() => {
+        setMessage((currentMessage) =>
+          currentMessage === removedMessage ? "" : currentMessage
+        );
+      }, 5000);
     } catch (err) {
       console.error(err);
       setMessage("Could not remove that singer. Check your connection and try again.");
@@ -531,20 +569,28 @@ export default function JoinSessionPage() {
     if (!sessionId) return;
 
     return subscribeToSessionParticipants(sessionId, (payload) => {
-      setParticipants((currentParticipants) => {
-        const updatedParticipants = applyParticipantChange(
-          currentParticipants,
-          payload,
-          sessionId
-        );
-        void refreshParticipantProfileNames(updatedParticipants);
-        return updatedParticipants;
-      });
+      const previousParticipants = participantsRef.current;
+      const updatedParticipants = applyParticipantChange(
+        previousParticipants,
+        payload,
+        sessionId
+      );
+      setTrackedParticipants(updatedParticipants);
+      if (
+        didCurrentParticipantGetRemoved(
+          previousParticipants,
+          updatedParticipants,
+          currentUserId
+        )
+      ) {
+        markCurrentUserRemovedFromQuartet(sessionId);
+      }
+      void refreshParticipantProfileNames(updatedParticipants);
       void refreshParticipants(sessionId, { showErrorMessage: false }).catch(
         () => undefined
       );
     });
-  }, [sessionId]);
+  }, [currentUserId, sessionId]);
 
   const participantUserIds = Array.from(
     new Set(participants.map((participant) => participant.user_id))
@@ -646,6 +692,18 @@ export default function JoinSessionPage() {
         ) {
           setPendingActiveQuartet(activeQuartet);
           setMessage("");
+          return;
+        }
+
+        if (
+          !alreadyJoined &&
+          activeQuartet?.sessionId === session.id &&
+          !hasLeftQuartet
+        ) {
+          window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
+          clearActiveQuartetIfMatches(session.id);
+          setLeftQuartet(true);
+          setMessage("You were removed from this quartet.");
           return;
         }
 

--- a/lib/__tests__/sessionParticipantRemoval.test.ts
+++ b/lib/__tests__/sessionParticipantRemoval.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { DbParticipant } from "../sessionStore";
+import { didCurrentParticipantGetRemoved } from "../sessionParticipantRemoval";
+
+function participant(id: string, userId: string): DbParticipant {
+  return {
+    id,
+    session_id: "session-1",
+    user_id: userId,
+    display_name: userId,
+    repertoire: [],
+    joined_at: "2026-04-28T00:00:00.000Z",
+  };
+}
+
+describe("didCurrentParticipantGetRemoved", () => {
+  it("detects when the current user's participant row disappears", () => {
+    expect(
+      didCurrentParticipantGetRemoved(
+        [participant("1", "current"), participant("2", "other")],
+        [participant("2", "other")],
+        "current"
+      )
+    ).toBe(true);
+  });
+
+  it("does not fire before the current user has joined", () => {
+    expect(
+      didCurrentParticipantGetRemoved(
+        [participant("2", "other")],
+        [participant("2", "other")],
+        "current"
+      )
+    ).toBe(false);
+  });
+
+  it("does not fire while the current user remains in the quartet", () => {
+    expect(
+      didCurrentParticipantGetRemoved(
+        [participant("1", "current")],
+        [participant("1", "current"), participant("2", "other")],
+        "current"
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/sessionParticipantRemoval.ts
+++ b/lib/sessionParticipantRemoval.ts
@@ -1,0 +1,18 @@
+import type { DbParticipant } from "@/lib/sessionStore";
+
+export function didCurrentParticipantGetRemoved(
+  previousParticipants: DbParticipant[],
+  nextParticipants: DbParticipant[],
+  currentUserId: string
+) {
+  if (!currentUserId) return false;
+
+  const wasParticipant = previousParticipants.some(
+    (participant) => participant.user_id === currentUserId
+  );
+  const isParticipant = nextParticipants.some(
+    (participant) => participant.user_id === currentUserId
+  );
+
+  return wasParticipant && !isParticipant;
+}


### PR DESCRIPTION
## Summary

- detect when the current user's `session_participants` row disappears from realtime or refreshed participant data
- mark the removed singer as no longer in the quartet, clear the active quartet pointer, and prevent refresh/return from silently re-adding them
- handle the missed-realtime case on `/join/[code]` load when local active-quartet state points to a quartet where the user no longer has a participant row
- auto-clear the remover's success message after a short delay
- add a focused regression test for current-participant removal detection

Follow-up to #166.

## Verification

- `npm run test:run`
- `npm run build`

## Supabase

No new Supabase migration or dashboard change is required.