### PR TITLE
Replace quartet confirmation popups

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { MatchCard } from "@/components/MatchCard";
+import { QuartetActionConfirmation } from "@/components/QuartetActionConfirmation";
 import { trackEvent } from "@/lib/analytics";
 import { intentionalJoinStorageKey } from "@/lib/joinIntent";
 import { resolveCurrentUserRepertoireForMarkAsSung } from "@/lib/markAsSung";
@@ -132,8 +133,11 @@ export default function JoinSessionPage() {
   const [now, setNow] = useState(() => new Date());
   const [leftQuartet, setLeftQuartet] = useState(false);
   const [leaving, setLeaving] = useState(false);
+  const [showLeaveConfirmation, setShowLeaveConfirmation] = useState(false);
   const [joiningQuartet, setJoiningQuartet] = useState(false);
   const [removingParticipantId, setRemovingParticipantId] = useState("");
+  const [participantToRemove, setParticipantToRemove] =
+    useState<DbParticipant | null>(null);
   const [pendingActiveQuartet, setPendingActiveQuartet] =
     useState<ActiveQuartet | null>(null);
   const [leavingCurrentQuartet, setLeavingCurrentQuartet] = useState(false);
@@ -382,7 +386,7 @@ export default function JoinSessionPage() {
         "Could not leave yet. Wait for the quartet to finish loading.",
         "error"
       );
-      return;
+      return false;
     }
 
     setLeaving(true);
@@ -403,6 +407,7 @@ export default function JoinSessionPage() {
         participant_count: Math.max(0, participants.length - 1),
       });
       window.location.href = "/?leftQuartet=1";
+      return true;
     } catch (err) {
       console.error(err);
       showStatusMessage(
@@ -410,14 +415,20 @@ export default function JoinSessionPage() {
         "error"
       );
       setLeaving(false);
+      return false;
     }
   }
 
-  async function confirmLeaveQuartet() {
-    const confirmed = window.confirm("Remove yourself from this quartet?");
-    if (!confirmed) return;
+  function requestLeaveQuartet() {
+    clearStatusMessage();
+    setShowLeaveConfirmation(true);
+  }
 
-    await leaveQuartet();
+  async function confirmLeaveQuartet() {
+    const didLeave = await leaveQuartet();
+    if (!didLeave) {
+      setShowLeaveConfirmation(false);
+    }
   }
 
   async function removeQuartetParticipant(participant: DbParticipant) {
@@ -430,20 +441,22 @@ export default function JoinSessionPage() {
     }
 
     if (participant.user_id === currentUserId) {
-      await confirmLeaveQuartet();
+      requestLeaveQuartet();
       return;
     }
 
+    clearStatusMessage();
+    setParticipantToRemove(participant);
+  }
+
+  async function confirmRemoveQuartetParticipant() {
+    if (!sessionId || !participantToRemove) return;
+
+    const participant = participantToRemove;
     const participantName = getParticipantDisplayName(
       participant,
       profileDisplayNamesByUserId
     );
-    const confirmed = window.confirm(
-      `Remove ${participantName} from this quartet?`
-    );
-
-    if (!confirmed) return;
-
     setRemovingParticipantId(participant.id);
     clearStatusMessage();
 
@@ -460,12 +473,14 @@ export default function JoinSessionPage() {
         `${participantName} was removed from the quartet.`,
         "transient"
       );
+      setParticipantToRemove(null);
     } catch (err) {
       console.error(err);
       showStatusMessage(
         "Could not remove that singer. Check your connection and try again.",
         "error"
       );
+      setParticipantToRemove(null);
     } finally {
       setRemovingParticipantId("");
     }
@@ -1081,6 +1096,33 @@ export default function JoinSessionPage() {
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-5xl">
         <AppNav />
+        <QuartetActionConfirmation
+          open={showLeaveConfirmation}
+          busy={leaving}
+          title="Leave quartet?"
+          description="You'll be removed from this quartet. You can rejoin later with the code if there is still room."
+          confirmLabel="Leave quartet"
+          busyLabel="Leaving..."
+          onCancel={() => setShowLeaveConfirmation(false)}
+          onConfirm={confirmLeaveQuartet}
+        />
+        <QuartetActionConfirmation
+          open={Boolean(participantToRemove)}
+          busy={Boolean(removingParticipantId)}
+          title="Remove singer?"
+          description={`${
+            participantToRemove
+              ? getParticipantDisplayName(
+                  participantToRemove,
+                  profileDisplayNamesByUserId
+                )
+              : "This singer"
+          } will be removed from this quartet. They can rejoin later with the code if there is still room.`}
+          confirmLabel="Remove from quartet"
+          busyLabel="Removing..."
+          onCancel={() => setParticipantToRemove(null)}
+          onConfirm={confirmRemoveQuartetParticipant}
+        />
 
         <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-4xl font-bold">Quartet {code}</h1>
@@ -1260,7 +1302,7 @@ export default function JoinSessionPage() {
                         Change my display name
                       </a>
                       <button
-                        onClick={confirmLeaveQuartet}
+                        onClick={requestLeaveQuartet}
                         disabled={leaving || !sessionId}
                         className="rounded-xl bg-rose-200 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-40"
                       >
@@ -1303,7 +1345,7 @@ export default function JoinSessionPage() {
 
                       <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                         <button
-                          onClick={confirmLeaveQuartet}
+                          onClick={requestLeaveQuartet}
                           disabled={leaving || !sessionId}
                           className="rounded-xl bg-rose-200 px-5 py-3 font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-40"
                         >

--- a/components/ActiveQuartetIndicator.tsx
+++ b/components/ActiveQuartetIndicator.tsx
@@ -11,6 +11,7 @@ import {
 import { getCurrentUser } from "@/lib/profileStore";
 import { trackEvent } from "@/lib/analytics";
 import { removeParticipant } from "@/lib/sessionStore";
+import { QuartetActionConfirmation } from "@/components/QuartetActionConfirmation";
 
 function isViewingActiveQuartet(pathname: string, code: string) {
   return pathname.toUpperCase() === `/JOIN/${code.toUpperCase()}`;
@@ -20,6 +21,7 @@ export function ActiveQuartetIndicator() {
   const pathname = usePathname();
   const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
   const [leaving, setLeaving] = useState(false);
+  const [showLeaveConfirmation, setShowLeaveConfirmation] = useState(false);
   const [message, setMessage] = useState("");
 
   useEffect(() => {
@@ -58,12 +60,14 @@ export function ActiveQuartetIndicator() {
 
       clearActiveQuartet();
       setActiveQuartet(null);
+      setShowLeaveConfirmation(false);
 
       if (window.location.pathname === `/join/${activeQuartet.code}`) {
         window.location.href = "/?leftQuartet=1";
       }
     } catch (err) {
       console.error("Failed to leave active quartet", err);
+      setShowLeaveConfirmation(false);
       setMessage("Could not leave quartet. Try again.");
     } finally {
       setLeaving(false);
@@ -78,6 +82,16 @@ export function ActiveQuartetIndicator() {
 
   return (
     <div className="mt-3 rounded-xl border border-cyan-300/30 bg-cyan-300/10 p-3">
+      <QuartetActionConfirmation
+        open={showLeaveConfirmation}
+        busy={leaving}
+        title="Leave quartet?"
+        description="You'll be removed from this quartet. You can rejoin later with the code if there is still room."
+        confirmLabel="Leave quartet"
+        busyLabel="Leaving..."
+        onCancel={() => setShowLeaveConfirmation(false)}
+        onConfirm={leaveQuartet}
+      />
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm font-semibold text-slate-100">
           In quartet{" "}
@@ -93,7 +107,10 @@ export function ActiveQuartetIndicator() {
           </a>
           <button
             type="button"
-            onClick={leaveQuartet}
+            onClick={() => {
+              setMessage("");
+              setShowLeaveConfirmation(true);
+            }}
             disabled={leaving}
             className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-slate-700 disabled:opacity-40"
           >

--- a/components/QuartetActionConfirmation.test.tsx
+++ b/components/QuartetActionConfirmation.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { QuartetActionConfirmation } from "./QuartetActionConfirmation";
+
+const baseProps = {
+  busy: false,
+  title: "Leave quartet?",
+  description:
+    "You'll be removed from this quartet. You can rejoin later with the code if there is still room.",
+  confirmLabel: "Leave quartet",
+  busyLabel: "Leaving...",
+  onCancel: () => undefined,
+  onConfirm: () => undefined,
+};
+
+describe("QuartetActionConfirmation", () => {
+  it("does not render when closed", () => {
+    expect(
+      renderToStaticMarkup(
+        <QuartetActionConfirmation {...baseProps} open={false} />
+      )
+    ).toBe("");
+  });
+
+  it("renders a mobile-safe in-app confirmation dialog", () => {
+    const html = renderToStaticMarkup(
+      <QuartetActionConfirmation {...baseProps} open />
+    );
+
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+    expect(html).toContain("Leave quartet?");
+    expect(html).toContain("Cancel");
+    expect(html).toContain("Leave quartet");
+  });
+
+  it("shows busy copy while the action is running", () => {
+    const html = renderToStaticMarkup(
+      <QuartetActionConfirmation {...baseProps} open busy />
+    );
+
+    expect(html).toContain("Leaving...");
+  });
+});

--- a/components/QuartetActionConfirmation.tsx
+++ b/components/QuartetActionConfirmation.tsx
@@ -1,0 +1,64 @@
+type QuartetActionConfirmationProps = {
+  open: boolean;
+  busy: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  busyLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function QuartetActionConfirmation({
+  open,
+  busy,
+  title,
+  description,
+  confirmLabel,
+  busyLabel,
+  onCancel,
+  onConfirm,
+}: QuartetActionConfirmationProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-slate-950/80 px-4 py-4 sm:items-center">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quartet-action-title"
+        aria-describedby="quartet-action-description"
+        className="w-full max-w-md rounded-2xl border border-white/10 bg-slate-900 p-5 text-white shadow-2xl"
+      >
+        <h2 id="quartet-action-title" className="text-2xl font-semibold">
+          {title}
+        </h2>
+        <p
+          id="quartet-action-description"
+          className="mt-2 text-sm text-slate-300"
+        >
+          {description}
+        </p>
+
+        <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-xl border border-white/10 px-5 py-3 font-semibold text-slate-200 hover:bg-white/10 disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className="rounded-xl bg-rose-200 px-5 py-3 font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-40"
+          >
+            {busy ? busyLabel : confirmLabel}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace current-user Leave quartet browser confirmation with a mobile-safe in-app dialog
- route the active quartet indicator Leave action through the same confirmation UI
- replace other-singer Remove from quartet browser confirmation with the same app-controlled dialog pattern
- keep the underlying leave/remove flows separate so voluntary leave and removing another singer still behave differently

## Docs and tests
- Docs not updated: this changes an existing UI confirmation pattern without changing setup, deployment, Supabase contracts, or user-facing instructions outside the app.
- Added render tests for the shared confirmation component, including closed/open/busy states.

## Supabase
No migration or dashboard change required. Existing session_participants delete/remove calls are reused.

## Testing
- npm run test:run
- npm run build

Closes #165