### PR TITLE
Improve arranger suggestions, matching, and privacy navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
 - TTBB parts: Tenor, Lead, Baritone, Bass.
 - SATB parts: Soprano, Alto, Tenor, Bass.
 - SSAA parts: Soprano 1, Soprano 2, Alto 1, Alto 2.
-- Same title + same voicing can be grouped, but different arrangers or missing arrangers should be flagged as possible matches, not ignored.
+- Same title + same voicing can be grouped. Different explicit arranger names
+  should be flagged for confirmation, while missing arranger information should
+  be shown as context rather than treated as a problem.
 - Do not combine different voicings.
 - Repertoire is cloud-backed in Supabase.
 - Sessions store participant repertoire snapshots; repertoire add/edit/delete
@@ -31,7 +33,8 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
 - A singer may know multiple parts to the same arrangement, but a single valid quartet assignment cannot use one singer for more than one part.
 - Barbershop songs may exist in multiple arrangements. Title alone is not always enough.
 - Arranger is optional because singers often do not know it, but when arrangers differ, the app should warn users rather than silently treat the arrangements as identical.
-- Missing arranger should not block matching; it should create a “possible match / confirm arrangement” warning.
+- Missing arranger should not block matching and should be shown as missing
+  information, not as an arrangement problem.
 - The app should be forgiving of imperfect data and help singers decide quickly, not enforce a perfect catalog.
 
 ## Part abbreviations (UI standard)

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,15 +1,12 @@
+import { AppNav } from "@/components/AppNav";
+
 export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-3xl">
-        <a
-          href="/"
-          className="text-sm font-semibold text-cyan-300 hover:text-cyan-200"
-        >
-          What Can We Sing
-        </a>
+        <AppNav />
 
-        <h1 className="mt-4 text-4xl font-bold tracking-tight">Privacy</h1>
+        <h1 className="mt-8 text-4xl font-bold tracking-tight">Privacy</h1>
         <p className="mt-3 text-lg text-slate-300">
           What Can We Sing is built to help singers compare repertoire in the
           room. This page explains what information the app uses, what other

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -52,6 +52,7 @@ export function MatchCard({
     match.warnings.length > 0 ||
     match.arrangerNames.length > 0 ||
     match.hasMissingArrangerInfo ||
+    Boolean(match.arrangerVariantNote) ||
     personalNotes.length > 0 ||
     isRecentlySung;
 
@@ -140,6 +141,12 @@ export function MatchCard({
             {[...match.arrangerNames, match.hasMissingArrangerInfo ? noArrangerEnteredLabel : null]
               .filter((name): name is string => Boolean(name))
               .join(", ")}
+          </p>
+        )}
+
+        {match.arrangerVariantNote && (
+          <p className="mt-2 text-sm text-slate-300">
+            {match.arrangerVariantNote}
           </p>
         )}
 

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -24,7 +24,10 @@ import {
   updateRepertoireItem,
   type RepertoireRow,
 } from "@/lib/repertoireStore";
-import type { SongSuggestion } from "@/lib/songSuggestions";
+import {
+  songSuggestionSubtitle,
+  type SongSuggestion,
+} from "@/lib/songSuggestions";
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
 import { arrangerDisplayName } from "@/lib/arrangerDisplay";
@@ -1096,9 +1099,7 @@ export default function RepertoireManager() {
                               {suggestion.songTitle}
                             </span>
                             <span className="mt-1 block text-xs text-slate-300">
-                              {suggestion.voicing}
-                              {" · "}
-                              {arrangerDisplayName(suggestion.arrangerName)}
+                              {songSuggestionSubtitle(suggestion)}
                             </span>
                           </button>
                         ))}

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -70,9 +70,11 @@ voicing. Title matching is forgiving enough to catch close variants, but
 different voicings are not combined.
 
 Arranger differences or missing arranger values do not block a match. They are
-shown so singers can decide quickly in the room. Different entered arranger
-names are treated as a confirmation warning. A blank arranger simply means no
-arranger was entered; it is shown as missing information, not as a problem. A
+shown so singers can decide quickly in the room. Clearly different entered
+arranger names are treated as a confirmation warning. Likely variants such as
+full name, first initial plus last name, and last name only are shown as similar
+arranger names to confirm, not as hard conflicts. A blank arranger simply means
+no arranger was entered; it is shown as missing information, not as a problem. A
 literal value such as `Unknown` is treated as an entered arranger name and
 should not be collapsed with blank data.
 

--- a/lib/__tests__/arrangerDisplay.test.ts
+++ b/lib/__tests__/arrangerDisplay.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { arrangerDisplayName, hasArrangerEntered } from "../arrangerDisplay";
+import {
+  areLikelySameArranger,
+  arrangerDisplayName,
+  hasArrangerEntered,
+  normalizeArrangerName,
+} from "../arrangerDisplay";
 
 describe("arranger display helpers", () => {
   it("labels blank arranger values as not entered", () => {
@@ -18,5 +23,24 @@ describe("arranger display helpers", () => {
   it("trims entered arranger names for display", () => {
     expect(arrangerDisplayName("  Joe Arranger  ")).toBe("Joe Arranger");
     expect(hasArrangerEntered("  Joe Arranger  ")).toBe(true);
+  });
+
+  it("normalizes capitalization, punctuation, and spacing", () => {
+    expect(normalizeArrangerName("  C.   Outerbridge ")).toBe("c outerbridge");
+  });
+
+  it("recognizes cautious likely arranger variants", () => {
+    expect(areLikelySameArranger("Cay Outerbridge", "C. Outerbridge")).toBe(
+      true
+    );
+    expect(areLikelySameArranger("Cay Outerbridge", "Outerbridge")).toBe(true);
+    expect(areLikelySameArranger("Outerbridge", "C. Outerbridge")).toBe(true);
+  });
+
+  it("does not collapse clearly different arranger names", () => {
+    expect(areLikelySameArranger("Cay Outerbridge", "David Wright")).toBe(
+      false
+    );
+    expect(areLikelySameArranger("David Wright", "Doug Wright")).toBe(false);
   });
 });

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   arrangementCheckNote,
   arrangerConflictNote,
+  arrangerVariantNote,
   findMatches,
   normalizeConfidence,
   possibleSameSongNote,
@@ -94,6 +95,29 @@ describe("findMatches", () => {
     expect(matches[0].arrangerNames).toEqual(["Arranger One", "Arranger Two"]);
     expect(matches[0].warnings).toContain(arrangerConflictNote);
     expect(matches[0].warnings).toContain(arrangementCheckNote);
+  });
+
+  it("surfaces likely arranger name variants without a conflict warning", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "A", songTitle: "Variant Song", voicing: "TTBB", arrangerName: "Cay Outerbridge", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "B", songTitle: "Variant Song", voicing: "TTBB", arrangerName: "C. Outerbridge", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "C", songTitle: "Variant Song", voicing: "TTBB", arrangerName: "Outerbridge", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "D", songTitle: "Variant Song", voicing: "TTBB", arrangerName: "Cay Outerbridge", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches[0].category).toBe("ready");
+    expect(matches[0].arrangerNames).toEqual([
+      "Cay Outerbridge",
+      "C. Outerbridge",
+      "Outerbridge",
+    ]);
+    expect(matches[0].arrangerVariantNote).toBe(
+      arrangerVariantNote(matches[0].arrangerNames)
+    );
+    expect(matches[0].warnings).not.toContain(arrangerConflictNote);
+    expect(matches[0].warnings).not.toContain(arrangementCheckNote);
   });
 
   it("keeps a complete match ready when some arrangers are missing", () => {

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -8,6 +8,11 @@ const privacyPage = readFileSync(
 );
 
 describe("privacy page copy", () => {
+  it("uses the shared app navigation", () => {
+    expect(privacyPage).toContain('import { AppNav }');
+    expect(privacyPage).toContain("<AppNav />");
+  });
+
   it("discloses account, repertoire, quartet, feedback, analytics, and providers", () => {
     expect(privacyPage).toContain("email address");
     expect(privacyPage).toContain("We do not show your email address");

--- a/lib/__tests__/songSuggestions.test.ts
+++ b/lib/__tests__/songSuggestions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getSongSuggestions } from "../songSuggestions";
+import {
+  getSongSuggestions,
+  songSuggestionSubtitle,
+} from "../songSuggestions";
 
 describe("getSongSuggestions", () => {
   const rows = [
@@ -70,7 +73,9 @@ describe("getSongSuggestions", () => {
   });
 
   it("keeps blank arranger distinct from literal Unknown and entered names", () => {
-    expect(getSongSuggestions(rows, "heart")).toEqual([
+    const suggestions = getSongSuggestions(rows, "heart");
+
+    expect(suggestions).toEqual([
       {
         songTitle: "Heart of My Heart",
         voicing: "TTBB",
@@ -86,6 +91,11 @@ describe("getSongSuggestions", () => {
         voicing: "TTBB",
         arrangerName: "Unknown",
       },
+    ]);
+    expect(suggestions.map(songSuggestionSubtitle)).toEqual([
+      "TTBB · No arranger entered",
+      "TTBB · Joe Arranger",
+      "TTBB · Unknown",
     ]);
   });
 });

--- a/lib/arrangerDisplay.ts
+++ b/lib/arrangerDisplay.ts
@@ -8,3 +8,72 @@ export function arrangerDisplayName(arrangerName?: string | null) {
 export function hasArrangerEntered(arrangerName?: string | null) {
   return Boolean(arrangerName?.trim());
 }
+
+export function normalizeArrangerName(arrangerName: string) {
+  return arrangerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+type ArrangerNameParts = {
+  first: string | null;
+  last: string;
+};
+
+function arrangerNameParts(arrangerName: string): ArrangerNameParts | null {
+  const normalized = normalizeArrangerName(arrangerName);
+  if (!normalized) return null;
+
+  const parts = normalized.split(" ").filter(Boolean);
+  const last = parts.at(-1);
+  if (!last) return null;
+
+  return {
+    first: parts.length > 1 ? parts[0] : null,
+    last,
+  };
+}
+
+function firstNamesAreCompatible(first: string | null, second: string | null) {
+  if (!first || !second) return true;
+  if (first === second) return true;
+
+  return first[0] === second[0] && (first.length === 1 || second.length === 1);
+}
+
+export function areLikelySameArranger(
+  firstArrangerName: string,
+  secondArrangerName: string
+) {
+  const first = arrangerNameParts(firstArrangerName);
+  const second = arrangerNameParts(secondArrangerName);
+
+  if (!first || !second) return false;
+  if (
+    normalizeArrangerName(firstArrangerName) ===
+    normalizeArrangerName(secondArrangerName)
+  ) {
+    return true;
+  }
+
+  return (
+    first.last === second.last &&
+    firstNamesAreCompatible(first.first, second.first)
+  );
+}
+
+export function areLikelySameArrangerGroup(arrangerNames: string[]) {
+  if (arrangerNames.length <= 1) return true;
+
+  for (let i = 0; i < arrangerNames.length; i += 1) {
+    for (let j = i + 1; j < arrangerNames.length; j += 1) {
+      if (!areLikelySameArranger(arrangerNames[i], arrangerNames[j])) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -49,7 +49,8 @@ export const helpSections: HelpSection[] = [
   {
     title: "Possible Matches",
     body: [
-      "Sometimes the app may show a possible match instead of a clean match. This can happen when song titles are slightly different, arranger information is missing, or the same song may exist in more than one arrangement.",
+      "Sometimes the app may show a possible match instead of a clean match. This can happen when song titles are slightly different or the same song may exist in more than one arrangement.",
+      "Missing arranger information is shown as context, not as a problem. Similar arranger names such as a full name, first initial, or last name only may be shown so the quartet can quickly confirm they refer to the same arranger.",
       "Use the match details to compare what each singer has entered. If the titles or arrangement details do not match, check with the quartet before singing.",
     ],
   },

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -1,4 +1,5 @@
 import { isLikelySameSongTitle } from "./fuzzySongTitles";
+import { areLikelySameArrangerGroup } from "./arrangerDisplay";
 
 export type Voicing = "TTBB" | "SATB" | "SSAA";
 
@@ -43,6 +44,7 @@ export type MatchResult = {
   voicing: Voicing;
   arrangerNames: string[];
   hasMissingArrangerInfo: boolean;
+  arrangerVariantNote?: string;
   category: "ready" | "possible" | "one_part_missing";
   missingParts: Part[];
   assignments: Partial<Record<Part, SingerEntry[]>>;
@@ -72,6 +74,9 @@ export const arrangementCheckNote =
   "Consider double-checking that everyone is singing the same arrangement.";
 export const arrangerConflictNote =
   "Different arranger names were entered for this song.";
+export function arrangerVariantNote(arrangerNames: string[]) {
+  return `Arranger names look similar: ${arrangerNames.join(", ")}. Confirm with the quartet.`;
+}
 
 export function possibleSameSongNote(firstTitle: string, secondTitle: string) {
   return `Possible same song: Is "${firstTitle}" the same as "${secondTitle}"?`;
@@ -259,12 +264,21 @@ function hasMissingArrangerInfo(group: SingerEntry[]) {
   return group.some((e) => !e.arrangerName?.trim());
 }
 
+function arrangerVariantNoteForGroup(knownArrangers: string[]) {
+  if (knownArrangers.length <= 1) return undefined;
+  if (!areLikelySameArrangerGroup(knownArrangers)) return undefined;
+
+  return arrangerVariantNote(knownArrangers);
+}
+
 function arrangementWarningsForGroup(knownArrangers: string[]) {
   const hasMultipleArrangers = knownArrangers.length > 1;
+  const hasConflictingArrangers =
+    hasMultipleArrangers && !areLikelySameArrangerGroup(knownArrangers);
 
   const warnings = [];
 
-  if (hasMultipleArrangers) warnings.push(arrangerConflictNote);
+  if (hasConflictingArrangers) warnings.push(arrangerConflictNote);
   if (warnings.length > 0) warnings.push(arrangementCheckNote);
 
   return warnings;
@@ -331,6 +345,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     const knownArrangers = knownArrangersForGroup(group);
     const warnings = arrangementWarningsForGroup(knownArrangers);
     const missingArrangerInfo = hasMissingArrangerInfo(group);
+    const arrangerVariant = arrangerVariantNoteForGroup(knownArrangers);
 
     if (fullAssignment) {
       const confidence = confidenceWarning(fullAssignment);
@@ -341,6 +356,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         voicing,
         arrangerNames: knownArrangers,
         hasMissingArrangerInfo: missingArrangerInfo,
+        arrangerVariantNote: arrangerVariant,
         category: "ready",
         missingParts: [],
         assignments: buildAssignments(fullAssignment),
@@ -381,6 +397,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         voicing,
         arrangerNames: knownArrangers,
         hasMissingArrangerInfo: missingArrangerInfo,
+        arrangerVariantNote: arrangerVariant,
         category: "one_part_missing",
         missingParts: [bestNearMatch.missingPart],
         assignments: buildAssignments(bestNearMatch.assignment),
@@ -435,6 +452,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         ...arrangementWarningsForGroup(knownArrangers),
       ];
       const missingArrangerInfo = hasMissingArrangerInfo(group);
+      const arrangerVariant = arrangerVariantNoteForGroup(knownArrangers);
       const confidence = confidenceWarning(fullAssignment);
       if (confidence) warnings.push(confidence);
 
@@ -443,6 +461,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         voicing: first.voicing,
         arrangerNames: knownArrangers,
         hasMissingArrangerInfo: missingArrangerInfo,
+        arrangerVariantNote: arrangerVariant,
         category: "possible",
         missingParts: [],
         assignments: buildAssignments(fullAssignment),

--- a/lib/songSuggestions.ts
+++ b/lib/songSuggestions.ts
@@ -1,4 +1,5 @@
 import type { Voicing } from "@/lib/matching";
+import { arrangerDisplayName } from "./arrangerDisplay";
 
 export type SongSuggestionSource = {
   song_title: string;
@@ -11,6 +12,14 @@ export type SongSuggestion = {
   voicing: Voicing;
   arrangerName: string;
 };
+
+export function songSuggestionArrangerLabel(suggestion: SongSuggestion) {
+  return arrangerDisplayName(suggestion.arrangerName);
+}
+
+export function songSuggestionSubtitle(suggestion: SongSuggestion) {
+  return `${suggestion.voicing} · ${songSuggestionArrangerLabel(suggestion)}`;
+}
 
 const validVoicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
 


### PR DESCRIPTION
Closes #225
Closes #227
Closes #228

## Summary

- Improved add-song suggestion display by sharing a suggestion subtitle helper that preserves the blank arranger vs literal `Unknown` distinction.
- Added cautious arranger normalization/matching for likely variants such as `Cay Outerbridge`, `C. Outerbridge`, and `Outerbridge`.
- Shows likely arranger variants as a neutral match detail instead of a hard arranger conflict.
- Keeps clearly different explicit arranger names as a confirmation warning.
- Keeps missing arranger information as neutral context, not a problem.
- Added the shared app navigation to the privacy page.
- Updated AGENTS/docs/help copy so future work keeps missing arranger info neutral.

## Overlap / Dependencies

These issues intentionally build on #224. #225 and #227 both use the shared arranger display/normalization helper, while #228 is isolated to privacy page chrome. No Supabase schema or migration changes are needed.

## Tests

- `npm run test:run`
- `npm run build`

## Docs / Tests Notes

Docs were updated for arranger matching semantics because behavior changed. Tests were added/updated for suggestion subtitles, arranger normalization, likely arranger variants, privacy nav, and match warnings/details.