### PR TITLE
Simplify primary navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,6 +53,7 @@ const setupPrompts: Record<
 export default function Home() {
   const [setupState, setSetupState] = useState<SetupState>("loading");
   const [activeQuartet, setActiveQuartet] = useState<ActiveQuartet | null>(null);
+  const [repertoireCount, setRepertoireCount] = useState(0);
   const [message, setMessage] = useState("");
   const [messageTone, setMessageTone] = useState<"error" | "success">("error");
 
@@ -82,6 +83,7 @@ export default function Home() {
         }
 
         const repertoire = await getMyRepertoire();
+        setRepertoireCount(repertoire.length);
         setActiveQuartet(getActiveQuartet());
         setSetupState(repertoire.length > 0 ? "ready" : "missing_repertoire");
       } catch (err) {
@@ -109,7 +111,7 @@ export default function Home() {
           What Can We Sing
         </p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight">
-          Find songs your quartet can sing now.
+          What can we sing right now?
         </h1>
 
         {message && (
@@ -144,9 +146,15 @@ export default function Home() {
 
         {setupState === "ready" && (
           <>
-            <p className="mt-6 rounded-xl bg-white/10 px-4 py-3 text-sm text-slate-300">
-              Start a quartet, join with a code, or update your repertoire.
-            </p>
+            <div className="mt-6 rounded-xl bg-white/10 px-4 py-3">
+              <p className="text-sm font-semibold text-slate-100">
+                {repertoireCount} {repertoireCount === 1 ? "song" : "songs"} in
+                your repertoire
+              </p>
+              <p className="mt-1 text-sm text-slate-300">
+                Start a quartet, join with a code, or update your song list.
+              </p>
+            </div>
 
             {activeQuartet && (
               <a
@@ -162,12 +170,12 @@ export default function Home() {
               </a>
             )}
 
-            <div className="mt-4 space-y-3">
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
               {actions.map((action) => (
                 <a
                   key={action.href}
                   href={action.href}
-                  className="block rounded-xl border border-white/10 bg-white/10 px-5 py-4 hover:border-cyan-300/60 hover:bg-white/15"
+                  className="block rounded-xl border border-white/10 bg-white/10 px-5 py-4 hover:border-cyan-300/60 hover:bg-white/15 sm:min-h-32"
                 >
                   <span className="block text-lg font-semibold text-white">
                     {action.title}
@@ -177,6 +185,21 @@ export default function Home() {
                   </span>
                 </a>
               ))}
+            </div>
+
+            <div className="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-sm">
+              <a
+                href="/settings"
+                className="font-semibold text-slate-300 hover:text-cyan-200"
+              >
+                Profile
+              </a>
+              <a
+                href="/feedback"
+                className="font-semibold text-slate-300 hover:text-cyan-200"
+              >
+                Feedback
+              </a>
             </div>
           </>
         )}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -4,35 +4,33 @@ import { ActiveQuartetIndicator } from "@/components/ActiveQuartetIndicator";
 import { usePathname } from "next/navigation";
 import { SignOutButton } from "@/components/SignOutButton";
 
-const navItems = [
-  {
-    href: "/",
-    label: "Home",
-    isActive: (pathname: string) => pathname === "/",
-  },
+const primaryNavItems = [
   {
     href: "/session",
-    label: "Start a quartet",
+    label: "Start",
     isActive: (pathname: string) => pathname === "/session",
   },
   {
     href: "/join",
-    label: "Join a quartet",
+    label: "Join",
     isActive: (pathname: string) => pathname.startsWith("/join"),
   },
   {
     href: "/repertoire",
-    label: "Manage my rep",
+    label: "Repertoire",
     isActive: (pathname: string) => pathname === "/repertoire",
   },
+];
+
+const secondaryNavItems = [
   {
     href: "/settings",
-    label: "Settings",
+    label: "Profile",
     isActive: (pathname: string) => pathname === "/settings",
   },
   {
     href: "/feedback",
-    label: "Send feedback",
+    label: "Feedback",
     isActive: (pathname: string) => pathname === "/feedback",
   },
 ];
@@ -45,8 +43,35 @@ export function AppNav() {
       aria-label="Main navigation"
       className="rounded-2xl border border-white/10 bg-white/10 p-3"
     >
-      <div className="flex flex-wrap items-center gap-2">
-        {navItems.map((item) => {
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <a href="/" className="text-sm font-bold uppercase text-cyan-300">
+          What Can We Sing
+        </a>
+
+        <div className="grid grid-cols-3 gap-2 sm:flex sm:items-center">
+          {primaryNavItems.map((item) => {
+            const active = item.isActive(pathname);
+
+            return (
+              <a
+                key={item.label}
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={`rounded-xl px-3 py-2 text-center text-sm font-semibold ${
+                  active
+                    ? "bg-cyan-300 text-slate-950"
+                    : "bg-white/5 text-cyan-200 hover:bg-white/10 hover:text-white"
+                }`}
+              >
+                {item.label}
+              </a>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+        {secondaryNavItems.map((item) => {
           const active = item.isActive(pathname);
 
           return (
@@ -54,10 +79,10 @@ export function AppNav() {
               key={item.label}
               href={item.href}
               aria-current={active ? "page" : undefined}
-              className={`rounded-xl px-3 py-2 text-sm font-semibold ${
+              className={`font-semibold ${
                 active
-                  ? "bg-cyan-300 text-slate-950"
-                  : "text-cyan-200 hover:bg-white/10 hover:text-white"
+                  ? "text-white"
+                  : "text-slate-300 hover:text-cyan-200"
               }`}
             >
               {item.label}
@@ -65,7 +90,7 @@ export function AppNav() {
           );
         })}
 
-        <SignOutButton className="rounded-xl px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/10 hover:text-white disabled:opacity-50" />
+        <SignOutButton className="font-semibold text-slate-300 hover:text-cyan-200 disabled:opacity-50" />
       </div>
       <ActiveQuartetIndicator />
     </nav>


### PR DESCRIPTION
## Summary
- make Start, Join, and Repertoire the dominant primary nav items
- move Profile, Feedback, and Sign out into a secondary nav row
- keep home access through the app name link and preserve the active quartet indicator
- make the home page more useful for returning users with repertoire count, active quartet access, and primary action cards

## Docs and tests
- Docs not updated: this is a UI/navigation hierarchy change with no setup, deployment, Supabase contract, or external behavior changes.
- Tests not added: no business logic or helper logic changed; existing test/build coverage verifies the app still compiles.

## Supabase
No migration or dashboard change required.

## Testing
- npm run test:run
- npm run build

Closes #169