### PR TITLE
Make help page public

### DIFF
--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -77,7 +77,8 @@ shown as confirmation warnings so singers can decide quickly in the room.
 The home page is an action hub. It offers Start Quartet, Join Quartet, Return to
 Quartet when local state exists, and Repertoire. Manual code entry belongs on
 `/join`, while QR and shared links use `/join/[code]`. Help and feedback live at
-`/help`; `/feedback` redirects there for older links.
+`/help`; `/feedback` redirects there for older links. Help is public so new or
+logged-out users can read it before signing in.
 
 ## Auth
 

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -15,6 +15,12 @@ describe("isPublicAuthPath", () => {
     expect(isPublicAuthPath("/privacy")).toBe(true);
   });
 
+  it("allows help and legacy feedback routes without an auth redirect", () => {
+    expect(isPublicAuthPath("/help")).toBe(true);
+    expect(isPublicAuthPath("/help/getting-started")).toBe(true);
+    expect(isPublicAuthPath("/feedback")).toBe(true);
+  });
+
   it("protects app routes", () => {
     expect(isPublicAuthPath("/repertoire")).toBe(false);
     expect(isPublicAuthPath("/join/ABC123")).toBe(false);

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -2,6 +2,10 @@ export function isPublicAuthPath(pathname: string): boolean {
   return (
     pathname === "/login" ||
     pathname.startsWith("/login/") ||
+    pathname === "/help" ||
+    pathname.startsWith("/help/") ||
+    pathname === "/feedback" ||
+    pathname.startsWith("/feedback/") ||
     pathname === "/privacy"
   );
 }


### PR DESCRIPTION
## Summary
- Makes `/help` publicly reachable so new or logged-out users can read the help content.
- Keeps legacy `/feedback` public so it can redirect to `/help` instead of being intercepted by auth.
- Updates the auth-route test and app-flow docs.

Follow-up to #200 / PR #203.

## Tests
- npm run test:run
- npm run build

## Supabase / manual steps
- No Supabase migration or dashboard change is required.

## Deployment note
- PR #203 merged, but Vercel production was still on #202 when this follow-up was opened. After this merges, production should be verified against this commit; if Vercel still does not promote main automatically, redeploy main from Vercel.