### PR TITLE
Add lightweight site footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { AnalyticsIdentity } from "@/components/AnalyticsIdentity";
+import { SiteFooter } from "@/components/SiteFooter";
 import "./globals.css";
 
 const siteTitle = "What Can We Sing";
@@ -62,7 +63,8 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         <AnalyticsIdentity />
-        {children}
+        <div className="flex-1">{children}</div>
+        <SiteFooter />
       </body>
     </html>
   );

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -1,0 +1,29 @@
+const footerLinks = [
+  { href: "/help", label: "Help & Feedback" },
+  { href: "/privacy", label: "Privacy" },
+  {
+    href: "https://github.com/coloradotim/what-can-we-sing",
+    label: "GitHub",
+  },
+];
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-white/10 bg-slate-950 px-6 py-6 text-sm text-slate-500">
+      <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center">
+        <span>&copy; 2026 What Can We Sing</span>
+        {footerLinks.map((link) => (
+          <span key={link.href} className="flex items-center gap-2">
+            <span aria-hidden="true">·</span>
+            <a
+              href={link.href}
+              className="font-semibold text-slate-400 hover:text-cyan-200"
+            >
+              {link.label}
+            </a>
+          </span>
+        ))}
+      </div>
+    </footer>
+  );
+}

--- a/lib/__tests__/siteFooter.test.ts
+++ b/lib/__tests__/siteFooter.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const footer = readFileSync(join(repoRoot, "components/SiteFooter.tsx"), "utf8");
+const layout = readFileSync(join(repoRoot, "app/layout.tsx"), "utf8");
+
+describe("site footer", () => {
+  it("uses the required footer text and links", () => {
+    expect(footer).toContain("&copy; 2026 What Can We Sing");
+    expect(footer).toContain("Help & Feedback");
+    expect(footer).toContain('href: "/help"');
+    expect(footer).toContain("Privacy");
+    expect(footer).toContain('href: "/privacy"');
+    expect(footer).toContain("GitHub");
+    expect(footer).toContain("https://github.com/coloradotim/what-can-we-sing");
+  });
+
+  it("is rendered from the root layout", () => {
+    expect(layout).toContain("SiteFooter");
+    expect(layout).toContain("<SiteFooter />");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a shared `SiteFooter` component with the requested footer text and secondary links.
- Renders the footer from the root layout so it appears across authenticated and unauthenticated pages.
- Keeps the main navigation focused on primary app actions.
- Adds a guard test for the footer copy, links, and root layout placement.

Closes #221.

## Tests
- `npm run test:run`
- `npm run build`

## Docs / Supabase
- No Supabase changes required.
- No separate docs update needed; this is a small shared layout/UI change.