### PR TITLE
Audit and strengthen data flow tests

### DIFF
--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -261,6 +261,10 @@ Automated tests currently cover:
 - Display names derived from `profiles` instead of stale participant names in
   `lib/__tests__/sessionParticipantDisplayName.test.ts`
 - Active quartet local-storage behavior in `lib/__tests__/activeQuartet.test.ts`
+- Active quartet snapshot refresh behavior in
+  `lib/__tests__/activeQuartetSnapshot.test.ts`
+- Supabase-backed participant write verification in
+  `lib/__tests__/sessionStore.test.ts`
 - Auth route guards and post-login redirect behavior in
   `lib/__tests__/authRoute.test.ts` and
   `lib/__tests__/authRedirect.test.ts`

--- a/docs/test-coverage-notes.md
+++ b/docs/test-coverage-notes.md
@@ -1,0 +1,50 @@
+# Test Coverage Notes
+
+This file tracks high-risk behavior that should stay covered as the app changes.
+
+## Covered In Unit Tests
+
+- Matching rules, ranking, fuzzy title suggestions, arranger warnings, distinct
+  singer assignment, per-part confidence, and part abbreviations.
+- Join code parsing, auth route guards, post-login redirects, and active quartet
+  local-storage helpers.
+- Participant resolution by `user_id`, including rejoin recognition when a
+  display name changes or the quartet is already full.
+- Realtime participant payload application for insert, update, and delete
+  events.
+- Detecting when the current participant has been removed from a quartet.
+- Building participant snapshot entries from profile display names and
+  repertoire rows without leaking private notes.
+- Refreshing an active quartet snapshot from current repertoire, clearing stale
+  local active-quartet state when the user is no longer a participant, and
+  refusing to write a snapshot without a display name.
+- `sessionStore` write helpers for participant upsert, leave/delete, and
+  remove-by-id RPC calls, including verification that database writes changed
+  the intended row.
+- Repertoire filtering/sorting, mark-as-sung resolution, feedback helpers,
+  analytics property sanitization, deployment guardrails, Supabase contract
+  guardrails, and Help page content coverage.
+
+## Remaining Gaps
+
+- The suite still does not run a browser-level test for the full start -> join
+  -> edit repertoire -> refresh matches -> leave/remove flow. The current tests
+  cover the pure helpers and store calls underneath those flows.
+- The suite does not execute RLS policies against a real Supabase instance.
+  `docs/supabase-contract.md` describes the smallest follow-up: add
+  Supabase CLI-backed integration tests with fixture auth users.
+- The quartet page is large and currently difficult to mount in a focused unit
+  test without broad Supabase and browser mocks. If regressions continue in that
+  page, the smallest useful refactor is to extract more state-transition helpers
+  for full-quartet, left/rejoin, and match-refresh UI states.
+
+## Future Checklist
+
+When changing quartet or repertoire data flow, add or update tests that prove:
+
+- database helpers read/write the expected Supabase table or RPC
+- stale local active-quartet state is reconciled against database state
+- repertoire edits refresh `session_participants.repertoire` when applicable
+- matching derives from participant snapshots, not local-only component state
+- UI copy does not imply a user joined, left, or refreshed before the database
+  operation has been verified

--- a/lib/__tests__/activeQuartetSnapshot.test.ts
+++ b/lib/__tests__/activeQuartetSnapshot.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const activeQuartetMock = vi.hoisted(() => ({
+  getActiveQuartet: vi.fn(),
+  clearActiveQuartetIfMatches: vi.fn(),
+  setActiveQuartet: vi.fn(),
+}));
+
+const profileMock = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  getMyProfile: vi.fn(),
+}));
+
+const repertoireMock = vi.hoisted(() => ({
+  getMyRepertoire: vi.fn(),
+}));
+
+const sessionMock = vi.hoisted(() => ({
+  getParticipants: vi.fn(),
+  upsertParticipant: vi.fn(),
+}));
+
+vi.mock("@/lib/activeQuartet", () => activeQuartetMock);
+vi.mock("@/lib/profileStore", () => profileMock);
+vi.mock("@/lib/repertoireStore", () => repertoireMock);
+vi.mock("@/lib/sessionStore", () => sessionMock);
+vi.mock("@/lib/participantEntries", () => ({
+  buildParticipantEntries: (
+    displayName: string,
+    repertoire: Array<{
+      id: string;
+      user_id: string;
+      song_title: string;
+      voicing: string;
+      arranger_name: string | null;
+      parts_known: string[];
+      confidence: string;
+      part_confidences: Array<{ part: string; confidence: string }>;
+    }>
+  ) =>
+    repertoire.map((item) => ({
+      repertoireId: item.id,
+      userId: item.user_id,
+      displayName,
+      songTitle: item.song_title,
+      voicing: item.voicing,
+      arrangerName: item.arranger_name,
+      partsKnown: item.parts_known,
+      confidence: item.confidence,
+      partConfidences: Object.fromEntries(
+        item.part_confidences.map(({ part, confidence }) => [part, confidence])
+      ),
+    })),
+}));
+vi.mock("@/lib/sessionParticipantResolution", () => ({
+  findParticipantByUserId: (
+    participants: Array<{ user_id: string }>,
+    userId: string
+  ) => participants.find((participant) => participant.user_id === userId),
+}));
+
+import {
+  ActiveQuartetSnapshotError,
+  refreshActiveQuartetSnapshot,
+} from "../activeQuartetSnapshot";
+
+const activeQuartet = {
+  sessionId: "session-1",
+  code: "ABC123",
+  joinedAt: "2026-04-28T18:00:00.000Z",
+};
+
+const currentParticipant = {
+  id: "participant-1",
+  session_id: "session-1",
+  user_id: "user-1",
+  display_name: "Old Name",
+  repertoire: [],
+  joined_at: "2026-04-28T18:00:00.000Z",
+};
+
+const repertoireRow = {
+  id: "rep-1",
+  user_id: "user-1",
+  song_title: "Bright Was the Night",
+  voicing: "TTBB",
+  arranger_name: null,
+  parts_known: ["Lead", "Bass"],
+  part_confidences: [
+    { part: "Lead", confidence: "Good to Go" },
+    { part: "Bass", confidence: "Music Required" },
+  ],
+  confidence: "Good to Go",
+  notes: "private note",
+  last_sung_at: null,
+  times_sung_count: 0,
+  created_at: "2026-04-28T00:00:00.000Z",
+  updated_at: "2026-04-28T00:00:00.000Z",
+};
+
+describe("refreshActiveQuartetSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when there is no active quartet", async () => {
+    activeQuartetMock.getActiveQuartet.mockReturnValue(null);
+
+    await expect(refreshActiveQuartetSnapshot()).resolves.toEqual({
+      status: "no_active_quartet",
+    });
+
+    expect(sessionMock.upsertParticipant).not.toHaveBeenCalled();
+  });
+
+  it("clears stale local state when the user is no longer a participant", async () => {
+    activeQuartetMock.getActiveQuartet.mockReturnValue(activeQuartet);
+    profileMock.getCurrentUser.mockResolvedValue({ id: "user-1" });
+    sessionMock.getParticipants.mockResolvedValue([]);
+
+    await expect(refreshActiveQuartetSnapshot()).resolves.toEqual({
+      status: "not_participant",
+    });
+
+    expect(activeQuartetMock.clearActiveQuartetIfMatches).toHaveBeenCalledWith(
+      "session-1"
+    );
+    expect(sessionMock.upsertParticipant).not.toHaveBeenCalled();
+  });
+
+  it("updates the database-backed participant snapshot from current repertoire", async () => {
+    activeQuartetMock.getActiveQuartet.mockReturnValue(activeQuartet);
+    profileMock.getCurrentUser.mockResolvedValue({ id: "user-1" });
+    sessionMock.getParticipants.mockResolvedValue([currentParticipant]);
+    profileMock.getMyProfile.mockResolvedValue({ display_name: "New Name" });
+    repertoireMock.getMyRepertoire.mockResolvedValue([repertoireRow]);
+    sessionMock.upsertParticipant.mockResolvedValue({
+      ...currentParticipant,
+      display_name: "New Name",
+    });
+
+    const result = await refreshActiveQuartetSnapshot();
+
+    expect(result.status).toBe("updated");
+    expect(sessionMock.upsertParticipant).toHaveBeenCalledWith(
+      "session-1",
+      "user-1",
+      "New Name",
+      [
+        {
+          repertoireId: "rep-1",
+          userId: "user-1",
+          displayName: "New Name",
+          songTitle: "Bright Was the Night",
+          voicing: "TTBB",
+          arrangerName: null,
+          partsKnown: ["Lead", "Bass"],
+          confidence: "Good to Go",
+          partConfidences: {
+            Lead: "Good to Go",
+            Bass: "Music Required",
+          },
+        },
+      ],
+      expect.any(String)
+    );
+    expect(activeQuartetMock.setActiveQuartet).toHaveBeenCalledWith({
+      ...activeQuartet,
+      joinedAt: expect.any(String),
+    });
+  });
+
+  it("throws when the profile display name is missing", async () => {
+    activeQuartetMock.getActiveQuartet.mockReturnValue(activeQuartet);
+    profileMock.getCurrentUser.mockResolvedValue({ id: "user-1" });
+    sessionMock.getParticipants.mockResolvedValue([currentParticipant]);
+    profileMock.getMyProfile.mockResolvedValue({ display_name: "" });
+
+    await expect(refreshActiveQuartetSnapshot()).rejects.toBeInstanceOf(
+      ActiveQuartetSnapshotError
+    );
+    expect(sessionMock.upsertParticipant).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/sessionStore.test.ts
+++ b/lib/__tests__/sessionStore.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const supabaseMock = vi.hoisted(() => {
+  const queryQueue: Array<Record<string, unknown>> = [];
+  const rpc = vi.fn();
+
+  return {
+    queryQueue,
+    rpc,
+    from: vi.fn((table: string) => {
+      const query = queryQueue.shift();
+      if (!query) throw new Error(`Unexpected table query: ${table}`);
+      query.table = table;
+      return query;
+    }),
+    channel: vi.fn(),
+    removeChannel: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: supabaseMock.from,
+    rpc: supabaseMock.rpc,
+    channel: supabaseMock.channel,
+    removeChannel: supabaseMock.removeChannel,
+  },
+}));
+
+import {
+  removeParticipant,
+  removeParticipantById,
+  SessionParticipantWriteError,
+  upsertParticipant,
+} from "../sessionStore";
+
+function query(result: {
+  data?: unknown;
+  error?: unknown;
+  maybeData?: unknown;
+}) {
+  const builder = {
+    table: "",
+    insert: vi.fn(() => builder),
+    upsert: vi.fn(() => builder),
+    update: vi.fn(() => builder),
+    delete: vi.fn(() => builder),
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    single: vi.fn(async () => ({
+      data: result.data ?? null,
+      error: result.error ?? null,
+    })),
+    maybeSingle: vi.fn(async () => ({
+      data: result.maybeData ?? result.data ?? null,
+      error: result.error ?? null,
+    })),
+  };
+
+  return builder;
+}
+
+describe("sessionStore writes", () => {
+  beforeEach(() => {
+    supabaseMock.queryQueue.length = 0;
+    supabaseMock.from.mockClear();
+    supabaseMock.rpc.mockReset();
+  });
+
+  it("upserts the current user's participant snapshot and updates session activity", async () => {
+    const savedParticipant = {
+      id: "participant-1",
+      session_id: "session-1",
+      user_id: "user-1",
+      display_name: "Tim",
+      repertoire: [],
+      joined_at: "2026-04-28T00:00:00.000Z",
+    };
+    const participantQuery = query({ data: savedParticipant });
+    const sessionQuery = query({});
+    supabaseMock.queryQueue.push(participantQuery, sessionQuery);
+
+    await expect(
+      upsertParticipant(
+        "session-1",
+        "user-1",
+        "Tim",
+        [],
+        "2026-04-28T19:00:00.000Z"
+      )
+    ).resolves.toEqual(savedParticipant);
+
+    expect(supabaseMock.from).toHaveBeenNthCalledWith(
+      1,
+      "session_participants"
+    );
+    expect(participantQuery.upsert).toHaveBeenCalledWith(
+      {
+        session_id: "session-1",
+        user_id: "user-1",
+        display_name: "Tim",
+        repertoire: [],
+      },
+      { onConflict: "session_id,user_id" }
+    );
+    expect(supabaseMock.from).toHaveBeenNthCalledWith(2, "sessions");
+    expect(sessionQuery.update).toHaveBeenCalledWith({
+      last_activity_at: "2026-04-28T19:00:00.000Z",
+    });
+    expect(sessionQuery.eq).toHaveBeenCalledWith("id", "session-1");
+  });
+
+  it("rejects unverified participant upserts", async () => {
+    supabaseMock.queryQueue.push(
+      query({
+        data: {
+          id: "participant-1",
+          session_id: "session-2",
+          user_id: "user-1",
+        },
+      })
+    );
+
+    await expect(
+      upsertParticipant("session-1", "user-1", "Tim", [])
+    ).rejects.toBeInstanceOf(SessionParticipantWriteError);
+
+    expect(supabaseMock.from).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the current user's participant row and verifies it is gone", async () => {
+    const lookupQuery = query({
+      maybeData: {
+        id: "participant-1",
+        session_id: "session-1",
+        user_id: "user-1",
+      },
+    });
+    const deleteQuery = query({});
+    const verifyQuery = query({ maybeData: null });
+    supabaseMock.queryQueue.push(lookupQuery, deleteQuery, verifyQuery);
+
+    await expect(removeParticipant("session-1", "user-1")).resolves.toEqual({
+      id: "participant-1",
+      session_id: "session-1",
+      user_id: "user-1",
+    });
+
+    expect(deleteQuery.table).toBe("session_participants");
+    expect(deleteQuery.delete).toHaveBeenCalled();
+    expect(deleteQuery.eq).toHaveBeenCalledWith("session_id", "session-1");
+    expect(deleteQuery.eq).toHaveBeenCalledWith("user_id", "user-1");
+    expect(verifyQuery.maybeSingle).toHaveBeenCalled();
+  });
+
+  it("fails leave when the current user's participant row cannot be found", async () => {
+    supabaseMock.queryQueue.push(query({ maybeData: null }));
+
+    await expect(
+      removeParticipant("session-1", "user-1")
+    ).rejects.toBeInstanceOf(SessionParticipantWriteError);
+
+    expect(supabaseMock.from).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes another participant through the database function and verifies deletion", async () => {
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: {
+        id: "participant-2",
+        session_id: "session-1",
+        user_id: "user-2",
+      },
+      error: null,
+    });
+    const verifyQuery = query({ maybeData: null });
+    supabaseMock.queryQueue.push(verifyQuery);
+
+    await expect(
+      removeParticipantById("session-1", "participant-2")
+    ).resolves.toEqual({
+      id: "participant-2",
+      session_id: "session-1",
+      user_id: "user-2",
+    });
+
+    expect(supabaseMock.rpc).toHaveBeenCalledWith(
+      "remove_session_participant_by_id",
+      {
+        p_session_id: "session-1",
+        p_participant_id: "participant-2",
+      }
+    );
+    expect(verifyQuery.eq).toHaveBeenCalledWith("id", "participant-2");
+  });
+});

--- a/lib/activeQuartetSnapshot.ts
+++ b/lib/activeQuartetSnapshot.ts
@@ -1,5 +1,5 @@
 import { getActiveQuartet, clearActiveQuartetIfMatches, setActiveQuartet } from "@/lib/activeQuartet";
-import { type SingerEntry } from "@/lib/matching";
+import { buildParticipantEntries } from "@/lib/participantEntries";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 import { getParticipants, upsertParticipant } from "@/lib/sessionStore";
@@ -35,18 +35,7 @@ export async function refreshActiveQuartetSnapshot() {
   }
 
   const repertoire = await getMyRepertoire();
-  const entries: SingerEntry[] = repertoire.map((item) => ({
-    userId: item.user_id,
-    displayName: profile.display_name,
-    songTitle: item.song_title,
-    voicing: item.voicing,
-    arrangerName: item.arranger_name,
-    partsKnown: item.parts_known,
-    confidence: item.confidence,
-    partConfidences: Object.fromEntries(
-      item.part_confidences.map(({ part, confidence }) => [part, confidence])
-    ),
-  }));
+  const entries = buildParticipantEntries(profile.display_name, repertoire);
   const lastActivityAt = new Date().toISOString();
 
   const updatedParticipant = await upsertParticipant(


### PR DESCRIPTION
## Summary
- Adds focused store-level tests for `sessionStore` participant writes: snapshot upsert, leave/delete, remove-by-id RPC, and failed verification paths.
- Adds active quartet snapshot refresh tests for no-active-quartet, stale local state clearing, database-backed snapshot update, and missing display-name failure.
- Updates `refreshActiveQuartetSnapshot` to use the shared participant-entry builder so active snapshot refreshes preserve repertoire row IDs like start/join snapshots do.
- Documents current coverage and remaining gaps in `docs/test-coverage-notes.md` and updates the Supabase contract coverage list.

Closes #173.

## Tests
- npm run test:run
- npm run build

## Coverage audit notes
- Current focused unit coverage now protects the highest-risk database-backed helpers beneath start/join/leave/remove/repertoire-refresh flows.
- Remaining gaps are documented: browser-level full quartet flow tests, real Supabase RLS execution tests, and possible future extraction of quartet-page state-transition helpers.

## Supabase / manual steps
- No Supabase migration or dashboard change is required.