### PR TITLE
Remove repertoire duplicate suggestions

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -9,10 +9,6 @@ import type {
   PartConfidence,
   Voicing,
 } from "@/lib/matching";
-import {
-  findFuzzySongTitleSuggestions,
-  type FuzzySongTitleSuggestion,
-} from "@/lib/fuzzySongTitles";
 import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
 import {
   filterAndSortRepertoire,
@@ -89,10 +85,6 @@ export default function RepertoireManager() {
   const [savingEditId, setSavingEditId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [itemToDelete, setItemToDelete] = useState<RepertoireRow | null>(null);
-  const [dismissedSuggestionIds, setDismissedSuggestionIds] = useState<string[]>(
-    []
-  );
-  const [updatingSuggestionId, setUpdatingSuggestionId] = useState("");
 
   function completePartConfidences(
     rows: PartConfidenceFormRow[]
@@ -490,52 +482,6 @@ export default function RepertoireManager() {
     }
   }
 
-  function dismissSuggestion(suggestionId: string) {
-    setDismissedSuggestionIds((current) =>
-      current.includes(suggestionId) ? current : [...current, suggestionId]
-    );
-  }
-
-  async function applyTitleSuggestion(suggestion: FuzzySongTitleSuggestion) {
-    if (updatingSuggestionId) return;
-
-    const item = items.find((candidate) => candidate.id === suggestion.itemId);
-    if (!item) {
-      setMessage("Could not find that song. Refresh and try again.");
-      return;
-    }
-
-    const confirmed = window.confirm(
-      `Update "${suggestion.itemTitle}" to "${suggestion.suggestedTitle}"?`
-    );
-
-    if (!confirmed) return;
-
-    try {
-      setUpdatingSuggestionId(suggestion.id);
-      await updateRepertoireItem(item.id, {
-        songTitle: suggestion.suggestedTitle,
-        voicing: item.voicing,
-        arrangerName: item.arranger_name ?? undefined,
-        partConfidences: item.part_confidences,
-        notes: item.notes ?? undefined,
-      });
-      dismissSuggestion(suggestion.id);
-      setMessage("Song title updated.");
-      try {
-        await refreshActiveQuartetSnapshot();
-      } catch (err) {
-        console.error("Could not update active quartet snapshot", err);
-      }
-      await loadRepertoire();
-    } catch (err) {
-      console.error(err);
-      setMessage("Could not update that song title. Please try again.");
-    } finally {
-      setUpdatingSuggestionId("");
-    }
-  }
-
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
@@ -572,14 +518,6 @@ export default function RepertoireManager() {
   ]
     .filter(Boolean)
     .join(" ");
-  const titleSuggestions = findFuzzySongTitleSuggestions(
-    items.map((item) => ({
-      id: item.id,
-      songTitle: item.song_title,
-      voicing: item.voicing,
-    }))
-  ).filter((suggestion) => !dismissedSuggestionIds.includes(suggestion.id));
-
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-5xl">
@@ -643,64 +581,6 @@ export default function RepertoireManager() {
             Add song
           </button>
         </section>
-
-        {titleSuggestions.length > 0 && (
-          <section className="mt-8 rounded-2xl border border-amber-300/25 bg-amber-300/10 p-4">
-            <div>
-              <h2 className="text-xl font-semibold text-amber-100">
-                Possible duplicate titles
-              </h2>
-              <p className="mt-1 text-sm text-amber-50/80">
-                These are not used as confirmed matches unless you update your
-                own repertoire.
-              </p>
-            </div>
-
-            <div className="mt-4 space-y-3">
-              {titleSuggestions.map((suggestion) => (
-                <div
-                  key={suggestion.id}
-                  className="rounded-xl border border-amber-200/20 bg-slate-950/50 p-3"
-                >
-                  <p className="text-sm text-amber-50">
-                    Possible same song: Is{" "}
-                    <span className="font-semibold">
-                      "{suggestion.itemTitle}"
-                    </span>{" "}
-                    the same as{" "}
-                    <span className="font-semibold">
-                      "{suggestion.suggestedTitle}"
-                    </span>
-                    ?
-                  </p>
-                  <p className="mt-1 text-xs font-semibold text-amber-100/80">
-                    {suggestion.voicing}
-                  </p>
-                  <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                    <button
-                      type="button"
-                      onClick={() => applyTitleSuggestion(suggestion)}
-                      disabled={Boolean(updatingSuggestionId)}
-                      className="rounded-lg bg-amber-200 px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-100 disabled:opacity-40"
-                    >
-                      {updatingSuggestionId === suggestion.id
-                        ? "Updating..."
-                        : "Update my title"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => dismissSuggestion(suggestion.id)}
-                      disabled={Boolean(updatingSuggestionId)}
-                      className="rounded-lg bg-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/20 disabled:opacity-40"
-                    >
-                      Dismiss
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
 
         <section className="mt-8">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">

--- a/lib/__tests__/fuzzySongTitles.test.ts
+++ b/lib/__tests__/fuzzySongTitles.test.ts
@@ -1,64 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { findFuzzySongTitleSuggestions } from "../fuzzySongTitles";
+import { isLikelySameSongTitle } from "../fuzzySongTitles";
 
-describe("findFuzzySongTitleSuggestions", () => {
-  it("suggests conservative same-voicing typo matches", () => {
-    const suggestions = findFuzzySongTitleSuggestions([
-      { id: "1", songTitle: "Hello Mary Lu", voicing: "TTBB" },
-      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
-    ]);
-
-    expect(suggestions).toEqual([
-      {
-        id: "1:2",
-        itemId: "1",
-        itemTitle: "Hello Mary Lu",
-        suggestedItemId: "2",
-        suggestedTitle: "Hello, Mary Lou!",
-        voicing: "TTBB",
-      },
-    ]);
+describe("isLikelySameSongTitle", () => {
+  it("recognizes conservative typo variants for quartet matching", () => {
+    expect(isLikelySameSongTitle("Hello Mary Lu", "Hello, Mary Lou!")).toBe(
+      true
+    );
   });
 
-  it("suggests likely partial title matches", () => {
-    const suggestions = findFuzzySongTitleSuggestions([
-      { id: "1", songTitle: "Mary Lou", voicing: "TTBB" },
-      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
-    ]);
-
-    expect(suggestions).toHaveLength(1);
-    expect(suggestions[0]).toMatchObject({
-      itemTitle: "Mary Lou",
-      suggestedTitle: "Hello, Mary Lou!",
-      voicing: "TTBB",
-    });
+  it("recognizes likely partial title variants for quartet matching", () => {
+    expect(
+      isLikelySameSongTitle(
+        "Why Try to Change Me",
+        "Why Try To Change Me Now"
+      )
+    ).toBe(true);
   });
 
-  it("does not suggest exact normalized matches", () => {
-    const suggestions = findFuzzySongTitleSuggestions([
-      { id: "1", songTitle: "Hello Mary Lou", voicing: "TTBB" },
-      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "TTBB" },
-    ]);
-
-    expect(suggestions).toEqual([]);
-  });
-
-  it("does not compare titles across different voicings", () => {
-    const suggestions = findFuzzySongTitleSuggestions([
-      { id: "1", songTitle: "Hello Mary Lu", voicing: "TTBB" },
-      { id: "2", songTitle: "Hello, Mary Lou!", voicing: "SSAA" },
-    ]);
-
-    expect(suggestions).toEqual([]);
+  it("does not treat exact normalized titles as fuzzy variants", () => {
+    expect(isLikelySameSongTitle("Hello Mary Lou", "Hello, Mary Lou!")).toBe(
+      false
+    );
   });
 
   it("avoids obvious false positives", () => {
-    const suggestions = findFuzzySongTitleSuggestions([
-      { id: "1", songTitle: "Hello Mary Lou", voicing: "TTBB" },
-      { id: "2", songTitle: "Goodbye My Coney Island Baby", voicing: "TTBB" },
-      { id: "3", songTitle: "Sweet Adeline", voicing: "TTBB" },
-    ]);
-
-    expect(suggestions).toEqual([]);
+    expect(
+      isLikelySameSongTitle("Hello Mary Lou", "Goodbye My Coney Island Baby")
+    ).toBe(false);
   });
 });

--- a/lib/fuzzySongTitles.ts
+++ b/lib/fuzzySongTitles.ts
@@ -1,20 +1,3 @@
-import type { Voicing } from "@/lib/matching";
-
-export type FuzzySongTitleItem = {
-  id: string;
-  songTitle: string;
-  voicing: Voicing;
-};
-
-export type FuzzySongTitleSuggestion = {
-  id: string;
-  itemId: string;
-  itemTitle: string;
-  suggestedItemId: string;
-  suggestedTitle: string;
-  voicing: Voicing;
-};
-
 function normalizeTitleForExactMatch(title: string) {
   return title.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
@@ -110,52 +93,5 @@ export function isLikelySameSongTitle(a: string, b: string) {
     aTokens.length >= 3 &&
     bTokens.length >= 3 &&
     tokenOverlap(aTokens, bTokens) >= 0.75
-  );
-}
-
-function canonicalFirstTitle(
-  a: FuzzySongTitleItem,
-  b: FuzzySongTitleItem
-): [FuzzySongTitleItem, FuzzySongTitleItem] {
-  if (b.songTitle.length > a.songTitle.length) return [b, a];
-  if (a.songTitle.length > b.songTitle.length) return [a, b];
-
-  return a.songTitle.localeCompare(b.songTitle, undefined, {
-    sensitivity: "base",
-  }) <= 0
-    ? [a, b]
-    : [b, a];
-}
-
-export function findFuzzySongTitleSuggestions(
-  items: FuzzySongTitleItem[]
-): FuzzySongTitleSuggestion[] {
-  const suggestions: FuzzySongTitleSuggestion[] = [];
-
-  for (let i = 0; i < items.length; i += 1) {
-    for (let j = i + 1; j < items.length; j += 1) {
-      const first = items[i];
-      const second = items[j];
-
-      if (first.voicing !== second.voicing) continue;
-      if (!isLikelySameSongTitle(first.songTitle, second.songTitle)) continue;
-
-      const [canonical, variant] = canonicalFirstTitle(first, second);
-
-      suggestions.push({
-        id: [variant.id, canonical.id].sort().join(":"),
-        itemId: variant.id,
-        itemTitle: variant.songTitle,
-        suggestedItemId: canonical.id,
-        suggestedTitle: canonical.songTitle,
-        voicing: variant.voicing,
-      });
-    }
-  }
-
-  return suggestions.sort((a, b) =>
-    a.suggestedTitle.localeCompare(b.suggestedTitle, undefined, {
-      sensitivity: "base",
-    })
   );
 }


### PR DESCRIPTION
## Summary
- Removes the repertoire-screen fuzzy duplicate warning panel and its dismiss/update state.
- Removes the repertoire-only fuzzy title suggestion builder while preserving `isLikelySameSongTitle` for quartet matching.
- Updates fuzzy title tests to cover the shared quartet-matching predicate instead of repertoire duplicate suggestions.

Closes #177.

## Tests
- npm run test:run
- npm run build

## Docs / Supabase
- No docs update needed; this removes an internal repertoire-screen feature that was not part of the documented app flow.
- No Supabase migration or dashboard change is required.