### PR TITLE
Separate voluntary rejoin from removal state

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
 import { trackEvent } from "@/lib/analytics";
+import { intentionalJoinStorageKey } from "@/lib/joinIntent";
 import { resolveCurrentUserRepertoireForMarkAsSung } from "@/lib/markAsSung";
 import { findMatches, type MatchResult, type SingerEntry } from "@/lib/matching";
 import {
@@ -181,10 +182,11 @@ export default function JoinSessionPage() {
     }
 
     window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
+    window.sessionStorage.removeItem(intentionalJoinStorageKey(code));
     clearActiveQuartetIfMatches(id);
     setLeftQuartet(true);
     setPendingActiveQuartet(null);
-    showStatusMessage("You were removed from this quartet.");
+    window.location.href = "/join?removed=1";
   }
 
   async function refreshParticipantProfileNames(data: DbParticipant[]) {
@@ -488,7 +490,7 @@ export default function JoinSessionPage() {
   }
 
   async function copyJoinLink() {
-    const joinUrl = `${window.location.origin}/join/${code}`;
+    const joinUrl = `${window.location.origin}/join/${code}?intent=join`;
 
     try {
       await window.navigator.clipboard.writeText(joinUrl);
@@ -738,7 +740,7 @@ export default function JoinSessionPage() {
           // refreshRecentSungSongs handles its own message.
         }
 
-        const joinUrl = `${window.location.origin}/join/${code}`;
+        const joinUrl = `${window.location.origin}/join/${code}?intent=join`;
         try {
           const qr = await QRCode.toDataURL(joinUrl);
           setQrUrl(qr);
@@ -749,7 +751,21 @@ export default function JoinSessionPage() {
 
         const hasLeftQuartet =
           window.sessionStorage.getItem(leftQuartetStorageKey(code)) === "true";
-        setLeftQuartet(hasLeftQuartet);
+        const pageIntent = new URLSearchParams(window.location.search).get(
+          "intent"
+        );
+        const hasIntentionalJoin =
+          window.sessionStorage.getItem(intentionalJoinStorageKey(code)) ===
+            "true" || pageIntent === "join";
+
+        if (hasIntentionalJoin) {
+          window.sessionStorage.removeItem(intentionalJoinStorageKey(code));
+          window.sessionStorage.removeItem(leftQuartetStorageKey(code));
+          window.history.replaceState(null, "", `/join/${code}`);
+        }
+
+        const shouldTreatAsLeft = hasLeftQuartet && !hasIntentionalJoin;
+        setLeftQuartet(shouldTreatAsLeft);
 
         const currentParticipants = await refreshParticipants(session.id);
 
@@ -764,7 +780,7 @@ export default function JoinSessionPage() {
           !alreadyJoined &&
           activeQuartet &&
           activeQuartet.sessionId !== session.id &&
-          !hasLeftQuartet
+          !shouldTreatAsLeft
         ) {
           setPendingActiveQuartet(activeQuartet);
           clearStatusMessage();
@@ -774,17 +790,15 @@ export default function JoinSessionPage() {
         if (
           !alreadyJoined &&
           activeQuartet?.sessionId === session.id &&
-          !hasLeftQuartet
+          !shouldTreatAsLeft
         ) {
-          window.sessionStorage.setItem(leftQuartetStorageKey(code), "true");
           clearActiveQuartetIfMatches(session.id);
-          setLeftQuartet(true);
-          showStatusMessage("You were removed from this quartet.");
+          window.location.href = "/join?removed=1";
           return;
         }
 
         if (alreadyJoined) {
-          if (hasLeftQuartet) {
+          if (shouldTreatAsLeft) {
             window.sessionStorage.removeItem(leftQuartetStorageKey(code));
             setLeftQuartet(false);
           }
@@ -808,10 +822,10 @@ export default function JoinSessionPage() {
               "transient"
             );
           }
-        } else if (!hasAutoJoined.current && !hasLeftQuartet) {
+        } else if (!hasAutoJoined.current && !shouldTreatAsLeft) {
           hasAutoJoined.current = true;
           await joinSession(session.id, profile.display_name, user.id);
-        } else if (hasLeftQuartet) {
+        } else if (shouldTreatAsLeft) {
           clearActiveQuartetIfMatches(session.id);
           showStatusMessage("You left this quartet.");
         }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -6,6 +6,7 @@ import {
   getActiveQuartet,
   type ActiveQuartet,
 } from "@/lib/activeQuartet";
+import { intentionalJoinStorageKey } from "@/lib/joinIntent";
 import { parseJoinCode } from "@/lib/joinCode";
 import { getCurrentUser } from "@/lib/profileStore";
 import { trackEvent } from "@/lib/analytics";
@@ -47,7 +48,8 @@ export default function JoinPage() {
       return;
     }
 
-    window.location.href = `/join/${encodeURIComponent(code)}`;
+    window.sessionStorage.setItem(intentionalJoinStorageKey(code), "true");
+    window.location.href = `/join/${encodeURIComponent(code)}?intent=join`;
   }
 
   function joinQuartet() {
@@ -78,7 +80,11 @@ export default function JoinPage() {
         session_id: activeQuartet.sessionId,
       });
       clearActiveQuartet();
-      window.location.href = `/join/${encodeURIComponent(pendingCode)}`;
+      window.sessionStorage.setItem(
+        intentionalJoinStorageKey(pendingCode),
+        "true"
+      );
+      window.location.href = `/join/${encodeURIComponent(pendingCode)}?intent=join`;
     } catch (err) {
       console.error("Failed to leave current quartet", err);
       setMessage(
@@ -91,6 +97,15 @@ export default function JoinPage() {
   function closeScanner() {
     setScannerOpen(false);
   }
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    if (params.get("removed") === "1") {
+      clearActiveQuartet();
+      setMessage("You were removed from the quartet.");
+    }
+  }, []);
 
   useEffect(() => {
     if (!scannerOpen) return;

--- a/lib/__tests__/joinIntent.test.ts
+++ b/lib/__tests__/joinIntent.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { intentionalJoinStorageKey } from "../joinIntent";
+
+describe("intentionalJoinStorageKey", () => {
+  it("scopes intentional join state by quartet code", () => {
+    expect(intentionalJoinStorageKey("ABC123")).toBe("intentional-join:ABC123");
+  });
+});

--- a/lib/joinIntent.ts
+++ b/lib/joinIntent.ts
@@ -1,0 +1,3 @@
+export function intentionalJoinStorageKey(code: string) {
+  return `intentional-join:${code}`;
+}


### PR DESCRIPTION
## Summary

- add an explicit intentional-join marker for manual code entry, QR scan, and app-generated join links
- allow voluntary leave followed by a fresh intentional code/link entry to rejoin without an extra in-context rejoin step
- redirect users removed by someone else to the clean `/join` page with a removal message
- clear stale active quartet context on removal so an old join page cannot silently reinsert the removed participant
- keep copied/QR join links marked as intentional joins

Closes #171.

## Verification

- `npm run test:run`
- `npm run build`

## Supabase

No Supabase migration or dashboard change required.