### PR TITLE
Clarify blank arranger handling

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -63,8 +63,9 @@ export default function PrivacyPage() {
               When you join a quartet, other singers in that quartet may see
               your display name and repertoire-derived information needed for
               matching, such as songs, voicing, parts, confidence, and possible
-              arrangement warnings. This sharing is the core purpose of the app:
-              helping the quartet answer what can we sing together right now.
+              arrangement details or warnings. This sharing is the core purpose
+              of the app: helping the quartet answer what can we sing together
+              right now.
             </p>
             <p className="mt-2 text-slate-300">
               Personal repertoire notes are stored for you and are not included

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -3,6 +3,7 @@ import {
   type MatchResult,
 } from "@/lib/matching";
 import { partAbbreviation } from "@/lib/partAbbreviations";
+import { noArrangerEnteredLabel } from "@/lib/arrangerDisplay";
 
 type MatchCardProps = {
   match: MatchResult;
@@ -50,6 +51,7 @@ export function MatchCard({
     Boolean(match.titleVariants?.length) ||
     match.warnings.length > 0 ||
     match.arrangerNames.length > 0 ||
+    match.hasMissingArrangerInfo ||
     personalNotes.length > 0 ||
     isRecentlySung;
 
@@ -132,10 +134,12 @@ export function MatchCard({
           })}
         </div>
 
-        {match.arrangerNames.length > 0 && (
+        {(match.arrangerNames.length > 0 || match.hasMissingArrangerInfo) && (
           <p className="mt-3">
             <span className="font-semibold text-white">Arranger:</span>{" "}
-            {match.arrangerNames.join(", ")}
+            {[...match.arrangerNames, match.hasMissingArrangerInfo ? noArrangerEnteredLabel : null]
+              .filter((name): name is string => Boolean(name))
+              .join(", ")}
           </p>
         )}
 

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -27,6 +27,7 @@ import {
 import type { SongSuggestion } from "@/lib/songSuggestions";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
+import { arrangerDisplayName } from "@/lib/arrangerDisplay";
 
 const voicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
 
@@ -992,11 +993,9 @@ export default function RepertoireManager() {
                             {partAbbreviation(item.voicing, part)} · {confidence}
                           </span>
                         ))}
-                        {item.arranger_name && (
-                          <span className="truncate text-slate-400">
-                            Arr. {item.arranger_name}
-                          </span>
-                        )}
+                        <span className="truncate text-slate-400">
+                          Arr. {arrangerDisplayName(item.arranger_name)}
+                        </span>
                       </div>
                       {item.notes && (
                         <p className="mt-1 line-clamp-2 text-xs text-slate-400">
@@ -1098,9 +1097,8 @@ export default function RepertoireManager() {
                             </span>
                             <span className="mt-1 block text-xs text-slate-300">
                               {suggestion.voicing}
-                              {suggestion.arrangerName
-                                ? ` · ${suggestion.arrangerName}`
-                                : " · Arranger unknown"}
+                              {" · "}
+                              {arrangerDisplayName(suggestion.arrangerName)}
                             </span>
                           </button>
                         ))}

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -70,7 +70,11 @@ voicing. Title matching is forgiving enough to catch close variants, but
 different voicings are not combined.
 
 Arranger differences or missing arranger values do not block a match. They are
-shown as confirmation warnings so singers can decide quickly in the room.
+shown so singers can decide quickly in the room. Different entered arranger
+names are treated as a confirmation warning. A blank arranger simply means no
+arranger was entered; it is shown as missing information, not as a problem. A
+literal value such as `Unknown` is treated as an entered arranger name and
+should not be collapsed with blank data.
 
 ## Navigation
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -112,7 +112,8 @@ Required database contract:
   distinct global song identity suggestions from all repertoire rows:
   `song_title`, `voicing`, and `arranger_name`. It must not return `user_id`,
   singer names, notes, parts, confidence, timestamps, or other per-user
-  repertoire details.
+  repertoire details. Blank `arranger_name` values remain `null`/blank in app
+  display and are distinct from a literal entered value such as `Unknown`.
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`

--- a/lib/__tests__/arrangerDisplay.test.ts
+++ b/lib/__tests__/arrangerDisplay.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { arrangerDisplayName, hasArrangerEntered } from "../arrangerDisplay";
+
+describe("arranger display helpers", () => {
+  it("labels blank arranger values as not entered", () => {
+    expect(arrangerDisplayName(null)).toBe("No arranger entered");
+    expect(arrangerDisplayName("")).toBe("No arranger entered");
+    expect(arrangerDisplayName("   ")).toBe("No arranger entered");
+    expect(hasArrangerEntered(null)).toBe(false);
+    expect(hasArrangerEntered("   ")).toBe(false);
+  });
+
+  it("preserves literal Unknown as an entered arranger value", () => {
+    expect(arrangerDisplayName("Unknown")).toBe("Unknown");
+    expect(hasArrangerEntered("Unknown")).toBe(true);
+  });
+
+  it("trims entered arranger names for display", () => {
+    expect(arrangerDisplayName("  Joe Arranger  ")).toBe("Joe Arranger");
+    expect(hasArrangerEntered("  Joe Arranger  ")).toBe(true);
+  });
+});

--- a/lib/__tests__/markAsSung.test.ts
+++ b/lib/__tests__/markAsSung.test.ts
@@ -7,6 +7,7 @@ function match(assignments: MatchResult["assignments"]): MatchResult {
     songTitle: "Test Song",
     voicing: "TTBB",
     arrangerNames: [],
+    hasMissingArrangerInfo: false,
     category: "ready",
     missingParts: [],
     assignments,

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   arrangementCheckNote,
+  arrangerConflictNote,
   findMatches,
   normalizeConfidence,
   possibleSameSongNote,
@@ -90,6 +91,8 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].category).toBe("ready");
+    expect(matches[0].arrangerNames).toEqual(["Arranger One", "Arranger Two"]);
+    expect(matches[0].warnings).toContain(arrangerConflictNote);
     expect(matches[0].warnings).toContain(arrangementCheckNote);
   });
 
@@ -104,7 +107,26 @@ describe("findMatches", () => {
     const matches = findMatches(entries);
 
     expect(matches[0].category).toBe("ready");
-    expect(matches[0].warnings).toContain(arrangementCheckNote);
+    expect(matches[0].arrangerNames).toEqual(["Known Arranger"]);
+    expect(matches[0].hasMissingArrangerInfo).toBe(true);
+    expect(matches[0].warnings).not.toContain(arrangementCheckNote);
+  });
+
+  it("treats literal Unknown as an entered arranger distinct from blank", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Unknown Credit Song", voicing: "TTBB", arrangerName: "Unknown", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "B", songTitle: "Unknown Credit Song", voicing: "TTBB", arrangerName: "Unknown", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "C", songTitle: "Unknown Credit Song", voicing: "TTBB", arrangerName: "", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "D", songTitle: "Unknown Credit Song", voicing: "TTBB", arrangerName: "Unknown", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].category).toBe("ready");
+    expect(matches[0].arrangerNames).toEqual(["Unknown"]);
+    expect(matches[0].hasMissingArrangerInfo).toBe(true);
+    expect(matches[0].warnings).not.toContain(arrangerConflictNote);
+    expect(matches[0].warnings).not.toContain(arrangementCheckNote);
   });
 
   it("uses SATB required parts", () => {

--- a/lib/__tests__/songSuggestions.test.ts
+++ b/lib/__tests__/songSuggestions.test.ts
@@ -23,6 +23,21 @@ describe("getSongSuggestions", () => {
       voicing: "TTBB" as const,
       arranger_name: "SPEBSQSA",
     },
+    {
+      song_title: "Heart of My Heart",
+      voicing: "TTBB" as const,
+      arranger_name: null,
+    },
+    {
+      song_title: "Heart of My Heart",
+      voicing: "TTBB" as const,
+      arranger_name: "Unknown",
+    },
+    {
+      song_title: "Heart of My Heart",
+      voicing: "TTBB" as const,
+      arranger_name: "Joe Arranger",
+    },
   ];
 
   it("waits until the query is useful", () => {
@@ -50,6 +65,26 @@ describe("getSongSuggestions", () => {
         songTitle: "Why Try to Change Me Now",
         voicing: "TTBB",
         arrangerName: "SPEBSQSA",
+      },
+    ]);
+  });
+
+  it("keeps blank arranger distinct from literal Unknown and entered names", () => {
+    expect(getSongSuggestions(rows, "heart")).toEqual([
+      {
+        songTitle: "Heart of My Heart",
+        voicing: "TTBB",
+        arrangerName: "",
+      },
+      {
+        songTitle: "Heart of My Heart",
+        voicing: "TTBB",
+        arrangerName: "Joe Arranger",
+      },
+      {
+        songTitle: "Heart of My Heart",
+        voicing: "TTBB",
+        arrangerName: "Unknown",
       },
     ]);
   });

--- a/lib/arrangerDisplay.ts
+++ b/lib/arrangerDisplay.ts
@@ -1,0 +1,10 @@
+export const noArrangerEnteredLabel = "No arranger entered";
+
+export function arrangerDisplayName(arrangerName?: string | null) {
+  const trimmed = arrangerName?.trim();
+  return trimmed || noArrangerEnteredLabel;
+}
+
+export function hasArrangerEntered(arrangerName?: string | null) {
+  return Boolean(arrangerName?.trim());
+}

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -42,6 +42,7 @@ export type MatchResult = {
   songTitle: string;
   voicing: Voicing;
   arrangerNames: string[];
+  hasMissingArrangerInfo: boolean;
   category: "ready" | "possible" | "one_part_missing";
   missingParts: Part[];
   assignments: Partial<Record<Part, SingerEntry[]>>;
@@ -69,6 +70,8 @@ type InternalMatchResult = MatchResult & {
 
 export const arrangementCheckNote =
   "Consider double-checking that everyone is singing the same arrangement.";
+export const arrangerConflictNote =
+  "Different arranger names were entered for this song.";
 
 export function possibleSameSongNote(firstTitle: string, secondTitle: string) {
   return `Possible same song: Is "${firstTitle}" the same as "${secondTitle}"?`;
@@ -252,17 +255,19 @@ function knownArrangersForGroup(group: SingerEntry[]) {
   );
 }
 
-function arrangementWarningsForGroup(
-  group: SingerEntry[],
-  knownArrangers: string[]
-) {
-  const hasSomeMissingArranger =
-    knownArrangers.length > 0 && group.some((e) => !e.arrangerName?.trim());
+function hasMissingArrangerInfo(group: SingerEntry[]) {
+  return group.some((e) => !e.arrangerName?.trim());
+}
+
+function arrangementWarningsForGroup(knownArrangers: string[]) {
   const hasMultipleArrangers = knownArrangers.length > 1;
 
-  return hasSomeMissingArranger || hasMultipleArrangers
-    ? [arrangementCheckNote]
-    : [];
+  const warnings = [];
+
+  if (hasMultipleArrangers) warnings.push(arrangerConflictNote);
+  if (warnings.length > 0) warnings.push(arrangementCheckNote);
+
+  return warnings;
 }
 
 function preferredSuggestionTitle(firstTitle: string, secondTitle: string) {
@@ -324,7 +329,8 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
 
     const fullAssignment = findDistinctAssignment(requiredParts, group);
     const knownArrangers = knownArrangersForGroup(group);
-    const warnings = arrangementWarningsForGroup(group, knownArrangers);
+    const warnings = arrangementWarningsForGroup(knownArrangers);
+    const missingArrangerInfo = hasMissingArrangerInfo(group);
 
     if (fullAssignment) {
       const confidence = confidenceWarning(fullAssignment);
@@ -334,6 +340,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         songTitle,
         voicing,
         arrangerNames: knownArrangers,
+        hasMissingArrangerInfo: missingArrangerInfo,
         category: "ready",
         missingParts: [],
         assignments: buildAssignments(fullAssignment),
@@ -373,6 +380,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         songTitle,
         voicing,
         arrangerNames: knownArrangers,
+        hasMissingArrangerInfo: missingArrangerInfo,
         category: "one_part_missing",
         missingParts: [bestNearMatch.missingPart],
         assignments: buildAssignments(bestNearMatch.assignment),
@@ -424,8 +432,9 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
       const knownArrangers = knownArrangersForGroup(group);
       const warnings = [
         possibleSameSongNote(first.songTitle, second.songTitle),
-        ...arrangementWarningsForGroup(group, knownArrangers),
+        ...arrangementWarningsForGroup(knownArrangers),
       ];
+      const missingArrangerInfo = hasMissingArrangerInfo(group);
       const confidence = confidenceWarning(fullAssignment);
       if (confidence) warnings.push(confidence);
 
@@ -433,6 +442,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         songTitle: preferredSuggestionTitle(first.songTitle, second.songTitle),
         voicing: first.voicing,
         arrangerNames: knownArrangers,
+        hasMissingArrangerInfo: missingArrangerInfo,
         category: "possible",
         missingParts: [],
         assignments: buildAssignments(fullAssignment),


### PR DESCRIPTION
## Summary

Fixes #224.

- Distinguishes blank arranger data from a literal entered value like `Unknown`.
- Shows blank arranger values as `No arranger entered` in repertoire rows, song suggestions, and match details.
- Keeps literal `Unknown` visible as an entered arranger value.
- Updates matching so missing arranger info is displayed as neutral information, not as an arrangement warning/problem.
- Keeps actual different explicit arranger names as a confirmation warning.
- Updates docs for the blank-vs-entered arranger contract.

## Tests

- `npm run test:run`
- `npm run build`

## Notes

No Supabase migration is required. This preserves the existing data model: blank arranger remains `null`/blank, while user-entered text is preserved after normal trimming.