### PR TITLE
Debug PostHog analytics capture

### DIFF
--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -16,6 +16,14 @@
           "series": [{ "event": "user_logged_in", "math": "dau" }]
         },
         {
+          "key": "analytics-client-ready",
+          "name": "Analytics client ready",
+          "description": "Browser sessions where the configured PostHog client accepted its first app event.",
+          "type": "trend",
+          "dateFrom": "-30d",
+          "series": [{ "event": "analytics_client_ready" }]
+        },
+        {
           "key": "weekly-active-users",
           "name": "Weekly active users",
           "description": "Distinct signed-in users seen each week.",

--- a/app/api/analytics/status/route.test.ts
+++ b/app/api/analytics/status/route.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./route";
+
+describe("analytics status route", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reports safe PostHog configuration status without exposing the key", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_public-project-key");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://us.i.posthog.com");
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "abc123");
+
+    const response = GET();
+    const body = await response.json();
+
+    expect(body).toEqual({
+      posthogConfigured: true,
+      hasPostHogKey: true,
+      hasPostHogHost: true,
+      posthogHost: "https://us.i.posthog.com",
+      vercelEnv: "production",
+      gitCommitSha: "abc123",
+    });
+    expect(JSON.stringify(body)).not.toContain("phc_public-project-key");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("reports missing public PostHog variables", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "");
+
+    const response = GET();
+    const body = await response.json();
+
+    expect(body).toMatchObject({
+      posthogConfigured: false,
+      hasPostHogKey: false,
+      hasPostHogHost: false,
+      posthogHost: null,
+    });
+  });
+});

--- a/app/api/analytics/status/route.ts
+++ b/app/api/analytics/status/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+function configured(value: string | undefined) {
+  return Boolean(value && value.trim());
+}
+
+export function GET() {
+  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+
+  return NextResponse.json(
+    {
+      posthogConfigured: configured(posthogKey) && configured(posthogHost),
+      hasPostHogKey: configured(posthogKey),
+      hasPostHogHost: configured(posthogHost),
+      posthogHost: posthogHost || null,
+      vercelEnv: process.env.VERCEL_ENV || null,
+      gitCommitSha: process.env.VERCEL_GIT_COMMIT_SHA || null,
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    }
+  );
+}

--- a/components/AnalyticsIdentity.tsx
+++ b/components/AnalyticsIdentity.tsx
@@ -13,8 +13,20 @@ function loggedInStorageKey(userId: string) {
   return `analytics:user_logged_in:${userId}`;
 }
 
+function clientReadyStorageKey() {
+  return "analytics:client_ready";
+}
+
 export function AnalyticsIdentity() {
   const pathname = usePathname();
+
+  useEffect(() => {
+    const storageKey = clientReadyStorageKey();
+    if (window.sessionStorage.getItem(storageKey)) return;
+
+    trackEvent("analytics_client_ready");
+    window.sessionStorage.setItem(storageKey, "true");
+  }, []);
 
   useEffect(() => {
     trackEvent("app_route_viewed", {

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -39,6 +39,7 @@ The app currently tracks these events through `lib/analytics.ts`:
 
 | Event | Fires from | Properties | PII? | Dashboard usage |
 | --- | --- | --- | --- | --- |
+| `analytics_client_ready` | `components/AnalyticsIdentity.tsx` once per browser session when the client analytics layer mounts | none | No | Product Health |
 | `app_route_viewed` | `components/AnalyticsIdentity.tsx` on route changes | `route` | No; join codes are normalized | Product Health, Quartet Funnel |
 | `user_logged_in` | `components/AnalyticsIdentity.tsx` once per browser session after auth is restored | none | No | Product Health, Quartet Funnel |
 | `quartet_created` | `app/session/page.tsx` after a new session and participant row are created | `session_id`, `participant_count`, `song_count` | No free text | Product Health |
@@ -106,6 +107,49 @@ The sync script is idempotent by dashboard and insight name:
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.
+
+## Production Verification
+
+Use `/api/analytics/status` on the deployed app to verify the production build
+has the public PostHog configuration baked in. The response intentionally
+reports only safe values:
+
+- whether `NEXT_PUBLIC_POSTHOG_KEY` is present
+- whether `NEXT_PUBLIC_POSTHOG_HOST` is present
+- the configured PostHog host
+- the Vercel environment and commit SHA, when Vercel exposes them
+
+The status route does not return the PostHog project key or any private API key.
+
+When dashboards are empty, check these in order:
+
+1. Open `/api/analytics/status` on the same deployment users are testing. If
+   `posthogConfigured` is `false`, add `NEXT_PUBLIC_POSTHOG_KEY` and
+   `NEXT_PUBLIC_POSTHOG_HOST` in Vercel for Production and Preview, then rebuild.
+2. Confirm the dashboard sync used the same PostHog environment/project as the
+   `NEXT_PUBLIC_POSTHOG_KEY`. A common failure mode is syncing dashboards with a
+   personal API key against one PostHog environment while the app sends events
+   with a project key from another environment.
+3. If PostHog's pre-built dashboards show traffic but the repo-managed
+   dashboards are empty, the app is still sending data to PostHog. In that case,
+   first suspect a dashboard environment/project mismatch or managed dashboard
+   event filters that do not match the deployed app version.
+4. In PostHog, open Live Events and load the app in a normal browser profile
+   without Brave shields, content blockers, or strict tracking protection. A page
+   load should show `analytics_client_ready` and `app_route_viewed`.
+5. If Live Events shows app events but dashboard cards are empty, re-run
+   `npm run posthog:dashboards:sync` with the correct
+   `POSTHOG_ENVIRONMENT_ID`.
+6. If Live Events shows no events but `/api/analytics/status` is configured,
+   check the browser network tab for blocked requests to the configured PostHog
+   host. Ad blockers and privacy browsers can suppress analytics completely.
+
+During this audit, the deployed production JavaScript was verified to include
+the PostHog browser client, the public project key, the configured capture host,
+and the `app_route_viewed` event code. The repo event names also match the
+managed dashboard definitions. That means empty dashboards are most likely due
+to a PostHog environment/project mismatch, a deployment built before env changes,
+or browser blocking rather than a missing capture call in the app.
 
 ## Known Gaps
 

--- a/lib/__tests__/posthogDashboardSpec.test.ts
+++ b/lib/__tests__/posthogDashboardSpec.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { ANALYTICS_EVENT_NAMES } from "../analytics";
 
 const repoRoot = process.cwd();
 const dashboardSpec = JSON.parse(
@@ -55,6 +56,21 @@ describe("PostHog dashboard spec", () => {
 
     for (const event of events) {
       expect(analyticsDocs).toContain(`\`${event}\``);
+    }
+  });
+
+  it("only uses events emitted by the app analytics contract", () => {
+    const emittedEvents = new Set(ANALYTICS_EVENT_NAMES);
+    const dashboardEvents = new Set(
+      dashboardSpec.dashboards.flatMap((dashboard) =>
+        dashboard.insights.flatMap((insight) =>
+          insight.series.map((series) => series.event)
+        )
+      )
+    );
+
+    for (const event of dashboardEvents) {
+      expect(emittedEvents.has(event)).toBe(true);
     }
   });
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,6 +1,7 @@
 import posthog from "posthog-js";
 
 export type AnalyticsEventName =
+  | "analytics_client_ready"
   | "app_route_viewed"
   | "user_logged_in"
   | "quartet_created"
@@ -28,6 +29,37 @@ export type AnalyticsEventName =
   | "help_viewed"
   | "feedback_submitted"
   | "feedback_failed";
+
+export const ANALYTICS_EVENT_NAMES = [
+  "analytics_client_ready",
+  "app_route_viewed",
+  "user_logged_in",
+  "quartet_created",
+  "quartet_join_attempted",
+  "repertoire_song_added",
+  "repertoire_song_edited",
+  "repertoire_song_deleted",
+  "repertoire_updated",
+  "repertoire_update_failed",
+  "quartet_started",
+  "quartet_joined",
+  "quartet_join_failed",
+  "quartet_leave_clicked",
+  "quartet_leave_confirmed",
+  "quartet_left",
+  "quartet_leave_failed",
+  "quartet_rejoined",
+  "quartet_full",
+  "quartet_member_removed",
+  "quartet_matches_viewed",
+  "matches_generated",
+  "zero_matches_found",
+  "song_marked_sung",
+  "song_mark_sung_failed",
+  "help_viewed",
+  "feedback_submitted",
+  "feedback_failed",
+] as const satisfies readonly AnalyticsEventName[];
 
 type AnalyticsPropertyValue = string | number | boolean | null | undefined;
 type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;


### PR DESCRIPTION
## Summary

Fixes #218.

- Added a safe `/api/analytics/status` endpoint so production/preview deployments can confirm whether the public PostHog key and host are present without exposing the key.
- Added a low-noise `analytics_client_ready` event once per browser session and included it in the managed Product Health dashboard.
- Added a dashboard guardrail test so repo-managed dashboards can only reference events in the app analytics contract.
- Expanded analytics docs with the empty-dashboard diagnosis path, including the important distinction that pre-built PostHog dashboards showing data means events are still reaching PostHog, and the repo-managed dashboards may be synced to the wrong environment/project or filtering for events from a newer deploy.

## Audit Notes

I verified that the current production JavaScript includes the PostHog browser client, a public PostHog project key, the configured capture host, and `app_route_viewed` code. The app event names also match the managed dashboard definitions. That points away from a missing app capture call and toward one of these remaining external/config causes when dashboards are empty:

- dashboards synced with a `POSTHOG_ENVIRONMENT_ID` that does not match the app's `NEXT_PUBLIC_POSTHOG_KEY`
- production/preview deployed before the latest analytics/dashboard changes
- browser privacy tooling blocking PostHog requests

## Tests

- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Manual Follow-Up

After this deploys, open `/api/analytics/status` on production and then check PostHog Live Events while loading the app in a normal browser profile. If `analytics_client_ready` and `app_route_viewed` appear in Live Events but the repo-managed dashboards are empty, re-run `npm run posthog:dashboards:sync` using the matching PostHog environment ID.