### PR TITLE
Add deployment automation guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,44 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check migration filenames
+        run: |
+          set -euo pipefail
+          bad_files="$(
+            find supabase/migrations -type f -name '*.sql' \
+              | awk -F/ '{
+                  file=$NF
+                  if (file !~ /^[0-9]{14}_[a-z0-9_]+\.sql$/) print $0
+                }'
+          )"
+
+          if [ -n "$bad_files" ]; then
+            echo "Migration filenames must use YYYYMMDDHHMMSS_descriptive_name.sql:"
+            echo "$bad_files"
+            exit 1
+          fi
+
+      - name: Check for committed secret values
+        run: |
+          set -euo pipefail
+          if git grep -n -I -E '(SUPABASE_SERVICE_ROLE_KEY=[^$[:space:]]{12,}|RESEND_API_KEY=[^$[:space:]]{12,}|sbp_[A-Za-z0-9_-]{20,}|sb_secret_[A-Za-z0-9_-]{20,})' -- ':!README.md' ':!docs/**' ':!.env.example'; then
+            echo "Potential committed secret value found. Keep production secrets in GitHub Actions, Supabase, or Vercel settings."
+            exit 1
+          fi
+
   test-and-build:
     runs-on: ubuntu-latest
+    needs: guardrails
 
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,48 @@
+name: Supabase Migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/supabase-migrations.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supabase-migrations-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Supabase migrations
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: production
+
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      - name: Verify required secrets
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_ACCESS_TOKEN"
+          test -n "$SUPABASE_DB_PASSWORD"
+          test -n "$SUPABASE_PROJECT_ID"
+
+      - name: Link production Supabase project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID" --password "$SUPABASE_DB_PASSWORD"
+
+      - name: Apply migrations
+        run: supabase --yes db push

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes
 Supabase usage must update that contract, migrations, and tests or test notes.
 
-Database migrations live in `supabase/migrations`. Apply unapplied migrations
-to the linked Supabase project with:
+Database migrations live in `supabase/migrations`. In production, migrations are
+deployed by GitHub Actions after a migration PR is merged to `main`; see
+[docs/deployment-automation.md](docs/deployment-automation.md). For local
+development or emergency fallback, apply unapplied migrations to the linked
+Supabase project with:
 
 ```bash
 supabase db push

--- a/docs/deployment-automation.md
+++ b/docs/deployment-automation.md
@@ -1,0 +1,84 @@
+# Deployment Automation
+
+This repo uses GitHub Actions to keep Codex-authored PRs reviewable while
+removing the easy-to-forget manual Supabase migration step.
+
+## PR Lifecycle
+
+1. Codex creates a feature branch and opens a PR.
+2. The `CI` workflow runs on the PR.
+3. The maintainer reviews the PR.
+4. GitHub auto-merge may merge the PR after required checks and any required
+   approvals pass.
+5. Vercel deploys the app from `main`.
+6. If the merge includes files under `supabase/migrations`, the
+   `Supabase Migrations` workflow applies them to the production Supabase
+   project after the code is on `main`.
+
+Supabase migrations are not deployed from unmerged PR branches.
+
+## CI Checks
+
+The `CI` workflow runs on pull requests and pushes to `main`.
+
+Required checks:
+- Migration filenames use `YYYYMMDDHHMMSS_descriptive_name.sql`.
+- Obvious committed secret values are rejected.
+- `npm run test:run`.
+- `npm run build`.
+
+## Supabase Migration Deployment
+
+The `Supabase Migrations` workflow runs only on `main` pushes that touch
+`supabase/migrations/**` or the migration workflow itself. It can also be rerun
+manually with `workflow_dispatch`.
+
+The workflow:
+- installs the Supabase CLI
+- verifies required GitHub Actions secrets are present
+- links the intended Supabase project
+- runs `supabase --yes db push`
+- fails visibly if linking or migration deployment fails
+
+Required GitHub Actions secrets:
+- `SUPABASE_ACCESS_TOKEN`: Supabase personal access token for CI
+- `SUPABASE_PROJECT_ID`: production Supabase project ref
+- `SUPABASE_DB_PASSWORD`: production database password
+- `NEXT_PUBLIC_SUPABASE_URL`: used by the app build in CI
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: used by the app build in CI
+
+Do not commit these values. Do not use a service-role key in frontend code.
+
+## Branch Protection
+
+Configure GitHub branch protection for `main` in repository settings:
+
+- Require a pull request before merging.
+- Require status checks to pass before merging.
+- Require the `CI / test-and-build` check.
+- Require the `CI / guardrails` check.
+- Optionally require one approval before merging.
+- Prevent direct pushes to `main` where practical.
+- Allow auto-merge only after required checks and approvals pass.
+
+These settings are repository settings and are not stored in the codebase.
+
+## Auto-Merge Guidance
+
+For trusted Codex PRs, the maintainer may enable GitHub auto-merge after review.
+Auto-merge should wait for required CI checks and any required approval. Do not
+merge or auto-merge PRs with failing tests, failing builds, or failed guardrails.
+
+## Failure Recovery
+
+If the `Supabase Migrations` workflow fails after a merge:
+
+1. Treat production app code as potentially ahead of the database.
+2. Open the failed GitHub Actions run and read the failed step.
+3. Fix the migration or missing secret in a new PR.
+4. Merge the fix to `main`, or rerun the failed workflow after correcting only
+   repository secrets/configuration.
+5. Confirm the migration workflow passes before relying on the affected app
+   behavior.
+
+Manual `supabase db push` is now a fallback only, not the primary workflow.

--- a/lib/__tests__/deploymentAutomation.test.ts
+++ b/lib/__tests__/deploymentAutomation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const ciWorkflow = readFileSync(
+  join(repoRoot, ".github/workflows/ci.yml"),
+  "utf8"
+);
+const migrationWorkflow = readFileSync(
+  join(repoRoot, ".github/workflows/supabase-migrations.yml"),
+  "utf8"
+);
+const deploymentDocs = readFileSync(
+  join(repoRoot, "docs/deployment-automation.md"),
+  "utf8"
+);
+
+describe("deployment automation guardrails", () => {
+  it("runs required PR checks before merge", () => {
+    expect(ciWorkflow).toContain("pull_request:");
+    expect(ciWorkflow).toContain("Check migration filenames");
+    expect(ciWorkflow).toContain("Check for committed secret values");
+    expect(ciWorkflow).toContain("npm run test:run");
+    expect(ciWorkflow).toContain("npm run build");
+  });
+
+  it("deploys Supabase migrations only from main", () => {
+    expect(migrationWorkflow).toContain("branches: [main]");
+    expect(migrationWorkflow).toContain("if: github.ref == 'refs/heads/main'");
+    expect(migrationWorkflow).not.toContain("pull_request:");
+    expect(migrationWorkflow).toContain("supabase/migrations/**");
+    expect(migrationWorkflow).toContain("supabase --yes db push");
+  });
+
+  it("keeps production Supabase credentials in GitHub Actions secrets", () => {
+    for (const secretName of [
+      "SUPABASE_ACCESS_TOKEN",
+      "SUPABASE_DB_PASSWORD",
+      "SUPABASE_PROJECT_ID",
+    ]) {
+      expect(migrationWorkflow).toContain(`secrets.${secretName}`);
+      expect(deploymentDocs).toContain(secretName);
+    }
+  });
+
+  it("documents merge, branch protection, auto-merge, and failure recovery", () => {
+    expect(deploymentDocs).toContain("Branch Protection");
+    expect(deploymentDocs).toContain("Require a pull request before merging");
+    expect(deploymentDocs).toContain("Auto-Merge Guidance");
+    expect(deploymentDocs).toContain("Failure Recovery");
+    expect(deploymentDocs).toContain(
+      "Supabase migrations are not deployed from unmerged PR branches"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add CI guardrails for migration filename format and obvious committed secret values
- add a main-only Supabase migration deployment workflow using GitHub Actions secrets
- document the PR lifecycle, branch protection, auto-merge guidance, migration deployment, and failure recovery
- add tests that pin the deployment automation contract in place

## Supabase deployment / manual setup
No database migration is included in this PR.

Before the migration workflow can deploy production migrations, configure these GitHub Actions secrets:
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_PROJECT_ID`
- `SUPABASE_DB_PASSWORD`
- existing build secrets `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`

Also configure `main` branch protection in GitHub settings as documented in `docs/deployment-automation.md`.

## Testing
- `npm run test:run`
- `npm run build`

Closes #190