### PR TITLE
Use global repertoire source for song suggestions

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -20,13 +20,11 @@ import {
   addRepertoireItem,
   deleteRepertoireItem,
   getMyRepertoire,
+  searchRepertoireSongSuggestions,
   updateRepertoireItem,
   type RepertoireRow,
 } from "@/lib/repertoireStore";
-import {
-  getSongSuggestions,
-  type SongSuggestion,
-} from "@/lib/songSuggestions";
+import type { SongSuggestion } from "@/lib/songSuggestions";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
 
@@ -73,6 +71,8 @@ export default function RepertoireManager() {
   const [partFilter, setPartFilter] = useState<Part | "">("");
   const [neverSungOnly, setNeverSungOnly] = useState(false);
   const [songTitle, setSongTitle] = useState("");
+  const [songSuggestions, setSongSuggestions] = useState<SongSuggestion[]>([]);
+  const [songSuggestionsOpen, setSongSuggestionsOpen] = useState(false);
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
   const [notes, setNotes] = useState("");
@@ -186,8 +186,37 @@ export default function RepertoireManager() {
     return () => window.cancelAnimationFrame(frame);
   }, [isAddOpen]);
 
+  useEffect(() => {
+    if (!isAddOpen || !songSuggestionsOpen || songTitle.trim().length < 2) {
+      setSongSuggestions([]);
+      return;
+    }
+
+    let cancelled = false;
+    const timeout = window.setTimeout(async () => {
+      try {
+        const suggestions = await searchRepertoireSongSuggestions(songTitle);
+        if (!cancelled) {
+          setSongSuggestions(suggestions);
+        }
+      } catch (err) {
+        console.error("Could not load song suggestions", err);
+        if (!cancelled) {
+          setSongSuggestions([]);
+        }
+      }
+    }, 150);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+    };
+  }, [isAddOpen, songSuggestionsOpen, songTitle]);
+
   function resetAddForm() {
     setSongTitle("");
+    setSongSuggestions([]);
+    setSongSuggestionsOpen(false);
     setVoicing("");
     setArrangerName("");
     setNotes("");
@@ -208,6 +237,7 @@ export default function RepertoireManager() {
 
   function selectSongSuggestion(suggestion: SongSuggestion) {
     setSongTitle(suggestion.songTitle);
+    setSongSuggestionsOpen(false);
     setVoicing(suggestion.voicing);
     setArrangerName(suggestion.arrangerName);
     setShowArranger(Boolean(suggestion.arrangerName));
@@ -539,7 +569,6 @@ export default function RepertoireManager() {
     sort: sortOption,
   };
   const visibleItems = filterAndSortRepertoire(items, repertoireFilters);
-  const songSuggestions = getSongSuggestions(items, songTitle);
   const hasActiveFilters = hasActiveRepertoireFilters(repertoireFilters);
   const partFilterOptions = voicingFilter
     ? partsByVoicing[voicingFilter]
@@ -1043,11 +1072,15 @@ export default function RepertoireManager() {
                   <input
                     ref={songTitleInputRef}
                     value={songTitle}
-                    onChange={(e) => setSongTitle(e.target.value)}
+                    onChange={(e) => {
+                      setSongTitle(e.target.value);
+                      setSongSuggestionsOpen(true);
+                    }}
+                    onFocus={() => setSongSuggestionsOpen(true)}
                     autoComplete="off"
                     className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                   />
-                  {songSuggestions.length > 0 && (
+                  {songSuggestionsOpen && songSuggestions.length > 0 && (
                     <div className="mt-2 overflow-hidden rounded-xl border border-cyan-300/20 bg-slate-900">
                       <p className="px-3 py-2 text-xs font-semibold uppercase tracking-normal text-slate-400">
                         Existing songs

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -75,6 +75,9 @@ Code:
 - Mark own song as sung:
   `lib/repertoireStore.ts#markRepertoireItemAsSung`, through
   `public.mark_repertoire_sung`
+- Search global song identity suggestions:
+  `lib/repertoireStore.ts#searchRepertoireSongSuggestions`, through
+  `public.search_repertoire_song_suggestions`
 - Used by `lib/activeQuartetSnapshot.ts` to refresh the current user's
   `session_participants.repertoire` snapshot.
 
@@ -104,11 +107,18 @@ Required database contract:
   updates only the authenticated user's matching `user_repertoire` row,
   increments `times_sung_count`, sets `last_sung_at`, and records the matching
   private `sung_song_events` row in one database operation.
+- `public.search_repertoire_song_suggestions(p_query text, p_limit integer)`
+  is a security-definer RPC available only to authenticated users. It returns
+  distinct global song identity suggestions from all repertoire rows:
+  `song_title`, `voicing`, and `arranger_name`. It must not return `user_id`,
+  singer names, notes, parts, confidence, timestamps, or other per-user
+  repertoire details.
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
 - `20260428142000_add_part_confidences_to_repertoire.sql`
 - `20260428145000_add_repertoire_sung_metadata.sql`
+- `20260428223000_add_global_song_suggestions.sql`
 
 ### `sessions`
 

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -37,6 +37,13 @@ const participantRemovalMigration = readFileSync(
   ),
   "utf8"
 );
+const songSuggestionsMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260428223000_add_global_song_suggestions.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -120,5 +127,21 @@ describe("Supabase contract guardrails", () => {
     expect(sungMetadataMigration).toContain("times_sung_count + 1");
     expect(sungMetadataMigration).toContain("user_id = auth.uid()");
     expect(sungMetadataMigration).toContain("sung_song_events");
+  });
+
+  it("documents and migrates global song identity suggestions", () => {
+    expect(contract).toContain("search_repertoire_song_suggestions");
+    expect(contract).toContain("distinct global song identity suggestions");
+    expect(contract).toContain("must not return `user_id`");
+    expect(songSuggestionsMigration).toContain(
+      "search_repertoire_song_suggestions"
+    );
+    expect(songSuggestionsMigration).toContain("security definer");
+    expect(songSuggestionsMigration).toContain("auth.role() = 'authenticated'");
+    expect(songSuggestionsMigration).toContain("song_title text");
+    expect(songSuggestionsMigration).toContain("voicing text");
+    expect(songSuggestionsMigration).toContain("arranger_name text");
+    expect(songSuggestionsMigration).toContain("grant execute");
+    expect(songSuggestionsMigration).not.toContain("returns table (\n  user_id");
   });
 });

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -7,6 +7,11 @@ import {
   type Voicing,
 } from "@/lib/matching";
 import { getCurrentUser } from "@/lib/profileStore";
+import {
+  getSongSuggestions,
+  type SongSuggestion,
+  type SongSuggestionSource,
+} from "@/lib/songSuggestions";
 
 export type RepertoireRow = {
   id: string;
@@ -102,6 +107,26 @@ export async function getMyRepertoire() {
 
   if (error) throw error;
   return (data as RawRepertoireRow[]).map(normalizeRepertoireRow);
+}
+
+export async function searchRepertoireSongSuggestions(
+  query: string,
+  limit = 6
+): Promise<SongSuggestion[]> {
+  const { data, error } = await supabase.rpc(
+    "search_repertoire_song_suggestions",
+    {
+      p_query: query,
+      p_limit: limit,
+    }
+  );
+
+  if (error) throw error;
+  return getSongSuggestions(
+    (data ?? []) as SongSuggestionSource[],
+    query,
+    limit
+  );
 }
 
 export async function markRepertoireItemAsSung(id: string, sessionId: string) {

--- a/lib/songSuggestions.ts
+++ b/lib/songSuggestions.ts
@@ -2,7 +2,7 @@ import type { Voicing } from "@/lib/matching";
 
 export type SongSuggestionSource = {
   song_title: string;
-  voicing: Voicing;
+  voicing: string;
   arranger_name: string | null;
 };
 
@@ -11,6 +11,12 @@ export type SongSuggestion = {
   voicing: Voicing;
   arrangerName: string;
 };
+
+const validVoicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
+
+function isVoicing(value: string): value is Voicing {
+  return validVoicings.includes(value as Voicing);
+}
 
 function normalizeSearchText(value: string) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
@@ -36,6 +42,8 @@ export function getSongSuggestions(
   const suggestions = new Map<string, SongSuggestion>();
 
   for (const row of rows) {
+    if (!isVoicing(row.voicing)) continue;
+
     const suggestion = {
       songTitle: row.song_title.trim(),
       voicing: row.voicing,

--- a/supabase/migrations/20260428223000_add_global_song_suggestions.sql
+++ b/supabase/migrations/20260428223000_add_global_song_suggestions.sql
@@ -1,0 +1,47 @@
+drop function if exists public.search_repertoire_song_suggestions(text, integer);
+
+create or replace function public.search_repertoire_song_suggestions(
+  p_query text,
+  p_limit integer default 6
+)
+returns table (
+  song_title text,
+  voicing text,
+  arranger_name text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with normalized_input as (
+    select lower(
+      regexp_replace(coalesce(p_query, ''), '[^[:alnum:]]+', ' ', 'g')
+    ) as query
+  ),
+  suggestions as (
+    select distinct
+      btrim(user_repertoire.song_title) as song_title,
+      user_repertoire.voicing,
+      nullif(btrim(coalesce(user_repertoire.arranger_name, '')), '') as arranger_name
+    from public.user_repertoire
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(user_repertoire.song_title) <> ''
+      and (
+        lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+        or lower(regexp_replace(coalesce(user_repertoire.arranger_name, ''), '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+      )
+  )
+  select suggestions.song_title, suggestions.voicing, suggestions.arranger_name
+  from suggestions
+  order by suggestions.song_title, suggestions.voicing, suggestions.arranger_name nulls first
+  limit least(greatest(coalesce(p_limit, 6), 1), 20);
+$$;
+
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from public;
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from anon;
+grant execute on function public.search_repertoire_song_suggestions(text, integer) to authenticated;


### PR DESCRIPTION
## Summary
- Corrects issue #91 song suggestions to use a global source instead of only the current user's repertoire.
- Adds authenticated Supabase RPC `public.search_repertoire_song_suggestions(p_query text, p_limit integer)` that searches distinct song identity fields across all users' repertoire history.
- The RPC returns only song title, voicing, and arranger when known; it does not expose user IDs, singer names, notes, parts, confidence, timestamps, or ownership data.
- Updates the add-song modal to fetch suggestions from that RPC while preserving free-form entry and requiring the singer to choose their own parts/confidence.
- Updates the Supabase contract and guard test for the new privacy-limited RPC.

Follow-up to #91 / #216.

## Tests
- `npm run test:run`
- `npm run build`

## Supabase / manual steps
- Adds migration `20260428223000_add_global_song_suggestions.sql`.
- Production Supabase needs this migration deployed before global suggestions work in the deployed app.