### PR TITLE
Smooth quartet start transition

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -53,6 +53,7 @@ import {
   getMyRepertoire,
   markRepertoireItemAsSung,
 } from "@/lib/repertoireStore";
+import { buildParticipantEntries } from "@/lib/participantEntries";
 import {
   getRecentSungSongs,
   type SungSongEvent,
@@ -249,20 +250,7 @@ export default function JoinSessionPage() {
 
   async function getMyEntries(name: string): Promise<SingerEntry[]> {
     const repertoire = await loadMyRepertoire();
-
-    return repertoire.map((item) => ({
-      repertoireId: item.id,
-      userId: item.user_id,
-      displayName: name,
-      songTitle: item.song_title,
-      voicing: item.voicing,
-      arrangerName: item.arranger_name,
-      partsKnown: item.parts_known,
-      confidence: item.confidence,
-      partConfidences: Object.fromEntries(
-        item.part_confidences.map(({ part, confidence }) => [part, confidence])
-      ),
-    }));
+    return buildParticipantEntries(name, repertoire);
   }
 
   async function joinSession(

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -1,21 +1,31 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { AppNav } from "@/components/AppNav";
 import {
   clearActiveQuartet,
   getActiveQuartet,
+  setActiveQuartet as persistActiveQuartet,
   type ActiveQuartet,
 } from "@/lib/activeQuartet";
-import { getCurrentUser } from "@/lib/profileStore";
+import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
+import { buildParticipantEntries } from "@/lib/participantEntries";
+import { getMyRepertoire } from "@/lib/repertoireStore";
 import { trackEvent } from "@/lib/analytics";
-import { createSession, removeParticipant } from "@/lib/sessionStore";
+import {
+  createSession,
+  removeParticipant,
+  upsertParticipant,
+} from "@/lib/sessionStore";
 
 function makeJoinCode() {
   return Math.random().toString(36).slice(2, 8).toUpperCase();
 }
 
 export default function SessionPage() {
+  const router = useRouter();
+  const creatingQuartet = useRef(false);
   const [loading, setLoading] = useState(true);
   const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
   const [leavingCurrent, setLeavingCurrent] = useState(false);
@@ -34,30 +44,72 @@ export default function SessionPage() {
   }, []);
 
   async function createNewQuartet() {
+    if (creatingQuartet.current) return true;
+
+    creatingQuartet.current = true;
     setLoading(true);
     setErrorMessage("");
+    let didNavigate = false;
 
-    async function init() {
+    try {
+      const user = await getCurrentUser();
+      if (!user) {
+        router.replace("/login?redirect=/session");
+        didNavigate = true;
+        return true;
+      }
+
+      const profile = await getMyProfile();
+      if (!profile?.display_name) {
+        router.replace("/settings");
+        didNavigate = true;
+        return true;
+      }
+
+      const repertoire = await getMyRepertoire();
       const code = makeJoinCode();
+      const session = await createSession(code);
+      const entries = buildParticipantEntries(profile.display_name, repertoire);
+      const lastActivityAt = new Date().toISOString();
 
-      try {
-        const session = await createSession(code);
-        trackEvent("quartet_started", {
-          session_id: session.id,
-          participant_count: 0,
-        });
-        window.location.href = `/join/${code}`;
-      } catch (err) {
-        console.error("Failed to create session", err);
-        setErrorMessage(
-          "Could not create a quartet code. Check your connection and try again."
-        );
-      } finally {
+      await upsertParticipant(
+        session.id,
+        user.id,
+        profile.display_name,
+        entries,
+        lastActivityAt
+      );
+
+      persistActiveQuartet({
+        sessionId: session.id,
+        code,
+        joinedAt: lastActivityAt,
+      });
+      trackEvent("quartet_started", {
+        session_id: session.id,
+        participant_count: 1,
+        song_count: entries.length,
+      });
+      trackEvent("quartet_joined", {
+        session_id: session.id,
+        participant_count: 1,
+        song_count: entries.length,
+      });
+      didNavigate = true;
+      router.replace(`/join/${code}`);
+      return true;
+    } catch (err) {
+      console.error("Failed to create session", err);
+      setErrorMessage(
+        "Could not create a quartet code. Check your connection and try again."
+      );
+      return false;
+    } finally {
+      if (!didNavigate) {
+        creatingQuartet.current = false;
         setLoading(false);
       }
     }
-
-    init();
   }
 
   async function leaveCurrentAndContinue() {
@@ -78,7 +130,10 @@ export default function SessionPage() {
       });
       clearActiveQuartet();
       setActiveQuartet(null);
-      await createNewQuartet();
+      const didStartNewQuartet = await createNewQuartet();
+      if (!didStartNewQuartet) {
+        setLeavingCurrent(false);
+      }
     } catch (err) {
       console.error("Failed to leave current quartet", err);
       setErrorMessage(

--- a/lib/__tests__/participantEntries.test.ts
+++ b/lib/__tests__/participantEntries.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildParticipantEntries } from "../participantEntries";
+import type { RepertoireRow } from "../repertoireStore";
+
+function repertoireRow(
+  overrides: Partial<RepertoireRow> = {}
+): RepertoireRow {
+  return {
+    id: "rep-1",
+    user_id: "user-1",
+    song_title: "Bright Was the Night",
+    voicing: "TTBB",
+    arranger_name: "A. Arranger",
+    parts_known: ["Lead", "Bass"],
+    part_confidences: [
+      { part: "Lead", confidence: "Good To Go" },
+      { part: "Bass", confidence: "Music Required" },
+    ],
+    confidence: "Good To Go",
+    notes: "private note",
+    last_sung_at: null,
+    times_sung_count: 0,
+    created_at: "2026-04-28T00:00:00.000Z",
+    updated_at: "2026-04-28T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildParticipantEntries", () => {
+  it("builds participant snapshots from repertoire rows", () => {
+    expect(buildParticipantEntries("Tim", [repertoireRow()])).toEqual([
+      {
+        repertoireId: "rep-1",
+        userId: "user-1",
+        displayName: "Tim",
+        songTitle: "Bright Was the Night",
+        voicing: "TTBB",
+        arrangerName: "A. Arranger",
+        partsKnown: ["Lead", "Bass"],
+        confidence: "Good To Go",
+        partConfidences: {
+          Lead: "Good To Go",
+          Bass: "Music Required",
+        },
+      },
+    ]);
+  });
+
+  it("does not include private repertoire notes in participant snapshots", () => {
+    const [entry] = buildParticipantEntries("Tim", [
+      repertoireRow({ notes: "please do not share" }),
+    ]);
+
+    expect(entry).not.toHaveProperty("notes");
+  });
+});

--- a/lib/participantEntries.ts
+++ b/lib/participantEntries.ts
@@ -1,0 +1,21 @@
+import type { SingerEntry } from "@/lib/matching";
+import type { RepertoireRow } from "@/lib/repertoireStore";
+
+export function buildParticipantEntries(
+  displayName: string,
+  repertoire: RepertoireRow[]
+): SingerEntry[] {
+  return repertoire.map((item) => ({
+    repertoireId: item.id,
+    userId: item.user_id,
+    displayName,
+    songTitle: item.song_title,
+    voicing: item.voicing,
+    arrangerName: item.arranger_name,
+    partsKnown: item.parts_known,
+    confidence: item.confidence,
+    partConfidences: Object.fromEntries(
+      item.part_confidences.map(({ part, confidence }) => [part, confidence])
+    ),
+  }));
+}


### PR DESCRIPTION
## Summary
- keep the Start flow in a stable creating state while the new quartet is prepared
- create the current singer's session_participants snapshot before navigating to the quartet page
- switch the final transition to a client-side route replace instead of a full page navigation
- share participant snapshot mapping between Start and Join flows

## Docs and tests
- Docs not updated: this changes an existing flow's behavior, but does not change setup, deployment, environment variables, Supabase contracts, or user-facing instructions.
- Tests added for participant snapshot mapping, including preserving per-part confidence and excluding private notes.

## Supabase
No migration or dashboard change required. The flow uses the existing sessions and session_participants writes covered by current RLS policies.

## Testing
- npm run test:run
- npm run build

Closes #170