### PR TITLE
Fix PostHog dashboard insight sync payloads

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -101,6 +101,8 @@ The sync script is idempotent by dashboard and insight name:
 - existing dashboards are patched by exact name
 - existing insights are patched by exact name
 - missing dashboards and insights are created
+- insights are created with PostHog query objects rather than legacy insight
+  filters
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -101,41 +101,42 @@ async function readSpec() {
   return spec;
 }
 
-function eventToFilter(event, order) {
-  const filter = {
-    id: event.event,
+function eventToQueryNode(event) {
+  const node = {
+    kind: "EventsNode",
+    event: event.event,
     name: event.event,
-    type: "events",
-    order,
     math: event.math || "total",
   };
 
   if (event.mathProperty) {
-    filter.math_property = event.mathProperty;
+    node.math_property = event.mathProperty;
   }
 
-  return filter;
+  return node;
 }
 
-function filtersForInsight(insight) {
-  const filters = {
-    insight: insight.type === "funnel" ? "FUNNELS" : "TRENDS",
-    date_from: insight.dateFrom || "-30d",
-    events: insight.series.map(eventToFilter),
+function queryForInsight(insight) {
+  const query = {
+    kind: insight.type === "funnel" ? "FunnelsQuery" : "TrendsQuery",
+    dateRange: {
+      date_from: insight.dateFrom || "-30d",
+    },
+    series: insight.series.map(eventToQueryNode),
   };
 
   if (insight.interval) {
-    filters.interval = insight.interval;
+    query.interval = insight.interval;
   }
 
   if (insight.breakdown) {
-    filters.breakdown = insight.breakdown;
-    filters.breakdown_type = insight.breakdown.startsWith("$")
-      ? "event"
-      : "event";
+    query.breakdownFilter = {
+      breakdown: insight.breakdown,
+      breakdown_type: "event",
+    };
   }
 
-  return filters;
+  return query;
 }
 
 async function posthogFetch(endpoint, options = {}) {
@@ -210,7 +211,7 @@ async function upsertInsight(environment, dashboardId, insight, tags) {
   const body = {
     name: insight.name,
     description: insight.description,
-    filters: filtersForInsight(insight),
+    query: queryForInsight(insight),
     dashboards: [dashboardId],
     saved: true,
     tags,


### PR DESCRIPTION
## Summary
- Updates the PostHog dashboard sync script to create/update insights with query objects instead of legacy `filters` payloads.
- Documents that managed insights use query objects.

This fixes the PostHog API error:

```text
Creating or updating insights with legacy filters is not available for this user.
```

Follow-up to #168 / #213.

## Tests
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Manual steps
After this merges, pull latest `main` and rerun:

```sh
npm run posthog:dashboards:sync
```

No Supabase changes required.