### PR TITLE
Audit and align documentation with current app behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,8 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # Optional product analytics. Leave blank to disable PostHog locally.
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=
+
+# Server-only feedback email settings. Do not prefix these with NEXT_PUBLIC_.
+RESEND_API_KEY=
+FEEDBACK_FROM_EMAIL=
+FEEDBACK_TO_EMAIL=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,11 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
 - Same title + same voicing can be grouped, but different arrangers or missing arrangers should be flagged as possible matches, not ignored.
 - Do not combine different voicings.
 - Repertoire is cloud-backed in Supabase.
-- Sessions store participant repertoire snapshots; users can refresh their snapshot.
+- Sessions store participant repertoire snapshots; repertoire add/edit/delete
+  flows refresh the active quartet snapshot when a user is in a quartet.
+- `profiles.display_name` is the source of truth for names shown in quartet UI;
+  do not depend on `session_participants.display_name` for display.
+- `session_participants` is the source of truth for active quartet membership.
 
 ## Barbershop-specific context
 - Pickup quartets often form informally at rehearsals, conventions, afterglows, or social singing events.
@@ -136,5 +140,8 @@ Guardrails:
 - `lib/__tests__/matching.test.ts`: matching tests
 - `lib/sessionStore.ts`: sessions/participants/realtime
 - `lib/repertoireStore.ts`: cloud repertoire
+- `lib/activeQuartetSnapshot.ts`: refreshes active quartet snapshots after repertoire changes
+- `lib/participantEntries.ts`: combines participant rows with profile display names
 - `app/join/[code]/page.tsx`: session join/results
 - `app/repertoire/page.tsx`: repertoire management
+- `docs/supabase-contract.md`: app/database contract and Supabase guardrails

--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # what-can-we-sing
+
 An app to allow a pick-up barbershop quartet to quickly find songs they can sing together
+
+## Product model
+
+What Can We Sing is optimized for in-the-room pickup quartet decisions. The
+important question is "what can these singers sing right now?"
+
+Current source-of-truth model:
+
+- `profiles` stores the singer display name.
+- `user_repertoire` stores each singer's saved songs, voicing, parts,
+  per-part confidence values, optional arranger, private notes, and personal
+  sung metadata.
+- `sessions` stores quartet join codes and activity.
+- `session_participants` stores active quartet membership and each singer's
+  repertoire snapshot.
+
+The quartet screen derives participants and matches from
+`session_participants`. Local active-quartet state is only a navigation
+shortcut, not the source of truth.
+
+See [docs/app-flows.md](docs/app-flows.md) for the current start, join, rejoin,
+leave, remove, repertoire refresh, and matching flow.
 
 ## Environment variables
 
@@ -21,6 +44,9 @@ FEEDBACK_TO_EMAIL=feedback destination address
 settings for the in-app feedback form. Configure them in Vercel, not as
 `NEXT_PUBLIC_*` variables. For the current deployment, set
 `FEEDBACK_TO_EMAIL` to the app owner address.
+
+The feedback destination email must never be rendered in the client or returned
+from an API response.
 
 ## Supabase auth email
 
@@ -71,3 +97,21 @@ supabase db push
 
 If the project is not linked locally, run `supabase link --project-ref <project-ref>`
 first, then `supabase db push`.
+
+## Analytics
+
+PostHog setup and event rules are documented in
+[docs/analytics.md](docs/analytics.md). Analytics is optional and must never
+block core app behavior.
+
+## Testing
+
+Run the normal local checks before finishing a change:
+
+```bash
+npm run test:run
+npm run build
+```
+
+Matching logic lives in `lib/matching.ts` and should be covered with focused
+unit tests whenever matching behavior changes.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,49 @@
+# Analytics
+
+Analytics are optional. If `NEXT_PUBLIC_POSTHOG_KEY` or
+`NEXT_PUBLIC_POSTHOG_HOST` is missing, the app should continue to work without
+tracking.
+
+## Provider
+
+The app initializes PostHog from `instrumentation-client.ts` using:
+
+- `NEXT_PUBLIC_POSTHOG_KEY`
+- `NEXT_PUBLIC_POSTHOG_HOST`
+
+Autocapture is disabled. Event capture is non-blocking and should not affect app
+behavior if PostHog is unavailable.
+
+## Privacy Contract
+
+Do not send free-text user content to PostHog. This includes:
+
+- feedback text
+- repertoire notes
+- song titles
+- arranger names
+- singer names
+- email addresses
+
+Analytics properties should be limited to counts, booleans, IDs, enum-like
+values, and coarse app context.
+
+## Current Events
+
+The app currently tracks these events through `lib/analytics.ts`:
+
+- `user_logged_in`
+- `repertoire_song_added`
+- `repertoire_song_edited`
+- `repertoire_song_deleted`
+- `quartet_started`
+- `quartet_joined`
+- `quartet_left`
+- `quartet_member_removed`
+- `quartet_matches_viewed`
+- `song_marked_sung`
+- `song_mark_sung_failed`
+- `feedback_submitted`
+
+When adding an event, update this document and keep the privacy contract above
+in sync with the event properties.

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -1,0 +1,94 @@
+# App Flows
+
+This document describes the current user-facing data flow. It should stay in
+sync with `README.md`, `AGENTS.md`, and `docs/supabase-contract.md`.
+
+## Source Of Truth
+
+- `profiles.display_name` is the source of truth for singer names.
+- `user_repertoire` is the source of truth for a user's saved songs, parts,
+  confidence values, private notes, and recently sung metadata.
+- `sessions` is the source of truth for quartet join codes and session activity.
+- `session_participants` is the source of truth for active quartet membership
+  and each singer's repertoire snapshot.
+- Local active-quartet state is only a navigation shortcut. The quartet screen
+  must reconcile it against `session_participants`.
+
+## Quartet Lifecycle
+
+### Start Quartet
+
+Starting a quartet creates a `sessions` row, reads the current user's profile
+and repertoire, writes that user's `session_participants` snapshot, stores the
+active quartet shortcut locally, and then sends the user to `/join/[code]`.
+
+The first singer should appear in the quartet without needing to manually join
+again.
+
+### Join Quartet
+
+Joining by `/join/[code]` reads the session by join code and fetches current
+`session_participants` rows from Supabase. Existing participants are recognized
+by `user_id`, not by display name.
+
+New participants can join until the quartet has four singers. The four-singer
+limit is enforced before inserting another `session_participants` row.
+
+### Rejoin Quartet
+
+Returning to `/join/[code]` as an existing participant should not insert a
+duplicate row. The page should use the existing row and the latest database
+state.
+
+If a user previously left or was removed from the quartet, they should not be
+silently re-added just because local active-quartet state still exists.
+
+### Leave Quartet
+
+Leaving a quartet deletes the current user's `session_participants` row. Other
+clients should update from Realtime or from the next explicit refetch.
+
+### Remove Singer
+
+A current participant may remove another singer through
+`remove_session_participant_by_id`. The removed singer's
+`session_participants` row is deleted, and their client should stop treating the
+quartet as active after it observes that database state.
+
+### Repertoire Updates While In A Quartet
+
+Adding, editing, or deleting repertoire updates `user_repertoire`. If the user
+has an active quartet, the app refreshes that user's
+`session_participants.repertoire` snapshot so quartet results derive from the
+database snapshot instead of stale local component state.
+
+## Matching
+
+Matching uses the current `session_participants` rows. A valid quartet match
+requires distinct singers assigned to distinct required parts for the song's
+voicing. Title matching is forgiving enough to catch close variants, but
+different voicings are not combined.
+
+Arranger differences or missing arranger values do not block a match. They are
+shown as confirmation warnings so singers can decide quickly in the room.
+
+## Navigation
+
+The home page is an action hub. It offers Start Quartet, Join Quartet, Return to
+Quartet when local state exists, and Repertoire. Manual code entry belongs on
+`/join`, while QR and shared links use `/join/[code]`.
+
+## Auth
+
+The app uses Supabase Auth email one-time codes. Login and first-time signup
+emails should use the template in `docs/auth-email-template.md`; the app does
+not rely on magic-link callback redirects.
+
+## Analytics
+
+PostHog is optional and controlled by `NEXT_PUBLIC_POSTHOG_KEY` and
+`NEXT_PUBLIC_POSTHOG_HOST`. Events must not include free-text user content such
+as feedback text, repertoire notes, song titles, arranger names, singer names,
+or email addresses.
+
+See `docs/analytics.md` for the current event contract.

--- a/docs/deployment-automation.md
+++ b/docs/deployment-automation.md
@@ -55,11 +55,14 @@ Configure GitHub branch protection for `main` in repository settings:
 
 - Require a pull request before merging.
 - Require status checks to pass before merging.
-- Require the `CI / test-and-build` check.
-- Require the `CI / guardrails` check.
+- Require the `CI / test-and-build (pull_request)` check.
+- Require the `CI / guardrails (pull_request)` check.
 - Optionally require one approval before merging.
 - Prevent direct pushes to `main` where practical.
 - Allow auto-merge only after required checks and approvals pass.
+
+Do not require the `Supabase Migrations` workflow as a pre-merge PR check. It
+runs after migration changes merge to `main`.
 
 These settings are repository settings and are not stored in the codebase.
 

--- a/docs/private-repertoire-notes.md
+++ b/docs/private-repertoire-notes.md
@@ -3,8 +3,9 @@
 Issue #87 adds optional private notes to each `user_repertoire` row.
 
 This schema requirement is now captured in
-`supabase/migrations/20260428060000_supabase_contract_alignment.sql`. Apply
-unapplied migrations with `supabase db push`.
+`supabase/migrations/20260428060000_supabase_contract_alignment.sql`.
+Production migrations are deployed by GitHub Actions after merge. For local
+development or emergency fallback, see `docs/deployment-automation.md`.
 
 No changes are needed to session participant data. Notes stay in
 `user_repertoire` and are not copied into quartet snapshots.

--- a/docs/recently-sung-events.md
+++ b/docs/recently-sung-events.md
@@ -6,8 +6,9 @@ results. Issue #179 also stores personal sung metadata on `user_repertoire`.
 The event schema and RLS requirement is captured in
 `supabase/migrations/20260428060000_supabase_contract_alignment.sql`. The
 repertoire metadata and `mark_repertoire_sung` database function are captured in
-`supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql`. Apply
-unapplied migrations with `supabase db push`.
+`supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql`.
+Production migrations are deployed by GitHub Actions after merge. For local
+development or emergency fallback, see `docs/deployment-automation.md`.
 
 Events are private to the user who marked the song. They are not copied into
 quartet participant snapshots and do not affect matching rank yet. The database

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -14,6 +14,25 @@ migrations in `supabase/migrations`, and tests or test documentation.
   It uses Supabase Auth only to identify the current user and read their profile.
 - Realtime is required for `profiles` and `session_participants`.
 
+## App Flow Contract
+
+- Starting a quartet creates a `sessions` row and immediately inserts the
+  current user's `session_participants` snapshot before navigating to
+  `/join/[code]`.
+- `/join/[code]` reads fresh session and participant data from Supabase on load.
+  Existing participants are recognized by `user_id`, not by display name.
+- Local active-quartet state is a shortcut for navigation only. It must not be
+  treated as proof that the user still has a current `session_participants` row.
+- Repertoire add, edit, delete, and mark-as-sung actions update
+  `user_repertoire`. Add/edit/delete actions refresh the active quartet
+  `session_participants.repertoire` snapshot when the user is in a quartet.
+- Leaving a quartet deletes the current user's `session_participants` row.
+- Removing another singer uses `remove_session_participant_by_id` and deletes
+  the selected participant row when the requester is also a current participant
+  in that session.
+- Quartet participant lists and match results derive from the latest
+  `session_participants` rows plus profile display names.
+
 ## Tables And Objects
 
 ### `profiles`
@@ -100,6 +119,8 @@ Code:
 - Read by join code: `lib/sessionStore.ts#getSessionByCode`
 - Update `last_activity_at`: internal helper in `lib/sessionStore.ts`, called
   after participant snapshot upserts.
+- Start quartet flow: `app/session/page.tsx` creates the session before
+  inserting the first participant snapshot.
 
 Expected context:
 - Browser authenticated user.
@@ -133,6 +154,9 @@ Code:
   `lib/sessionStore.ts#subscribeToSessionParticipants`
 - Repertoire snapshot refresh:
   `lib/activeQuartetSnapshot.ts#refreshActiveQuartetSnapshot`
+- Participant display data:
+  `lib/participantEntries.ts` combines participant membership with
+  `profiles.display_name`
 - Match calculation source:
   `app/join/[code]/page.tsx` builds entries from current participants and calls
   `findMatches`.
@@ -206,7 +230,9 @@ Expected context:
 
 ## Auth Assumptions
 
-- Users sign in with Supabase Auth OTP from `app/login/page.tsx`.
+- Users sign in with Supabase Auth email OTP from `app/login/page.tsx`.
+- The app verifies typed codes with Supabase and does not rely on magic-link
+  callback redirects.
 - Most app pages require an authenticated user before reading or writing app
   tables.
 - RLS policies are written for the `authenticated` role and `auth.uid()`.
@@ -224,6 +250,10 @@ Expected context:
 
 Automated tests currently cover:
 - Matching rules and ranking in `lib/__tests__/matching.test.ts`
+- Title normalization and suggested matches in
+  `lib/__tests__/matching.test.ts`
+- Participant entry derivation from profile names in
+  `lib/__tests__/participantEntries.test.ts`
 - Participant realtime payload application in
   `lib/__tests__/sessionParticipantChanges.test.ts`
 - Existing participant/rejoin recognition by `user_id` in
@@ -231,6 +261,16 @@ Automated tests currently cover:
 - Display names derived from `profiles` instead of stale participant names in
   `lib/__tests__/sessionParticipantDisplayName.test.ts`
 - Active quartet local-storage behavior in `lib/__tests__/activeQuartet.test.ts`
+- Auth route guards and post-login redirect behavior in
+  `lib/__tests__/authRoute.test.ts` and
+  `lib/__tests__/authRedirect.test.ts`
+- Feedback route validation and server-only destination handling in API route
+  tests
+- Analytics event sanitization in `lib/__tests__/analytics.test.ts`
+- Quartet action confirmation controls in
+  `components/QuartetActionConfirmation.test.tsx`
+- Deployment automation docs/workflow guardrails in
+  `lib/__tests__/deploymentAutomation.test.ts`
 - Supabase contract/migration text in
   `lib/__tests__/supabaseContract.test.ts`
 

--- a/docs/supabase-resend-smtp.md
+++ b/docs/supabase-resend-smtp.md
@@ -64,7 +64,7 @@ In Supabase, go to **Authentication > URL Configuration**.
 Set:
 
 ```text
-Site URL: https://what-can-we-sing.vercel.app
+Site URL: your production app URL, for example https://www.whatcanwesing.com
 ```
 
 The OTP login flow does not use magic-link redirects or `/auth/callback`.

--- a/lib/__tests__/deploymentAutomation.test.ts
+++ b/lib/__tests__/deploymentAutomation.test.ts
@@ -49,6 +49,11 @@ describe("deployment automation guardrails", () => {
     expect(deploymentDocs).toContain("Require a pull request before merging");
     expect(deploymentDocs).toContain("Auto-Merge Guidance");
     expect(deploymentDocs).toContain("Failure Recovery");
+    expect(deploymentDocs).toContain("CI / test-and-build (pull_request)");
+    expect(deploymentDocs).toContain("CI / guardrails (pull_request)");
+    expect(deploymentDocs).toContain(
+      "Do not require the `Supabase Migrations` workflow as a pre-merge PR check"
+    );
     expect(deploymentDocs).toContain(
       "Supabase migrations are not deployed from unmerged PR branches"
     );

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -7,6 +7,8 @@ const contract = readFileSync(
   join(repoRoot, "docs/supabase-contract.md"),
   "utf8"
 );
+const appFlows = readFileSync(join(repoRoot, "docs/app-flows.md"), "utf8");
+const analyticsDocs = readFileSync(join(repoRoot, "docs/analytics.md"), "utf8");
 const migration = readFileSync(
   join(
     repoRoot,
@@ -75,6 +77,19 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("leave");
     expect(contract).toContain("repertoire snapshot");
     expect(contract).toContain("Match calculation source");
+    expect(contract).toContain("App Flow Contract");
+    expect(contract).toContain("Local active-quartet state is a shortcut");
+    expect(appFlows).toContain("Source Of Truth");
+    expect(appFlows).toContain("Rejoin Quartet");
+    expect(appFlows).toContain("Remove Singer");
+  });
+
+  it("documents the analytics privacy contract", () => {
+    expect(analyticsDocs).toContain("Autocapture is disabled");
+    expect(analyticsDocs).toContain("Do not send free-text user content");
+    expect(analyticsDocs).toContain("feedback text");
+    expect(analyticsDocs).toContain("song titles");
+    expect(analyticsDocs).toContain("quartet_member_removed");
   });
 
   it("documents and migrates participant removal by quartet members", () => {


### PR DESCRIPTION
## Summary
- Audits and updates docs to reflect current source-of-truth behavior for profiles, repertoire, sessions, and session participants.
- Adds app flow and analytics docs covering quartet lifecycle, auth OTP behavior, PostHog privacy, and feedback email env handling.
- Updates Supabase/deployment docs for automated migration workflow, current required check names, Realtime/RLS expectations, and production URL wording.
- Adds doc guardrail assertions for app flow, analytics privacy, and branch protection guidance.

Closes #172.

## Tests
- npm run test:run
- npm run build

## Supabase / manual steps
- No database migration or Supabase dashboard change is required for this docs-only PR.
- Existing docs continue to point to the automated migration workflow for future migration changes.