### PR TITLE
Add friendly product intro to login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getPostLoginRedirectPath } from "@/lib/authRedirect";
+import { loginIntro } from "@/lib/loginContent";
 import { supabase } from "@/lib/supabase";
 import { useState } from "react";
 
@@ -98,7 +99,23 @@ export default function LoginPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-md">
-        <h1 className="text-4xl font-bold">Log in</h1>
+        <section className="rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-5">
+          <p className="text-sm font-semibold uppercase text-cyan-300">
+            {loginIntro.title}
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight">
+            What can we sing together right now?
+          </h1>
+          <p className="mt-3 text-slate-200">{loginIntro.description}</p>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            {loginIntro.details}
+          </p>
+          <p className="mt-3 text-sm font-semibold text-cyan-100">
+            {loginIntro.signInReason}
+          </p>
+        </section>
+
+        <h2 className="mt-8 text-3xl font-bold">Log in</h2>
         <p className="mt-3 text-slate-300">
           Enter your email and we’ll send you a one-time code. There is no
           password to remember.

--- a/lib/__tests__/loginContent.test.ts
+++ b/lib/__tests__/loginContent.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { loginIntro } from "../loginContent";
+
+describe("login intro content", () => {
+  it("explains the product before asking new users to sign in", () => {
+    const copy = Object.values(loginIntro).join(" ");
+
+    expect(copy).toContain("pickup quartet");
+    expect(copy).toContain("what can we sing together right now");
+    expect(copy).toContain("songs they know");
+    expect(copy).toContain("parts they can sing");
+    expect(copy).toContain("Sign in to save your repertoire");
+  });
+});

--- a/lib/loginContent.ts
+++ b/lib/loginContent.ts
@@ -1,0 +1,8 @@
+export const loginIntro = {
+  title: "What Can We Sing?",
+  description:
+    "What Can We Sing helps a pickup quartet quickly answer the question: what can we sing together right now?",
+  details:
+    "Each singer adds the songs they know, the voicing, the parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's repertoire and shows songs where the required parts are covered by different people.",
+  signInReason: "Sign in to save your repertoire and join or start a quartet.",
+} as const;


### PR DESCRIPTION
## Summary
- Adds a short, friendly product intro to the login page so first-time visitors understand the app before requesting a code.
- Keeps the existing Supabase one-time-code auth flow unchanged.
- Adds a small content test for the public login intro copy.

Closes #208.

## Tests
- `npm run test:run`
- `npm run build`

## Supabase / manual steps
- No Supabase migration or dashboard change required.