### PR TITLE
Improve Help page copy for new users

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -99,8 +99,14 @@ export default function HelpPage() {
             Get started quickly
           </h1>
           <p className="mt-3 max-w-2xl text-slate-300">
-            What Can We Sing helps a pickup quartet find songs everyone can sing
-            together right now.
+            What Can We Sing helps a pickup quartet quickly answer the question:
+            what can we sing together right now?
+          </p>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
+            Each singer adds the songs they know, the voicing, the parts they
+            can sing, and how confident they feel. When singers join the same
+            quartet, the app compares everyone&apos;s repertoire and shows songs
+            where the required parts are covered by different people.
           </p>
         </header>
 
@@ -127,9 +133,11 @@ export default function HelpPage() {
               <h2 className="text-lg font-semibold text-white">
                 {section.title}
               </h2>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
-                {section.body}
-              </p>
+              <div className="mt-2 space-y-3 text-sm leading-6 text-slate-300">
+                {section.body.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
             </article>
           ))}
         </section>
@@ -139,7 +147,8 @@ export default function HelpPage() {
             <h2 className="text-2xl font-semibold">Send feedback</h2>
             <p className="mt-2 text-sm leading-6 text-slate-300">
               Report a bug, describe confusing behavior, or suggest an
-              improvement. A short note is plenty.
+              improvement. A short note about what you were trying to do and
+              what happened is usually enough.
             </p>
           </div>
 

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -4,17 +4,19 @@ import { helpSections, quickStartSteps } from "../helpContent";
 describe("help content", () => {
   it("covers the core new-user flow", () => {
     expect(quickStartSteps.join(" ")).toContain("display name");
-    expect(quickStartSteps.join(" ")).toContain("songs");
+    expect(quickStartSteps.join(" ")).toContain("repertoire");
     expect(quickStartSteps.join(" ")).toContain("code");
 
     const sectionText = helpSections
-      .map((section) => `${section.title} ${section.body}`)
+      .map((section) => `${section.title} ${section.body.join(" ")}`)
       .join(" ");
 
     expect(sectionText).toContain("pickup quartet");
     expect(sectionText).toContain("Start");
     expect(sectionText).toContain("Join");
-    expect(sectionText).toContain("Possible matches");
+    expect(sectionText).toContain("Possible Matches");
     expect(sectionText).toContain("display name");
+    expect(sectionText).toContain("Leave quartet");
+    expect(sectionText).toContain("feedback");
   });
 });

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -1,46 +1,77 @@
 export type HelpSection = {
   title: string;
-  body: string;
+  body: string[];
 };
 
 export const quickStartSteps = [
-  "Add a display name so other singers know who you are.",
-  "Add songs you know, including voicing, parts, and confidence.",
-  "Start a quartet or join one with a code, QR code, or shared link.",
-  "Use the match list to pick something everyone can sing right now.",
+  "Add your display name. This is the name other singers will see in the quartet.",
+  "Add your repertoire. Add the songs you know, choose the voicing, select the parts you can sing, and set your confidence.",
+  "Start or join a quartet. One singer can start a quartet and share the code, QR code, or link. Other singers can join from their phones.",
+  "Pick a match and sing. Use the match list to find songs the quartet can sing together right now.",
 ] as const;
 
 export const helpSections: HelpSection[] = [
   {
-    title: "What Can We Sing?",
-    body: "This app helps a pickup quartet answer one question: what can we sing together right now?",
+    title: "What Is This App For?",
+    body: [
+      "This app is built for informal barbershop singing: rehearsals, afterglows, conventions, hospitality rooms, and any other time a pickup quartet wants to find something to sing.",
+      "It is not trying to be a perfect music library. It is meant to be fast, forgiving, and useful in the moment.",
+    ],
   },
   {
     title: "Add Your Repertoire",
-    body: "Add each song you know, choose the voicing, and mark the parts you can sing. You can edit songs later.",
+    body: [
+      "Use Repertoire to add songs you know. For each song, choose the voicing, select the part or parts you can sing, and set your confidence.",
+      "You can edit your repertoire later. If you are already in an active quartet, your updated repertoire can refresh your quartet snapshot so the match list stays current.",
+    ],
   },
   {
     title: "Start A Quartet",
-    body: "Start creates a quartet code. Other singers can join with the code, QR code, or link.",
+    body: [
+      "Use Start when you want to create a new quartet. The app will create a quartet code that other singers can use to join.",
+      "Other singers can join by entering the code, scanning the QR code, or opening the shared link.",
+    ],
   },
   {
     title: "Join A Quartet",
-    body: "Join with a code from another singer. Your saved repertoire is loaded into that quartet for matching.",
+    body: [
+      "Use Join when another singer has already started a quartet. Enter the code they give you, or use the QR code or shared link.",
+      "When you join, your saved repertoire is loaded into that quartet so the app can look for matches.",
+    ],
   },
   {
-    title: "Reading Matches",
-    body: "A match appears when different singers cover the required parts for the same song and voicing.",
+    title: "Reading The Match List",
+    body: [
+      "A match appears when the quartet has different singers covering the required parts for the same song and voicing.",
+      "For example, a TTBB song needs Tenor, Lead, Baritone, and Bass covered by four distinct singers. One singer may know multiple parts, but a valid quartet match only uses each singer once.",
+    ],
   },
   {
     title: "Possible Matches",
-    body: "Possible matches may mean song titles are slightly different or arrangement details are missing. Check with the quartet before singing.",
+    body: [
+      "Sometimes the app may show a possible match instead of a clean match. This can happen when song titles are slightly different, arranger information is missing, or the same song may exist in more than one arrangement.",
+      "Use the match details to compare what each singer has entered. If the titles or arrangement details do not match, check with the quartet before singing.",
+    ],
   },
   {
     title: "Update Your Songs Or Name",
-    body: "Use Repertoire to change songs and Profile to change your display name. Repertoire edits refresh your active quartet snapshot.",
+    body: [
+      "Use Repertoire to add, edit, or delete songs. Use Change my display name or Profile to update the name other singers see.",
+      "If something looks wrong in a match, the first thing to check is usually whether the song title, voicing, part, or arranger is entered consistently in everyone's repertoire.",
+    ],
   },
   {
     title: "Leaving Or Being Removed",
-    body: "Leaving removes you from the active quartet. If another singer removes you, you can join again with the code if that is what the group wants.",
+    body: [
+      "Use Leave quartet when you want to remove yourself from the active quartet.",
+      "If another singer removes you from a quartet, you will be returned to the join flow. You can rejoin with the code if that is what the group wants and there is still room.",
+    ],
+  },
+  {
+    title: "Feedback And Problems",
+    body: [
+      "If something is confusing, broken, or missing, please send feedback from this page.",
+      "A short note about what you were trying to do and what happened is usually enough.",
+    ],
   },
 ];


### PR DESCRIPTION
## Summary
- Rewrites Help page copy to be friendlier and more useful for first-time singers while keeping the page lightweight.
- Expands quick-start and help sections to cover display name, repertoire, start/join, match results, possible matches, updating data, leaving/removal, and feedback.
- Keeps the existing Help page layout, route behavior, and feedback form/backend flow intact.
- Updates help-content coverage tests for the richer copy structure.

Closes #205.

## Tests
- npm run test:run
- npm run build

## Docs / Supabase
- No Supabase migration or dashboard change is required.
- No separate docs update needed; this PR changes the user-facing Help page copy itself.