### PR TITLE
Add reproducible PostHog analytics dashboards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=
 
+# Optional local dashboard sync variables. Do not expose the personal API key
+# to the browser or prefix it with NEXT_PUBLIC_.
+POSTHOG_PERSONAL_API_KEY=
+POSTHOG_HOST=https://us.posthog.com
+POSTHOG_ENVIRONMENT_ID=
+
 # Server-only feedback email settings. Do not prefix these with NEXT_PUBLIC_.
 RESEND_API_KEY=
 FEEDBACK_FROM_EMAIL=

--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -1,0 +1,278 @@
+{
+  "version": 1,
+  "tags": ["what-can-we-sing", "managed-in-repo"],
+  "dashboards": [
+    {
+      "key": "product-health",
+      "name": "What Can We Sing - Product Health",
+      "description": "Core usage, quartet creation, feedback, and route health.",
+      "insights": [
+        {
+          "key": "daily-active-users",
+          "name": "Daily active users",
+          "description": "Distinct signed-in users seen each day.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [{ "event": "user_logged_in", "math": "dau" }]
+        },
+        {
+          "key": "weekly-active-users",
+          "name": "Weekly active users",
+          "description": "Distinct signed-in users seen each week.",
+          "type": "trend",
+          "dateFrom": "-12w",
+          "interval": "week",
+          "series": [{ "event": "user_logged_in", "math": "weekly_active" }]
+        },
+        {
+          "key": "quartet-activity",
+          "name": "Quartet activity",
+          "description": "Quartets created, joined, left, and rejoined.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "quartet_created" },
+            { "event": "quartet_joined" },
+            { "event": "quartet_left" },
+            { "event": "quartet_rejoined" }
+          ]
+        },
+        {
+          "key": "full-quartets",
+          "name": "Quartets reaching full state",
+          "description": "Quartets with four participants.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [{ "event": "quartet_full" }]
+        },
+        {
+          "key": "feedback-submissions",
+          "name": "Feedback submissions",
+          "description": "Feedback sent successfully by category.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "category",
+          "series": [{ "event": "feedback_submitted" }]
+        },
+        {
+          "key": "top-routes",
+          "name": "Top routes",
+          "description": "Route visits with join codes normalized to /join/[code].",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "route",
+          "series": [{ "event": "app_route_viewed" }]
+        }
+      ]
+    },
+    {
+      "key": "quartet-funnel",
+      "name": "What Can We Sing - Quartet Funnel",
+      "description": "From visiting the app to a full quartet with generated matches.",
+      "insights": [
+        {
+          "key": "quartet-funnel-core",
+          "name": "Quartet funnel",
+          "description": "Visit, authenticate, create or join, update repertoire, reach full quartet, and generate matches.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "quartet_joined" },
+            { "event": "repertoire_updated" },
+            { "event": "quartet_full" },
+            { "event": "matches_generated" }
+          ]
+        },
+        {
+          "key": "quartet-funnel-browser",
+          "name": "Quartet funnel by browser",
+          "description": "Core quartet funnel broken down by browser.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "breakdown": "$browser",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "quartet_joined" },
+            { "event": "quartet_full" },
+            { "event": "matches_generated" }
+          ]
+        },
+        {
+          "key": "quartet-funnel-device",
+          "name": "Quartet funnel by device",
+          "description": "Core quartet funnel broken down by device type.",
+          "type": "funnel",
+          "dateFrom": "-30d",
+          "breakdown": "$device_type",
+          "series": [
+            { "event": "app_route_viewed" },
+            { "event": "user_logged_in" },
+            { "event": "quartet_joined" },
+            { "event": "quartet_full" },
+            { "event": "matches_generated" }
+          ]
+        },
+        {
+          "key": "join-by-route",
+          "name": "Create vs join route",
+          "description": "Quartet joins by route context.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "route",
+          "series": [{ "event": "quartet_joined" }]
+        }
+      ]
+    },
+    {
+      "key": "repertoire-matching",
+      "name": "What Can We Sing - Repertoire & Matching",
+      "description": "Repertoire edits, snapshot size, match counts, and zero-match cases.",
+      "insights": [
+        {
+          "key": "repertoire-updates",
+          "name": "Repertoire updates",
+          "description": "Add, edit, and delete activity.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "action",
+          "series": [{ "event": "repertoire_updated" }]
+        },
+        {
+          "key": "song-count-snapshot",
+          "name": "Average songs per participant snapshot",
+          "description": "Average song count reported when singers join or refresh a quartet snapshot.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "quartet_joined", "math": "avg", "mathProperty": "song_count" },
+            { "event": "quartet_rejoined", "math": "avg", "mathProperty": "song_count" }
+          ]
+        },
+        {
+          "key": "match-generation",
+          "name": "Matches generated",
+          "description": "Total and ready/possible/missing-part match counts.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "matches_generated", "math": "avg", "mathProperty": "match_count" },
+            { "event": "matches_generated", "math": "avg", "mathProperty": "ready_match_count" },
+            { "event": "matches_generated", "math": "avg", "mathProperty": "possible_match_count" },
+            { "event": "matches_generated", "math": "avg", "mathProperty": "one_part_missing_count" }
+          ]
+        },
+        {
+          "key": "zero-matches",
+          "name": "Full quartets with zero matches",
+          "description": "Quartets that reached four singers but generated no matches.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [{ "event": "zero_matches_found" }]
+        }
+      ]
+    },
+    {
+      "key": "reliability-errors",
+      "name": "What Can We Sing - Reliability / Errors",
+      "description": "Tracked client-side failures and feedback delivery issues.",
+      "insights": [
+        {
+          "key": "join-errors",
+          "name": "Join errors",
+          "description": "Quartet join failures by reason.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "reason",
+          "series": [{ "event": "quartet_join_failed" }]
+        },
+        {
+          "key": "leave-errors",
+          "name": "Leave errors",
+          "description": "Quartet leave failures by source.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "source",
+          "series": [{ "event": "quartet_leave_failed" }]
+        },
+        {
+          "key": "repertoire-errors",
+          "name": "Repertoire update errors",
+          "description": "Repertoire update failures by action.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "action",
+          "series": [{ "event": "repertoire_update_failed" }]
+        },
+        {
+          "key": "feedback-errors",
+          "name": "Feedback errors",
+          "description": "Feedback send failures.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "category",
+          "series": [{ "event": "feedback_failed" }]
+        },
+        {
+          "key": "recently-sung-errors",
+          "name": "Mark sung errors",
+          "description": "Failures when marking a match as recently sung.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "voicing",
+          "series": [{ "event": "song_mark_sung_failed" }]
+        }
+      ]
+    },
+    {
+      "key": "browser-mobile-compatibility",
+      "name": "What Can We Sing - Browser / Mobile Compatibility",
+      "description": "Key action success and failure by browser, operating system, and device type.",
+      "insights": [
+        {
+          "key": "leave-flow-by-browser",
+          "name": "Leave flow by browser",
+          "description": "Leave clicks, confirmations, successes, and failures by browser.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "$browser",
+          "series": [
+            { "event": "quartet_leave_clicked" },
+            { "event": "quartet_leave_confirmed" },
+            { "event": "quartet_left" },
+            { "event": "quartet_leave_failed" }
+          ]
+        },
+        {
+          "key": "join-flow-by-device",
+          "name": "Join flow by device",
+          "description": "Join attempts, successes, and failures by device type.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "$device_type",
+          "series": [
+            { "event": "quartet_join_attempted" },
+            { "event": "quartet_joined" },
+            { "event": "quartet_join_failed" }
+          ]
+        },
+        {
+          "key": "key-actions-ios-brave",
+          "name": "Key actions on browser/OS combinations",
+          "description": "Useful for Brave on iOS and Chrome on Mac compatibility checks.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "breakdown": "$browser",
+          "series": [
+            { "event": "quartet_joined" },
+            { "event": "quartet_left" },
+            { "event": "quartet_member_removed" },
+            { "event": "repertoire_updated" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -63,6 +63,10 @@ export default function HelpPage() {
       const data = (await response.json()) as { message?: string };
 
       if (!response.ok) {
+        trackEvent("feedback_failed", {
+          category: type,
+          status_code: response.status,
+        });
         setStatusTone("error");
         setStatusMessage(data.message ?? "Could not send feedback.");
         return;
@@ -77,6 +81,10 @@ export default function HelpPage() {
       setMessage("");
     } catch (err) {
       console.error(err);
+      trackEvent("feedback_failed", {
+        category: type,
+        reason: "network",
+      });
       setStatusTone("error");
       setStatusMessage(
         "Network unavailable. Try again when you have a connection."

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -278,6 +278,10 @@ export default function JoinSessionPage() {
       return;
     }
 
+    trackEvent("quartet_join_attempted", {
+      session_id: id,
+    });
+
     try {
       setJoiningQuartet(true);
       if (options.clearLeftFlag) {
@@ -294,6 +298,15 @@ export default function JoinSessionPage() {
       );
 
       if (participantResolution.status === "full") {
+        trackEvent("quartet_join_failed", {
+          session_id: id,
+          reason: "quartet_full",
+          participant_count: existingParticipants.length,
+        });
+        trackEvent("quartet_full", {
+          session_id: id,
+          participant_count: existingParticipants.length,
+        });
         showStatusMessage("This quartet already has four singers.");
         return;
       }
@@ -310,6 +323,11 @@ export default function JoinSessionPage() {
       const updatedParticipants = await refreshParticipants(id);
 
       if (participantResolution.status === "existing") {
+        trackEvent("quartet_rejoined", {
+          session_id: id,
+          participant_count: updatedParticipants.length,
+          song_count: entries.length,
+        });
         showStatusMessage(
           options.successMessage ??
             `Updated ${name}'s repertoire with ${entries.length} songs.`,
@@ -323,12 +341,22 @@ export default function JoinSessionPage() {
         participant_count: updatedParticipants.length,
         song_count: entries.length,
       });
+      if (updatedParticipants.length >= MAX_QUARTET_PARTICIPANTS) {
+        trackEvent("quartet_full", {
+          session_id: id,
+          participant_count: updatedParticipants.length,
+        });
+      }
       showStatusMessage(
         `Joined as ${name} with ${entries.length} songs.`,
         "transient"
       );
     } catch (err) {
       console.error(err);
+      trackEvent("quartet_join_failed", {
+        session_id: id,
+        reason: "write_failed",
+      });
       showStatusMessage("Could not join quartet. Please try again.", "error");
     } finally {
       setJoiningQuartet(false);
@@ -389,6 +417,10 @@ export default function JoinSessionPage() {
       return false;
     }
 
+    trackEvent("quartet_leave_confirmed", {
+      session_id: sessionId,
+      source: "quartet_page",
+    });
     setLeaving(true);
     clearStatusMessage();
 
@@ -410,6 +442,10 @@ export default function JoinSessionPage() {
       return true;
     } catch (err) {
       console.error(err);
+      trackEvent("quartet_leave_failed", {
+        session_id: sessionId,
+        source: "quartet_page",
+      });
       showStatusMessage(
         "Could not leave quartet. Check your connection and try again.",
         "error"
@@ -421,6 +457,12 @@ export default function JoinSessionPage() {
 
   function requestLeaveQuartet() {
     clearStatusMessage();
+    if (sessionId) {
+      trackEvent("quartet_leave_clicked", {
+        session_id: sessionId,
+        source: "quartet_page",
+      });
+    }
     setShowLeaveConfirmation(true);
   }
 
@@ -523,6 +565,10 @@ export default function JoinSessionPage() {
       return;
     }
 
+    trackEvent("quartet_leave_clicked", {
+      session_id: pendingActiveQuartet.sessionId,
+      source: "join_different_quartet",
+    });
     setLeavingCurrentQuartet(true);
     clearStatusMessage();
 
@@ -533,6 +579,10 @@ export default function JoinSessionPage() {
         throw new Error("You must be logged in to leave a quartet.");
       }
 
+      trackEvent("quartet_leave_confirmed", {
+        session_id: pendingActiveQuartet.sessionId,
+        source: "join_different_quartet",
+      });
       await removeParticipant(pendingActiveQuartet.sessionId, userId);
       trackEvent("quartet_left", {
         session_id: pendingActiveQuartet.sessionId,
@@ -544,6 +594,10 @@ export default function JoinSessionPage() {
       });
     } catch (err) {
       console.error(err);
+      trackEvent("quartet_leave_failed", {
+        session_id: pendingActiveQuartet.sessionId,
+        source: "join_different_quartet",
+      });
       showStatusMessage(
         "Could not leave your current quartet. Check your connection and try again.",
         "error"
@@ -986,6 +1040,26 @@ export default function JoinSessionPage() {
       possible_match_count: possibleMatchCount,
       one_part_missing_count: onePartMissingCount,
     });
+    trackEvent("matches_generated", {
+      session_id: sessionId,
+      participant_count: participants.length,
+      match_count: matches.length,
+      ready_match_count: readyMatchCount,
+      possible_match_count: possibleMatchCount,
+      one_part_missing_count: onePartMissingCount,
+    });
+    if (participants.length >= MAX_QUARTET_PARTICIPANTS) {
+      trackEvent("quartet_full", {
+        session_id: sessionId,
+        participant_count: participants.length,
+      });
+    }
+    if (participants.length >= MAX_QUARTET_PARTICIPANTS && matches.length === 0) {
+      trackEvent("zero_matches_found", {
+        session_id: sessionId,
+        participant_count: participants.length,
+      });
+    }
   }, [
     loading,
     loadError,

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -66,6 +66,10 @@ export default function JoinPage() {
   async function leaveCurrentAndContinue() {
     if (!activeQuartet || !pendingCode) return;
 
+    trackEvent("quartet_leave_clicked", {
+      session_id: activeQuartet.sessionId,
+      source: "manual_join_existing_quartet",
+    });
     setLeavingCurrent(true);
     setMessage("");
 
@@ -75,6 +79,10 @@ export default function JoinPage() {
         throw new Error("You must be logged in to leave a quartet.");
       }
 
+      trackEvent("quartet_leave_confirmed", {
+        session_id: activeQuartet.sessionId,
+        source: "manual_join_existing_quartet",
+      });
       await removeParticipant(activeQuartet.sessionId, user.id);
       trackEvent("quartet_left", {
         session_id: activeQuartet.sessionId,
@@ -87,6 +95,10 @@ export default function JoinPage() {
       window.location.href = `/join/${encodeURIComponent(pendingCode)}?intent=join`;
     } catch (err) {
       console.error("Failed to leave current quartet", err);
+      trackEvent("quartet_leave_failed", {
+        session_id: activeQuartet.sessionId,
+        source: "manual_join_existing_quartet",
+      });
       setMessage(
         "Could not leave your current quartet. Check your connection and try again."
       );

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -85,6 +85,11 @@ export default function SessionPage() {
         code,
         joinedAt: lastActivityAt,
       });
+      trackEvent("quartet_created", {
+        session_id: session.id,
+        participant_count: 1,
+        song_count: entries.length,
+      });
       trackEvent("quartet_started", {
         session_id: session.id,
         participant_count: 1,
@@ -115,6 +120,10 @@ export default function SessionPage() {
   async function leaveCurrentAndContinue() {
     if (!activeQuartet) return;
 
+    trackEvent("quartet_leave_clicked", {
+      session_id: activeQuartet.sessionId,
+      source: "start_page_existing_quartet",
+    });
     setLeavingCurrent(true);
     setErrorMessage("");
 
@@ -124,6 +133,10 @@ export default function SessionPage() {
         throw new Error("You must be logged in to leave a quartet.");
       }
 
+      trackEvent("quartet_leave_confirmed", {
+        session_id: activeQuartet.sessionId,
+        source: "start_page_existing_quartet",
+      });
       await removeParticipant(activeQuartet.sessionId, user.id);
       trackEvent("quartet_left", {
         session_id: activeQuartet.sessionId,
@@ -136,6 +149,10 @@ export default function SessionPage() {
       }
     } catch (err) {
       console.error("Failed to leave current quartet", err);
+      trackEvent("quartet_leave_failed", {
+        session_id: activeQuartet.sessionId,
+        source: "start_page_existing_quartet",
+      });
       setErrorMessage(
         "Could not leave your current quartet. Check your connection and try again."
       );

--- a/components/ActiveQuartetIndicator.tsx
+++ b/components/ActiveQuartetIndicator.tsx
@@ -43,6 +43,10 @@ export function ActiveQuartetIndicator() {
   async function leaveQuartet() {
     if (!activeQuartet) return;
 
+    trackEvent("quartet_leave_confirmed", {
+      session_id: activeQuartet.sessionId,
+      source: "nav_active_quartet",
+    });
     setLeaving(true);
     setMessage("");
 
@@ -67,6 +71,10 @@ export function ActiveQuartetIndicator() {
       }
     } catch (err) {
       console.error("Failed to leave active quartet", err);
+      trackEvent("quartet_leave_failed", {
+        session_id: activeQuartet.sessionId,
+        source: "nav_active_quartet",
+      });
       setShowLeaveConfirmation(false);
       setMessage("Could not leave quartet. Try again.");
     } finally {
@@ -109,6 +117,10 @@ export function ActiveQuartetIndicator() {
             type="button"
             onClick={() => {
               setMessage("");
+              trackEvent("quartet_leave_clicked", {
+                session_id: activeQuartet.sessionId,
+                source: "nav_active_quartet",
+              });
               setShowLeaveConfirmation(true);
             }}
             disabled={leaving}

--- a/components/AnalyticsIdentity.tsx
+++ b/components/AnalyticsIdentity.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect } from "react";
-import { identifyAnalyticsUser, trackEvent } from "@/lib/analytics";
+import { usePathname } from "next/navigation";
+import {
+  getAnalyticsRoute,
+  identifyAnalyticsUser,
+  trackEvent,
+} from "@/lib/analytics";
 import { getCurrentUser } from "@/lib/profileStore";
 
 function loggedInStorageKey(userId: string) {
@@ -9,6 +14,14 @@ function loggedInStorageKey(userId: string) {
 }
 
 export function AnalyticsIdentity() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackEvent("app_route_viewed", {
+      route: getAnalyticsRoute(pathname),
+    });
+  }, [pathname]);
+
   useEffect(() => {
     async function identifyUser() {
       try {

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -337,6 +337,11 @@ export default function RepertoireManager() {
         song_count: items.length + 1,
         parts_known_count: partConfidences.length,
       });
+      trackEvent("repertoire_updated", {
+        action: "add",
+        song_count: items.length + 1,
+        parts_known_count: partConfidences.length,
+      });
       let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
@@ -357,6 +362,9 @@ export default function RepertoireManager() {
       }
     } catch (err) {
       console.error(err);
+      trackEvent("repertoire_update_failed", {
+        action: "add",
+      });
       setMessage("Could not add song. Please try again.");
     } finally {
       setIsAdding(false);
@@ -384,6 +392,10 @@ export default function RepertoireManager() {
       trackEvent("repertoire_song_deleted", {
         song_count: Math.max(0, items.length - 1),
       });
+      trackEvent("repertoire_updated", {
+        action: "delete",
+        song_count: Math.max(0, items.length - 1),
+      });
       let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
@@ -403,6 +415,9 @@ export default function RepertoireManager() {
       }
     } catch (err) {
       console.error(err);
+      trackEvent("repertoire_update_failed", {
+        action: "delete",
+      });
       setMessage("Could not delete song. Please try again.");
       setItemToDelete(null);
     } finally {
@@ -457,6 +472,11 @@ export default function RepertoireManager() {
         song_count: items.length,
         parts_known_count: partConfidences.length,
       });
+      trackEvent("repertoire_updated", {
+        action: "edit",
+        song_count: items.length,
+        parts_known_count: partConfidences.length,
+      });
       let snapshotUpdated = true;
       try {
         await refreshActiveQuartetSnapshot();
@@ -476,6 +496,9 @@ export default function RepertoireManager() {
       }
     } catch (err) {
       console.error(err);
+      trackEvent("repertoire_update_failed", {
+        action: "edit",
+      });
       setMessage("Could not save changes. Please try again.");
     } finally {
       setSavingEditId(null);

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 # Analytics
 
 Analytics are optional. If `NEXT_PUBLIC_POSTHOG_KEY` or
-`NEXT_PUBLIC_POSTHOG_HOST` is missing, the app should continue to work without
+`NEXT_PUBLIC_POSTHOG_HOST` is missing, the app continues to work without
 tracking.
 
 ## Provider
@@ -24,27 +24,97 @@ Do not send free-text user content to PostHog. This includes:
 - arranger names
 - singer names
 - email addresses
+- quartet join codes
 
 Analytics properties should be limited to counts, booleans, IDs, enum-like
-values, and coarse app context.
+values, and coarse app context. `lib/analytics.ts` drops properties whose keys
+look like free-text or identifying fields before sending events.
 
-## Current Events
+Route analytics use `app_route_viewed` with a normalized `route` property.
+Dynamic quartet links are reported as `/join/[code]`, not the actual code.
+
+## Event Audit
 
 The app currently tracks these events through `lib/analytics.ts`:
 
-- `user_logged_in`
-- `repertoire_song_added`
-- `repertoire_song_edited`
-- `repertoire_song_deleted`
-- `quartet_started`
-- `quartet_joined`
-- `quartet_left`
-- `quartet_member_removed`
-- `quartet_matches_viewed`
-- `song_marked_sung`
-- `song_mark_sung_failed`
-- `help_viewed`
-- `feedback_submitted`
+| Event | Fires from | Properties | PII? | Dashboard usage |
+| --- | --- | --- | --- | --- |
+| `app_route_viewed` | `components/AnalyticsIdentity.tsx` on route changes | `route` | No; join codes are normalized | Product Health, Quartet Funnel |
+| `user_logged_in` | `components/AnalyticsIdentity.tsx` once per browser session after auth is restored | none | No | Product Health, Quartet Funnel |
+| `quartet_created` | `app/session/page.tsx` after a new session and participant row are created | `session_id`, `participant_count`, `song_count` | No free text | Product Health |
+| `quartet_started` | `app/session/page.tsx` after a new session and participant row are created | `session_id`, `participant_count`, `song_count` | No free text | Legacy compatibility |
+| `quartet_join_attempted` | `app/join/[code]/page.tsx` before attempting to add or refresh a participant row | `session_id` | No free text | Quartet Funnel, Browser / Mobile Compatibility |
+| `quartet_joined` | `app/session/page.tsx` and `app/join/[code]/page.tsx` after a participant row exists | `session_id`, `participant_count`, `song_count` | No free text | Product Health, Quartet Funnel, Browser / Mobile Compatibility |
+| `quartet_join_failed` | `app/join/[code]/page.tsx` when joining is blocked or the write fails | `session_id`, `reason`, `participant_count` | No free text | Reliability / Errors |
+| `quartet_rejoined` | `app/join/[code]/page.tsx` when an existing participant refreshes their snapshot | `session_id`, `participant_count`, `song_count` | No free text | Product Health, Repertoire & Matching |
+| `quartet_full` | `app/join/[code]/page.tsx` when participant count reaches four | `session_id`, `participant_count` | No free text | Product Health, Quartet Funnel |
+| `quartet_leave_clicked` | Quartet page, active-quartet nav, start page, and manual join flow before leave confirmation/write | `session_id`, `source` | No free text | Browser / Mobile Compatibility |
+| `quartet_leave_confirmed` | Quartet page, active-quartet nav, start page, and manual join flow before deleting membership | `session_id`, `source` | No free text | Browser / Mobile Compatibility |
+| `quartet_left` | Quartet page, active-quartet nav, start page, and manual join flow after membership delete succeeds | `session_id`, `participant_count` | No free text | Product Health, Browser / Mobile Compatibility |
+| `quartet_leave_failed` | Quartet page, active-quartet nav, start page, and manual join flow when leave delete fails | `session_id`, `source` | No free text | Reliability / Errors, Browser / Mobile Compatibility |
+| `quartet_member_removed` | `app/join/[code]/page.tsx` after one singer removes another | `session_id`, `participant_count` | No free text | Browser / Mobile Compatibility |
+| `quartet_matches_viewed` | `app/join/[code]/page.tsx` when match counts change | `session_id`, `participant_count`, match counts | No free text | Legacy compatibility |
+| `matches_generated` | `app/join/[code]/page.tsx` when match counts change | `session_id`, `participant_count`, match counts | No free text | Quartet Funnel, Repertoire & Matching |
+| `zero_matches_found` | `app/join/[code]/page.tsx` when a full quartet has no matches | `session_id`, `participant_count` | No free text | Repertoire & Matching |
+| `repertoire_song_added` | `components/RepertoireManager.tsx` after adding a song | `song_count`, `parts_known_count` | No free text | Legacy compatibility |
+| `repertoire_song_edited` | `components/RepertoireManager.tsx` after editing a song | `song_count`, `parts_known_count` | No free text | Legacy compatibility |
+| `repertoire_song_deleted` | `components/RepertoireManager.tsx` after deleting a song | `song_count` | No free text | Legacy compatibility |
+| `repertoire_updated` | `components/RepertoireManager.tsx` after add/edit/delete succeeds | `action`, `song_count`, `parts_known_count` | No free text | Quartet Funnel, Repertoire & Matching |
+| `repertoire_update_failed` | `components/RepertoireManager.tsx` when add/edit/delete fails | `action` | No free text | Reliability / Errors |
+| `song_marked_sung` | `app/join/[code]/page.tsx` after marking a match as sung | `session_id`, `match_category`, `voicing` | No free text | Future recently sung dashboard |
+| `song_mark_sung_failed` | `app/join/[code]/page.tsx` when marking a match as sung fails | `session_id`, `match_category`, `voicing` | No free text | Reliability / Errors |
+| `help_viewed` | `app/help/page.tsx` when the help page loads | none | No | Product Health context |
+| `feedback_submitted` | `app/help/page.tsx` after feedback API succeeds | `category`, `length` | No message text | Product Health |
+| `feedback_failed` | `app/help/page.tsx` when feedback API fails | `category`, `status_code` or `reason` | No message text | Reliability / Errors |
 
-When adding an event, update this document and keep the privacy contract above
-in sync with the event properties.
+## Reproducible Dashboards
+
+Dashboard definitions live in `analytics/posthog/dashboards.json`. They cover:
+
+- Product Health
+- Quartet Funnel
+- Repertoire & Matching
+- Reliability / Errors
+- Browser / Mobile Compatibility
+
+Validate the dashboard spec locally with:
+
+```sh
+npm run posthog:dashboards:check
+```
+
+Sync dashboards to PostHog with:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=... \
+npm run posthog:dashboards:sync
+```
+
+`POSTHOG_PROJECT_ID` is accepted as a fallback name for older PostHog docs, but
+`POSTHOG_ENVIRONMENT_ID` matches the current PostHog dashboard and insight API
+paths.
+
+The sync script is idempotent by dashboard and insight name:
+
+- existing dashboards are patched by exact name
+- existing insights are patched by exact name
+- missing dashboards and insights are created
+- API keys are read from environment variables only
+
+The personal API key needs PostHog dashboard and insight read/write scopes.
+
+## Known Gaps
+
+- The app does not currently track auth-link delivery or Supabase server-side
+  auth errors because those happen outside the browser analytics layer.
+- The app does not track raw song titles, arranger names, feedback text, or
+  display names by design.
+- If dashboard sync fails because PostHog changes an insight filter shape, keep
+  `analytics/posthog/dashboards.json` as the source of truth and update
+  `scripts/posthog/sync-dashboards.mjs` rather than creating dashboards by hand.
+
+When adding an event, update this document, keep
+`analytics/posthog/dashboards.json` in sync if a dashboard should use it, and
+preserve the privacy contract above.

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeAnalyticsProperties } from "../analytics";
+import { getAnalyticsRoute, sanitizeAnalyticsProperties } from "../analytics";
 
 describe("sanitizeAnalyticsProperties", () => {
   it("keeps safe primitive analytics properties", () => {
@@ -32,5 +32,20 @@ describe("sanitizeAnalyticsProperties", () => {
     ).toEqual({
       song_count: 12,
     });
+  });
+});
+
+describe("getAnalyticsRoute", () => {
+  it("keeps public route names safe for dashboard breakdowns", () => {
+    expect(getAnalyticsRoute("/")).toBe("/");
+    expect(getAnalyticsRoute("/repertoire")).toBe("/repertoire");
+    expect(getAnalyticsRoute("/settings?tab=name")).toBe("/settings");
+  });
+
+  it("does not expose quartet join codes in route analytics", () => {
+    expect(getAnalyticsRoute("/join/ABC123")).toBe("/join/[code]");
+    expect(getAnalyticsRoute("/join/ABC123?intent=join")).toBe(
+      "/join/[code]"
+    );
   });
 });

--- a/lib/__tests__/posthogDashboardSpec.test.ts
+++ b/lib/__tests__/posthogDashboardSpec.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const dashboardSpec = JSON.parse(
+  readFileSync(join(repoRoot, "analytics/posthog/dashboards.json"), "utf8")
+) as {
+  version: number;
+  dashboards: Array<{
+    key: string;
+    name: string;
+    insights: Array<{
+      key: string;
+      name: string;
+      type: string;
+      series: Array<{ event: string }>;
+    }>;
+  }>;
+};
+const analyticsDocs = readFileSync(join(repoRoot, "docs/analytics.md"), "utf8");
+
+describe("PostHog dashboard spec", () => {
+  it("defines the expected managed dashboards", () => {
+    expect(dashboardSpec.version).toBe(1);
+    expect(dashboardSpec.dashboards.map((dashboard) => dashboard.key)).toEqual([
+      "product-health",
+      "quartet-funnel",
+      "repertoire-matching",
+      "reliability-errors",
+      "browser-mobile-compatibility",
+    ]);
+  });
+
+  it("keeps dashboard and insight keys unique", () => {
+    const dashboardKeys = dashboardSpec.dashboards.map(
+      (dashboard) => dashboard.key
+    );
+    const insightKeys = dashboardSpec.dashboards.flatMap((dashboard) =>
+      dashboard.insights.map((insight) => insight.key)
+    );
+
+    expect(new Set(dashboardKeys).size).toBe(dashboardKeys.length);
+    expect(new Set(insightKeys).size).toBe(insightKeys.length);
+  });
+
+  it("documents every event used by managed dashboards", () => {
+    const events = new Set(
+      dashboardSpec.dashboards.flatMap((dashboard) =>
+        dashboard.insights.flatMap((insight) =>
+          insight.series.map((series) => series.event)
+        )
+      )
+    );
+
+    for (const event of events) {
+      expect(analyticsDocs).toContain(`\`${event}\``);
+    }
+  });
+});

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,19 +1,33 @@
 import posthog from "posthog-js";
 
 export type AnalyticsEventName =
+  | "app_route_viewed"
   | "user_logged_in"
+  | "quartet_created"
+  | "quartet_join_attempted"
   | "repertoire_song_added"
   | "repertoire_song_edited"
   | "repertoire_song_deleted"
+  | "repertoire_updated"
+  | "repertoire_update_failed"
   | "quartet_started"
   | "quartet_joined"
+  | "quartet_join_failed"
+  | "quartet_leave_clicked"
+  | "quartet_leave_confirmed"
   | "quartet_left"
+  | "quartet_leave_failed"
+  | "quartet_rejoined"
+  | "quartet_full"
   | "quartet_member_removed"
   | "quartet_matches_viewed"
+  | "matches_generated"
+  | "zero_matches_found"
   | "song_marked_sung"
   | "song_mark_sung_failed"
   | "help_viewed"
-  | "feedback_submitted";
+  | "feedback_submitted"
+  | "feedback_failed";
 
 type AnalyticsPropertyValue = string | number | boolean | null | undefined;
 type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
@@ -59,6 +73,19 @@ export function sanitizeAnalyticsProperties(
       );
     })
   );
+}
+
+export function getAnalyticsRoute(pathname: string | null | undefined) {
+  if (!pathname) return "/";
+
+  const normalizedPathname = pathname.split("?")[0]?.split("#")[0] || "/";
+  const segments = normalizedPathname.split("/").filter(Boolean);
+
+  if (segments[0] === "join" && segments.length > 1) {
+    return "/join/[code]";
+  }
+
+  return normalizedPathname || "/";
 }
 
 export function trackEvent(

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "posthog:dashboards:check": "node scripts/posthog/sync-dashboards.mjs --check",
+    "posthog:dashboards:sync": "node scripts/posthog/sync-dashboards.mjs",
     "test": "vitest",
     "test:run": "vitest run",
     "ship": "./scripts/ship.sh",

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const specPath = path.join(repoRoot, "analytics/posthog/dashboards.json");
+
+const args = new Set(process.argv.slice(2));
+const checkOnly = args.has("--check");
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
+  return value;
+}
+
+function apiBaseUrl() {
+  return (
+    process.env.POSTHOG_HOST ||
+    process.env.POSTHOG_API_HOST ||
+    "https://us.posthog.com"
+  ).replace(/\/$/, "");
+}
+
+function environmentId() {
+  return (
+    process.env.POSTHOG_ENVIRONMENT_ID ||
+    process.env.POSTHOG_PROJECT_ID ||
+    ""
+  );
+}
+
+function asArray(value, message) {
+  if (!Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function validateSpec(spec) {
+  if (spec.version !== 1) {
+    throw new Error("Dashboard spec version must be 1.");
+  }
+
+  const dashboards = asArray(spec.dashboards, "Spec must include dashboards.");
+  const dashboardKeys = new Set();
+  const insightKeys = new Set();
+
+  for (const dashboard of dashboards) {
+    if (!dashboard.key || !dashboard.name) {
+      throw new Error("Every dashboard needs a key and name.");
+    }
+
+    if (dashboardKeys.has(dashboard.key)) {
+      throw new Error(`Duplicate dashboard key: ${dashboard.key}`);
+    }
+    dashboardKeys.add(dashboard.key);
+
+    const insights = asArray(
+      dashboard.insights,
+      `Dashboard ${dashboard.key} must include insights.`
+    );
+
+    for (const insight of insights) {
+      if (!insight.key || !insight.name || !insight.type) {
+        throw new Error(`Every insight in ${dashboard.key} needs key/name/type.`);
+      }
+
+      if (insightKeys.has(insight.key)) {
+        throw new Error(`Duplicate insight key: ${insight.key}`);
+      }
+      insightKeys.add(insight.key);
+
+      if (!["trend", "funnel"].includes(insight.type)) {
+        throw new Error(`Unsupported insight type for ${insight.key}.`);
+      }
+
+      const series = asArray(
+        insight.series,
+        `Insight ${insight.key} must include event series.`
+      );
+
+      for (const event of series) {
+        if (!event.event) {
+          throw new Error(`Insight ${insight.key} has a series without event.`);
+        }
+      }
+    }
+  }
+}
+
+async function readSpec() {
+  const spec = JSON.parse(await readFile(specPath, "utf8"));
+  validateSpec(spec);
+  return spec;
+}
+
+function eventToFilter(event, order) {
+  const filter = {
+    id: event.event,
+    name: event.event,
+    type: "events",
+    order,
+    math: event.math || "total",
+  };
+
+  if (event.mathProperty) {
+    filter.math_property = event.mathProperty;
+  }
+
+  return filter;
+}
+
+function filtersForInsight(insight) {
+  const filters = {
+    insight: insight.type === "funnel" ? "FUNNELS" : "TRENDS",
+    date_from: insight.dateFrom || "-30d",
+    events: insight.series.map(eventToFilter),
+  };
+
+  if (insight.interval) {
+    filters.interval = insight.interval;
+  }
+
+  if (insight.breakdown) {
+    filters.breakdown = insight.breakdown;
+    filters.breakdown_type = insight.breakdown.startsWith("$")
+      ? "event"
+      : "event";
+  }
+
+  return filters;
+}
+
+async function posthogFetch(endpoint, options = {}) {
+  const apiKey = requiredEnv("POSTHOG_PERSONAL_API_KEY");
+  const response = await fetch(`${apiBaseUrl()}${endpoint}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`${options.method || "GET"} ${endpoint} failed: ${response.status} ${body}`);
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function listAll(endpoint) {
+  const results = [];
+  let nextEndpoint = endpoint;
+
+  while (nextEndpoint) {
+    const page = await posthogFetch(nextEndpoint);
+    results.push(...(page.results || []));
+    if (!page.next) break;
+    nextEndpoint = page.next.startsWith("http")
+      ? page.next.replace(apiBaseUrl(), "")
+      : page.next;
+  }
+
+  return results;
+}
+
+async function upsertDashboard(environment, dashboard, tags) {
+  const dashboards = await listAll(
+    `/api/environments/${environment}/dashboards/?limit=100`
+  );
+  const existing = dashboards.find((item) => item.name === dashboard.name);
+  const body = {
+    name: dashboard.name,
+    description: dashboard.description,
+    pinned: true,
+    tags,
+  };
+
+  if (existing) {
+    return posthogFetch(
+      `/api/environments/${environment}/dashboards/${existing.id}/`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }
+    );
+  }
+
+  return posthogFetch(`/api/environments/${environment}/dashboards/`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function upsertInsight(environment, dashboardId, insight, tags) {
+  const insights = await listAll(
+    `/api/environments/${environment}/insights/?limit=100`
+  );
+  const existing = insights.find((item) => item.name === insight.name);
+  const body = {
+    name: insight.name,
+    description: insight.description,
+    filters: filtersForInsight(insight),
+    dashboards: [dashboardId],
+    saved: true,
+    tags,
+  };
+
+  if (existing) {
+    return posthogFetch(
+      `/api/environments/${environment}/insights/${existing.id}/`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }
+    );
+  }
+
+  return posthogFetch(`/api/environments/${environment}/insights/`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+async function main() {
+  const spec = await readSpec();
+
+  if (checkOnly) {
+    console.log(
+      `Validated ${spec.dashboards.length} dashboards from ${path.relative(
+        repoRoot,
+        specPath
+      )}.`
+    );
+    return;
+  }
+
+  const environment = environmentId();
+  if (!environment) {
+    throw new Error("Missing POSTHOG_ENVIRONMENT_ID or POSTHOG_PROJECT_ID");
+  }
+
+  const tags = spec.tags || [];
+
+  for (const dashboardSpec of spec.dashboards) {
+    const dashboard = await upsertDashboard(environment, dashboardSpec, tags);
+    console.log(`Synced dashboard: ${dashboardSpec.name}`);
+
+    for (const insight of dashboardSpec.insights) {
+      await upsertInsight(environment, dashboard.id, insight, tags);
+      console.log(`  Synced insight: ${insight.name}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Adds repo-managed PostHog dashboard definitions in `analytics/posthog/dashboards.json` for Product Health, Quartet Funnel, Repertoire & Matching, Reliability / Errors, and Browser / Mobile Compatibility.
- Adds an idempotent dashboard sync script with `npm run posthog:dashboards:check` and `npm run posthog:dashboards:sync`.
- Audits and documents the analytics event contract in `docs/analytics.md`, including event properties, PII review, dashboard usage, and remaining gaps.
- Adds low-noise canonical events for route views, quartet create/join/rejoin/full/leave/failure flows, repertoire updates/failures, match generation, zero matches, and feedback failures.
- Keeps existing legacy event names in place for compatibility.

Closes #168.

## Tables / objects reviewed
- No Supabase tables or RLS policies changed.
- Reviewed browser PostHog usage in `lib/analytics.ts`, `instrumentation-client.ts`, login/session/join/repertoire/help flows, and existing analytics docs/tests.

## Mismatches found
- Dashboards were not reproducible from the repo.
- Current event docs listed event names but not firing location, properties, PII review, or dashboard usage.
- Some desired dashboard metrics had no canonical event, especially route views, join attempts/failures, leave click/confirm/failure, repertoire update/failure, match generation, zero matches, and feedback failures.

## Tests
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Required PostHog step
Dashboard sync is intentionally not automatic because it requires a PostHog personal API key. To create/update the dashboards, run:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_HOST=https://us.posthog.com \
POSTHOG_ENVIRONMENT_ID=... \
npm run posthog:dashboards:sync
```

`POSTHOG_PROJECT_ID` is accepted as a fallback env var name, but `POSTHOG_ENVIRONMENT_ID` matches the current PostHog API paths.

## Supabase / manual steps
- No Supabase migration or dashboard change required.
- No secrets committed.