### PR TITLE
Add song suggestion catalog autocomplete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ POSTHOG_PERSONAL_API_KEY=
 POSTHOG_HOST=https://us.posthog.com
 POSTHOG_ENVIRONMENT_ID=
 
+# Optional local catalog import. Server-side only; never expose in browser code.
+SUPABASE_SERVICE_ROLE_KEY=
+
 # Server-only feedback email settings. Do not prefix these with NEXT_PUBLIC_.
 RESEND_API_KEY=
 FEEDBACK_FROM_EMAIL=

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ NEXT_PUBLIC_POSTHOG_HOST=your PostHog host URL
 RESEND_API_KEY=your Resend API key for server-side feedback email
 FEEDBACK_FROM_EMAIL=What Can We Sing <feedback@your-verified-domain>
 FEEDBACK_TO_EMAIL=feedback destination address
+SUPABASE_SERVICE_ROLE_KEY=only for local/server catalog import scripts
 ```
 
 `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` enable optional product analytics. Leave them blank to disable analytics in local development. Analytics events use counts, IDs, and booleans only; free-text repertoire notes, feedback text, song titles, arranger names, names, and email addresses should not be sent to PostHog.
@@ -80,6 +81,9 @@ The Supabase project should have the current production schema applied:
   recent-use indicators. Marking a song as sung is performed through the
   `mark_repertoire_sung` database function so repertoire metadata and the event
   log stay in sync.
+- `song_suggestion_catalog` stores optional reference suggestions imported from
+  `data/song_suggestion_catalog.psv`. It is used only for autocomplete; catalog
+  rows are not added to anyone's repertoire unless a user chooses to save one.
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes
@@ -97,6 +101,16 @@ supabase db push
 
 If the project is not linked locally, run `supabase link --project-ref <project-ref>`
 first, then `supabase db push`.
+
+To refresh the optional song suggestion catalog after migrations are applied,
+run the import script with a server-side Supabase service role key:
+
+```bash
+SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
+```
+
+Use `npm run song-suggestions:import -- --dry-run` to parse and deduplicate the
+catalog file without writing to Supabase.
 
 ## Analytics
 

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -77,6 +77,7 @@ export default function RepertoireManager() {
   const [songTitle, setSongTitle] = useState("");
   const [songSuggestions, setSongSuggestions] = useState<SongSuggestion[]>([]);
   const [songSuggestionsOpen, setSongSuggestionsOpen] = useState(false);
+  const [songSuggestionsLoading, setSongSuggestionsLoading] = useState(false);
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
   const [notes, setNotes] = useState("");
@@ -193,12 +194,14 @@ export default function RepertoireManager() {
   useEffect(() => {
     if (!isAddOpen || !songSuggestionsOpen || songTitle.trim().length < 2) {
       setSongSuggestions([]);
+      setSongSuggestionsLoading(false);
       return;
     }
 
     let cancelled = false;
     const timeout = window.setTimeout(async () => {
       try {
+        setSongSuggestionsLoading(true);
         const suggestions = await searchRepertoireSongSuggestions(songTitle);
         if (!cancelled) {
           setSongSuggestions(suggestions);
@@ -208,8 +211,12 @@ export default function RepertoireManager() {
         if (!cancelled) {
           setSongSuggestions([]);
         }
+      } finally {
+        if (!cancelled) {
+          setSongSuggestionsLoading(false);
+        }
       }
-    }, 150);
+    }, 250);
 
     return () => {
       cancelled = true;
@@ -220,6 +227,7 @@ export default function RepertoireManager() {
   function resetAddForm() {
     setSongTitle("");
     setSongSuggestions([]);
+    setSongSuggestionsLoading(false);
     setSongSuggestionsOpen(false);
     setVoicing("");
     setArrangerName("");
@@ -1082,34 +1090,53 @@ export default function RepertoireManager() {
                     autoComplete="off"
                     className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                   />
-                  {songSuggestionsOpen && songSuggestions.length > 0 && (
+                  <p className="mt-1 text-xs text-slate-400">
+                    Start typing to see suggestions, or enter your own song
+                    title.
+                  </p>
+                  {songSuggestionsOpen && songTitle.trim().length >= 2 && (
                     <div className="mt-2 overflow-hidden rounded-xl border border-cyan-300/20 bg-slate-900">
                       <p className="px-3 py-2 text-xs font-semibold uppercase tracking-normal text-slate-400">
-                        Existing songs
+                        Song suggestions
                       </p>
-                      <div className="divide-y divide-white/10">
-                        {songSuggestions.map((suggestion) => (
-                          <button
-                            key={`${suggestion.songTitle}:${suggestion.voicing}:${suggestion.arrangerName}`}
-                            type="button"
-                            onClick={() => selectSongSuggestion(suggestion)}
-                            className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
-                          >
-                            <span className="block font-semibold text-white">
-                              {suggestion.songTitle}
-                            </span>
-                            <span className="mt-1 block text-xs text-slate-300">
-                              {songSuggestionSubtitle(suggestion)}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
+                      {songSuggestionsLoading ? (
+                        <p className="px-3 py-3 text-sm text-slate-300">
+                          Searching suggestions...
+                        </p>
+                      ) : songSuggestions.length > 0 ? (
+                        <div className="divide-y divide-white/10">
+                          {songSuggestions.map((suggestion) => (
+                            <button
+                              key={`${suggestion.songTitle}:${suggestion.voicing}:${suggestion.arrangerName}`}
+                              type="button"
+                              onClick={() => selectSongSuggestion(suggestion)}
+                              className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
+                            >
+                              <span className="block font-semibold text-white">
+                                {suggestion.songTitle}
+                              </span>
+                              <span className="mt-1 block text-xs text-slate-300">
+                                {songSuggestionSubtitle(suggestion)}
+                              </span>
+                            </button>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="px-3 py-3 text-sm text-slate-300">
+                          No suggestion found. You can still add this song
+                          manually.
+                        </p>
+                      )}
                     </div>
                   )}
                 </label>
 
                 <div>
                   <p className="text-sm font-medium text-slate-300">Voicing</p>
+                  <p className="mt-1 text-xs text-slate-400">
+                    Suggestions are optional. You can always type your own title
+                    and choose the correct voicing.
+                  </p>
                   <div className="mt-2 grid grid-cols-3 gap-2">
                     {voicings.map((v) => (
                       <button

--- a/data/song_suggestion_catalog.psv
+++ b/data/song_suggestion_catalog.psv
@@ -1,0 +1,18368 @@
+Song Title|Voicing|Arranger
+Advance Australia Fair|TTBB|Linc Abbott
+Waltzing Matilda|TTBB|Linc Abbott
+Summer Sounds|TTBB|E. Douglas Adams
+And So It Goes|TTBB|Hilary Allen
+The Closest Thing To Crazy|TTBB|Hilary Allen
+Count On Me|TTBB|Hilary Allen
+Days|TTBB|Hilary Allen
+Edelweiss|TTBB|Hilary Allen
+The End of the World|TTBB|Hilary Allen
+Happy Working Song|SSAA|Hilary Allen
+I Saw Mommy Kissing Santa Claus|SSAA|Hilary Allen
+I Wish It Could Be Christmas Every Day|TTBB|Hilary Allen
+It Doesn't Matter Anymore|TTBB|Hilary Allen
+It's A Beautiful Day|TTBB|Hilary Allen
+Leaving on a Jet Plane|TTBB|Hilary Allen
+Make You Feel My Love|TTBB|Hilary Allen
+Megan's Fair Daughter|SSAA|Hilary Allen
+My Love Is Like a Red, Red Rose|SSAA|Hilary Allen
+Nine Million Bicycles|TTBB|Hilary Allen
+Scarborough Fair|SSAA|Hilary Allen
+Something Inside So Strong|TTBB|Hilary Allen
+Song Sung Blue|TTBB|Hilary Allen
+Stay Awake|SSAA|Hilary Allen
+Sunny Afternoon|TTBB|Hilary Allen
+Try Everything|TTBB|Hilary Allen
+A Winter's Tale|SSAA|Hilary Allen
+Angels We Have Heard On High|SSAA|Sylvia Alsbury
+Bare Necessities|SSAA|Sylvia Alsbury
+Believe It Or Not (Theme from 'The Greatest American Hero')|SSAA|Sylvia Alsbury
+Climb Ev'ry Mountain|SSAA|Sylvia Alsbury
+Colorado, My Home|SSAA|Sylvia Alsbury
+Crazy|SSAA|Sylvia Alsbury
+Do You Know What It Means To Miss New Orleans|SSAA|Sylvia Alsbury
+A Foggy Day|SSAA|Sylvia Alsbury
+How Could You Believe Me|SSAA|Sylvia Alsbury
+I Double Dare You|SSAA|Sylvia Alsbury
+I Love How You Love Me|SSAA|Sylvia Alsbury
+I'll Be Seeing You|SSAA|Sylvia Alsbury
+Let The River Run|SSAA|Sylvia Alsbury
+Let There Be Peace On Earth|SSAA|Sylvia Alsbury
+Lonely People Do Foolish Things|SSAA|Sylvia Alsbury
+The Lord's Prayer|SSAA|Sylvia Alsbury
+Mean To Me|SSAA|Sylvia Alsbury
+Money, Money|SSAA|Sylvia Alsbury
+On My Own|SSAA|Sylvia Alsbury
+Pigtails & Freckles|SSAA|Sylvia Alsbury
+Scotch And Soda|SSAA|Sylvia Alsbury
+Sing And Celebrate!|SSAA|Sylvia Alsbury
+Sleepy Time Gal|SSAA|Sylvia Alsbury
+Steppin' Out With My Baby|SSAA|Sylvia Alsbury
+Til The Season Comes Round Again|SSAA|Sylvia Alsbury
+Too Young|SSAA|Sylvia Alsbury
+What I Did For Love|SSAA|Sylvia Alsbury
+With Bells On|SSAA|Sylvia Alsbury
+When You Wish Upon A Star|TTBB|Jay Althof
+After Tonight|TTBB|Norma Andersen
+Anniversary Song|SSAA|Norma Andersen
+Bidin' My Time|SSAA|Norma Andersen
+Can't Get Over You|TTBB|Norma Andersen
+Caroling, Caroling|SSAA|Norma Andersen
+Dream A Little Dream Of Me|SSAA|Norma Andersen
+Give Me Your Tired, Your Poor|SSAA|Norma Andersen
+Grampa Loves Rock And Roll|TTBB|Norma Andersen
+It's Been A Long, Long Time|TTBB|Norma Andersen
+It's You, All Over Me|TTBB|Norma Andersen
+Kiss It (And Make It Well)|TTBB|Norma Andersen
+Kiss Me One More Time|TTBB|Norma Andersen
+Lavender and Lace|TTBB|Norma Andersen
+Let It Be|SSAA|Norma Andersen
+Let's Go To Vegas|SSAA|Norma Andersen
+Love Is Tomorrow|TTBB|Norma Andersen
+Love Me Tender|SSAA|Norma Andersen
+Lullaby Of The Leaves|SSAA|Norma Andersen
+My Boyfriend|TTBB|Norma Andersen
+My Buddy|SSAA|Norma Andersen
+My Star Is Rising Tonight|TTBB|Norma Andersen
+O Canada!|SSAA|Norma Andersen
+Play That Barbershop Chord|SSAA|Norma Andersen
+Pulling Me Down To Your Grave|TTBB|Norma Andersen
+Put On An Old Pair Of Shoes|SSAA|Norma Andersen
+Rock Around The Clock|SSAA|Norma Andersen
+Second Hand Rose|SSAA|Norma Andersen
+Sleigh Ride|SSAA|Norma Andersen
+That's My Weakness Now|SSAA|Norma Andersen
+Time After Time|SSAA|Norma Andersen
+Too Many Nights (Without You)|TTBB|Norma Andersen
+You Can't Go Out With Each Tom, Dick, And Harry|TTBB|Norma Andersen
+You Think (That You Love Me)|TTBB|Norma Andersen
+You're Here|TTBB|Norma Andersen
+You're Never Here Any More|TTBB|Norma Andersen
+Earth Angel|TTBB|Scott Anderson
+The Heather On The Hill|TTBB|Scott Anderson
+Pirates Who Don't Do Anything|TTBB|Scott Anderson
+Under The Mistletoe|SATB|Scott Anderson
+Do You Hear What I Hear|SSAA|Kim Andrews
+It's Your Song|SSAA|Kim Andrews
+Love Will Be Our Home|SSAA|Kim Andrews
+Who Would Imagine A King|SSAA|Kim Andrews
+Christmas Medley|TTBB|Bud Arberg
+Dream|TTBB|Bud Arberg
+A Garden In The Rain|TTBB|Bud Arberg
+Gay Nineties Medley|TTBB|Bud Arberg
+Oh By Jingo!|TTBB|Bud Arberg
+Alexander's Ragtime Band|TTBB|Steven Armstrong
+Angels Among Us|TTBB|Steven Armstrong
+Bad Day|TTBB|Steven Armstrong
+Bohemian Rhapsody|TTBB|Steven Armstrong
+Brother, Can You Spare A Dime?|TTBB|Steven Armstrong
+Embraceable You|TTBB|Steven Armstrong
+The End of the World|TTBB|Steven Armstrong
+God Defend New Zealand|TTBB|Steven Armstrong
+Good Enough for Now|TTBB|Steven Armstrong
+Grown-Up Christmas List|TTBB|Steven Armstrong
+I Can See Clearly Now|TTBB|Steven Armstrong
+I'll Get By (As Long As I Have You)|TTBB|Steven Armstrong
+If I Can Dream|TTBB, SATB|Steven Armstrong
+The Impossible Dream|TTBB|Steven Armstrong
+In My Life|TTBB|Steven Armstrong
+It Could Happen To You|TTBB|Steven Armstrong
+It Had To Be You|TTBB|Steven Armstrong
+Man! I Feel Like A Woman|TTBB|Steven Armstrong
+Maybe It's My Turn Now|TTBB|Steven Armstrong
+Medley: 1999, Purple Rain, Let's Go Crazy|TTBB|Steven Armstrong
+Naturally|TTBB|Steven Armstrong
+Nobody Knows You When You're Down And Out|TTBB|Steven Armstrong
+Over The Rainbow|TTBB|Steven Armstrong
+Polka Dots And Moonbeams|TTBB|Steven Armstrong
+The Prayer|TTBB|Steven Armstrong
+Sometimes When We Touch|TTBB|Steven Armstrong
+The Party's Over|TTBB|Steven Armstrong
+This Is The Moment|TTBB|Steven Armstrong
+Weekend In New England|TTBB|Steven Armstrong
+Welcome To The Rock|TTBB|Steven Armstrong
+Who'll Dry Your Tears When You Cry?|TTBB|Steven Armstrong
+With You|TTBB|Steven Armstrong
+Beautiful Lady In Blue|TTBB|Chris Arnold
+Big Yellow Taxi|SSAA|Chris Arnold
+Can't Smile Without You|TTBB, SSAA|Chris Arnold
+Candles Long Ago|TTBB, SSAA|Chris Arnold
+Christmas Of Love|SATB|Chris Arnold
+The Christmas Song|SATB|Chris Arnold
+Count On Me|SATB|Chris Arnold
+Daddy Sang Bass|TTBB|Chris Arnold
+Enterprise Theme (where My Heart Will Take Me)|TTBB|Chris Arnold
+Happy Together|TTBB|Chris Arnold
+Have Yourself A Merry Little Christmas|SATB|Chris Arnold
+Here Goes|TTBB|Chris Arnold
+The Hockey Song|SSAA|Chris Arnold
+I Don't Know Enough About You|TTBB, SSAA|Chris Arnold
+Imagine|TTBB, SSAA|Chris Arnold
+It's A Good Day|TTBB, SSAA|Chris Arnold
+Kiss To Build A Dream On|SSAA|Chris Arnold
+L-O-V-E|TTBB|Chris Arnold
+Luck Be A Lady|TTBB|Chris Arnold
+My Heart Will Go On|SSAA|Chris Arnold
+Once Upon A December|TTBB, SSAA|Chris Arnold
+One Fine Day|TTBB|Chris Arnold
+The Shadow Of Your Smile|TTBB|Chris Arnold
+She's Out Of My Life|TTBB|Chris Arnold
+Someone Like You|SATB|Chris Arnold
+Soon And Very Soon|TTBB|Chris Arnold
+Stand By Me|SSAA|Chris Arnold
+That's A Plenty|TTBB|Chris Arnold
+Those Were The Days|TTBB|Chris Arnold
+Top Hat, White Tie And Tails|TTBB|Chris Arnold
+True Colors|SSAA|Chris Arnold
+Until...|TTBB|Chris Arnold
+You Don't Bring Me Flowers|SSAA|Chris Arnold
+You're A Mean One, Mr. Grinch|SATB|Chris Arnold
+A Million Dreams|TTBB|Simon Arnott
+All Is Found|SSAA, SATB|Simon Arnott
+Almost There|TTBB|Simon Arnott
+Alone|TTBB|Simon Arnott
+Another Day of Sun|TTBB|Simon Arnott
+As Long as He Needs Me|SSAA|Simon Arnott
+Bad Romance|TTBB|Simon Arnott
+Bein' Green|TTBB|Simon Arnott
+Better Half Of Me|TTBB|Simon Arnott
+Bewitched|SSAA|Simon Arnott
+Bless The Telephone|SSAA|Simon Arnott
+Bound To You|SSAA|Simon Arnott
+The Brain|TTBB|Simon Arnott
+Bridge Over Troubled Water|TTBB|Simon Arnott
+But For Now|TTBB|Simon Arnott
+Can't Stop the Feeling!|TTBB|Simon Arnott
+Christmas (Baby Please Come Home)|SSAA|Simon Arnott
+Christmas Time (Don't Let The Bells End)|TTBB|Simon Arnott
+The Colors of My Life|TTBB|Simon Arnott
+Come Alive|TTBB|Simon Arnott
+Dancing Through Life|TTBB|Simon Arnott
+Deeper Shade Of Blue|SSAA|Simon Arnott
+Defying Gravity|SATB|Simon Arnott
+Don't Look Back In Anger|SSAA|Simon Arnott
+Downtown|SSAA|Simon Arnott
+Electricity|TTBB|Simon Arnott
+Evermore|TTBB, SSAA|Simon Arnott
+The Girl in 14G|SSAA|Simon Arnott
+Golden|SSAA|Simon Arnott
+Goldfinger|TTBB, SSAA|Simon Arnott
+Good Morning Baltimore|TTBB|Simon Arnott
+Goodbye Yellow Brick Road|TTBB|Simon Arnott
+The Great Escape|TTBB|Simon Arnott
+A Hand For Mrs. Claus|SSAA|Simon Arnott
+Heart And Soul|TTBB|Simon Arnott
+How Did We Come To This?|TTBB|Simon Arnott
+I Am Changing|SSAA|Simon Arnott
+I See The Light|SSAA|Simon Arnott
+Impossible Year|TTBB|Simon Arnott
+In A World Like This|TTBB|Simon Arnott
+Into the Unknown|TTBB|Simon Arnott
+Jason's Song (Gave It Away)|SSAA|Simon Arnott
+Journey To The Past|SSAA|Simon Arnott
+Just The Way You Are|TTBB|Simon Arnott
+Killer Queen|TTBB|Simon Arnott
+The Little Things|TTBB|Simon Arnott
+Look For The Light|SSAA|Simon Arnott
+Losing My Mind|TTBB|Simon Arnott
+Love Story|TTBB|Simon Arnott
+Love Yourself|SATB|Simon Arnott
+Mama Who Bore Me|SSAA|Simon Arnott
+Maybe This Time|SSAA|Simon Arnott
+Medley: Before And After You/one Second And A Million Miles with Always Better and It All Fades Away|TTBB|Simon Arnott
+A Million Miles Away|TTBB, SSAA|Simon Arnott
+Mission: Impossible Theme|TTBB|Simon Arnott
+Moving Too Fast|TTBB|Simon Arnott
+My Love My Life|SSAA|Simon Arnott
+My One And Only Love|TTBB|Simon Arnott
+My Way|TTBB|Simon Arnott
+New York State of Mind|SSAA|Simon Arnott
+Nice Work If You Can Get It|TTBB|Simon Arnott
+On My Way|SSAA|Simon Arnott
+Oops! I Did It Again|SSAA|Simon Arnott
+Perfect|TTBB, SATB|Simon Arnott
+Positoovity|TTBB|Simon Arnott
+Proud of Your Boy|TTBB|Simon Arnott
+Rather Be|SATB|Simon Arnott
+Royals|TTBB|Simon Arnott
+Sandcastles|SSAA|Simon Arnott
+September|TTBB|Simon Arnott
+The Shadow Of Your Smile|TTBB|Simon Arnott
+She Used To Be Mine|TTBB, SSAA|Simon Arnott
+Some Enchanted Evening|TTBB|Simon Arnott
+Someone In The Crowd|TTBB|Simon Arnott
+Someone Like You|TTBB|Simon Arnott
+Sweet Dreams (Are Made of These)|SSAA|Simon Arnott
+Symphony|SSAA|Simon Arnott
+Take A Look At Us Now|SSAA|Simon Arnott
+Take Me Or Leave Me|SSAA|Simon Arnott
+Taylor The Latte Boy|SSAA|Simon Arnott
+Telephone|SATB|Simon Arnott
+Ten Minutes Ago|TTBB, SATB|Simon Arnott
+This Christmas|SSAA|Simon Arnott
+This Is Me|SSAA|Simon Arnott
+This Is The Moment|TTBB|Simon Arnott
+A Thousand Years|TTBB|Simon Arnott
+To Where You Are|TTBB|Simon Arnott
+Together Again|TTBB|Simon Arnott
+Transylvania Mania|TTBB|Simon Arnott
+Treat People With Kindness|SSAA|Simon Arnott
+Trip A Little Light Fantastic|TTBB|Simon Arnott
+Underneath the Tree|SSAA|Simon Arnott
+Valentine|TTBB|Simon Arnott
+Wait A Bit|TTBB|Simon Arnott
+What Is This Feeling?|SSAA|Simon Arnott
+When We're Together|SSAA|Simon Arnott
+When Will My Life Begin|SSAA|Simon Arnott
+When You Believe|SSAA|Simon Arnott
+Who Can I Turn To? (When Nobody Needs Me)|TTBB|Simon Arnott
+Why Try to Change Me Now?|TTBB|Simon Arnott
+Wings|TTBB|Simon Arnott
+A Wink And A Smile|TTBB|Simon Arnott
+You Matter To Me|SSAA|Simon Arnott
+You Take My Breath Away|SSAA|Simon Arnott
+You Will Be Found|SATB|Simon Arnott
+You've Got A Friend In Me|TTBB|Simon Arnott
+All Purpose Carol|SSAA|Jim Arns
+Big Girls Don't Cry|SSAA|Jim Arns
+Birdland|SSAA|Jim Arns
+Can't Help Falling In Love|SSAA|Jim Arns
+Deep Purple|SSAA|Jim Arns
+Eight Candles|SSAA|Jim Arns
+Eight Street Association|SSAA|Jim Arns
+Eleanor Rigby|SSAA|Jim Arns
+Everybody Needs Somebody To Love|SSAA|Jim Arns
+Fever|SSAA|Jim Arns
+For Sentimental Reasons|SSAA|Jim Arns
+From The First Hello To The Last Goodbye|SSAA|Jim Arns
+Hanukkah Medley|SSAA|Jim Arns
+Hanukkah Medley|TTBB|Jim Arns
+Happy Feet|SSAA|Jim Arns
+Holding Out For A Hero|SSAA|Jim Arns
+How Many Hearts Have You Broken?|SSAA|Jim Arns
+I Remember You|SSAA|Jim Arns
+I Told Them All About You / You Dear|SSAA|Jim Arns
+I Wanna Talk About Me|SSAA|Jim Arns
+I'm Looking at the World Through Rose Colored Glasses / When You Wore a Tulip|SSAA|Jim Arns
+I've Grown Accustomed To Her Face|SSAA|Jim Arns
+In My Life|SSAA|Jim Arns
+In The Wee Small Hours Of The Morning|SSAA|Jim Arns
+Indiana Medley|SSAA|Jim Arns
+It's All Over Now / Who's Sorry Now Medley|TTBB|Jim Arns
+It's My Song|SSAA|Jim Arns
+It's Not Where You Start It's Where You Finish|SSAA|Jim Arns
+It's Not Where You Start It's Where You Finish|TTBB|Jim Arns
+It's Your Song|SSAA|Jim Arns
+Jeopardy Theme|SSAA|Jim Arns
+Let Me Call You Sweetheart|SSAA|Jim Arns
+Lulu's Back In Town|SSAA|Jim Arns
+Mighty Mouse|SSAA|Jim Arns
+Oh, How I Miss You Tonight|SSAA|Jim Arns
+Papa Oom Mow Mow|SSAA|Jim Arns
+Rocky Top|SSAA|Jim Arns
+Route 66|SSAA|Jim Arns
+Rudolph The Red Nosed Reindeer|SSAA|Jim Arns
+Sailing Down The Chesapeake Bay|SSAA|Jim Arns
+Saturday In The Park|SSAA|Jim Arns
+Seize The Day|SSAA|Jim Arns
+Shambala|SSAA|Jim Arns
+Smile Medley|SSAA|Jim Arns
+There's A Hero|SSAA|Jim Arns
+They Long To Be Close To You|SSAA|Jim Arns
+This Is The Moment|SSAA|Jim Arns
+Time After Time|SSAA|Jim Arns
+Underdog Theme|SSAA|Jim Arns
+The Very Thought Of You|SSAA|Jim Arns
+Wonderful Christmastime|SSAA|Jim Arns
+You Keep Coming Back Like A Song|SSAA|Jim Arns
+You Made Me Love You|SSAA|Jim Arns
+(It Must've Been Ol') Santa Claus|TTBB|Matt Astle
+Annie's Song|TTBB, SSAA, SATB|Matt Astle
+Another Day of Sun|TTBB|Matt Astle
+Audition (the Fools Who Dream)|TTBB, SSAA|Matt Astle
+Backwards|TTBB|Matt Astle
+Because|TTBB, SSAA, SATB|Matt Astle
+The Best Man|TTBB|Matt Astle
+Bring Me Sunshine|TTBB, SSAA|Matt Astle
+Comin' Home Baby|SATB|Matt Astle
+Copacabana|TTBB, SATB|Matt Astle
+Coventry Carol|TTBB|Matt Astle
+Drift Away|TTBB|Matt Astle
+Drive The Cold Winter Away|TTBB|Matt Astle
+Fields Of Gold|TTBB|Matt Astle
+The First Noel|TTBB|Matt Astle
+Forest Lawn|TTBB|Matt Astle
+Good Enough for Now|TTBB, SSAA, SATB|Matt Astle
+Good King Wenceslas|TTBB|Matt Astle
+Gravity|TTBB, SATB|Matt Astle
+Happy Ending|TTBB|Matt Astle
+Haven't Met You Yet|SATB|Matt Astle
+How Far I'll Go|SSAA|Matt Astle
+I Almost Do|TTBB|Matt Astle
+I Heard The Bells On Christmas Day|TTBB, SATB|Matt Astle
+I Love To See You Smile|TTBB|Matt Astle
+I'll Be Home For Christmas|TTBB|Matt Astle
+I'll Be There For You|TTBB|Matt Astle
+In Summer|TTBB|Matt Astle
+In This Life|TTBB|Matt Astle
+It Feels Like Christmas|TTBB|Matt Astle
+It Must've Been Ol' Santa Claus|TTBB|Matt Astle
+It's Time For Christmas|TTBB|Matt Astle
+Like I'm Gonna Lose You|TTBB|Matt Astle
+Ma Belle Evangeline|TTBB|Matt Astle
+No One|TTBB|Matt Astle
+Only Us|TTBB|Matt Astle
+Our Town|TTBB, SSAA|Matt Astle
+Overkill|TTBB|Matt Astle
+Perfect|TTBB, SSAA|Matt Astle
+Run, Freedom Run!|TTBB|Matt Astle
+Screen Door|TTBB|Matt Astle
+Seattle|TTBB|Matt Astle
+Someday|TTBB|Matt Astle
+Someone Like You|TTBB|Matt Astle
+Somewhere Down The Road|TTBB|Matt Astle
+Stuck Like Glue|TTBB, SSAA, SATB|Matt Astle
+Sweet Child O' Mine|TTBB, SSAA, SATB|Matt Astle
+Tell Her About It|TTBB|Matt Astle
+The Luckiest|TTBB|Matt Astle
+This Is Me|TTBB, SSAA|Matt Astle
+The Toilet Seat Song|TTBB|Matt Astle
+Writing's On the Wall|TTBB, SSAA, SATB|Matt Astle
+You Can't Stop the Sun|SSAA|Matt Astle
+Anything Goes|SSAA|George Avener
+Something|SSAA|George Avener
+Strike Up The Band|TTBB|George Avener
+This Can't Be Love|SSAA|George Avener
+A Dream (the Lost Ant)|SATB|David Avshalomov
+Ah! Sun-Flower|SATB|David Avshalomov
+The Angel|SSAA|David Avshalomov
+Blossom|SATB|David Avshalomov
+Chimney Sweeper|SATB|David Avshalomov
+The Chocolate Carol|SATB|David Avshalomov
+The Clod & the Pebble|SATB|David Avshalomov
+A Cradle Song|SATB|David Avshalomov
+The Divine Image|SATB|David Avshalomov
+Earth's Answer|SATB|David Avshalomov
+The Ecchoing Green|SATB|David Avshalomov
+Father The Tree|SATB|David Avshalomov
+The Fly|SATB|David Avshalomov
+Freedom/Uhuru|SATB|David Avshalomov
+The Garden of Love|SATB|David Avshalomov
+Go Ahead and Rejoice|SATB|David Avshalomov
+Happy Anniversary|TTBB, SSAA, SATB|David Avshalomov
+Hear the Voice of the Bard|SATB|David Avshalomov
+Holy Thursday|SATB|David Avshalomov
+The Human Abstract|SATB|David Avshalomov
+I Bend the Knee of My Heart|TTBB|David Avshalomov
+Infant Joy|SATB|David Avshalomov
+Infant Sorrow|SATB|David Avshalomov
+The Lamb|SATB|David Avshalomov
+Laughing Song|SATB|David Avshalomov
+The Lilly|SATB|David Avshalomov
+Little Boy Lost|SATB|David Avshalomov
+Little Girl Lost|SATB|David Avshalomov
+The Little Vagabond|SATB|David Avshalomov
+London|SATB|David Avshalomov
+Motto to the Songs of Innocence & Experience|SATB|David Avshalomov
+My Pretty Rose Tree|SATB|David Avshalomov
+Night|SATB|David Avshalomov
+Nurse's Song|SATB|David Avshalomov
+O Euchari Columba|TTBB|David Avshalomov
+On Another's Sorrow|SATB|David Avshalomov
+Piping down the Valleys Wild|SATB|David Avshalomov
+A Poison Tree|SATB|David Avshalomov
+The School Boy|SATB|David Avshalomov
+The Shepherd|SATB|David Avshalomov
+The Sick Rose|SATB|David Avshalomov
+Song for Late Summer|SATB|David Avshalomov
+Spring|SATB|David Avshalomov
+Star Spangled Banner|TTBB|David Avshalomov
+The Bear|TTBB|David Avshalomov
+There's a Wind|TTBB|David Avshalomov
+To Tirzah|SATB|David Avshalomov
+Tyger Tyger Burning Bright|SATB|David Avshalomov
+The U. S. Air Force|TTBB|David Avshalomov
+U.S. 30 in Idaho|TTBB|David Avshalomov
+The Voice of the Ancient Bard|SATB|David Avshalomov
+Where You Go, I Will Go|SSAA|David Avshalomov
+All I Ask Of You|SSAA|Bitsy Bacon
+Beauty And The Beast|SSAA|Bitsy Bacon
+Don't Be Anybodys Soldier Boy But Mine|SSAA|Bitsy Bacon
+Glory Of Love|SSAA|Bitsy Bacon
+Way Down Yonder In New Orleans|SSAA|Bitsy Bacon
+Angels Among Us|SSAA|Marge Bailey
+Applause|SSAA|Marge Bailey
+As Long As I Have Music|SSAA|Marge Bailey
+Broadway Baby|SSAA|Marge Bailey
+Calendar Girl|SSAA|Marge Bailey
+Can You Feel The Love Tonight?|SSAA|Marge Bailey
+Canadian Sunset|SSAA|Marge Bailey
+Chocolate|SSAA|Marge Bailey
+Dare To Dream|SSAA|Marge Bailey
+Down To The River To Pray|SSAA|Marge Bailey
+Firefly|SSAA|Marge Bailey
+The Fireman's Bride|SSAA|Marge Bailey
+Hard Hearted Hannah|SSAA|Marge Bailey
+Hernando's Hideaway|SSAA|Marge Bailey
+Hi Neighbor|SSAA|Marge Bailey
+Hot Diggity (Dog Ziggity Boom)|SSAA|Marge Bailey
+How Lucky You Are|SSAA|Marge Bailey
+I Don't Want To Set The World On Fire|SSAA|Marge Bailey
+I Love A Piano|SSAA|Marge Bailey
+If|SSAA|Marge Bailey
+Imagine|SSAA|Marge Bailey
+Lord Bless You And Keep You|SSAA|Marge Bailey
+Magic Moments|SSAA|Marge Bailey
+Man With The Bag|SSAA|Marge Bailey
+Maybe This Time|SSAA|Marge Bailey
+Miss Otis Regrets|SSAA|Marge Bailey
+Mississippi Squirrel Revival|SSAA|Marge Bailey
+Moments To Remember|SSAA|Marge Bailey
+Moscow Nights|SSAA|Marge Bailey
+Next To Lovin (I Like Fightin Best)|SSAA|Marge Bailey
+One Boy|SSAA|Marge Bailey
+One Voice|SSAA|Marge Bailey
+Over The Hill|SSAA|Marge Bailey
+Poor Little Raggedy Andy|SSAA|Marge Bailey
+Rainbow Connection|SSAA|Marge Bailey
+Ring Them Bells|SSAA|Marge Bailey
+Roll On, Columbia|SSAA|Marge Bailey
+Route 66|SSAA|Marge Bailey
+Silhouettes|SSAA|Marge Bailey
+Someone To Watch Over Me|SSAA|Marge Bailey
+Sometimes|SSAA|Marge Bailey
+Somewhere Out There|SSAA|Marge Bailey
+Tears On My Pillow|SSAA|Marge Bailey
+That Old Black Magic|SSAA|Marge Bailey
+The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Marge Bailey
+Those Lazy Hazy Crazy Days Of Summer|SSAA|Marge Bailey
+Up, Up And Away (My Beautiful Balloon)|SSAA|Marge Bailey
+The Way We Were|SSAA|Marge Bailey
+We Make A Beautiful Pair|SSAA|Marge Bailey
+What A Wonderful World|SSAA|Marge Bailey
+You Are Never Far Away From Me|SSAA|Marge Bailey
+You're All I Want For Christmas|TTBB|Richard Bain
+After The Roses Have Faded Away|TTBB|Jack Baird
+After You've Gone|TTBB|Jack Baird
+All In Down And Out|TTBB|Jack Baird
+All That I Ask Of You Is Love|TTBB|Jack Baird
+Always Take A Girl Named Daisy|TTBB|Jack Baird
+Auld Lang Syne|TTBB|Jack Baird
+Ballin' The Jack|TTBB|Jack Baird
+Before The World Began|TTBB|Jack Baird
+Betty Co-ed|TTBB|Jack Baird
+Bird In A Gilded Cage|TTBB|Jack Baird
+Chicago / My Kind Of Town Medley|TTBB|Jack Baird
+China We Owe A Lot To You|TTBB|Jack Baird
+Cohan Medley|TTBB|Jack Baird
+Crossing The Bar|TTBB|Jack Baird
+Curse Of An Aching Heart|TTBB|Jack Baird
+Daddy, You've Been a Mother To Me|TTBB|Jack Baird
+Dance Of The Grizzly Bear|TTBB|Jack Baird
+Darktown Strutters' Ball|TTBB|Jack Baird
+Darling Nellie Gray|TTBB|Jack Baird
+Dear Old Girl|TTBB|Jack Baird
+Deep In The Heart Of Texas|TTBB|Jack Baird
+Do Not Say Goodbye|TTBB|Jack Baird
+Doin' The Grizzly Bear|TTBB|Jack Baird
+Don't Fence Me In|TTBB|Jack Baird
+Don't Go In The Lion's Cage Tonight|TTBB|Jack Baird
+Down By The Old Mill Stream|TTBB|Jack Baird
+Dream Medley|TTBB|Jack Baird
+Freckles|TTBB|Jack Baird
+Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Jack Baird
+Gee But There's Class To A Girl Like You|TTBB|Jack Baird
+Girl Of My Dreams|TTBB|Jack Baird
+Goodbye Boys|TTBB|Jack Baird
+Heaven Will Protect The Working Girl|TTBB|Jack Baird
+Home On The Range|TTBB|Jack Baird
+How Do You Do It Mable On|TTBB|Jack Baird
+Huckleberry Finn|TTBB|Jack Baird
+I Ain't Got No Body|TTBB|Jack Baird
+I Love You Just The Same Sweet Adeline|TTBB|Jack Baird
+I May Be Gone For A Long Long Time|TTBB|Jack Baird
+I Think I'll Go Out On A Strike|TTBB|Jack Baird
+I Wish I Had A Girl|TTBB|Jack Baird
+I Wonder If You Miss Me Just As Much As I Miss You|TTBB|Jack Baird
+I Wonder Who's Kissing Her Now|TTBB|Jack Baird
+I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jack Baird
+I'll Forget You|TTBB|Jack Baird
+I'm Going Over The Hills To Virginia|TTBB|Jack Baird
+I'm Sorry I Made You Cry|TTBB|Jack Baird
+I've Lost You So Why Should I Care|TTBB|Jack Baird
+If All Moons Were Honeymoons|TTBB|Jack Baird
+If I Had My Way|TTBB|Jack Baird
+"If I Knock The ""L"" Out Of Kelly"|TTBB|Jack Baird
+If You Had All The World And Its Gold|TTBB|Jack Baird
+If You Talk In Your Sleep,Don't Mention My Name|TTBB|Jack Baird
+In The Heart Of The City That Has No Heart|TTBB|Jack Baird
+In The Shade Of The Old Apple Tree|TTBB|Jack Baird
+Indiana|TTBB|Jack Baird
+It's A Great Day For The Irish|TTBB|Jack Baird
+It's A Long Way To Tipperary|TTBB|Jack Baird
+Jazz Came Up The River From New Orleans|SSAA|Jack Baird
+Jazz Came Up The River From New Orleans|TTBB|Jack Baird
+Just A Baby's Prayer At Twilight|TTBB|Jack Baird
+Just A Closer Walk With Thee / When The Saints Go Marching In Medley|TTBB|Jack Baird
+Just Like The Rose You Gave|TTBB|Jack Baird
+Kansas City Star|TTBB|Jack Baird
+Keep Your Eye On The Girlie You Love|TTBB|Jack Baird
+Let The Rest Of The World Go By|TTBB|Jack Baird
+Lorabelle Lee|TTBB|Jack Baird
+Love Me And The World Is Mine|TTBB|Jack Baird
+M-O-T-H-E-R|TTBB|Jack Baird
+Man On The Flying Trapeze|TTBB|Jack Baird
+Mandy Lee|TTBB|Jack Baird
+Meet Me Tonight In Dreamland|TTBB|Jack Baird
+Mid The Green Fields Of Virginia|TTBB|Jack Baird
+Moon Medley|TTBB|Jack Baird
+My Heart Has Learned To Love You|TTBB|Jack Baird
+My Little Bimbo Down On A Bamboo Isle|TTBB|Jack Baird
+My Mother Was A Lady|TTBB|Jack Baird
+My Wild Irish Rose|TTBB|Jack Baird
+Oh! What A Pal Was Mary|TTBB|Jack Baird
+On The Banks Of The Wabash|TTBB|Jack Baird
+Pack Up Your Troubles / Long Way To Tipperary Medley|TTBB|Jack Baird
+Pennies from Heaven|TTBB|Jack Baird
+Play That Barbershop Chord|TTBB|Jack Baird
+Put On Your Old Grey Bonnet|TTBB|Jack Baird
+Ragtime Cowboy Joe|TTBB|Jack Baird
+Remember My Boy Medley|TTBB|Jack Baird
+Rock Me to Sleep In An Old Rocking Chair|TTBB|Jack Baird
+Rose Of No Man's Land|TTBB|Jack Baird
+Rose Of Washington Square|TTBB|Jack Baird
+Sailin' Away On The Henry Clay|TTBB|Jack Baird
+School Days|TTBB|Jack Baird
+Sensation Rag|TTBB|Jack Baird
+She Is More To Be Pitied Than Censured|TTBB|Jack Baird
+She's The Daughter Of Mother Machree|TTBB|Jack Baird
+Shine On, Harvest Moon|TTBB|Jack Baird
+Shine On, Harvest Moon / For Me And My Gal Medley|TTBB|Jack Baird
+Some Of These Days|TTBB|Jack Baird
+Somebody Knows|TTBB|Jack Baird
+Somebody Stole My Gal|TTBB|Jack Baird
+Stand Up And Sing For Your Father|TTBB|Jack Baird
+Step To The Rear|TTBB|Jack Baird
+Stephen Foster Medley|TTBB|Jack Baird
+Sunbonnet Sue|TTBB|Jack Baird
+Sweet Cider Time When You Were Mine|TTBB|Jack Baird
+Sweet Georgia Brown|TTBB|Jack Baird
+The Sweetheart Of Sigma Chi|TTBB|Jack Baird
+Take Me To The Land Of Jazz|TTBB|Jack Baird
+Tell Me You'll Forgive Me|TTBB|Jack Baird
+That Old Gang Of Mine|TTBB|Jack Baird
+That's The Kind Of A Baby For Me|TTBB|Jack Baird
+There's A Girl In The Heart Of Maryland|TTBB|Jack Baird
+There's Nobody Just Like You|TTBB|Jack Baird
+They Always Pick On Me|TTBB|Jack Baird
+They Go Wild, Simply Wild Over Me|TTBB|Jack Baird
+To Have, To Hold, To Love|TTBB|Jack Baird
+Trail Of The Lonesome Pine|TTBB|Jack Baird
+Turn Back The Universe|TTBB|Jack Baird
+Twas Only An Irishman's Dream|TTBB|Jack Baird
+When Irish Eyes Are Smiling|TTBB|Jack Baird
+When Old Bill Bailey Plays His Ukulele|TTBB|Jack Baird
+When The Roses Kissed The Autumn Leaves Goodbye|TTBB|Jack Baird
+When The Twilight Comes To Kiss The Rose Good Night|TTBB|Jack Baird
+When Uncle Joe Plays A Rag On His Banjo|TTBB|Jack Baird
+When You And I Were Young Maggie|TTBB|Jack Baird
+When You Are Old And Gray|TTBB|Jack Baird
+When You Were Sweet Sixteen|TTBB|Jack Baird
+When You're Smiling|TTBB|Jack Baird
+Where The Morning Glories Grow|TTBB|Jack Baird
+Whiffenpoof Song|TTBB|Jack Baird
+Who Threw The Overalls In Mrs. Murphy's Chowder|TTBB|Jack Baird
+Who's Going To Love You When I'm Gone|TTBB|Jack Baird
+Why Did You Make Me Care|TTBB|Jack Baird
+Wild Wild Women|TTBB|Jack Baird
+Yes Sir, That's My Baby|TTBB|Jack Baird
+You Don't Need The Wine To Have A Wonderful Time|TTBB|Jack Baird
+You Gotta Be A Football Hero|TTBB|Jack Baird
+You Made Me Love You|TTBB|Jack Baird
+You Planted A Rose In The Garden Of Love|TTBB|Jack Baird
+Becky from Babylon|TTBB|Al Baker
+Every Street's A Boulevard|SSAA|Al Baker
+I'll Be Seeing You|TTBB|Al Baker
+I'll Make A Ring Around Rosie|TTBB|Al Baker
+If You See Sally|TTBB|Al Baker
+Ma! (She's Makin' Eyes At Me)|TTBB|Al Baker
+May You Always|TTBB|Al Baker
+Nobody's Sweetheart|SSAA|Al Baker
+Second Hand Rose|SSAA|Al Baker
+Sheik Of Araby|SSAA|Al Baker
+Shuffle Off To Buffalo|TTBB|Al Baker
+Sonny Boy|TTBB|Al Baker
+Sophie|TTBB|Al Baker
+To Morrow|TTBB|David Baldwin
+Baby Face|TTBB|Tom Ball
+It's A Most Unusual Day|TTBB|Tom Ball
+Ain't She Sweet|TTBB|Barbershop Harmony Society
+Alexander's Ragtime Band|TTBB|Barbershop Harmony Society
+Alice Blue Gown|TTBB|Barbershop Harmony Society
+All That I Ask Of You Is Love|TTBB|Barbershop Harmony Society
+All the World Will Be Jealous|TTBB|Barbershop Harmony Society
+Among My Souvenirs|TTBB|Barbershop Harmony Society
+Are You Lonesome Tonight?|TTBB|Barbershop Harmony Society
+Asleep In The Deep|TTBB|Barbershop Harmony Society
+Baby Your Mother|TTBB|Barbershop Harmony Society
+Beer Barrel Polka|TTBB|Barbershop Harmony Society
+Bring Back Those Good Old Days|TTBB|Barbershop Harmony Society
+Bundle Of Old Love Letters|TTBB|Barbershop Harmony Society
+Bye Bye Love|TTBB, SSAA|Barbershop Harmony Society
+Cabaret|TTBB|Barbershop Harmony Society
+Cocktails For Two|TTBB|Barbershop Harmony Society
+Coney Island Baby / We All Fall Medley|TTBB|Barbershop Harmony Society
+Coney Island Washboard|TTBB|Barbershop Harmony Society
+Daddy Sang Bass|TTBB|Barbershop Harmony Society
+Darkness On The Delta|SATB|Barbershop Harmony Society
+Dear Little Boy Of Mine|TTBB|Barbershop Harmony Society
+Dear Old Girl|TTBB|Barbershop Harmony Society
+Do You Remember When?|TTBB|Barbershop Harmony Society
+Down The Trail To Home Sweet Home|TTBB|Barbershop Harmony Society
+Early American Medley|TTBB|Barbershop Harmony Society
+Firefly|TTBB|Barbershop Harmony Society
+Get Out Those Old Records|TTBB|Barbershop Harmony Society
+Girl Of My Dreams|TTBB|Barbershop Harmony Society
+God Save The Queen/King|TTBB|Barbershop Harmony Society
+Goodbye Rose|TTBB|Barbershop Harmony Society
+Hang On The Bell, Nellie|TTBB|Barbershop Harmony Society
+Heritage Medley|TTBB|Barbershop Harmony Society
+Hey Look Me Over|TTBB|Barbershop Harmony Society
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|Barbershop Harmony Society
+I Don't Mind Being All Alone|TTBB, SSAA|Barbershop Harmony Society
+I Love You The Best Of All|TTBB|Barbershop Harmony Society
+I Miss You Most Of All|TTBB|Barbershop Harmony Society
+I Want To Be In Chicago Town|TTBB|Barbershop Harmony Society
+I Was Born Seventy Years Too Late|TTBB|Barbershop Harmony Society
+I Wish I Had A Girl|TTBB|Barbershop Harmony Society
+I'll Be Home For Christmas|TTBB|Barbershop Harmony Society
+I'll Be Home For Christmas|SSAA|Barbershop Harmony Society
+I'll Take You Home Again, Kathleen|TTBB|Barbershop Harmony Society
+I'm Forever Blowing Bubbles|TTBB|Barbershop Harmony Society
+I'm Looking Over A Four Leaf Clover|TTBB|Barbershop Harmony Society
+If You Had All The World And Its Gold|TTBB|Barbershop Harmony Society
+It Had To Be You|TTBB, SSAA, SATB|Barbershop Harmony Society
+Jingle Bells|TTBB, SSAA|Barbershop Harmony Society
+Just Around The Corner|TTBB|Barbershop Harmony Society
+Keep The Whole World Singing|TTBB, SSAA, SATB|Barbershop Harmony Society
+Keep Your Eye On The Girlie You Love|TTBB|Barbershop Harmony Society
+Last Night Was The End Of The World|TTBB|Barbershop Harmony Society
+Last Night Was The End Of The World|TTBB, SSAA, SATB|Barbershop Harmony Society
+Last Night Was The End Of The World|SSAA|Barbershop Harmony Society
+The Last Time I Saw Henry|TTBB|Barbershop Harmony Society
+Let Me Call You Sweetheart|TTBB|Barbershop Harmony Society
+Let's Talk About My Sweetie|TTBB|Barbershop Harmony Society
+Little Boy That Santa Claus Forgot|TTBB|Barbershop Harmony Society
+Lucky Day|TTBB|Barbershop Harmony Society
+MacNamara's Band|TTBB|Barbershop Harmony Society
+Memory Medley|TTBB|Barbershop Harmony Society
+My Old Kentucky Home|TTBB, SSAA, SATB|Barbershop Harmony Society
+My Sally, Just The Same|TTBB|Barbershop Harmony Society
+My Wild Irish Rose|TTBB|Barbershop Harmony Society
+Nebulous Nineties Medley|TTBB|Barbershop Harmony Society
+Old Boffo Medley|TTBB|Barbershop Harmony Society
+Old Fashioned Girl|TTBB|Barbershop Harmony Society
+Old Time Medley|TTBB|Barbershop Harmony Society
+On Moonlight Bay|TTBB|Barbershop Harmony Society
+On San Francisco Bay|TTBB|Barbershop Harmony Society
+Play That Barbershop Chord|TTBB|Barbershop Harmony Society
+Praise Ye The Lord, The Almighty|TTBB|Barbershop Harmony Society
+Radio Jingles|TTBB|Barbershop Harmony Society
+Ragtime Cowboy Joe|TTBB|Barbershop Harmony Society
+Red River Valley|TTBB|Barbershop Harmony Society
+Ride The Chariot|SSAA|Barbershop Harmony Society
+Ride The Chariot|TTBB|Barbershop Harmony Society
+Ride The Chariot|SATB|Barbershop Harmony Society
+Rock Me to Sleep In An Old Rocking Chair|TTBB|Barbershop Harmony Society
+Silver Bells|TTBB|Barbershop Harmony Society
+Somebody Knows|TTBB|Barbershop Harmony Society
+Southern Medley|TTBB|Barbershop Harmony Society
+Spiritual Medley|TTBB, SSAA|Barbershop Harmony Society
+Story Of The Rose|TTBB|Barbershop Harmony Society
+Sweet Rosie Ogrady|TTBB|Barbershop Harmony Society
+The Sweetheart Of Sigma Chi|TTBB|Barbershop Harmony Society
+Take Me Out To The Ball Game|TTBB|Barbershop Harmony Society
+That Old Fashioned Mother Of Mine|TTBB|Barbershop Harmony Society
+That's Life|TTBB, SSAA, SATB|Barbershop Harmony Society
+There Is A Tavern In The Town|TTBB|Barbershop Harmony Society
+They Go Wild, Simply Wild Over Me|TTBB|Barbershop Harmony Society
+Under The Boardwalk|TTBB|Barbershop Harmony Society
+Under The Boardwalk|SSAA|Barbershop Harmony Society
+Under The Boardwalk|SATB|Barbershop Harmony Society
+When I Dream Of Old Erin|TTBB|Barbershop Harmony Society
+When I Lost You|TTBB|Barbershop Harmony Society
+When I Wore My Daddy's Brown Derby|TTBB|Barbershop Harmony Society
+When My Sugar Walks Down The Street|TTBB|Barbershop Harmony Society
+Where The Southern Roses Grow|TTBB|Barbershop Harmony Society
+Who Threw The Overalls In Mrs. Murphy's Chowder|TTBB|Barbershop Harmony Society
+Yona From Arizona|TTBB|Barbershop Harmony Society
+You'll Always Be Part Of That Old Gang Of Mine|TTBB|Barbershop Harmony Society
+You're A Grand Old Flag|TTBB|Barbershop Harmony Society
+You're The Only Girl That Made Me Cry|TTBB|Barbershop Harmony Society
+The Blessing|SSAA|Kathy Barnett
+Friends in Low Places|SSAA|Kathy Barnett
+Hotel Hallelu|SSAA|Kathy Barnett
+Little Arrows|SSAA|Kathy Barnett
+Peanut Butter and Jelly|SSAA|Kathy Barnett
+Reach Out Of The Darkness|SSAA|Kathy Barnett
+Sweet Violets|SSAA|Kathy Barnett
+All I Have To Do Is Dream|TTBB|R. Tony Baroni
+America (My Country, 'Tis Of Thee)|TTBB|TJ Barranger
+The Birds And The Bees|TTBB|TJ Barranger
+As Time Goes By|TTBB|Dick Barrett
+Be Anything (But Be Mine)|TTBB|Dick Barrett
+Hello Dolly|TTBB|Dick Barrett
+I Wanna Be Loved By You|TTBB|Dick Barrett
+She Is More To Be Pitied Than Censured|TTBB|Dick Barrett
+Teddy Bears' Picnic|TTBB|Dick Barrett
+A Day Just For You|SSAA|Lois Barrett
+The Christmas Savior|TTBB|Anthony Bartholomew
+Ring-A-Ding Ding|TTBB|Anthony Bartholomew
+Rolling In The Deep|SSAA|Anthony Bartholomew
+Supercalifragilisticexpialidocious|TTBB|Anthony Bartholomew
+What Are You Thirsty For?|TTBB|Anthony Bartholomew
+The Wishing Boot|TTBB|Anthony Bartholomew
+I Get The Blues When It Rains|SSAA|Anita Barzilla
+One God|SSAA|Anita Barzilla
+Chantez, Chantez|TTBB|Ken Bastien
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|Ken Bastien
+I'd Like To Teach The World To Sing|TTBB|Ken Bastien
+Pennies from Heaven|TTBB|Ken Bastien
+Powder Your Face With Sunshine|TTBB|Ken Bastien
+I'll Be Seeing You|TTBB|Patrick Bauer
+Moonglow|TTBB|Patrick Bauer
+You're Just A Flower From An Old Bouquet|TTBB|N. Bauman
+Hanukkah In Santa Monica|TTBB, SATB|Jake Bavarsky
+Happy Joyous Hanuka|TTBB|Jake Bavarsky
+Rubber Duckie|TTBB, SATB|Jake Bavarsky
+Someone's Waiting For You|SSAA|Jake Bavarsky
+You Raise Me Up|SATB|Jake Bavarsky
+Sentimental Journey|TTBB|James Bazewicz
+Baritone Blues|SSAA|Lawrence Bean
+Baritone Blues|TTBB|Lawrence Bean
+All By Myself|SSAA|Brian Beck
+At The Jazz Band Ball|TTBB|Brian Beck
+Birth Of The Blues|SSAA|Brian Beck
+Broadway|SSAA|Brian Beck
+Bye Bye Blackbird|TTBB|Brian Beck
+God Bless The U.S.A.|TTBB|Brian Beck
+Great Day|TTBB|Brian Beck
+I Guess It Must Be True|SSAA|Brian Beck
+I Just Found out About Love|SSAA|Brian Beck
+I Love A Piano|SSAA|Brian Beck
+I'm My Own Grandpa|TTBB|Brian Beck
+I'm Sorry I Made You Cry|SSAA|Brian Beck
+It's Christmas|TTBB, SSAA|Brian Beck
+Maggie Mine|TTBB|Brian Beck
+These Boots Are Made For Walkin'|SSAA|Brian Beck
+Wait'll You See My Girl|TTBB|Brian Beck
+Walkin' With My Sweetness|TTBB|Brian Beck
+You're My Baby|SSAA|Brian Beck
+Blah-Blah-Blah|TTBB|Douglas Beck
+Can't You Hear Me Callin' Caroline|TTBB|Douglas Beck
+I Get The Blues When It Rains|TTBB|Douglas Beck
+I've Heard That Song Before|TTBB|Douglas Beck
+Let A Smile Be Your Umbrella / When You're Smiling|TTBB|Douglas Beck
+Let The Rest Of The World Go By|TTBB|Douglas Beck
+Forever Friends|SSAA|Cynthia Becker
+Hail Holy Queen|SSAA|Cynthia Becker
+Hymn For A Sunday Evening|SSAA|Cynthia Becker
+Rhythm Of The Night|SSAA|Cynthia Becker
+Blues In The Night|TTBB|William Behrendt
+Folks Who Live On The Hill|TTBB|William Behrendt
+Let There Be Peace On Earth|TTBB|William Behrendt
+Old Cape Cod|TTBB|William Behrendt
+South Rampart Street Parade|TTBB|William Behrendt
+Lulu's Back In Town|TTBB|Mike Bell
+Last Night On The Back Porch|TTBB|Dick Belote
+Bring Him Home|SSAA|Gene Bender
+Do You Hear The People Sing?|SSAA|Gene Bender
+Seasons of Love|SSAA|Gene Bender
+This Is The Moment|SSAA|Gene Bender
+Be A Clown|TTBB|Bob Benson
+Can You Tame Wild Wimmen|TTBB|Bob Benson
+If You Do What You Do|TTBB|Bob Benson
+Let A Smile Be Your Umbrella|TTBB|Bob Benson
+Pennies from Heaven|TTBB|Bob Benson
+Rain|TTBB|Bob Benson
+Sentimental Journey|TTBB|Bob Benson
+Too Long At The Fair|TTBB|Bob Benson
+Too Many Parties And Too Many Pals|TTBB|Bob Benson
+Wonderful Day like Today|TTBB|Bob Benson
+Cotton Candy And A Toy Balloon|TTBB|Norm Benson
+Maybe You'll Be There|TTBB|Norm Benson
+Wake Up Little Girl|TTBB|Norm Benson
+Annie's Song|TTBB|Peter Benson
+Warm And Fuzzy|TTBB, SSAA|Peter Benson
+Softly And Tenderly|TTBB|Edward Berg
+Susie Brown|TTBB|Edward Berg
+Taxes|TTBB|Edward Berg
+'Til I Hear You Sing|SSAA|June Berg
+Again|SSAA|June Berg
+All My Loving|SSAA|June Berg
+All Of My Life|SSAA|June Berg
+All Things Bright and Beautiful|SSAA|June Berg
+Beautiful Star of Bethlehem|SSAA|June Berg
+Bridge Of Light|SSAA|June Berg
+Can You Feel The Love Tonight?|SSAA|June Berg
+The Christmas Song|SSAA|June Berg
+Christmas Waltz|SSAA|June Berg
+Color The Children|SSAA|June Berg
+Cool Yule|SSAA|June Berg
+Could I Have This Dance|SSAA|June Berg
+Count On Me|SSAA|June Berg
+Everything's All Right|SSAA|June Berg
+Feliz Navidad|SSAA|June Berg
+For Good|SSAA|June Berg
+Go Tell It On The Mountain|SSAA|June Berg
+Goodbye Cruel World|SSAA|June Berg
+Goodnight, Sweetheart, Goodnight|SSAA|June Berg
+Grown-Up Christmas List|SSAA|June Berg
+Happy Holiday|SSAA|June Berg
+Happy Trails|SSAA|June Berg
+Have You Got Any Castles, Baby?|SSAA|June Berg
+Here, There And Everywhere|SSAA|June Berg
+Hit Me With A Hot Note|SSAA|June Berg
+Hit Me With A Hot Note|TTBB|June Berg
+Hymn Of Promise|SSAA|June Berg
+I Found You Out When I Found You In|SSAA|June Berg
+I Heard The Bells On Christmas Day|SSAA|June Berg
+I Love You Truly|SSAA|June Berg
+I'm Glad There Is You|SSAA|June Berg
+I'm In Love With A Brand New Baby|SSAA|June Berg
+I've Got My Love To Keep Me Warm|SSAA|June Berg
+If I Had My Life To Live Over|SSAA|June Berg
+In The Bleak Midwinter|SSAA|June Berg
+It Was Almost Like A Song|SSAA|June Berg
+Jingle Bell Jazz|SSAA|June Berg
+Keep In The Middle Of The Road|SSAA|June Berg
+Keepin' Out Of Mischief Now|SSAA|June Berg
+Let Me Call You Sweetheart|SSAA|June Berg
+Little Lady Make Believe|SSAA|June Berg
+Little Saint Nick|SSAA|June Berg
+Looking Through The Eyes Of Love|SSAA|June Berg
+Love Letters|SSAA|June Berg
+Man With The Bag|SSAA|June Berg
+Mary Did You Know|SSAA|June Berg
+Merry Christmas Darling|SSAA|June Berg
+My Tribute|SSAA|June Berg
+On The Road Again|SSAA|June Berg
+The Peace Carol|SSAA|June Berg
+Peace, Peace|SSAA|June Berg
+Rejoice With Exceeding Great Joy|SSAA|June Berg
+The River|SSAA|June Berg
+Romancin' The Blues|SSAA|June Berg
+Santa Baby|SSAA|June Berg
+Second Time Around|SSAA|June Berg
+September In The Rain|SSAA|June Berg
+She's Got You|SSAA|June Berg
+Silent Night (Not The Traditional Hymn)|SSAA|June Berg
+Skylark|SSAA|June Berg
+Someone To Watch Over Me|SSAA|June Berg
+Songs|SSAA|June Berg
+A Stable Prayer|SSAA|June Berg
+The Way You Look Tonight|SSAA|June Berg
+There'll Be No New Tunes On This Old Piano|SSAA|June Berg
+They Go Wild, Simply Wild Over Me|SSAA|June Berg
+Three Carols for Christmas|SSAA|June Berg
+Til The Season Comes Round Again|SSAA|June Berg
+Time After Time|SSAA|June Berg
+Unfinished Songs|SSAA|June Berg
+Up On The Roof|SSAA|June Berg
+Valentine|SSAA, Young SSAA|June Berg
+We Need A Little Christmas|SSAA|June Berg
+White Wings|SSAA|June Berg
+You Belong To Me|SSAA|June Berg
+You Will Be Found|SSAA|June Berg
+You're A Mean One, Mr. Grinch|SSAA|June Berg
+Give Us Your Blessing, Lord|SSAA|Muriel Berg
+Hot Diggity (Dog Ziggity Boom)|SSAA|Muriel Berg
+Light One Candle|SSAA|Muriel Berg
+Someone To Watch Over Me|SSAA|Muriel Berg
+Way Down Yonder In New Orleans|SSAA|Muriel Berg
+Ev'ry Day Of My Life|TTBB|Ron Bergenstock
+Happy Trails|TTBB|Ron Bergenstock
+'Til Tomorrow|SSAA|Nancy Bergman
+A Christmas Night Story|SSAA|Nancy Bergman
+A Time For Us (Love Theme from Romeo and Juliet)|SSAA|Nancy Bergman
+Aba Daba Honeymoon|SSAA|Nancy Bergman
+Achy Breaky Heart|SSAA|Nancy Bergman
+After You've Gone|SSAA|Nancy Bergman
+Ain't We Got Fun/Sunny Side of the Street|SSAA|Nancy Bergman
+Alexander's Ragtime Band|SSAA|Nancy Bergman
+All American Girl|SSAA|Nancy Bergman
+All Of My Life|SSAA|Nancy Bergman
+Am I Blue?|SSAA|Nancy Bergman
+Amazing Grace / Old Time Religion Medley|SSAA|Nancy Bergman
+America The Beautiful|SATB|Nancy Bergman
+America The Beautiful|SSAA|Nancy Bergman
+An Affair To Remember|SSAA|Nancy Bergman
+Angry/Bill Bailey|SSAA|Nancy Bergman
+Anniversary Waltz|SSAA|Nancy Bergman
+Another Op'ning, Another Show|SSAA|Nancy Bergman
+Another Somebody Done Somebody Wrong Song|SSAA|Nancy Bergman
+Anything Can Happen|SSAA|Nancy Bergman
+Are You Lonesome Tonight?|TTBB|Nancy Bergman
+Arizona Big A|TTBB|Nancy Bergman
+Arizona, Big A|SSAA|Nancy Bergman
+Armed Forces Medley|SSAA|Nancy Bergman
+Armed Forces Medley|TTBB|Nancy Bergman
+At Last|SSAA|Nancy Bergman
+At Last|TTBB|Nancy Bergman
+Away In A Manger|SSAA|Nancy Bergman
+Back In The Old Routine|SSAA|Nancy Bergman
+Back In The Roaring 20s|SSAA|Nancy Bergman
+The Band Played On|SSAA|Nancy Bergman
+Bandstand In Central Park|SSAA|Nancy Bergman
+Bandstand In Central Park|TTBB|Nancy Bergman
+Banjo's Back In Town|SSAA|Nancy Bergman
+Basin Street Blues|SSAA|Nancy Bergman
+Be Our Guest|SSAA|Nancy Bergman
+Because|SSAA|Nancy Bergman
+Beer Barrel Polka (Roll Out The Barrel)|SSAA|Nancy Bergman
+Beer Barrel Polka (Roll Out The Barrel)|TTBB|Nancy Bergman
+Bein' Green|SSAA|Nancy Bergman
+Bill|SSAA|Nancy Bergman
+The Birthday Of A King|SSAA|Nancy Bergman
+Blue Hawaii|SSAA|Nancy Bergman
+Boogie Woogie Bugle Boy|SSAA|Nancy Bergman
+Brazil|SSAA|Nancy Bergman
+Breaking Up Is Hard To Do|SSAA|Nancy Bergman
+Breezin' Along With The Breeze|SSAA|Nancy Bergman
+Bring On The Beautiful Girls/I'm A Showgirl|SSAA|Nancy Bergman
+Broadway Grandma's Medley|SSAA|Nancy Bergman
+Broadway Medley|SSAA|Nancy Bergman
+Broken Hearted (Here Am I)|SSAA|Nancy Bergman
+By The Sea/Row Row Row|SSAA|Nancy Bergman
+Cabaret|SSAA|Nancy Bergman
+California Here I Come|SSAA|Nancy Bergman
+Candy Man|SSAA|Nancy Bergman
+Carolina In The Morning|SSAA|Nancy Bergman
+Charley, My Boy|SSAA|Nancy Bergman
+Climb Ev'ry Mountain|SSAA|Nancy Bergman
+Cohan Medley|SSAA|Nancy Bergman
+A Couple of Swells|SSAA|Nancy Bergman
+Crazy|SSAA|Nancy Bergman
+Crazy|TTBB|Nancy Bergman
+Creole Cutie|SATB|Nancy Bergman
+Creole Cutie|SSAA|Nancy Bergman
+Cry Baby|SSAA|Nancy Bergman
+Crying Myself To Sleep|SSAA|Nancy Bergman
+Cuddle Up A Little Closer|SSAA|Nancy Bergman
+Daddy (You oughta get the best for me...)|SSAA|Nancy Bergman
+Dancing In The Streets of New Orleans|SSAA|Nancy Bergman
+Darling, Je Vous Aime Beaucoup|SSAA|Nancy Bergman
+Dear Heart|TTBB|Nancy Bergman
+Dearie (Do You Remember?)|SSAA|Nancy Bergman
+Deck The Halls|SSAA|Nancy Bergman
+Deep In The Heart Of Texas|SSAA|Nancy Bergman
+Do - Re - Mi|SSAA|Nancy Bergman
+Do You See What I See?|SSAA|Nancy Bergman
+Doin' What Comes Natur'lly|SSAA|Nancy Bergman
+Don't Blame Me|SSAA|Nancy Bergman
+Don't Call Me Sweetie 'Cause I'm Bitter|SSAA|Nancy Bergman
+Don't Cry, Little Girl, Don't Cry|SSAA|Nancy Bergman
+Down and Out Blues|SSAA|Nancy Bergman
+Down At The Long Branch Saloon|SSAA|Nancy Bergman
+Down By The Old Mill Stream|SSAA|Nancy Bergman
+Dry Bones|SSAA|Nancy Bergman
+Easter Parade|SSAA|Nancy Bergman
+Everywhere You Go|SSAA|Nancy Bergman
+Feels Like Home|SSAA|Nancy Bergman
+Feliz Navidad|SSAA|Nancy Bergman
+Feliz Navidad|TTBB|Nancy Bergman
+Fifteen Minute Intermission|SSAA|Nancy Bergman
+Firefly|SSAA|Nancy Bergman
+The First Noel|SSAA|Nancy Bergman
+Five Foot Two|SSAA|Nancy Bergman
+Flag Waver (America The Beautiful / God Bless America)|TTBB|Nancy Bergman
+Flag Waver (America The Beautiful / God Bless America)|SSAA|Nancy Bergman
+Flirty Eyes|SSAA|Nancy Bergman
+Forty-Second Street|TTBB|Nancy Bergman
+Frog Kissin'|SSAA|Nancy Bergman
+George M. Cohan Medley|SSAA|Nancy Bergman
+Get Happy|SSAA|Nancy Bergman
+Get Out And Shop!|SSAA|Nancy Bergman
+Get Out And Vote!|SSAA|Nancy Bergman
+Give My Regards To Broadway Medley|SSAA|Nancy Bergman
+God Bless America|SSAA|Nancy Bergman
+Goin' Out Of My Head|SSAA|Nancy Bergman
+Gone|SSAA|Nancy Bergman
+Gonna Get Along Without You Now|SSAA|Nancy Bergman
+Goodbye, You Phony Lyin' Baby|SSAA|Nancy Bergman
+Goodtime Barbershop & Variety Show|SSAA|Nancy Bergman
+Goodtime Strutters' Ball|SSAA|Nancy Bergman
+Goody Goody|SSAA|Nancy Bergman
+Great Day|TTBB|Nancy Bergman
+Grinch Medley|SSAA|Nancy Bergman
+Happy Birthday To You|SSAA|Nancy Bergman
+Happy Hanukkah, My Friend|SSAA|Nancy Bergman
+Harmonize The World|SSAA|Nancy Bergman
+Hawaiian War Chant / Blue Hawaii|SSAA|Nancy Bergman
+He Was There (at the Mardi Gras)|SSAA|Nancy Bergman
+He'll Be Coming Down The Chimney (When He Comes)|SSAA|Nancy Bergman
+Heart of My Heart|SSAA|Nancy Bergman
+Hello, Hollywood, Hello|SSAA|Nancy Bergman
+Here Comes Santa Claus|SSAA|Nancy Bergman
+Here Comes Santa Claus / Up On The Housetop Medley|SSAA|Nancy Bergman
+Here Comes Santa Claus / Up On The Housetop Medley|TTBB|Nancy Bergman
+Hey Look Me Over|SSAA|Nancy Bergman
+Home On The Range|SSAA|Nancy Bergman
+Hoop Dee Doo!|TTBB|Nancy Bergman
+How Could You Believe Me|SATB|Nancy Bergman
+How Great Thou Art|SSAA|Nancy Bergman
+How Sweet It Is To Be Loved By You|SSAA|Nancy Bergman
+How Ya Gonna Keep 'Em/Johnny's In Town|SSAA|Nancy Bergman
+I Can't Get Off-a My Horse|SSAA|Nancy Bergman
+I Can't Give You Anything But Love|SSAA|Nancy Bergman
+I Can't Give You Anything But Love / L-O-V-E|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/Steppin' Out With My Baby|SSAA|Nancy Bergman
+I Can't Give You Anything/I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I Didn't Raise My Boy To Be A Soldier|SSAA|Nancy Bergman
+I Don't Care If The Sun Don't Shine|SSAA|Nancy Bergman
+I Don't Know Enough About You|SSAA|Nancy Bergman
+I Don't Want To Walk Without You|SSAA|Nancy Bergman
+I Don't Want To Walk Without You|TTBB|Nancy Bergman
+I Got Rhythm Medley|SSAA|Nancy Bergman
+I Heard The Bells On Christmas Day|SSAA|Nancy Bergman
+I Used To Love You But It's All Over|SSAA|Nancy Bergman
+I Wanna Be Around|SSAA|Nancy Bergman
+I Want To Be A Cowboys Sweetheart|SSAA|Nancy Bergman
+I Want You For My Sweetheart (but I Don't Want You For My Wife)|TTBB|Nancy Bergman
+I Wish I Could Shimmy Like My Sister Kate|SSAA|Nancy Bergman
+I Wish I Had A Girl|TTBB|Nancy Bergman
+I'd Give A Million Tomorrows|SSAA|Nancy Bergman
+I'd Like To Teach The World To Sing|SSAA|Nancy Bergman
+I'll Be Home For Christmas|SSAA|Nancy Bergman
+I'll Be Home For Christmas|TTBB|Nancy Bergman
+I'll Be With You In Apple Blossom Time|SSAA|Nancy Bergman
+I'll Bring You A Rainbow|TTBB|Nancy Bergman
+I'll Catch The Sun|SSAA|Nancy Bergman
+I'll Get By|SSAA|Nancy Bergman
+I'll Never Smile Again|SSAA|Nancy Bergman
+I'm A Woman|SSAA|Nancy Bergman
+I'm Always Chasing Rainbows|SSAA|Nancy Bergman
+I'm Beginning To See The Light|SSAA|Nancy Bergman
+I'm Gonna Follow The Boys Over There|SSAA|Nancy Bergman
+I'm Nobody's Baby|SSAA|Nancy Bergman
+I'm Sitting On Top Of The World|SSAA|Nancy Bergman
+I'm So Glad We Had This Time Together|SSAA|Nancy Bergman
+I've Been Waiting For Your Phone Call for 18 Years|SSAA|Nancy Bergman
+I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+If|SSAA|Nancy Bergman
+If I Had My Life To Live Over|SSAA|Nancy Bergman
+If I Had My Way|SSAA|Nancy Bergman
+If I Love Again|SSAA|Nancy Bergman
+If I Ruled The World|SSAA|Nancy Bergman
+If I Were The Only Girl In The World|SSAA|Nancy Bergman
+If You Are But A Dream|SSAA|Nancy Bergman
+If You Knew Susie|SSAA|Nancy Bergman
+If You Love Me, Really Love Me|SSAA|Nancy Bergman
+If You Love Me, Really Love Me|TTBB|Nancy Bergman
+If You See Johnny (Sally)|SSAA|Nancy Bergman
+In The Good Old Summertime|SSAA|Nancy Bergman
+Irish Lullabye|SSAA|Nancy Bergman
+Irish Medley (Harrigan / Toora Loora Loora)|SSAA|Nancy Bergman
+Isn't This A Lovely Day|SSAA|Nancy Bergman
+It Gets You Right Here|TTBB|Nancy Bergman
+It Gets You Right Here|SSAA|Nancy Bergman
+It's A Great Day For The Irish|SSAA|Nancy Bergman
+It's A Great Day For The Irish / MacNamara's Band|SSAA|Nancy Bergman
+It's beginning to look a lot like christmas|SSAA|Nancy Bergman
+It's Beginning To Look A Lot Like Christmas / Silver Bells|TTBB|Nancy Bergman
+It's The Most Wonderful Time Of The Year|TTBB|Nancy Bergman
+Ja-Da / Everybody's Doing It|SSAA|Nancy Bergman
+Jazz Came Up The River From New Orleans|SSAA|Nancy Bergman
+Jeanie With The Light Brown Hair|TTBB|Nancy Bergman
+Johnny Medley|SSAA|Nancy Bergman
+Joint Is Jumping|TTBB|Nancy Bergman
+Just A Closer Walk With Thee|SSAA|Nancy Bergman
+K-K-K-Katie|SSAA|Nancy Bergman
+L-O-V-E|SSAA|Nancy Bergman
+The Lady Takes The Cowboy Every Time|SSAA|Nancy Bergman
+Last Night On The Back Porch|SSAA|Nancy Bergman
+LaWanda Darlene, The Rodeo Queen|SSAA|Nancy Bergman
+LaWanda Darlene, The Rodeo Queen|TTBB|Nancy Bergman
+Let A Smile Be Your Umbrella|SSAA|Nancy Bergman
+Let There Be Peace On Earth|SATB|Nancy Bergman
+Let's Talk About MY Sweetie / Yessir That's My Baby|SSAA|Nancy Bergman
+Lida Rose / Will I Ever Tell You|TTBB, SSAA, SATB|Nancy Bergman
+Lili Marlene|SSAA|Nancy Bergman
+The Little Child|SSAA|Nancy Bergman
+Little Kiss Each Morning|TTBB|Nancy Bergman
+The Little Man Who Wasn't There|SSAA|Nancy Bergman
+Little On The Lonely Side|SSAA|Nancy Bergman
+The Lord's Prayer|SSAA|Nancy Bergman
+Love Me With All Your Heart|SSAA|Nancy Bergman
+Lover Come Back To Me|SSAA|Nancy Bergman
+MacNamara's Band|SSAA|Nancy Bergman
+Makin' Love Ukulele Style|SSAA|Nancy Bergman
+Mame|SSAA|Nancy Bergman
+Mamma Goes Where Papa Goes|SSAA|Nancy Bergman
+Man I Love|SSAA|Nancy Bergman
+Me And My Shadow|SSAA|Nancy Bergman
+Me, too!|SSAA|Nancy Bergman
+Memories Only Now|SSAA|Nancy Bergman
+Mighty Like A Rose|SSAA|Nancy Bergman
+MISSISSIPPI (M-I-Crooked Letter)|SSAA|Nancy Bergman
+Mississippi Mud|SSAA|Nancy Bergman
+Mister Lonely|TTBB|Nancy Bergman
+Mister Touchdown, U.S.A.|SSAA|Nancy Bergman
+Music In My Mothers House|SSAA|Nancy Bergman
+My Baby Just Cares For Me|SSAA|Nancy Bergman
+My Favorite Things|SSAA|Nancy Bergman
+My Mom|SSAA|Nancy Bergman
+Nearer, My God, To Thee|SSAA|Nancy Bergman
+Nevertheless|SSAA|Nancy Bergman
+New Ashmolian Marching Society And Students Conservatory Band|SSAA|Nancy Bergman
+Nobody Knows The Trouble I've Seen|SSAA|Nancy Bergman
+Nobody's Rose|SSAA|Nancy Bergman
+Nostalgia Medley|TTBB|Nancy Bergman
+Nostalgia Medley|SSAA|Nancy Bergman
+O Little Town Of Bethlehem|SSAA|Nancy Bergman
+Ode To America|SSAA|Nancy Bergman
+Oh By Jingo!|SSAA|Nancy Bergman
+Oh What A Beautiful Morning!|SSAA|Nancy Bergman
+Oh What A Beautiful Morning!|TTBB|Nancy Bergman
+Oh, How I Hate To Get Up In The Morning|TTBB|Nancy Bergman
+Oh, How I Hate To Get Up In The Morning|SSAA|Nancy Bergman
+On A Cruise|SSAA|Nancy Bergman
+On Broadway|SSAA|Nancy Bergman
+On The Sunny Side Of The Street|SSAA|Nancy Bergman
+One More Song|SSAA|Nancy Bergman
+One Of Those Songs|SSAA|Nancy Bergman
+Only You (And You Alone)|SSAA|Nancy Bergman
+Opening Night On Broadway|TTBB|Nancy Bergman
+Opening Night On Broadway|SSAA|Nancy Bergman
+Paddlin' Madelin' Home|SSAA|Nancy Bergman
+Powder Your Face With Sunshine|SSAA|Nancy Bergman
+Put Your Arms Around Me Honey|SSAA|Nancy Bergman
+Put Your Arms Around Me/Side By Side|SSAA|Nancy Bergman
+Rag Mop|TTBB|Nancy Bergman
+Ragime Cowgirl Jo|SSAA|Nancy Bergman
+Red Hot!|SSAA|Nancy Bergman
+Release Me|TTBB|Nancy Bergman
+Release Me|SSAA|Nancy Bergman
+Rockin' Chair|SSAA|Nancy Bergman
+Rose (A Ring To The Name Of Rose)|SATB|Nancy Bergman
+Roses Of Picardy|SSAA|Nancy Bergman
+Roses Of Yesterday|SSAA|Nancy Bergman
+Rosie|SSAA|Nancy Bergman
+Rudolph The Red Nosed Reindeer|SSAA|Nancy Bergman
+Runnin' Wild|SSAA|Nancy Bergman
+Say It Isn't So|SSAA|Nancy Bergman
+Second Hand Rose|SSAA|Nancy Bergman
+Second Hand Rose / She Is More To Be Pitied...|SSAA|Nancy Bergman
+Seven Or Eleven|TTBB|Nancy Bergman
+Seventy-Six Trombones|SSAA|Nancy Bergman
+Shanghai|SSAA|Nancy Bergman
+She Was There|TTBB|Nancy Bergman
+She'll Be Comin' Round The Mountain|SSAA|Nancy Bergman
+A Shine On Your Shoes|SSAA|Nancy Bergman
+Side by Side|SSAA|Nancy Bergman
+Silent Night|SATB|Nancy Bergman
+Silver Bells|SSAA|Nancy Bergman
+Small World, It's A|SSAA|Nancy Bergman
+Smile Medley (Pack Up Your Troubles / Smile, Darn Ya, Smile / Let A Smile Be Your Umbrella)|SSAA|Nancy Bergman
+So Long, Dearie|SSAA|Nancy Bergman
+So Long, It's Been Good To Know Yuh|TTBB|Nancy Bergman
+Someday My Prince Will Come|SSAA|Nancy Bergman
+Someone Like You|SSAA|Nancy Bergman
+South America, Take It Away!|SSAA|Nancy Bergman
+St Louis Blues|SSAA|Nancy Bergman
+Star Spangled Banner|SSAA|Nancy Bergman
+Star Spangled Banner|TTBB|Nancy Bergman
+Steppin' Out With My Baby|SSAA|Nancy Bergman
+Strangers|SSAA|Nancy Bergman
+Suddenly There's A Valley|TTBB|Nancy Bergman
+Sunny Side Medley|SSAA|Nancy Bergman
+Sunny Side Up|SSAA|Nancy Bergman
+Sweet Adeline|SSAA|Nancy Bergman
+Ta-Ra-Ra-Boom-Der-E (Can-Can Song)|SSAA|Nancy Bergman
+Take Me Out To The Ball Game|SSAA|Nancy Bergman
+Take Your Girlie To The Movies|SSAA|Nancy Bergman
+That Old Gang Of Mine|SSAA|Nancy Bergman
+That Wonderful Mother Of Mine|SSAA|Nancy Bergman
+That's All|SSAA|Nancy Bergman
+There Goes My Heart|SSAA|Nancy Bergman
+There I've Said It Again|SSAA|Nancy Bergman
+There Is No Greater Love|SSAA|Nancy Bergman
+There'll Be Some Changes Made|SSAA|Nancy Bergman
+There'll Be Some Changes Made / So Long, Dearie|SSAA|Nancy Bergman
+There'll Be Some Changes Made / Who's Sorry Now?|SSAA|Nancy Bergman
+There's No Business Like Show Business|SSAA|Nancy Bergman
+These Foolish Things|SSAA|Nancy Bergman
+This Is It!|SSAA|Nancy Bergman
+This Is My Country|SSAA|Nancy Bergman
+This is My Country / America the Beautiful|SSAA|Nancy Bergman
+This Is My Night|SSAA|Nancy Bergman
+This Is The Army, Mr. Jones|TTBB|Nancy Bergman
+This Is The Army, Mr. Jones|SSAA|Nancy Bergman
+Thoroughly Modern Millie|SSAA|Nancy Bergman
+Tiger Rag|SSAA|Nancy Bergman
+Toot, Toot, Tootsie|SSAA|Nancy Bergman
+Toyland|SSAA|Nancy Bergman
+Toyland|TTBB|Nancy Bergman
+Tribute To The U.S.A.|SSAA|Nancy Bergman
+Try To Remember|SSAA|Nancy Bergman
+Twenties Sing-A-Long|SSAA|Nancy Bergman
+Twilight Time|SSAA|Nancy Bergman
+U. S. Air Force Anthem / Stars & Stripes Forever|TTBB|Nancy Bergman
+The U. S. Air Force|TTBB|Nancy Bergman
+Until The Real Thing Comes Along|TTBB|Nancy Bergman
+Vaudeville (Two Shows A Day...)|SSAA|Nancy Bergman
+Way Down Yonder In New Orleans|SSAA|Nancy Bergman
+We Need A Little Christmas|TTBB|Nancy Bergman
+We Need A Little Christmas|SSAA|Nancy Bergman
+We Wish You A Merry Christmas|SSAA|Nancy Bergman
+We'll Meet Again|SSAA|Nancy Bergman
+We'll Meet Again|TTBB|Nancy Bergman
+We're Off To See The Wizard|SSAA|Nancy Bergman
+We're the Children/Harmonize the World|SSAA|Nancy Bergman
+Welcome To The Fold, Sweet Adeline|SSAA|Nancy Bergman
+What Are You Doing New Year's Eve?|SSAA|Nancy Bergman
+What Do You Do In The Infantry|TTBB|Nancy Bergman
+When I Grow Too Old To Dream|SSAA|Nancy Bergman
+When I Leave The World Behind|SSAA|Nancy Bergman
+When I Lost You|SSAA|Nancy Bergman
+When I Take My Sugar To Tea|SSAA|Nancy Bergman
+When Irish Eyes Are Smiling|SSAA|Nancy Bergman
+When My Sugar Walks Down The Street|SSAA, Young SSAA|Nancy Bergman
+When The Saints Go Marching In / Swing Down, Sweet Chariot|SSAA|Nancy Bergman
+When The Saints Go Marching In / Swing Down, Sweet Chariot|TTBB|Nancy Bergman
+When The Wind Was Green|SSAA|Nancy Bergman
+When You Wish Upon A Star|SSAA|Nancy Bergman
+When You Wish Upon A Star|SATB|Nancy Bergman
+When You're Smiling|SSAA|Nancy Bergman
+Where Are You Christmas?|SSAA|Nancy Bergman
+Where Does The Time Go?|SSAA|Nancy Bergman
+While Strolling Through The Park One Day|SSAA|Nancy Bergman
+While We're Young|SSAA|Nancy Bergman
+White Christmas|SSAA|Nancy Bergman
+White Cliffs Of Dover|SSAA|Nancy Bergman
+Who'll Be The Next One|SSAA|Nancy Bergman
+Who's Sorry Now|SSAA|Nancy Bergman
+Why Should I Cry Over You?|SSAA|Nancy Bergman
+Will It Be Me This Time?|SSAA|Nancy Bergman
+Winter Wonderland|SSAA|Nancy Bergman
+With A Song In My Heart|SSAA|Nancy Bergman
+World War Medley|SSAA|Nancy Bergman
+World, Here I Am!|SSAA|Nancy Bergman
+Ya Gotta Know / I Can't Give You Anything But Love|SSAA|Nancy Bergman
+Ya Gotta Know How To Love|TTBB|Nancy Bergman
+Ya Gotta Know How To Love|SSAA|Nancy Bergman
+Yellow Rose Of Texas|SSAA|Nancy Bergman
+You Better Keep Babyin' Baby|SSAA|Nancy Bergman
+You Brought Ireland Right Over To Me|TTBB|Nancy Bergman
+You Can Have Every Light On Broadway|SSAA|Nancy Bergman
+You Can Have Every Light On Broadway|TTBB|Nancy Bergman
+You Can't Get A Man With A Gun|SSAA|Nancy Bergman
+You Keep Coming Back Like A Song|SSAA|Nancy Bergman
+You Made Me Love You|SSAA|Nancy Bergman
+You Turned The Tables On Me|TTBB|Nancy Bergman
+You Turned The Tables On Me|SSAA|Nancy Bergman
+You'll Never Walk Alone|SSAA|Nancy Bergman
+You're A Grand Old Flag|SSAA|Nancy Bergman
+You're Just A Flower From An Old Bouquet|TTBB|Nancy Bergman
+You're Just A Flower From An Old Bouquet|SSAA|Nancy Bergman
+Hallelujah|SSAA|Sherry Berkley
+My Christmas Song For You|SSAA|Sherry Berkley
+Sentimental Journey|SSAA|Sherry Berkley
+Over The Rainbow|TTBB|Gary Bertelsen
+Alexander's Ragtime Band|SSAA, Young SSAA|Joni Bescos
+All American Girl|SSAA|Joni Bescos
+All The Way|SSAA|Joni Bescos
+Always|SSAA|Joni Bescos
+America The Beautiful|SSAA|Joni Bescos
+Away In A Manger|SSAA|Joni Bescos
+Baby Face|SSAA|Joni Bescos
+Baby, It's Cold Outside|SATB|Joni Bescos
+By The Light Of The Silvery Moon|SSAA|Joni Bescos
+For Once In My Life|SSAA|Joni Bescos
+Grandmas Feather Bed|SSAA|Joni Bescos
+Here's To The Winners|SSAA|Joni Bescos
+Hooray For Hollywood|SSAA|Joni Bescos
+I'd Like To Teach The World To Sing|SSAA, Young SSAA|Joni Bescos
+Jeepers Creepers|SSAA|Joni Bescos
+Jingle Bells|SSAA|Joni Bescos
+Juke Box Saturday Night|SSAA|Joni Bescos
+Just One Of Those Things|SSAA|Joni Bescos
+Little Bit Of Heaven|SSAA|Joni Bescos
+Lonesomest Girl In Town|SSAA|Joni Bescos
+Lucky Day|SSAA, Young SSAA|Joni Bescos
+Lullaby Of Broadway|SSAA|Joni Bescos
+A Marshmallow World|SSAA|Joni Bescos
+Me And My Shadow|SSAA|Joni Bescos
+Meet Me In St. Louis, Louis|SSAA|Joni Bescos
+My Wild Irish Rose|SSAA|Joni Bescos
+O Come, All Ye Faithful|SSAA|Joni Bescos
+O Holy Night|SSAA|Joni Bescos
+Over The Rainbow|SSAA|Joni Bescos
+Sentimental Journey|SSAA|Joni Bescos
+Star Spangled Banner|SSAA|Joni Bescos
+There's A Broken Heart For Every Light On Broadway|TTBB|Joni Bescos
+When I Leave The World Behind|SSAA|Joni Bescos
+You Made Me Love You|TTBB|Joni Bescos
+You'll Never Know|SSAA|Joni Bescos
+Little Things Mean A Lot|TTBB|Bob Biallas
+The Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
+I Want A Girl Medley|SSAA|Barbara Bianchi
+Let's Get Away From It All|SSAA|Barbara Bianchi
+Miss Celie's Blues|TTBB|Barbara Bianchi
+Old Fashioned Lady|SSAA|Barbara Bianchi
+Ten Feet Off The Ground|SSAA|Barbara Bianchi
+Who'll Take My Place When I'm Gone|SSAA|Barbara Bianchi
+Babe|TTBB|William Biehl
+Bidin' My Time|TTBB|Bill Biffle
+Polka Dots And Moonbeams|SSAA|Bill Biffle
+Toot, Toot, Tootsie|TTBB|Bill Biffle
+Zing! Went The Strings Of My Heart|TTBB|Bill Biffle
+Thriller|SSAA|Kay Bilodeau
+Firework|SSAA|Hari Birtles
+Happy|SSAA|Hari Birtles
+Keep Holding On|SSAA|Hari Birtles
+Make You Feel My Love|SSAA|Hari Birtles
+Price Tag|SSAA|Hari Birtles
+Treat People With Kindness|SSAA|Hari Birtles
+What A Wonderful World|SSAA|Hari Birtles
+Wind Beneath My Wings|SSAA|Hari Birtles
+Wings|SSAA|Hari Birtles
+Smile Medley|TTBB|Ron Black
+Let There Be Peace On Earth|TTBB|Roger Blackburn
+You Don't Need The Wine To Have A Wonderful Time|TTBB|Roger Blackburn
+Auctioneer|TTBB|Greg Blackwell
+Back In The Old Routine|TTBB|Greg Blackwell
+Smilin' Through|SSAA|Greg Blackwell
+The Twelve Days Of Christmas|TTBB|Greg Blackwell
+Keep Cool The Country's Saving Fuel|TTBB|Raleigh Block
+I'll Be Home For Christmas|TTBB|Frank Bloebaum
+Sam, The Old Accordion Man|TTBB|Frank Bloebaum
+Where Is Love?|TTBB|Frank Bloebaum
+Java Jive|TTBB, SSAA|Bluegrass Student Union
+Hot Time In The Old Town|TTBB|Jean Boardman
+I'm Beginning To See The Light|TTBB|John Bober
+On A Slow Boat To China|TTBB|John Bober
+Somewhere In My Memory|TTBB|John Bober
+You'd Be So Nice To Come Home To|TTBB|John Bober
+All I Want For Christmas Is You|SSAA|Adam Bock
+American Boy|SSAA|Adam Bock
+As Long As I Live|TTBB|Adam Bock
+Beautiful Soul|TTBB|Adam Bock
+Buddy's Blues|TTBB|Adam Bock
+Cabaret|TTBB|Adam Bock
+Californication|SATB|Adam Bock
+Can't Help Falling In Love|TTBB|Adam Bock
+Carol Of The Bells|SSAA|Adam Bock
+Carrying The Banner|TTBB|Adam Bock
+Cecilia|TTBB|Adam Bock
+Chapel Of Love|TTBB|Adam Bock
+Cherish|TTBB|Adam Bock
+Christmas Time Is Here|TTBB|Adam Bock
+Cinderella|TTBB|Adam Bock
+Climb Ev'ry Mountain|SSAA|Adam Bock
+Connecticut|SSAA|Adam Bock
+Cornflake Girl|SSAA|Adam Bock
+Count Your Blessings Instead Of Sheep|SATB|Adam Bock
+Creep|TTBB|Adam Bock
+Danger Zone|TTBB|Adam Bock
+Days of Wine and Roses|TTBB|Adam Bock
+Don't Look Back In Anger|TTBB|Adam Bock
+Dr. Who Theme|SATB|Adam Bock
+Dreaming With A Broken Heart|TTBB|Adam Bock
+Everything Changes|TTBB|Adam Bock
+Gimme Gimme|SSAA|Adam Bock
+Gold Mine|TTBB|Adam Bock
+Good Lovin'|TTBB|Adam Bock
+Good Night|SSAA|Adam Bock
+Gravity|SATB|Adam Bock
+The Greatest Show|SSAA|Adam Bock
+Happy Holiday|SSAA|Adam Bock
+Heaven's Light|TTBB|Adam Bock
+Helplessly Hoping|SATB|Adam Bock
+Hold On|SSAA|Adam Bock
+Holiday Inn|TTBB|Adam Bock
+How Long|SSAA|Adam Bock
+I Believe|SSAA|Adam Bock
+I Can't Make You Love Me|TTBB|Adam Bock
+I Get A Kick Out Of You|TTBB|Adam Bock
+I Got The Music In Me|SSAA|Adam Bock
+I Walk With Music|TTBB|Adam Bock
+I'm Just Ken|SSAA|Adam Bock
+If I Dare|TTBB|Adam Bock
+If You Can Dream|SSAA|Adam Bock
+In His Eyes|SSAA|Adam Bock
+It's Been A Long, Long Time|TTBB|Adam Bock
+Jing-a-ling, Jing-a-ling|TTBB|Adam Bock
+Jingle Bells|TTBB, SSAA|Adam Bock
+Journey To The Past|TTBB|Adam Bock
+Killer Queen|TTBB, SSAA|Adam Bock
+Let's Stay Together|TTBB|Adam Bock
+Livin' On A Prayer|SSAA|Adam Bock
+Look For The Silver Lining|TTBB|Adam Bock
+Losing My Mind|TTBB|Adam Bock
+Love The One You're With|TTBB|Adam Bock
+Mango Tree|TTBB|Adam Bock
+Manhattan|TTBB|Adam Bock
+Medley: For All We Know, We've Only Just Begun|SSAA|Adam Bock
+Medley: Tomorrow, Maybe, I Don't Need Anything But You, East Street Reprise|SATB|Adam Bock
+Miracle|SSAA|Adam Bock
+More Than You Know|TTBB|Adam Bock
+Near the Ivy Grown Cottage of Brown|TTBB|Adam Bock
+Nobody But Me|TTBB|Adam Bock
+Nothing Can Stop Me Now|TTBB|Adam Bock
+O Holy Night|SSAA, SATB|Adam Bock
+On The Atchison, Topeka And The Santa Fe|SSAA|Adam Bock
+Open Arms|SSAA|Adam Bock
+Overjoyed|TTBB|Adam Bock
+Plenty To Be Thankful For|SSAA|Adam Bock
+Safe and Sound|SSAA|Adam Bock
+The Seed|SSAA|Adam Bock
+September|SSAA|Adam Bock
+Snow|TTBB|Adam Bock
+Solid As A Rock|SATB|Adam Bock
+A Song For You|TTBB|Adam Bock
+The Spirit Of Adventure|TTBB|Adam Bock
+Sweet Caroline|TTBB|Adam Bock
+Swingin' On A Rainbow|TTBB|Adam Bock
+Take A Look At Us Now|SSAA|Adam Bock
+Trampoline|SSAA|Adam Bock
+Wandering Boy|TTBB|Adam Bock
+What Did You Mean When You Said Love|TTBB|Adam Bock
+Where The Sidewalk Ends|TTBB|Adam Bock
+You Can't Make Old Friends|SSAA|Adam Bock
+You Make Me Feel So Young|SSAA|Adam Bock
+You'll Be In My Heart|TTBB|Adam Bock
+You'll Never Walk Alone|SSAA|Adam Bock
+If I Had Someone To Love|TTBB|Jerry Bockus
+Just One More Chance|TTBB|Jerry Bockus
+If I Had My Life To Live Over|TTBB|Hal Boehler
+Beale Street Mama|TTBB|Edward Boehm
+Doin' The New Lowdown|TTBB|Edward Boehm
+Hooray For Hollywood|TTBB|Edward Boehm
+Lulu's Back In Town|TTBB|Edward Boehm
+The Heather On The Hill|TTBB|Bob Bohn
+Wonderful One|TTBB|Bob Bohn
+Tell Me That You're Gonna Be My Sweetheart|TTBB|M. H. Bolds
+When You And I Were Young Maggie|TTBB|M. H. Bolds
+Almost Like Being In Love|TTBB|James Bongard
+Best Of Times|TTBB|James Bongard
+Dreamer's Holiday|TTBB|James Bongard
+Forgetting You|TTBB|James Bongard
+Let's Do It (Let's Fall In Love)|TTBB|Bruce Bonnyard
+Golden Earrings|TTBB|George Booth
+Love's Old Sweet Song|TTBB|George Booth
+My Mother's Eyes|TTBB|Bill Borah
+Ride Red Ride|TTBB|Ernie Boring
+You Can Make It Happen|TTBB|Kent Borrowdale
+Broadway Opener|TTBB|Paul Bowman
+Carolina In The Morning / Goin' Back To Caroline Medley|TTBB|Paul Bowman
+Clancy Lowered The Boom|TTBB|Paul Bowman
+Ireland Must Be Heaven|TTBB|Paul Bowman
+It's A Great Day For The Irish|TTBB|Paul Bowman
+Mother Machree|TTBB|Paul Bowman
+That Tumble Down Shack In Athlone|TTBB|Paul Bowman
+That's An Irish Lullaby|TTBB|Paul Bowman
+When Irish Eyes Are Smiling|TTBB|Paul Bowman
+You Ain't Heard Nothing Yet|TTBB|Paul Bowman
+Alice Blue Gown|TTBB|Sherleigh Bowman
+Mister Sandman|SSAA|Bertha Bradley
+Into My Arms|SSAA|Hannah Braham
+Little Black Dress|SATB|Hannah Braham
+Sheffield Park|SSAA|Hannah Braham
+Little Street Where Old Friends Meet|TTBB|Sam Breedon
+New Ashmolean Band|SSAA|Peter Briant
+Yes, We Have No Bananas|TTBB|Peter Briant
+Does Your Mother Know|TTBB|Jack Bridges
+Dream A Little Dream Of Me|TTBB|Jack Bridges
+In The Bleak Midwinter|TTBB|Jack Bridges
+Keep On Movin'|SATB|Jack Bridges
+Love Led Us Here|TTBB|Jack Bridges
+Make You Feel My Love|SSAA|Jack Bridges
+Medley: Baby Won't You Please Come Home / After You've Gone|TTBB|Jack Bridges
+Moon River|SATB|Jack Bridges
+Only You|TTBB|Jack Bridges
+Professional Pirate|TTBB|Jack Bridges
+Santa Claus Is Comin' To Town|SATB|Jack Bridges
+Shotgun|TTBB|Jack Bridges
+To Make You Feel My Love|TTBB|Jack Bridges
+You've Got A Friend|SSAA|Jack Bridges
+You've Got A Friend In Me|TTBB|Jack Bridges
+Dreamers Ball|SSAA|Kirsten Bridges
+Four Brothers (Four Sisters)|SSAA|Kirsten Bridges
+Seaside Rendezvous|SSAA|Kirsten Bridges
+Cold-Hearted Man|SATB|Hannah Briggs
+Dancing In The Dark|SATB|Hannah Briggs
+Mele Kalikimaka|SSAA|Hannah Briggs
+Sexy Lady|SSAA|Hannah Briggs
+We'll Meet Again|SATB|Hannah Briggs
+Your Song|SSAA|Hannah Briggs
+Smiles Medley|TTBB|Vic Brimacombe
+Alexander's Ragtime Band|TTBB|David Briner
+All The Way|TTBB, SSAA|David Briner
+All The World Will Be Jealous Of Me|TTBB|David Briner
+All The World Will Be Jealous Of Me|SSAA|David Briner
+Auld Lang Syne|SSAA|David Briner
+Auld Lang Syne|TTBB|David Briner
+Away In A Manger|TTBB|David Briner
+Away In A Manger|SSAA|David Briner
+Basin Street Blues|TTBB|David Briner
+Basin Street Blues|SSAA|David Briner
+Blue Moon|SSAA|David Briner
+Blue Moon|TTBB|David Briner
+Blues In The Night|SSAA|David Briner
+Blues In The Night|TTBB|David Briner
+Breezin' Along With The Breeze|TTBB|David Briner
+Breezin' Along With The Breeze|SSAA|David Briner
+Bring Him Home|SSAA|David Briner
+Can You Tame Wild Wimmen|TTBB|David Briner
+Charleston|TTBB|David Briner
+Cruisin' Down The River|TTBB|David Briner
+Curtain Falls|SSAA|David Briner
+Curtain Falls|TTBB|David Briner
+Doin' The Raccoon|TTBB|David Briner
+Embraceable You|SSAA|David Briner
+Feliz Navidad|TTBB|David Briner
+For All The World|SSAA|David Briner
+For All We Know|TTBB, SSAA|David Briner
+Freddie Feelgood|TTBB|David Briner
+Getting Some Fun Out Of Life|SSAA|David Briner
+Goodnight Angeline|TTBB|David Briner
+Hello Young Lovers|SSAA|David Briner
+Here Comes The Showboat|SSAA|David Briner
+How About Me?|SSAA|David Briner
+I Don't Know How To Say Goodbye|SSAA|David Briner
+I Had Someone Else Before I Had You|SSAA|David Briner
+I Had Someone Else Before I Had You / Who's Sorry Now Medley|TTBB|David Briner
+I Have Dreamed|SSAA|David Briner
+I Just Found out About Love|TTBB, SSAA, SATB|David Briner
+I'll Walk Alone|SSAA|David Briner
+I'm In Love With The Mother Of My Best Girl|TTBB|David Briner
+If I Could Be With You / Honey Medley|SSAA|David Briner
+If I Could Be With You / Honey Medley|TTBB|David Briner
+If There's Anybody Here|SSAA, SATB|David Briner
+If There's Anybody Here|SATB|David Briner
+If You Can't Get A Girl In The Summertime|TTBB|David Briner
+It Might As Well Be Spring|SSAA|David Briner
+It's A Sin To Tell A Lie|SATB|David Briner
+It's A Sin To Tell A Lie/Lies Medley|TTBB|David Briner
+It's All Right With Me|SSAA|David Briner
+It's Time|SSAA|David Briner
+Ja-Da|TTBB|David Briner
+Jazz Baby|TTBB|David Briner
+Joshua Fit The Battle Of Jericho|TTBB|David Briner
+Just A Kid Named Joe|TTBB|David Briner
+Just In Time|TTBB|David Briner
+Just In Time|SSAA|David Briner
+Keep Christmas With You (All Through The Year)|TTBB|David Briner
+Keep Your Eyes On The Hands|TTBB|David Briner
+Kisses Sweeter Than Wine|TTBB|David Briner
+Let's Be Buddies|TTBB|David Briner
+Let's Be Buddies|SSAA|David Briner
+Let's Do It (Let's Fall In Love)|TTBB|David Briner
+Lora-Belle Lee|TTBB|David Briner
+Love In Any Language|SSAA|David Briner
+Love Is A Many Splendored Thing|SSAA|David Briner
+Love Is A Many Splendored Thing|TTBB|David Briner
+Man I Love|SSAA|David Briner
+Man With The Bag|TTBB|David Briner
+Mardi Gras March|TTBB|David Briner
+Mardi Gras March|SSAA|David Briner
+Memphis Blues|TTBB|David Briner
+My Favorite Things|TTBB, SSAA|David Briner
+New Ashmolean Band|TTBB|David Briner
+New Ashmolean Band|SSAA|David Briner
+One|TTBB|David Briner
+Opus One|SSAA|David Briner
+Our Time|SSAA|David Briner
+Paintin' This Old Town Blue|SSAA|David Briner
+Pure Imagination|SSAA|David Briner
+Pure Imagination|TTBB|David Briner
+Radio|TTBB, SSAA|David Briner
+Radio|SSAA|David Briner
+Renaissance Woman|SSAA|David Briner
+Riders In The Sky|TTBB|David Briner
+Rocky Top|SSAA|David Briner
+Romancin' The Blues|SSAA|David Briner
+Saturday Night Medley|TTBB|David Briner
+Somebody Else - Not Me|TTBB|David Briner
+Somebody Else Is Taking My Place|SSAA|David Briner
+Someone To Watch Over Me|SSAA|David Briner
+Something's Gotta Give|SSAA|David Briner
+Something's Gotta Give|TTBB|David Briner
+Song For A Russian Child|SSAA|David Briner
+Stuff Like That There|SSAA|David Briner
+Summer Sounds|TTBB|David Briner
+Sunbonnet Sue|TTBB|David Briner
+Take Another Guess|SSAA|David Briner
+Teddy Bears' Picnic|TTBB|David Briner
+Thank You|TTBB|David Briner
+There You'll Be|SSAA|David Briner
+They Didn't Believe Me / Smoke Gets In Your Eyes Medley|TTBB|David Briner
+Things Are Looking Up|TTBB|David Briner
+Things Are Looking Up|SSAA|David Briner
+This Time Around|SSAA|David Briner
+Those Lazy Hazy Crazy Days Of Summer|SATB|David Briner
+Tie Me To Your Apron Strings Again|TTBB|David Briner
+To Keep My Love Alive|SSAA|David Briner
+Trickle, Trickle|SSAA|David Briner
+The Very Thought Of You|SSAA|David Briner
+Walkin' My Baby Back Home / When My Sugar Walks Down the Street (Medley)|TTBB|David Briner
+We Need A Little Christmas|TTBB|David Briner
+What A Wonderful World|SSAA|David Briner
+What Are You Doing The Rest Of Your Life|TTBB|David Briner
+What Can I Say After I Say I'm Sorry|TTBB|David Briner
+Whatever Happened To Melody|TTBB|David Briner
+When October Goes|SSAA|David Briner
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|David Briner
+When The Morning Glories Wake Up In The Morning|TTBB|David Briner
+When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|David Briner
+When You're Smiling|TTBB|David Briner
+Who Will Buy|TTBB, SSAA, SATB|David Briner
+Who's Sorry Now|TTBB, SSAA|David Briner
+Willow Weep For Me|SSAA|David Briner
+A Wink And A Smile|SSAA|David Briner
+Witchcraft|TTBB|David Briner
+Y'all Come Back Saloon|TTBB|David Briner
+Ya Got Trouble|TTBB|David Briner
+You Must Have Been A Beautiful Baby|TTBB|David Briner
+You Must Have Been A Beautiful Baby / You're Some Pretty Doll Medley|TTBB|David Briner
+You'll Never Know|TTBB|David Briner
+You'll Never Know|SSAA|David Briner
+You're In Style When You're Wearing A Smile|TTBB|David Briner
+Breaking Up Is Hard To Do|TTBB, SSAA|Kim Brittain
+From A Distance|TTBB|Kim Brittain
+I'd Love To Be A Baby Again|TTBB|Kim Brittain
+If I Have To Go To War|TTBB|Kim Brittain
+Little Arrows|TTBB, SSAA|Kim Brittain
+Lulu's Back In Town|TTBB|Kim Brittain
+Moonlight Medley|TTBB|Kim Brittain
+Somewhere Out There|TTBB|Kim Brittain
+Where The River Shannon Flows|TTBB|Kim Brittain
+A Wink And A Smile|TTBB, SSAA, SATB|Kim Brittain
+I've Got A Lovely Bunch Of Hot Dogs|TTBB|Bob Brock
+It Happened In Monterey|TTBB|John Brockman
+Let's Do It (Let's Fall In Love)|TTBB, SSAA|John Brockman
+Make Someone Happy|TTBB|John Brockman
+The Nearness Of You|TTBB|John Brockman
+You Didn't Know Me When|TTBB|John Brockman
+A Million Dreams|SSAA, Young SSAA|Kay Bromert
+Above the Northern Lights|SSAA|Kay Bromert
+Abraham, Martin, and John|SSAA|Kay Bromert
+After I've Called You Sweetheart|SSAA|Kay Bromert
+All Dressed Up With A Broken Heart|SSAA|Kay Bromert
+All I Want For Christmas Is You|SSAA|Kay Bromert
+Alleluia|SSAA|Kay Bromert
+Almost There|SSAA|Kay Bromert
+Auld Lang Syne Christmas|SSAA|Kay Bromert
+Autumn Leaves|SSAA|Kay Bromert
+Baby, Oh Where Can You Be?|SSAA|Kay Bromert
+Beer Barrel Polka|SSAA|Kay Bromert
+Bein' Green|SSAA|Kay Bromert
+A Bird Without Wings|SSAA|Kay Bromert
+Blowin' In the Wind|SSAA|Kay Bromert
+Bury Me Not On The Lone Prairie|SSAA|Kay Bromert
+Can't Take My Eyes Off Of You|SSAA|Kay Bromert
+Carol Me|SSAA|Kay Bromert
+Change The World|SSAA|Kay Bromert
+Children Run Joyfully|SSAA|Kay Bromert
+A Christmas Call To Worship|SSAA|Kay Bromert
+Christmas Children|SSAA|Kay Bromert
+Christmas Lights|SSAA|Kay Bromert
+Christmas Waltz|SSAA|Kay Bromert
+Circle Of Friends|SSAA|Kay Bromert
+Class of '57|SSAA|Kay Bromert
+Come On Home|SSAA|Kay Bromert
+Come Right In, Sit Right Down, And Make Yourself At Home|SSAA|Kay Bromert
+The Day After Thanksgiving|SATB|Kay Bromert
+Don't Be A Baby, Baby|SSAA|Kay Bromert
+Don't Go Breaking My Heart|SSAA|Kay Bromert
+Dust In The Wind|SSAA|Kay Bromert
+Far Side Banks of Jordan|SSAA|Kay Bromert
+Footloose|SSAA|Kay Bromert
+The Friendly Beasts|SATB|Kay Bromert
+From A Distance|SSAA|Kay Bromert
+From Now On|SSAA|Kay Bromert
+The Gift of Song|SSAA|Kay Bromert
+Hallelujah|SSAA, SATB|Kay Bromert
+Hallelujah Christmas|SSAA|Kay Bromert
+Happy Haunkkah|SSAA|Kay Bromert
+Have You Ever Seen The Rain?|SSAA|Kay Bromert
+He Touched Me|SSAA|Kay Bromert
+Here I Am, Lord|SSAA|Kay Bromert
+High Cost Of Lovin'|SSAA|Kay Bromert
+His Eye Is On The Sparrow|SSAA|Kay Bromert
+Home Again|SSAA|Kay Bromert
+Home For The Holidays|SATB|Kay Bromert
+I Asked The Lord|SSAA|Kay Bromert
+I Can See Clearly Now|SSAA|Kay Bromert
+I Got The Sun In The Morning|SSAA|Kay Bromert
+I Have Nothing|SSAA|Kay Bromert
+I Want A Hippopotamus For Christmas|SSAA|Kay Bromert
+I'll Be Home For Christmas|SSAA|Kay Bromert
+I'm Beginning To See The Light|SSAA|Kay Bromert
+If I Can Dream|SSAA|Kay Bromert
+In a Box on a Shelf|SSAA|Kay Bromert
+In This Very Room|SSAA|Kay Bromert
+It Might As Well Be Spring|SSAA|Kay Bromert
+It Was Almost Like A Song|SSAA|Kay Bromert
+It's A Jungle Out There|SSAA|Kay Bromert
+It's A Million To One You're In Love|SSAA|Kay Bromert
+It's The Most Wonderful Time Of The Year|SATB|Kay Bromert
+A Jingle Bell Travelogue|SSAA|Kay Bromert
+La Bamba|SSAA|Kay Bromert
+La Cucaracha|SSAA, Young SSAA|Kay Bromert
+Let It Snow Let It Snow Let It Snow|SSAA|Kay Bromert
+Let's Have An Old Fashioned Christmas|SSAA|Kay Bromert
+Little Mother of Mine|SSAA|Kay Bromert
+The Longest Time|SSAA|Kay Bromert
+The Lord's Prayer|SSAA|Kay Bromert
+Love The World Away|SSAA|Kay Bromert
+Magical Mystery Tour|SSAA|Kay Bromert
+Make Mine Barbershop|SSAA|Kay Bromert
+Makin' Music|SSAA, Young SSAA|Kay Bromert
+Mary's Boy Child|SSAA|Kay Bromert
+Melodias de America|SSAA|Kay Bromert
+Mr. Wonderful|SSAA|Kay Bromert
+Mrs. Santa Claus|SSAA|Kay Bromert
+Music Moves Me|SSAA|Kay Bromert
+The Musics Always There With You|SSAA|Kay Bromert
+My Christmas Song For You|SSAA|Kay Bromert
+My Cutey's Due At Two-To-Two To-day|SSAA|Kay Bromert
+My God and I|SSAA|Kay Bromert
+My Wish For You|SSAA|Kay Bromert
+O Christmas Tree|SSAA|Kay Bromert
+The Old Lamplighter|SSAA|Kay Bromert
+Old Rugged Cross|SSAA|Kay Bromert
+Old Time Hymn Medley|SSAA|Kay Bromert
+One Little Candle|TTBB|Kay Bromert
+One Of Those Songs|SSAA|Kay Bromert
+The One on the Right is On the Left|SSAA|Kay Bromert
+One Small Child|SSAA|Kay Bromert
+Only Me|SSAA|Kay Bromert
+Only Time|SSAA|Kay Bromert
+Perhaps Love|SSAA|Kay Bromert
+Place in the Choir|SSAA|Kay Bromert
+Puttin' On The Ritz|SSAA|Kay Bromert
+Rawhide|SSAA|Kay Bromert
+Right Here Waiting|SSAA|Kay Bromert
+The Rose|SSAA|Kay Bromert
+Sadie, Sadie, Married Lady|SSAA|Kay Bromert
+Say It With Music|SSAA|Kay Bromert
+Search Me, Lord|SSAA|Kay Bromert
+Send In The Clowns|SSAA|Kay Bromert
+Sesame Street Songs|SSAA|Kay Bromert
+Shape Of Things, The (The Ballad Of)|SSAA|Kay Bromert
+Shoot For The Moon|SSAA|Kay Bromert
+Silver Bells|SSAA|Kay Bromert
+Sister Mead's Lord's Prayer|SSAA|Kay Bromert
+Skyfall|SSAA|Kay Bromert
+Some Children See Him|SSAA|Kay Bromert
+Someday I'll Make You Glad|SSAA|Kay Bromert
+Sometimes|SSAA|Kay Bromert
+Somewhere In My Memory|SATB|Kay Bromert
+Still, Still, Still|SSAA|Kay Bromert
+Sweet Little Jesus Boy|SSAA|Kay Bromert
+That's Christmas To Me|SSAA|Kay Bromert
+There's A Vacant Chair At Home Sweet Home|SSAA|Kay Bromert
+This Is Me|SSAA, Young SSAA|Kay Bromert
+Til We Meet Again|SSAA|Kay Bromert
+Time In A Bottle|SSAA|Kay Bromert
+A Tree in the Meadow|SSAA|Kay Bromert
+Tumbling Tumbleweeds|SSAA|Kay Bromert
+Twelve Days of Christmas Parody|SSAA|Kay Bromert
+Valentine|SSAA|Kay Bromert
+Vaya Con Dios|SSAA|Kay Bromert
+Waitin' On The Far Side Banks of Jordan|SSAA|Kay Bromert
+Way Down in Iowa|SSAA|Kay Bromert
+We Need A Little Christmas|TTBB|Kay Bromert
+We Three (My Echo, My Shadow and Me)|SSAA|Kay Bromert
+What Can I Give Him?|SSAA|Kay Bromert
+What Wondrous Love Is This|SSAA|Kay Bromert
+When I Look In Your Eyes|SSAA|Kay Bromert
+When You Believe|SSAA|Kay Bromert
+Where Did Robinson Crusoe Go With Friday On Saturday Night|SSAA|Kay Bromert
+Where Is Love?|SSAA|Kay Bromert
+Who'll Dry Your Tears When You Cry?|SSAA|Kay Bromert
+You Are the New Day|SSAA|Kay Bromert
+You Don't Own Me|SSAA|Kay Bromert
+You're Never Fully Dressed Without A Smile|SSAA|Kay Bromert
+Red Roses For A Blue Lady|TTBB|Chuck Brooks
+There'll Be Some Changes Made|TTBB|Chuck Brooks
+I'm Knee Deep In Daisies|TTBB|Sherry Brown
+Indiana|TTBB|Sherry Brown
+It All Belongs To Me|TTBB|Sherry Brown
+It Looks Like Rain In Cherry Blossom Lane|TTBB|Sherry Brown
+Looking At The World Through Rose Colored Glasses|TTBB|Sherry Brown
+Twas Only An Irishman's Dream|TTBB|Sherry Brown
+Blue Moon|TTBB|Joe Browne
+Blues In The Night|TTBB|Joe Browne
+Somebody Bigger Than You And I|TTBB|Joe Browne
+Thou Art Worthy|TTBB|Joe Browne
+Amazing Grace|TTBB|Nick Bryant
+And So It Goes|TTBB|Nick Bryant
+Away In A Manger|TTBB|Nick Bryant
+The Ballad Of Bonnie And Clyde|TTBB|Nick Bryant
+Chitty Chitty Bang Bang|TTBB|Nick Bryant
+The Christmas Song|SATB|Nick Bryant
+A Cradle In Bethlehem|TTBB|Nick Bryant
+Dance of the Sugarplum Fairy|SSAA|Nick Bryant
+Danny Boy|TTBB|Nick Bryant
+Deck The Halls|TTBB|Nick Bryant
+The First Noel|TTBB|Nick Bryant
+God Rest Ye Merry, Gentlemen|SATB|Nick Bryant
+Goodbye Mr. A|TTBB|Nick Bryant
+Great Adventure|SATB|Nick Bryant
+Hushabye Mountain|TTBB|Nick Bryant
+I'm A Dreamer, Aren't We All|TTBB|Nick Bryant
+In The Bleak Midwinter|TTBB|Nick Bryant
+Joy To The World|TTBB|Nick Bryant
+Let's Go Fly a Kite|TTBB, SSAA|Nick Bryant
+Lovely Lonely Man|SSAA|Nick Bryant
+Nowhere to Go but Up|TTBB|Nick Bryant
+O Holy Night|TTBB|Nick Bryant
+Only Love|SSAA|Nick Bryant
+Silent Night|TTBB|Nick Bryant
+This Is The Moment|TTBB|Nick Bryant
+Weekend In New England|TTBB|Nick Bryant
+You're The First, The Last, My Everything|TTBB|Nick Bryant
+He May Be Old, But He's Got Young Ideas|TTBB|Harry Buerer
+Silver Bells|TTBB|Harry Buerer
+Star Spangled Banner|TTBB|Harry Buerer
+When You Wore A Tulip|TTBB|Harry Buerer
+America The Beautiful|SSAA|Suzy Buerer
+O Holy Night|SSAA|Suzy Buerer
+On The Banks Of The Wabash|SSAA|Suzy Buerer
+Percy, The Puny Poinsettia|SSAA|Suzy Buerer
+What Strangers Are These|SSAA|Suzy Buerer
+"Cruisin' Along In My Old Model ""T"""|TTBB|Ray Buntaine
+Great Is Thy Faithfulness|TTBB|Ray Buntaine
+I Fall In Love With You Every Day|TTBB|Ray Buntaine
+I Like Chinese|TTBB|Ray Buntaine
+I'll See You In My Dreams|TTBB|Ray Buntaine
+I'm A Lonely Little Petunia|TTBB|Ray Buntaine
+Little On The Lonely Side|TTBB|Ray Buntaine
+Pennies from Heaven|TTBB|Ray Buntaine
+Sailors Medley|TTBB|Ray Buntaine
+Stouthearted Men|TTBB|Ray Buntaine
+Super Heroes|TTBB|Ray Buntaine
+The Tag|TTBB|Ray Buntaine
+Teddy Bears' Picnic|TTBB|Ray Buntaine
+Thanks For The Memory|TTBB|Ray Buntaine
+We'll Meet Again|TTBB|Ray Buntaine
+Winter Song|TTBB|Ray Buntaine
+Zing! Went The Strings Of My Heart|TTBB|Ray Buntaine
+When The Moon Comes Over The Mountain|TTBB|Al Burgess
+SPEBSQSA Theme Songs Medley|TTBB|Clarence Burgess
+We Sing That They Shall Speak|TTBB|Clarence Burgess
+Baby Rose|TTBB|Dennis Burnett
+Broadway Rose|TTBB|Dennis Burnett
+Comedy Tonight|TTBB|Dennis Burnett
+If You Leave Me, I'll Never Cry|TTBB|Dennis Burnett
+Little Pal|TTBB|Dennis Burnett
+Mandy Lee|TTBB|Dennis Burnett
+Mem'ries Of Mother|TTBB|Dennis Burnett
+Oh! What A Pal Was Mary|TTBB|Dennis Burnett
+Tackin' 'Em Down|TTBB|Dennis Burnett
+Toot, Toot, Tootsie|TTBB|Dennis Burnett
+We'll Have A Jubilee In My Old Kentucky Home|TTBB|Dennis Burnett
+What Do You Want To Make Those Eyes At Me For|TTBB|Dennis Burnett
+When You Look In The Heart Of A Rose|TTBB|Dennis Burnett
+Air on a G Swing|TTBB, SSAA|Mark Burnip
+The Air That I Breathe|TTBB|Mark Burnip
+Beatles Medley|TTBB, SSAA|Mark Burnip
+Bring Him Home|TTBB|Mark Burnip
+Can't Take My Eyes Off Of You|TTBB|Mark Burnip
+The Circle Of Life|TTBB|Mark Burnip
+Cry Me A River|TTBB|Mark Burnip
+Delilah|TTBB, SSAA|Mark Burnip
+Dick Van Dyke Celebration|TTBB, SSAA|Mark Burnip
+Don't Let The Sun Go Down On Me|TTBB, SSAA|Mark Burnip
+Fair Phyllis|TTBB|Mark Burnip
+Feels Like Home|TTBB|Mark Burnip
+Food, Glorious Food|TTBB|Mark Burnip
+He Ain't Heavy, He's My Brother|TTBB|Mark Burnip
+He ain't heavy/Air that I breathe|TTBB, SSAA|Mark Burnip
+How Great Thou Art|TTBB, SSAA|Mark Burnip
+I Can See Clearly Now|TTBB|Mark Burnip
+I Heard It Through The Grapevine|TTBB, SSAA|Mark Burnip
+I Still Have Faith In You|TTBB|Mark Burnip
+I Write the Songs/Lola|TTBB, SSAA|Mark Burnip
+It Feels Like Home|TTBB, SSAA|Mark Burnip
+It's Madness Medley|TTBB, SSAA|Mark Burnip
+Kingston Town|TTBB, SSAA|Mark Burnip
+Lady Madonna|TTBB, SSAA|Mark Burnip
+Let's Go To San Francisco|TTBB, SSAA|Mark Burnip
+The Longest Time|TTBB, SSAA|Mark Burnip
+Losing You|TTBB|Mark Burnip
+Make You Feel My Love|TTBB|Mark Burnip
+Manilow Magic|TTBB, SSAA|Mark Burnip
+Maria|TTBB|Mark Burnip
+Memory|TTBB, SSAA|Mark Burnip
+My Foolish Heart|TTBB, SSAA|Mark Burnip
+My Way|TTBB, SSAA|Mark Burnip
+The Night Has a Thousand Eyes|TTBB, SSAA|Mark Burnip
+Oklahoma|TTBB, SSAA|Mark Burnip
+Old Bazar in Cairo|TTBB, SSAA|Mark Burnip
+One Hand, One Heart|TTBB|Mark Burnip
+One Voice/Peace on Earth|TTBB, SSAA|Mark Burnip
+Perfect|TTBB, SSAA|Mark Burnip
+Poor Little Millionaire|TTBB|Mark Burnip
+The Shadow Of Your Smile|TTBB|Mark Burnip
+She's The One|TTBB|Mark Burnip
+Singin' In The Rain|TTBB|Mark Burnip
+Somewhere|TTBB|Mark Burnip
+Till There Was You|TTBB, SSAA|Mark Burnip
+We Meet Again|TTBB|Mark Burnip
+We'll Meet Again|TTBB|Mark Burnip
+We've Only Just Begun|TTBB|Mark Burnip
+Who Will Buy|TTBB|Mark Burnip
+Wichita Lineman|TTBB|Mark Burnip
+Yesterday|TTBB, SSAA|Mark Burnip
+You Take My Breath Away|TTBB|Mark Burnip
+You'll Be In My Heart|TTBB|Mark Burnip
+You've Got A Friend In Me|TTBB|Mark Burnip
+Your Mother Should Know|TTBB|Mark Burnip
+In A Shanty In Old Shanty Town|TTBB|Mort Burt
+Yes, We Have No Bananas|TTBB|Mort Burt
+Creole Cutie|TTBB|Bill Busby
+You've Had A Long, Long Day|TTBB|Bill Busby
+Longer|SSAA|Diane Buschel
+Amazing Grace|SSAA|Carolyn Butler
+Can't Help Lovin' Dat Man|SSAA|Carolyn Butler
+Toot, Toot, Tootsie|TTBB|Carolyn Butler
+Delilah|SSAA|Diane Butler
+I Remember You|SSAA|Diane Butler
+Sh Boom|TTBB|Diane Butler
+Skyfall|SSAA|Diane Butler
+The Sound Of Silence|SSAA|Diane Butler
+Till There Was You|SSAA|Diane Butler
+Welsh National Anthem|TTBB|Diane Butler
+A Nightingale Sang In Berkeley Square|TTBB|Ted Byers
+A Foggy Night In San Francisco|TTBB|Ted Byrne
+I Left My Heart In San Francisco|TTBB|Ted Byrne
+Lord's My Shepherd|TTBB|Hugh Calhoun
+Lorabelle Lee|TTBB|Dave Calland
+Another Op'nin|SSAA|Dot Calvin
+By The Beautiful Sea|SSAA|Dot Calvin
+By The Beautiful Sea|TTBB|Dot Calvin
+Bye Bye Baby|SSAA|Dot Calvin
+Consider Yourself|SSAA|Dot Calvin
+Let Tonight Be The Night|SSAA|Dot Calvin
+My Melancholy Baby|SSAA|Dot Calvin
+Shine On, Harvest Moon|SSAA|Dot Calvin
+Smile|SSAA|Dot Calvin
+Take Me Out To The Ball Game|SSAA|Dot Calvin
+That Old Feeling|SSAA|Dot Calvin
+When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Dot Calvin
+Mama Yo Quiero|SSAA|Jim Campbell
+Adieu, My Lovely Nancy|TTBB|Rob Campbell
+Alabama Jubilee|TTBB|Rob Campbell
+Alexander's Ragtime Band|TTBB|Rob Campbell
+All The Things You Are|TTBB, SSAA|Rob Campbell
+Alone Medley|TTBB|Rob Campbell
+Benny's From Heaven|TTBB|Rob Campbell
+Bridge Over Troubled Water|TTBB|Rob Campbell
+California Here I Come|TTBB|Rob Campbell
+Call Me Back Pal O' Mine|TTBB|Rob Campbell
+Chesapeake Bay / Old Dominion Line Medley|TTBB|Rob Campbell
+Circus Medley|TTBB|Rob Campbell
+Crazy 'Bout Ya Baby|TTBB|Rob Campbell
+Dear Hearts And Gentle People|TTBB|Rob Campbell
+Dear Old Pal Of Mine|TTBB|Rob Campbell
+Dream A Little Dream Of Me|SATB|Rob Campbell
+Edelweiss|TTBB, SSAA, SATB|Rob Campbell
+For The Sake Of Auld Lang Syne|TTBB|Rob Campbell
+Four Seasons Medley|TTBB|Rob Campbell
+Frosty The Snowman|TTBB, SSAA, SATB|Rob Campbell
+Here We Come A-Caroling|TTBB|Rob Campbell
+Here, There And Everywhere|TTBB|Rob Campbell
+Hoagy Medley|TTBB|Rob Campbell
+I Can't Give You Anything But Love|SATB|Rob Campbell
+I Know What It Means To Be Lonesome|TTBB|Rob Campbell
+I Miss You Most Of All|TTBB|Rob Campbell
+I'll Be Back|TTBB|Rob Campbell
+I'm An Old Cowhand|TTBB|Rob Campbell
+It's All Over / So Long, Dearie Medley|TTBB|Rob Campbell
+Jean|TTBB|Rob Campbell
+Just A Kid Named Joe|TTBB|Rob Campbell
+Lord Bless You And Keep You|TTBB|Rob Campbell
+More I Cannot Wish You|TTBB|Rob Campbell
+My Girl|TTBB, SATB|Rob Campbell
+My Man|TTBB|Rob Campbell
+Nice Work If You Can Get It|TTBB|Rob Campbell
+Now I'm Following You|TTBB|Rob Campbell
+Oh, You Beautiful Doll|TTBB|Rob Campbell
+Old Rocking Chair|TTBB|Rob Campbell
+Once Upon A Time|TTBB, SSAA|Rob Campbell
+Polka Dots And Moonbeams|TTBB|Rob Campbell
+Poor Little Rich Girl|TTBB|Rob Campbell
+Portrait Of My Love/Mona Lisa Medley|TTBB|Rob Campbell
+A Room With A View|TTBB|Rob Campbell
+Sam Cooke Medley|TTBB|Rob Campbell
+Slap That Bass|TTBB, SATB|Rob Campbell
+Somewhere|TTBB, SATB|Rob Campbell
+Stepping Around|TTBB|Rob Campbell
+Swan Song|TTBB|Rob Campbell
+Sweet Blindness|TTBB|Rob Campbell
+The Sweetheart Of Sigma Chi|TTBB|Rob Campbell
+Take Me To The Land Of Jazz|TTBB|Rob Campbell
+Tell Her About It|TTBB|Rob Campbell
+Thanksgiving Hymn|TTBB|Rob Campbell
+There's A Goldmine in the Sky|TTBB|Rob Campbell
+To Sir With Love|TTBB|Rob Campbell
+To Sir With Love|SSAA|Rob Campbell
+Together Wherever We Go|TTBB|Rob Campbell
+Up A Lazy River|TTBB|Rob Campbell
+We All Stand Together|TTBB|Rob Campbell
+We'll Have A Jubilee In My Old Kentucky Home|TTBB|Rob Campbell
+Wedding Song|TTBB|Rob Campbell
+What Child Is This|TTBB|Rob Campbell
+When I Get You Alone Tonight/All Alone Medley|TTBB|Rob Campbell
+When She Loved Me|SSAA|Rob Campbell
+When Sunny Gets Blue|SATB|Rob Campbell
+When The Twilight Comes To Kiss The Rose Good Night|TTBB|Rob Campbell
+When You Look In The Heart Of A Rose|TTBB|Rob Campbell
+When You Say You Love Me|TTBB|Rob Campbell
+When You Wore A Tulip|TTBB|Rob Campbell
+Where Are The Roses Of Yesterday|TTBB|Rob Campbell
+Who's Sorry Now|TTBB|Rob Campbell
+Baby Sister Blues|SSAA|Tom Campbell
+Breaking Up Is Hard To Do|TTBB, SSAA, SATB|Tom Campbell
+Do You Know What It Means To Miss New Orleans|TTBB|Tom Campbell
+I Want To Be Somebody's Baby Girl|SSAA|Tom Campbell
+I'll Never Miss Another Girl As I Miss You|TTBB|Tom Campbell
+Nevertheless|SSAA|Tom Campbell
+Nevertheless|TTBB|Tom Campbell
+Oh, Susanna Dust Off That Old Pianna|TTBB|Tom Campbell
+Oh, You Beautiful Doll|TTBB|Tom Campbell
+Something Tells Me You Will Break My Heart|TTBB|Tom Campbell
+Star Spangled Banner|TTBB|Tom Campbell
+That Slippery Slide Trombone|TTBB|Tom Campbell
+When She Loved Me|SSAA|Tom Campbell
+When You're Smiling|TTBB|Tom Campbell
+Heart Of A Clown|TTBB|Bruce Cannon
+I Wonder What's Become Of Sally|TTBB|George Canon
+Fit As A Fiddle|SSAA|Arline Cardoso
+Dr. Jazz/Jazz Holiday Medley|SSAA|Sharon Carlson
+Reach|SSAA|Sharon Carlson
+Stray Cat Strut|SSAA|Sharon Carlson
+When Sunny Gets Blue|SSAA|Sharon Carlson
+Yesterday I Heard The Rain|SSAA|Sharon Carlson
+Beautiful City|TTBB|Andrew Carolan
+Hide and Seek|SATB|Andrew Carolan
+I Get Along Without You Very Well|TTBB|Andrew Carolan
+I'll Be Seeing You|SSAA|Andrew Carolan
+The Late Late Show|SATB|Andrew Carolan
+Let's Get Lost|TTBB|Andrew Carolan
+Nancy (With The Laughing Face)|TTBB|Andrew Carolan
+Nothing But The Best|TTBB|Andrew Carolan
+Straighten Up And Fly Right|SSAA, SATB|Andrew Carolan
+Too Young To Go Steady|SATB|Andrew Carolan
+That's What God Made Mothers For|TTBB|David Carr
+Jukebox In My Mind|TTBB|Richard Carr
+Thank God For Kids|TTBB|Richard Carr
+All Is Found|SSAA|Fran Carter
+Both Sides Now|SSAA|Fran Carter
+Bread and Roses|SSAA|Fran Carter
+God Save The Queen/King|SSAA|Fran Carter
+Happiness|SSAA|Fran Carter
+Hold On|SSAA|Fran Carter
+I Couldn't Live Without Your Love|SSAA|Fran Carter
+I Will|SSAA|Fran Carter
+Jerusalem|SSAA|Fran Carter
+Perfect|SSAA|Fran Carter
+Something Inside So Strong|SSAA|Fran Carter
+Songbird|SSAA|Fran Carter
+Thursday|SSAA|Fran Carter
+Treat People With Kindness|SSAA|Fran Carter
+We All Stand Together|SSAA|Fran Carter
+What The World Needs Now Is Love|SSAA|Fran Carter
+What's Inside|TTBB|Fran Carter
+Will The Sun Ever Shine Again|SSAA|Fran Carter
+Falling In Love Again (Can't Help It)|SSAA|Becky Cartine
+For All We Know|SSAA|Becky Cartine
+Gotta Be This Or That|SSAA|Becky Cartine
+Happy Times|SSAA|Becky Cartine
+Have A Good Time|SSAA|Becky Cartine
+Love in a Home (You Can Tell When There's)|SSAA|Becky Cartine
+Please Don't Talk About Me When I'm Gone|SSAA|Becky Cartine
+Real American Folk Song, The (Is A Rag)|SSAA|Becky Cartine
+Sweetheart Tree|SSAA|Becky Cartine
+Take Me Along|SSAA|Becky Cartine
+Too Late Now (from ROYAL WEDDING)|SSAA|Becky Cartine
+What A Difference A Day Made|SSAA|Becky Cartine
+You're Breaking My Heart|SSAA|Becky Cartine
+What A Wonderful World|TTBB|F. J. Catto
+Over The Rainbow|TTBB|Joe Caulkins
+Walking After Midnight|TTBB|Neil Cerutti
+Frosty The Snowman|TTBB|G. Chelemedos
+Why Should I Cry Over You?|TTBB|G. Chelemedos
+American Armed Forces Medley|TTBB, SSAA|Jim Clancy
+American Trilogy|TTBB|Jim Clancy
+Auld Lang Syne|TTBB|Jim Clancy
+The Birthday Of A King|TTBB|Jim Clancy
+Come Take Your Place in My Heart|TTBB, SSAA|Jim Clancy
+Delta Dawn|TTBB|Jim Clancy
+God Be With You 'til We Meet Again|TTBB|Jim Clancy
+God Rest Ye Merry, Gentlemen|TTBB|Jim Clancy
+Home On The Range|TTBB|Jim Clancy
+Hymn to Freedom|TTBB, SSAA, SATB|Jim Clancy
+Hymns of the Cross Medley|TTBB|Jim Clancy
+It Came Upon A Midnight Clear|TTBB, SSAA|Jim Clancy
+It Is Well With My Soul|TTBB|Jim Clancy
+King Hymn Medley|TTBB|Jim Clancy
+My Country 'Tis Of Thee (The Penny)|TTBB|Jim Clancy
+O Come O Come Emmanuel|TTBB|Jim Clancy
+O Come, All Ye Faithful|TTBB|Jim Clancy
+O Holy Night|TTBB|Jim Clancy
+Silent Night|TTBB|Jim Clancy
+Songs of Christmas Medley|TTBB, SSAA|Jim Clancy
+Star Spangled Banner|TTBB, SSAA|Jim Clancy
+Sweet Hour Of Prayer|TTBB, SSAA|Jim Clancy
+The Sweetheart Of Sigma Chi|TTBB|Jim Clancy
+The Pledge of Allegiance|TTBB|Jim Clancy
+Those Chords Will Ring Forever|TTBB|Jim Clancy
+Toyland|TTBB|Jim Clancy
+You Don't Know Me|TTBB, SSAA|Jim Clancy
+A Certain Smile|SSAA|Diane Clark
+A Hundred Years from Now|SSAA|Diane Clark
+Ash Grove|SSAA|Diane Clark
+Ave Maria|SATB|Diane Clark
+Believe Me, If All Those|SSAA|Diane Clark
+Better Luck Next Time|SSAA|Diane Clark
+The Blue Room|SSAA|Diane Clark
+Breathe On Me, Breath of God|SATB|Diane Clark
+The Briar and the Rose|SSAA|Diane Clark
+Drink To Me Only With Thine Eyes|SSAA|Diane Clark
+Everywhere I Look|SSAA|Diane Clark
+For All We Know|SSAA|Diane Clark
+A Garden In The Rain|SSAA|Diane Clark
+Gentle Annie|SSAA|Diane Clark
+God's Healing Love|SSAA|Diane Clark
+God's Healing Love|TTBB|Diane Clark
+The Holly And The Ivy|SSAA|Diane Clark
+I Cannot Sing The Old Songs|SSAA|Diane Clark
+I Could Be Happy With You|SSAA|Diane Clark
+I Saw Three Ships|SSAA|Diane Clark
+I Wish I Didn't Love You So|SSAA|Diane Clark
+I'm In The Mood For Love|SSAA|Diane Clark
+I'm Old Fashioned|SSAA|Diane Clark
+In Between Ox & Donkey Gray|SSAA|Diane Clark
+In The Garden|SSAA|Diane Clark
+Jesus, Jesus, Rest Your Head|SSAA|Diane Clark
+Joseph's Lullaby|SSAA|Diane Clark
+Lo How a Rose Ere Blooming|SSAA|Diane Clark
+Long Ago (And Far Away)|SSAA|Diane Clark
+Nice Work If You Can Get It|SSAA|Diane Clark
+Ring, Ring the Banjo!|SSAA|Diane Clark
+Scarborough Fair|TTBB|Diane Clark
+Scarborough Fair|SSAA|Diane Clark
+Tell Me Again|SSAA|Diane Clark
+That Certain Party|SSAA|Diane Clark
+The Way You Look Tonight|SSAA|Diane Clark
+There Will Never Be Another You|SSAA|Diane Clark
+They Say It's Wonderful|SSAA|Diane Clark
+Wassail Song|SSAA|Diane Clark
+Wassail Song|TTBB|Diane Clark
+What Did I Have that I Don't Have?|SSAA|Diane Clark
+Where is the One?|SSAA|Diane Clark
+Where Or When|SSAA|Diane Clark
+Lonesomest Girl In Town|TTBB|Jack Clark
+Tumbling Tumbleweeds|TTBB|Jim Clark
+Erie Canal|TTBB|Keith Clark
+I Can Never Get Over A Girl Like You|TTBB|Keith Clark
+Just A Little Bit Of Green|TTBB|Keith Clark
+Show Biz Is|TTBB|Keith Clark
+It's A Grand Night For Singing|SSAA|Molly Clark
+Lion Sleeps Tonight|SSAA|Molly Clark
+Ten Feet Off The Ground|SSAA|Molly Clark
+Tulsa Time|SSAA|Molly Clark
+Happy Birthday To You|TTBB|Robert Clark
+I Wanna Be Loved By You|SSAA|Anne Clarke
+Only You (And You Alone)|TTBB|Chuck Clauser
+Cause I'm A Blonde|SSAA|Debbie Cleveland
+The M.T.A.|TTBB|James Coates
+Baby Face|TTBB|Ted Cobb
+If I Had My Life To Live Over|TTBB|Ted Cobb
+Looking At The World Through Rose Colored Glasses|TTBB|Ted Cobb
+Hunting Song|TTBB|John Coffin
+Oklahoma|TTBB|John Coffin
+All Dressed Up With A Broken Heart|SSAA|Mary K. Coffman Music Fund
+Among My Souvenirs|SSAA|Mary K. Coffman Music Fund
+Ballin' The Jack|SSAA|Mary K. Coffman Music Fund
+Blues In The Night|SSAA|Mary K. Coffman Music Fund
+Call Me Back Pal O' Mine|SSAA|Mary K. Coffman Music Fund
+Christmas Dreams Song|SSAA|Mary K. Coffman Music Fund
+Georgia On My Mind|SSAA|Mary K. Coffman Music Fund
+God Bless The U.S.A.|SSAA|Mary K. Coffman Music Fund
+Goodbye Medley|SSAA|Mary K. Coffman Music Fund
+Harbor Lights|SSAA|Mary K. Coffman Music Fund
+I Don't Know Why/You Made Me Medley|SSAA|Mary K. Coffman Music Fund
+I'd Give The World To Be In My Home Town|SSAA|Mary K. Coffman Music Fund
+I'm Alone Because I Love You|SSAA|Mary K. Coffman Music Fund
+If I Had My Life To Live Over|SSAA|Mary K. Coffman Music Fund
+It's A Small World|SSAA, Young SSAA|Mary K. Coffman Music Fund
+It's Hard To Be Humble (Oh, Lord)|SSAA|Mary K. Coffman Music Fund
+Ja-Da|SSAA|Mary K. Coffman Music Fund
+Lazy River|SSAA|Mary K. Coffman Music Fund
+Let It Shine|SSAA|Mary K. Coffman Music Fund
+A Little Old Lady In Tennis Shoes|SSAA|Mary K. Coffman Music Fund
+Mama Don't Low|SSAA|Mary K. Coffman Music Fund
+Never Again|SSAA|Mary K. Coffman Music Fund
+Only You (And You Alone)|SSAA|Mary K. Coffman Music Fund
+Row, Row, Row|SSAA|Mary K. Coffman Music Fund
+Satisfied|SSAA|Mary K. Coffman Music Fund
+Scotch And Soda|SSAA|Mary K. Coffman Music Fund
+Stars Fell On Alabama|SSAA|Mary K. Coffman Music Fund
+Straighten Up And Fly Right|SSAA|Mary K. Coffman Music Fund
+Take Me To The Land Of Jazz|SSAA|Mary K. Coffman Music Fund
+Thank You, Dear Lord, For Music|SSAA|Mary K. Coffman Music Fund
+Unchained Melody|SSAA|Mary K. Coffman Music Fund
+Unforgettable|SSAA|Mary K. Coffman Music Fund
+Waitin' For The Train To Come In|SSAA|Mary K. Coffman Music Fund
+Where Is Love?|SSAA|Mary K. Coffman Music Fund
+M-O-T-H-E-R|SSAA|Lauree Cogley
+Peace On Earth/Little Drummer Boy medley|SSAA|Lauree Cogley
+A Dream Is A Wish Your Heart Makes|TTBB|Gene Cokeroft
+A Sunday Kind Of Love|SSAA|Gene Cokeroft
+American Tears|SSAA|Gene Cokeroft
+Angelina|SSAA|Gene Cokeroft
+As Long as He Needs Me|SSAA|Gene Cokeroft
+Carolina Moon|TTBB|Gene Cokeroft
+Cinderella|TTBB|Gene Cokeroft
+Danny Boy|TTBB|Gene Cokeroft
+Finale|TTBB|Gene Cokeroft
+Glory Of Love|TTBB|Gene Cokeroft
+Hospitality|TTBB|Gene Cokeroft
+I'm Always Chasing Rainbows|TTBB|Gene Cokeroft
+I'm Going Back To Carolina|TTBB|Gene Cokeroft
+I'm Sorry I Made You Cry|TTBB|Gene Cokeroft
+It Could Happen To You|TTBB, SSAA, SATB|Gene Cokeroft
+Jerry Vale Medley|TTBB|Gene Cokeroft
+Jolson Medley|TTBB|Gene Cokeroft
+King Of The Road|TTBB|Gene Cokeroft
+Let's Call The Whole Thing Off|SATB|Gene Cokeroft
+Life Is Just A Bowl of Cherries|SATB|Gene Cokeroft
+Light Up Your Life With Harmony|TTBB|Gene Cokeroft
+May Each Day|TTBB|Gene Cokeroft
+Meet Me Where They Play The Blues|SSAA|Gene Cokeroft
+Over The Rainbow|TTBB|Gene Cokeroft
+Please Mr. Columbus|TTBB|Gene Cokeroft
+Powder Your Face With Sunshine|TTBB|Gene Cokeroft
+The River Of No Return|TTBB|Gene Cokeroft
+Show Me Where The Good Times Are|TTBB, SSAA, SATB|Gene Cokeroft
+Smile, Darn Ya, Smile|TTBB|Gene Cokeroft
+South|TTBB|Gene Cokeroft
+Sweet Caroline|TTBB|Gene Cokeroft
+That's Amore|SSAA|Gene Cokeroft
+There'll Be No New Tunes On This Old Piano|TTBB|Gene Cokeroft
+There's A New Gang On The Corner|TTBB|Gene Cokeroft
+They Wrote 'Em In The Good Old Days|TTBB|Gene Cokeroft
+This Is My Country|TTBB|Gene Cokeroft
+Volare|TTBB|Gene Cokeroft
+We're Through|SSAA|Gene Cokeroft
+Welcome Song|SSAA|Gene Cokeroft
+Where Is Love?|TTBB|Gene Cokeroft
+Whiffenpoof Song|TTBB|Gene Cokeroft
+Ya Got Trouble|TTBB|Gene Cokeroft
+You're In Style When You're Wearing A Smile|TTBB|Gene Cokeroft
+You Gotta Be A Football Hero|TTBB|Don Coldren
+Deep Purple|SSAA|Scott Colman
+Singin' In The Bathtub|SSAA|Scott Colman
+Christmas Eve In My Home Town|TTBB|Joe Colon
+Beach Boys Medley|TTBB|Tom Colville
+Johnny Angel|TTBB|Tom Colville
+America (My Country, 'Tis Of Thee)|SSAA|Cris Conerty
+Bill Bailey Instrumental|SSAA|Cris Conerty
+Black Roses and Black Balloons|SSAA|Cris Conerty
+Come, Oh Ye Christians|SATB|Cris Conerty
+Happy Birthday (Keep a Song In Your Heart)|SSAA|Cris Conerty
+Heart Of Gold|SSAA|Cris Conerty
+I Can't Make You Love Me|SSAA|Cris Conerty
+I See The Light|SSAA|Cris Conerty
+I'll Never Look Up To You|SSAA|Cris Conerty
+In Our Day|SSAA|Cris Conerty
+It's You|SSAA|Cris Conerty
+Joy To The World|SSAA|Cris Conerty
+Just Keep Singin' Your Song!|SSAA|Cris Conerty
+Phfft! You Were Gone Parody|SSAA|Cris Conerty
+Show Me The Way|SSAA|Cris Conerty
+Silent Night|SSAA|Cris Conerty
+Young At Heart|SSAA|Cris Conerty
+I've Lost All My Love For You|TTBB|Randy Conner
+A Carol Medley|SSAA|Floyd Connett
+Down Our Way|TTBB|Floyd Connett
+Honey / Little 'Lize Medley|TTBB|Floyd Connett
+I'm All Alone|SSAA|Floyd Connett
+If I Had My Way|SSAA|Floyd Connett
+It Came Upon A Midnight Clear|SSAA|Floyd Connett
+Lida Rose|TTBB|Floyd Connett
+Lida Rose / Will I Ever Tell You|TTBB|Floyd Connett
+Love's Old Sweet Song|SSAA|Floyd Connett
+My Hometown Is A One Horse Town|TTBB|Floyd Connett
+Please Don't Talk About Me When I'm Gone|SSAA|Floyd Connett
+Silent Night|SSAA|Floyd Connett
+Sweet Adeline|SSAA|Floyd Connett
+Tell Me Why|SSAA|Floyd Connett
+The Rose of Tralee|TTBB|Floyd Connett
+There's A New Gang On The Corner|TTBB|Floyd Connett
+When I Wore My Daddy's Brown Derby|TTBB|Floyd Connett
+When You're Smiling|SSAA|Floyd Connett
+You're As Welcome As the Flowers In May|TTBB|Floyd Connett
+Love Can Build A Bridge|SSAA|Yvonne Connolly
+Don't Forget|TTBB|Matt Coombs
+I Remember You|SSAA|Sheila Cope
+Little Saint Nick|SSAA|Sheila Cope
+Making Our Dreams Come True|SSAA|Sheila Cope
+Somewhere Out There|SSAA|Sheila Cope
+Think Of Me|SSAA|Sheila Cope
+Waiting For The Guy To Die|SSAA|Margaret Cornell
+She Don't Wanna|TTBB|Richard Cornell
+Alice Blue Gown|TTBB|Roger Cote
+I Don't Want To Get Well|TTBB|Roger Cote
+I'm Knee Deep In Daisies|TTBB|Roger Cote
+Many Happy Returns Of The Day|TTBB|Roger Cote
+Grow Old With Me|SATB|John Cowlishaw
+Blues (My Naughty Sweetie Gives To Me)|TTBB|L. M. Coyle
+Jazz Me Blues|TTBB|L. M. Coyle
+Perfect Day|TTBB|L. M. Coyle
+Save The Bones For Henry Jones|TTBB|L. M. Coyle
+That Lonesome Road|TTBB|L. M. Coyle
+Weekend In New England|TTBB|L. M. Coyle
+All By Myself|SSAA|Renee Craig
+At The End Of The Day With You|TTBB|Renee Craig
+The Band Played On|SSAA|Renee Craig
+Blue Skies|SSAA, Young SSAA|Renee Craig
+Broadway Rose|SSAA|Renee Craig
+By The Sea / In The Good Old Summertime Medley|TTBB|Renee Craig
+Celebrate The Music|SSAA|Renee Craig
+Coventry Carol|SSAA|Renee Craig
+Danny Boy|TTBB|Renee Craig
+Don't Fence Me In|TTBB|Renee Craig
+Down By The Riverside|SSAA|Renee Craig
+Girl Of My Dreams|TTBB|Renee Craig
+God Rest Ye Merry, Gentlemen|SSAA|Renee Craig
+Hark! The Herald Angels Sing|SSAA|Renee Craig
+How Can You Buy Killarney|TTBB|Renee Craig
+I Don't Want To Walk Without You|SSAA|Renee Craig
+I'm Singing Your Love Song To Somebody Else|TTBB|Renee Craig
+I'm Sitting On Top Of The World|SSAA|Renee Craig
+If My Friends Could See Me Now|TTBB|Renee Craig
+If We All Said A Prayer|SSAA|Renee Craig
+In A Shanty In Old Shanty Town|SSAA|Renee Craig
+Jimmy Durante Medley|TTBB|Renee Craig
+Let Me Sing And I'm Happy|SSAA, Young SSAA|Renee Craig
+Let's Sing An Old Time Song|SSAA|Renee Craig
+Little Bit Of Heaven|SSAA|Renee Craig
+Lost In The Heart Of My Own Home Town|TTBB|Renee Craig
+May I Never Love Again|TTBB|Renee Craig
+My Mother's Eyes|SSAA|Renee Craig
+My Mother's Eyes|TTBB|Renee Craig
+New York, New York|TTBB|Renee Craig
+Nobody's Sweetheart / I Used To Love You Medley|TTBB|Renee Craig
+Roaring Twenties|TTBB|Renee Craig
+Row, Row, Row/Paddlin' Madelin' Home - Medley|TTBB|Renee Craig
+Royal Garden Blues|TTBB|Renee Craig
+Scarlet Ribbons (For Her Hair)|SSAA|Renee Craig
+Send Your Love|SSAA|Renee Craig
+Shaking The Blues Away|SSAA|Renee Craig
+Tessie Stop Teasin' Me|TTBB|Renee Craig
+That's Entertainment|SSAA, Young SSAA|Renee Craig
+Those Vaudeville Men Medley|TTBB|Renee Craig
+The Trolley Song|TTBB|Renee Craig
+The Trolley Song|SSAA|Renee Craig
+What'll I Do?|SSAA|Renee Craig
+What'll I Do?|TTBB, SSAA, SATB|Renee Craig
+When I Grow Too Old To Dream|TTBB|Renee Craig
+When I Take My Sugar To Tea|SSAA|Renee Craig
+When You're Smiling / Sunny Side Up Medley|TTBB|Renee Craig
+Whiffenpoof Song|TTBB|Renee Craig
+White Cliffs Of Dover|TTBB|Renee Craig
+White Cliffs Of Dover|SSAA|Renee Craig
+Why Do They Always Say No / There's Yes Yes In Your Eyes Medley|TTBB|Renee Craig
+With A Song In My Heart|SATB|Renee Craig
+Yesterday|SSAA|Renee Craig
+You Ain't Heard Nothing Yet|TTBB|Renee Craig
+You Must Have Been A Beautiful Baby|TTBB|Renee Craig
+You're Nobody's Sweetheart Medley|TTBB|Renee Craig
+Broadway Rose|SSAA|Roger Craig
+Have You Ever Been Lonely?|TTBB|Roger Craig
+Ida! Sweet As Apple Cider|TTBB|Roger Craig
+Time After Time|TTBB|Tony Crain
+Is You Is Or Is You Ain't (Ma Baby)|TTBB|Ian Crane
+Side by Side|SSAA, Young SSAA|Ruth Emley Craven
+Winter Is The Loveliest Time|SSAA|Ruth Emley Craven
+Beautiful Ohio|TTBB|Lee Crews
+Lullaby Of Broadway|TTBB|Bob Crist
+Take Me Back To Toyland|SSAA|DeDe Crow
+Say It With Music|SSAA|Flora Beth Cunningham
+Over There|TTBB|Robert Curt
+All Is Well|TTBB|Richard Curtis
+Break Your Limits|SATB|Richard Curtis
+Bring Me Sunshine|TTBB|Richard Curtis
+Can't Take My Eyes Off Of You|TTBB|Richard Curtis
+The Crimond|TTBB|Richard Curtis
+Defying Gravity|TTBB|Richard Curtis
+Get Lost|SATB|Richard Curtis
+Here, There And Everywhere|SATB|Richard Curtis
+I'm Still Standing|SATB|Richard Curtis
+If You Could See Her|TTBB|Richard Curtis
+In The Light Of Tomorrow|SATB|Richard Curtis
+It's A Good Day|TTBB|Richard Curtis
+The Lord's Prayer|TTBB|Richard Curtis
+Love Was Waiting Here|SATB|Richard Curtis
+Me And My Shadow|SATB|Richard Curtis
+Medley: I Can Dream Can't I?, I'll Be Seeing You|TTBB|Richard Curtis
+Mood Indigo|SATB|Richard Curtis
+Oh, Pretty Woman|TTBB|Richard Curtis
+Poor Little Millionaire|TTBB|Richard Curtis
+Pure Imagination|TTBB, SATB|Richard Curtis
+Rolling In The Deep|TTBB|Richard Curtis
+Skyfall|SATB|Richard Curtis
+Somebody to Love|TTBB|Richard Curtis
+When There Is Someone|TTBB, SATB|Richard Curtis
+Wherever You Are|TTBB|Richard Curtis
+Wing and a Prayer|SATB|Richard Curtis
+Yuletide Medley|TTBB|Richard Curtis
+Happy Birthday|SSAA|Jess Curtiss
+A Thousand Stars in the Sky|SSAA|Joan D 'Agostino
+All Alone|SSAA|Joan D 'Agostino
+All Of Me|SSAA|Joan D 'Agostino
+Butter|SSAA|Joan D 'Agostino
+Christmas Island|TTBB|Joan D 'Agostino
+Do You Believe In Magic|SSAA|Joan D 'Agostino
+Does He Love You?|SSAA|Joan D 'Agostino
+Emily Remembers|SSAA|Joan D 'Agostino
+Follow The Crowd|SSAA|Joan D 'Agostino
+For Good|SSAA|Joan D 'Agostino
+From Sunrise to Sunset|SSAA|Joan D 'Agostino
+Give Me Wings|SSAA|Joan D 'Agostino
+Here Comes The Sun|SSAA|Joan D 'Agostino
+Hey There|SSAA|Joan D 'Agostino
+How Soon|SSAA|Joan D 'Agostino
+I Go For That|SSAA|Joan D 'Agostino
+I Got The Sun In The Morning|SSAA|Joan D 'Agostino
+Isn't It Romantic|SSAA|Joan D 'Agostino
+It's The Same Old Dream|SSAA|Joan D 'Agostino
+Just a Bird's-eye view|SSAA|Joan D 'Agostino
+Let Yourself Go|SSAA|Joan D 'Agostino
+Man With The Bag|SSAA|Joan D 'Agostino
+Me And The Boy Friend|SSAA|Joan D 'Agostino
+Merry Christmas Darling|SSAA|Joan D 'Agostino
+Moonlight|SSAA|Joan D 'Agostino
+Moonlight in Vermont|SSAA|Joan D 'Agostino
+Mother Goose Suite|SSAA|Joan D 'Agostino
+My Melody Of Love|SSAA|Joan D 'Agostino
+Nature Boy|SSAA|Joan D 'Agostino
+Now Is The Hour|SSAA|Joan D 'Agostino
+The Prayer|SSAA|Joan D 'Agostino
+Right As The Rain|SSAA|Joan D 'Agostino
+Save Your Sorrow|SSAA|Joan D 'Agostino
+So Lun Bushi|SSAA|Joan D 'Agostino
+Thankful|SSAA|Joan D 'Agostino
+That Smile|SSAA|Joan D 'Agostino
+Together, We Two|SSAA|Joan D 'Agostino
+Trick Or Treat|SSAA|Joan D 'Agostino
+Walkin' After Midnight|SSAA|Joan D 'Agostino
+Where Are You Christmas?|SSAA|Joan D 'Agostino
+White Christmas|SSAA|Joan D 'Agostino
+You Taught Me to Care|SSAA|Joan D 'Agostino
+You'd Be Surprised|SSAA|Joan D 'Agostino
+You've Been A Good Ol Wagon|SSAA|Joan D 'Agostino
+Hip To Be Square|TTBB|Sam Dabrusin
+Oh Yes! I'd Climb (The Highest Mountain Just for You)|TTBB|Sam Dabrusin
+Up Where We Belong|TTBB|Sam Dabrusin
+25 or 6 to 4|TTBB|Aaron Dale
+A Fool Such As I|TTBB, SSAA|Aaron Dale
+After Today|TTBB|Aaron Dale
+Ain't Goin' Down ('Til The Sun Comes Up)|TTBB, SSAA|Aaron Dale
+Ain't Too Proud to Beg|TTBB|Aaron Dale
+Alabama Jubilee|TTBB, SSAA|Aaron Dale
+Aladdin Medley|SSAA|Aaron Dale
+Aladdin Medley|TTBB|Aaron Dale
+All I Do Is Dream Of You|TTBB|Aaron Dale
+All My Exes Live In Texas|TTBB|Aaron Dale
+Almost Paradise|SATB|Aaron Dale
+Almost There|TTBB, SSAA|Aaron Dale
+Almost There|SSAA|Aaron Dale
+Amen|TTBB|Aaron Dale
+American Pie|TTBB|Aaron Dale
+An American Soldier|TTBB|Aaron Dale
+Angels We Have Heard On High|TTBB|Aaron Dale
+Another Day of Sun|TTBB|Aaron Dale
+As Long as He Needs Me|TTBB, SSAA|Aaron Dale
+Away In A Manger|TTBB|Aaron Dale
+Baby Can Dance|SSAA|Aaron Dale
+Be My Baby Tonight|TTBB, SSAA|Aaron Dale
+Before The Parade Passes By|TTBB, SSAA|Aaron Dale
+The Bells of Notre Dame|TTBB|Aaron Dale
+Between You And The Birds And The Bees And Cupid|TTBB, SSAA|Aaron Dale
+Beyond the Sea|TTBB|Aaron Dale
+Beyond The Sea/Avalon - Medley|TTBB|Aaron Dale
+Blow Gabriel Blow|TTBB|Aaron Dale
+Blue Moon|TTBB|Aaron Dale
+Blue Moon Of Kentucky|TTBB, SSAA|Aaron Dale
+Boogie Down Medley|TTBB|Aaron Dale
+Burnin The Roadhouse Down|TTBB, SSAA|Aaron Dale
+Can't Buy Me Love|TTBB|Aaron Dale
+Can't Stop the Feeling!|TTBB, SSAA, SATB|Aaron Dale
+The Chain|TTBB|Aaron Dale
+Chocolate In My Stocking|TTBB|Aaron Dale
+Chocolate In My Stocking|SSAA|Aaron Dale
+The Christmas Song|TTBB|Aaron Dale
+Classical Gas|SATB|Aaron Dale
+Come Alive|TTBB|Aaron Dale
+Come Back To Me|TTBB, SSAA|Aaron Dale
+Come On Get Happy|TTBB, SSAA, SATB|Aaron Dale
+Come, Come Ye Saints|TTBB|Aaron Dale
+Cool Yule|TTBB|Aaron Dale
+Country Boy|TTBB, SSAA|Aaron Dale
+Crazy Little Thing Called Love|TTBB, SSAA|Aaron Dale
+Danny's Arrival Song|TTBB|Aaron Dale
+Deed I Do|TTBB, SSAA|Aaron Dale
+Defying Gravity|TTBB|Aaron Dale
+The Devil Ain't Lazy|TTBB|Aaron Dale
+Didn't My Lord Deliver Daniel?|TTBB, SSAA, SATB|Aaron Dale
+Do A Little Good|TTBB|Aaron Dale
+Dock Of The Bay, The (Sittin On)|TTBB|Aaron Dale
+Don't Be A Baby, Baby|TTBB|Aaron Dale
+Don't Break the Rules|TTBB|Aaron Dale
+Down With Love|TTBB|Aaron Dale
+Earth Wind and Fire Medley|SSAA|Aaron Dale
+East of The Rockies/Don't Sit Under The Apple Tree Medley|TTBB|Aaron Dale
+Every Breath You Take|TTBB, SSAA|Aaron Dale
+Everybody Needs a Best Friend|TTBB|Aaron Dale
+Everybody Says Don't|TTBB, SSAA|Aaron Dale
+Everything|TTBB, SSAA|Aaron Dale
+Fly Me To The Moon|TTBB|Aaron Dale
+Fly Me To The Moon|TTBB, SSAA|Aaron Dale
+Footloose|TTBB, SSAA|Aaron Dale
+For Good|TTBB|Aaron Dale
+For Once In My Life|TTBB|Aaron Dale
+Forget You|TTBB|Aaron Dale
+Free Fallin'|TTBB|Aaron Dale
+The Frim Fram Sauce|TTBB|Aaron Dale
+From Now On/Come Alive|TTBB|Aaron Dale
+Frosty The Snowman|TTBB|Aaron Dale
+Fun Fun Fun|TTBB|Aaron Dale
+Funk Medley|TTBB|Aaron Dale
+Georgia May|TTBB, SSAA|Aaron Dale
+Get Me To The Church On Time|TTBB, SSAA|Aaron Dale
+Get On Your Feet|SSAA|Aaron Dale
+Get Out And Get Under The Moon|TTBB|Aaron Dale
+Get Your Happy Days On!|TTBB|Aaron Dale
+Girl on Fire|SSAA|Aaron Dale
+Give Me The Simple Life|TTBB, SSAA, SATB|Aaron Dale
+Give Me The Simple Life|SSAA|Aaron Dale
+Go Tell It On The Mountain|TTBB, SATB|Aaron Dale
+Go The Distance|TTBB, SSAA|Aaron Dale
+Goin to the Dance with You|TTBB|Aaron Dale
+Good Luck Charm|TTBB, SSAA|Aaron Dale
+Grow Old With You|TTBB, SSAA|Aaron Dale
+Hallelujah, I Love Her So|TTBB|Aaron Dale
+Happy Happy Birthday Baby|TTBB|Aaron Dale
+Haven't Met You Yet|TTBB, SSAA|Aaron Dale
+The Headless Horseman|TTBB|Aaron Dale
+Heartache Tonight|TTBB|Aaron Dale
+Hit That Jive Jack|TTBB|Aaron Dale
+Hold On|TTBB|Aaron Dale
+Honey of Mine|TTBB|Aaron Dale
+Honey Won't You Open That Door/Hey Good Lookin' Medley|TTBB|Aaron Dale
+Honeysuckle Rose|TTBB|Aaron Dale
+Honky Tonkin'|TTBB|Aaron Dale
+Hooray For Love|SSAA|Aaron Dale
+Hope of Israel|TTBB|Aaron Dale
+How Deep Is Your Love?|TTBB|Aaron Dale
+How Far I'll Go|TTBB|Aaron Dale
+Hymn Medley|TTBB|Aaron Dale
+I Ain't Gonna Give Nobody None O' This Jelly Roll|TTBB|Aaron Dale
+I am A Child of God/I wonder When He Comes Again Medley|TTBB, SSAA|Aaron Dale
+I Am A Man of Constant Sorrow|TTBB|Aaron Dale
+I Got Lucky|TTBB, SSAA|Aaron Dale
+I Have Nothing|TTBB|Aaron Dale
+I Heard It Through The Grapevine|TTBB|Aaron Dale
+I Just Called To Say I Love You|TTBB|Aaron Dale
+I Just Can't Wait To Be King|TTBB|Aaron Dale
+I Love Being Here With You|TTBB, SSAA|Aaron Dale
+I Want You to Want Me|TTBB|Aaron Dale
+I Want You, I Need You, I Love You|SSAA|Aaron Dale
+I Want You, I Need You, I Love You|TTBB|Aaron Dale
+I'd Love To Live In Loveland|TTBB|Aaron Dale
+I'll Be Home For Christmas|TTBB|Aaron Dale
+I'm A Man of Constant Sorrow|TTBB|Aaron Dale
+I'm Alright|TTBB|Aaron Dale
+I'm Gonna Live Till I Die|SSAA|Aaron Dale
+I'm Into Something Good/Happy Together|SSAA|Aaron Dale
+I'm Putting All My Eggs In One Basket|TTBB|Aaron Dale
+I'm Walkin'|TTBB|Aaron Dale
+If All My Dreams Were Made Of Gold|TTBB|Aaron Dale
+If I Can Dream|TTBB|Aaron Dale
+If I Ever Leave This World Alive|TTBB|Aaron Dale
+If I Were A Bell|TTBB|Aaron Dale
+If You've Got The Money|TTBB|Aaron Dale
+In My Room|TTBB|Aaron Dale
+In Summer|TTBB|Aaron Dale
+In the Hollow of Thy Hand|TTBB|Aaron Dale
+Into The Fire|TTBB|Aaron Dale
+It's A Beautiful Day|TTBB|Aaron Dale
+It's All Right With Me|TTBB|Aaron Dale
+Jackson 5 Medley|TTBB|Aaron Dale
+Jesus, What a Wonderful Child!|TTBB|Aaron Dale
+Joseph Smith's First Prayer|TTBB|Aaron Dale
+Jump Jive And Then You Wail|TTBB|Aaron Dale
+Jump Medley|SSAA|Aaron Dale
+Just My Imagination|TTBB|Aaron Dale
+Just One Of Those Things|TTBB|Aaron Dale
+A Kid at Christmas|TTBB|Aaron Dale
+Learnin' The Blues|TTBB|Aaron Dale
+Let's Live It Up|TTBB, SSAA|Aaron Dale
+Life's A Happy Song|TTBB|Aaron Dale
+Listen To The Music|TTBB|Aaron Dale
+Little Patch Of Heaven|TTBB, SSAA|Aaron Dale
+Love Me|TTBB, SSAA|Aaron Dale
+Love On Top|SSAA, SATB|Aaron Dale
+Man In The Mirror|TTBB|Aaron Dale
+Mardi Gras March|SSAA, SATB|Aaron Dale
+Mardi Gras March|TTBB|Aaron Dale
+Marry Me|TTBB|Aaron Dale
+Masters In This Hall|TTBB|Aaron Dale
+Medley: Arabian Nights, One Jump Ahead, Friend Like Me, Prince Ali, Whole New World|TTBB, SSAA|Aaron Dale
+Medley: I'm into Something Good, Happy Together|TTBB, SSAA|Aaron Dale
+Medley: Last Dance, Dancing Machine, Boogie Wonderland, Boot Scootin' Boogie, I Wanna Dance|SSAA|Aaron Dale
+Medley: Save The Last Dance For Me, Sway|TTBB|Aaron Dale
+Medley: Signed, Sealed, Delivered I'm Yours, For Once In My Life|TTBB|Aaron Dale
+Medley: The Bells of Notre Dame, Out There|TTBB, SSAA, SATB|Aaron Dale
+Medley: Tulou Tagaloa, How Far I'll Go, We Know The Way, I Am Moana|SATB|Aaron Dale
+Melancholy Blues|TTBB|Aaron Dale
+Music Of My Heart|SSAA|Aaron Dale
+My Blushin' Rosie|TTBB|Aaron Dale
+My Soul's Been Anchored in the Lord|TTBB|Aaron Dale
+My Valentine|TTBB|Aaron Dale
+Naughty|TTBB|Aaron Dale
+No Man Left For Me|SSAA|Aaron Dale
+No More Nights|TTBB|Aaron Dale
+Nothing Can Change This Love|TTBB|Aaron Dale
+Nothing Can Stop Me Now|SSAA|Aaron Dale
+Oh My Father|TTBB|Aaron Dale
+Oh! Look At Me Now|TTBB, SSAA|Aaron Dale
+Oh! Susanna|TTBB|Aaron Dale
+Old Devil Moon|TTBB|Aaron Dale
+On A Wonderful Day Like Today|TTBB|Aaron Dale
+On The Road Again|TTBB|Aaron Dale
+One More Last Chance|TTBB, SSAA|Aaron Dale
+Paper Doll|TTBB, SSAA|Aaron Dale
+Pure Imagination|TTBB|Aaron Dale
+Put A Little Love In Your Heart|TTBB|Aaron Dale
+Put Your Arms Around Me Honey|TTBB, SSAA|Aaron Dale
+Put Your Head On My Shoulder|TTBB, SSAA|Aaron Dale
+Ready, Willing and Able|TTBB|Aaron Dale
+The Rest of Your Life|TTBB|Aaron Dale
+Rhythm Medley (I Got Rhythm/Fascinating Rhythm/Crazy Rhythm)|TTBB|Aaron Dale
+Rock It For Me|TTBB, SSAA|Aaron Dale
+Rock It To (For) Me|TTBB|Aaron Dale
+Rock My Soul|TTBB|Aaron Dale
+Rock This Town|TTBB, SSAA|Aaron Dale
+Rock This Town|TTBB|Aaron Dale
+Rockin' Around The Christmas Tree|TTBB, SSAA|Aaron Dale
+Rockin' Chair|TTBB|Aaron Dale
+Rocky Top|TTBB, SSAA|Aaron Dale
+Roll On, Mississippi, Roll On|TTBB, SSAA|Aaron Dale
+Saints In The Street Medley|TTBB|Aaron Dale
+Santa Baby|SATB|Aaron Dale
+Santa Medley|TTBB|Aaron Dale
+Save The Last Dance / Sway Medley|TTBB|Aaron Dale
+Save The Last Dance For Me|TTBB, SSAA|Aaron Dale
+Seize The Day|TTBB|Aaron Dale
+Sesame Street Theme|TTBB|Aaron Dale
+A Shine On Your Shoes|TTBB, SSAA|Aaron Dale
+Silent Night|TTBB|Aaron Dale
+A Simple Song|TTBB|Aaron Dale
+Since I Don't Have You|TTBB|Aaron Dale
+Sing|SSAA|Aaron Dale
+Sir Duke|TTBB, SSAA|Aaron Dale
+Sloop John B|TTBB|Aaron Dale
+Sold|TTBB, SSAA|Aaron Dale
+Somebody to Love|TTBB, SSAA|Aaron Dale
+Somewhere My Love|TTBB|Aaron Dale
+Spiderman Theme|TTBB|Aaron Dale
+Stand Out|TTBB|Aaron Dale
+Star Spangled Banner|TTBB|Aaron Dale
+Stickshifts and Safety Belts|TTBB|Aaron Dale
+Still The One|TTBB|Aaron Dale
+Stormy Weather|TTBB, SSAA|Aaron Dale
+Strike Up The Band/Everybody Step Medley|TTBB, SSAA|Aaron Dale
+Such a Night|TTBB|Aaron Dale
+Sugar Medley|TTBB|Aaron Dale
+Surfer Girl|TTBB|Aaron Dale
+Sweet Georgia Brown|TTBB|Aaron Dale
+Sweet Pea|TTBB|Aaron Dale
+Teddy Bear|TTBB|Aaron Dale
+Tennessee Waltz|TTBB, SSAA|Aaron Dale
+That's All|TTBB|Aaron Dale
+That's My Girl|TTBB, SSAA|Aaron Dale
+The Jumpin' Jive|TTBB|Aaron Dale
+Their Hearts Were Full Of Spring|TTBB, SSAA|Aaron Dale
+There I've Said It Again|TTBB|Aaron Dale
+There's a Fine Fine Line|SSAA|Aaron Dale
+They Can't Take That Away From Me|TTBB, SSAA|Aaron Dale
+This Can't Be Love|TTBB|Aaron Dale
+Thriller|TTBB|Aaron Dale
+Til You Come Back to Me|TTBB|Aaron Dale
+To Make You Feel My Love|TTBB|Aaron Dale
+Together Again|TTBB, SSAA|Aaron Dale
+Too Close For Comfort|TTBB|Aaron Dale
+Too Darn Hot|TTBB|Aaron Dale
+Too Young for the Blues|TTBB|Aaron Dale
+Tulou Tagaloa|SATB|Aaron Dale
+Turn On The Sunshine|SSAA|Aaron Dale
+Two Of A Kind|TTBB|Aaron Dale
+Unbelievable|TTBB|Aaron Dale
+Viva La Vida|SATB|Aaron Dale
+Wagon Wheels|TTBB|Aaron Dale
+Walking On Sunshine|SSAA|Aaron Dale
+Walking On Sunshine|TTBB|Aaron Dale
+We'll Bring the World his Truth|TTBB|Aaron Dale
+What Are You Doing New Year's Eve?|TTBB|Aaron Dale
+What Child Is This|TTBB|Aaron Dale
+What Do I Need With Love|TTBB|Aaron Dale
+What Makes You Beautiful|TTBB|Aaron Dale
+When I was your Man|TTBB|Aaron Dale
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|Aaron Dale
+When The Summer Sun is Gone|TTBB, SSAA|Aaron Dale
+When You Wish Upon A Star|TTBB|Aaron Dale
+Who Put The Bomp|TTBB|Aaron Dale
+Who's Lovin' You|TTBB|Aaron Dale
+A Whole New World|TTBB|Aaron Dale
+Why Don't We Just Dance|TTBB|Aaron Dale
+Why Georgia|TTBB|Aaron Dale
+Winter Wonderland|TTBB|Aaron Dale
+Yona From Arizona|TTBB|Aaron Dale
+You and the Night and the Music|TTBB|Aaron Dale
+You Belong To Me|TTBB|Aaron Dale
+You Belong To Me|SSAA|Aaron Dale
+You Don't Have To Be A Baby To Cry|TTBB|Aaron Dale
+You Don't Mess Around with Me|TTBB|Aaron Dale
+You Don't You Won't|TTBB, SSAA|Aaron Dale
+You Took Advantage Of Me|SSAA|Aaron Dale
+You Took Advantage Of Me|TTBB|Aaron Dale
+You'll Be In My Heart|TTBB|Aaron Dale
+You're Falling Love|TTBB|Aaron Dale
+You're My Best Friend|TTBB|Aaron Dale
+You're Sixteen You're Beautiful And You're Mine|TTBB, SSAA|Aaron Dale
+Your Cheatin' Heart|TTBB|Aaron Dale
+Your First Day In Heaven|TTBB, SSAA|Aaron Dale
+Bidin' My Time|TTBB|Howard Dale
+From The Land Of Sky Blue Water|TTBB|Howard Dale
+Look For The Silver Lining|TTBB|Howard Dale
+Pore Jud Is Daid|TTBB|Howard Dale
+Put On A Happy Face|TTBB|Howard Dale
+Smilin' Through|TTBB|Howard Dale
+Song from Moulin Rouge|TTBB|Howard Dale
+Stumbling|TTBB|Howard Dale
+That Feeling In The Moonlight|TTBB|Howard Dale
+True Love|TTBB|Howard Dale
+Anchors Aweigh|SSAA|June Dale
+Angels Among Us|SSAA|June Dale
+Baby Face|SSAA|June Dale
+Because You Loved Me|SSAA|June Dale
+Boogie Woogie Bugle Boy|SSAA|June Dale
+Can You Feel The Love Tonight?|TTBB|June Dale
+Can You Feel The Love Tonight?|SATB|June Dale
+Can You Feel The Love Tonight?|SSAA|June Dale
+Candle On The Water|SSAA|June Dale
+Chim Chim Cher-ee|SSAA|June Dale
+The Climb|SSAA|June Dale
+Come On And Sing!|SSAA|June Dale
+Come Sail Away|SSAA|June Dale
+Dear Old Donegal|SSAA|June Dale
+Down At The Twist And Shout|SSAA|June Dale
+Drunken Sailor|SSAA|June Dale
+Feed The Birds|SSAA|June Dale
+Fields Of Gold|SSAA|June Dale
+Hallelujah|SSAA|June Dale
+I Believe (2010 Olympic Theme Song)|SSAA|June Dale
+Java Jive|SSAA, Young SSAA|June Dale
+Little Things Mean A Lot|SSAA|June Dale
+Love Potion No. 9|SSAA|June Dale
+The Martian Hop|SSAA|June Dale
+On My Own|SSAA|June Dale
+One Tin Soldier|SSAA|June Dale
+One Toy Soldier|SSAA|June Dale
+Oom Pah Pah|SSAA|June Dale
+Pick A Pocket Or Two|SSAA|June Dale
+Reach For The Light|SSAA|June Dale
+River, Stay 'Way from My Door|SSAA|June Dale
+Shine|SSAA|June Dale
+The Sky, The Dawn And The Sun|SSAA|June Dale
+Somebody to Love|SSAA|June Dale
+Someday|SSAA|June Dale
+A Spoonful Of Sugar|SSAA|June Dale
+Step In Time|SSAA|June Dale
+That Cat Is High|SSAA|June Dale
+That Old Black Magic|SSAA|June Dale
+Touch the Sky|SSAA|June Dale
+Turn Around|SSAA|June Dale
+Tuxedo Junction|SSAA|June Dale
+Wedding Song|SSAA|June Dale
+When She Loved Me|SSAA|June Dale
+Where Is Love?|SSAA|June Dale
+Where Is Your Heart At|SSAA|June Dale
+If My Friends Could See Me Now|TTBB|Ray Danley
+College Medley|TTBB|George Davidson
+They'll Never Believe Me|TTBB|George Davidson
+World War I Medley|TTBB|George Davidson
+Aloha Oe|TTBB|T. W. De Crow
+Christmas On The Beach At Waikiki|TTBB|T. W. De Crow
+Give Me The Simple Life|TTBB|T. W. De Crow
+Have A Smile|TTBB|T. W. De Crow
+My Sunny Tennessee|TTBB|T. W. De Crow
+Now Is The Hour|TTBB|T. W. De Crow
+On The Beach At Waikiki|TTBB|T. W. De Crow
+When Your Hair Has Turned To Silver|TTBB|T. W. De Crow
+All Of Me|SSAA|Sofia De Rama
+Put Your Records On|SSAA|Sofia De Rama
+Lover Come Back To Me|TTBB|Frank De Wolfe
+Ac-cent-tchu-ate The Positive|SSAA|Diana DeBruycker
+Feed The Birds|SSAA|Diana DeBruycker
+Goodnight, Sweetheart, Goodnight|SSAA|Diana DeBruycker
+The Lord's Prayer|SSAA|Diana DeBruycker
+Silver Bells|SSAA|Diana DeBruycker
+Thank You World|SSAA|Diana DeBruycker
+There's A Kind Of Hush (All Over The World)|SSAA|Diana DeBruycker
+Through The Years|SSAA|Diana DeBruycker
+We've Only Just Begun|SSAA|Diana DeBruycker
+Yesterday|SSAA|Diana DeBruycker
+All I Have To Do Is Dream|SATB|Thomas Degan
+Always|SATB|Thomas Degan
+Any Man Of Mine|TTBB|Thomas Degan
+Aura Lee|SATB|Thomas Degan
+The Chandler's Wife|TTBB|Thomas Degan
+Come On Eileen|TTBB|Thomas Degan
+Crabs Walk Sideways|TTBB|Thomas Degan
+Desperado|TTBB|Thomas Degan
+Drop Em Out|TTBB|Thomas Degan
+Eleanor Rigby|TTBB|Thomas Degan
+God Rest Ye Merry, Gentlemen|SATB|Thomas Degan
+Half Of The Way|TTBB|Thomas Degan
+Hard Times Come Again No More|SATB|Thomas Degan
+Hunting Song|TTBB|Thomas Degan
+If You Were Gay|TTBB|Thomas Degan
+Lion Sleeps Tonight|TTBB|Thomas Degan
+Lyin' Eyes|TTBB|Thomas Degan
+Margaritaville|TTBB|Thomas Degan
+Marvin Gaye|TTBB|Thomas Degan
+Movin' Out (Anthony's Song)|TTBB|Thomas Degan
+The Parting Glass|TTBB|Thomas Degan
+Poisoning Pigeons In The Park|TTBB|Thomas Degan
+Pretty Good At Drinkin' Beer|TTBB|Thomas Degan
+Red Is The Rose|TTBB|Thomas Degan
+Red Wing|TTBB|Thomas Degan
+Ring, Ring the Banjo!|SATB|Thomas Degan
+Shameless|TTBB|Thomas Degan
+Sherry|TTBB|Thomas Degan
+Slow Hands|TTBB|Thomas Degan
+So Long, Mom (A song For World War III)|TTBB|Thomas Degan
+Take Me Out To The Ball Game|SATB|Thomas Degan
+Tenting Tonight|SATB|Thomas Degan
+The Thing|TTBB|Thomas Degan
+Tramp! Tramp! Tramp!|SATB|Thomas Degan
+Where Do We Go From Here?|TTBB|Thomas Degan
+Your Man|TTBB|Thomas Degan
+Almost Like Being In Love|TTBB|Steve Delehanty
+Armed Forces Medley|TTBB, SSAA, SATB|Steve Delehanty
+Autumn Leaves|TTBB|Steve Delehanty
+Be Our Guest|TTBB, SSAA, SATB|Steve Delehanty
+Beach Boys Medley|TTBB|Steve Delehanty
+Being With You|TTBB|Steve Delehanty
+Buttons And Bows|TTBB|Steve Delehanty
+Cabaret|TTBB|Steve Delehanty
+Climb Ev'ry Mountain|TTBB|Steve Delehanty
+George M. Cohan Medley|TTBB|Steve Delehanty
+Happy Trails|TTBB|Steve Delehanty
+Have Yourself A Merry Little Christmas|SSAA|Steve Delehanty
+Have Yourself A Merry Little Christmas|TTBB|Steve Delehanty
+Hooked On Classics medley|SSAA|Steve Delehanty
+I Hold Your Hand In Mine|TTBB|Steve Delehanty
+I Love The Ladies|TTBB|Steve Delehanty
+I'll Be With You In Apple Blossom Time|TTBB|Steve Delehanty
+Jersey Boys Medley|TTBB|Steve Delehanty
+Keep Your Eye On The Girlie You Love|TTBB|Steve Delehanty
+Lazy River|TTBB|Steve Delehanty
+Love Letters|TTBB|Steve Delehanty
+May You Always|SSAA|Steve Delehanty
+Michelle|TTBB|Steve Delehanty
+More Than You Know|TTBB|Steve Delehanty
+New Ashmolean Band|TTBB|Steve Delehanty
+Oh, Pretty Woman|TTBB|Steve Delehanty
+The Old Lamplighter|SSAA|Steve Delehanty
+On A Slow Boat To China|TTBB|Steve Delehanty
+Second Time Around|TTBB|Steve Delehanty
+Shaking The Blues Away|TTBB|Steve Delehanty
+Short People|TTBB|Steve Delehanty
+Sing A Little Doo Wop|TTBB|Steve Delehanty
+Smile Medley|TTBB|Steve Delehanty
+Speak Softly Love|TTBB|Steve Delehanty
+Stand By Me|TTBB, SSAA, SATB|Steve Delehanty
+Star Medley|TTBB|Steve Delehanty
+Star Medley (You Oughta Be In Pictures/Over The Rainbow)|SSAA|Steve Delehanty
+Statue of Liberty|TTBB|Steve Delehanty
+Strike Up The Band|TTBB|Steve Delehanty
+There Is Love Wherever There Is Song|TTBB|Steve Delehanty
+This Could be the Start of Something Big|TTBB|Steve Delehanty
+Timeless To Me|TTBB|Steve Delehanty
+Turn Me On|TTBB|Steve Delehanty
+Wouldn't It Be Nice|TTBB|Steve Delehanty
+Zing! Went The Strings Of My Heart|TTBB|James Della Badin
+The Sound Of Silence|TTBB|Erik DeLong
+Down By The Old Red Mill|TTBB|Bob Demchak
+After Today|TTBB|Soren Detlefsen
+Breaking Free|TTBB, SATB|Soren Detlefsen
+A Drink On The House|TTBB|Soren Detlefsen
+Euphoria|SSAA|Soren Detlefsen
+I've Got A Dream|TTBB|Soren Detlefsen
+Isn't This A Lovely Day To Be Caught In The Rain|TTBB|Soren Detlefsen
+Leave The Door Open|SATB|Soren Detlefsen
+Mamma Mia|SATB|Soren Detlefsen
+No Matter What Happens|SSAA|Soren Detlefsen
+Nobody Else But You|TTBB|Soren Detlefsen
+Not For The Life Of Me|SSAA|Soren Detlefsen
+O Holy Night|TTBB|Soren Detlefsen
+Only In New York|SSAA|Soren Detlefsen
+Part Of Your World|SSAA|Soren Detlefsen
+She Used To Be Mine|SSAA|Soren Detlefsen
+Stick To The Status Quo|SATB|Soren Detlefsen
+What I Want Is A Proper Cup Of Coffee|TTBB|Soren Detlefsen
+Who I'd Be|TTBB|Soren Detlefsen
+Joshua Fit The Battle Of Jericho|TTBB|David Dettinger
+Hello Ma Baby|TTBB|Bill Diekema
+Liza|TTBB|Bill Diekema
+Meet Me Tonight In Dreamland|TTBB|Bill Diekema
+My Sweetie In Tahiti|TTBB|Bill Diekema
+The Sunshine Of Your Smile|TTBB|Bill Diekema
+Till The Day|TTBB|Bill Diekema
+Don't Fence Me In|TTBB|Willis Diekema
+It's Beginning To Look A Lot Like Christmas|SSAA|Willis Diekema
+It's Beginning To Look A Lot Like Christmas|TTBB|Willis Diekema
+Little Brown Church in the Vale|TTBB|Willis Diekema
+Roses Of Picardy|TTBB|Willis Diekema
+Till There Was You|TTBB|Willis Diekema
+Cabaret|TTBB|Jim Dillett
+Send In The Clowns|TTBB|Jim Dillett
+B & O Line|TTBB|Robert Disney
+Drivin' Me Crazy|TTBB|Robert Disney
+Drivin' Me Crazy|SSAA|Robert Disney
+Is This Just Another Song|TTBB|Robert Disney
+Is This Just Another Song|SSAA|Robert Disney
+It's A Brand New Day|TTBB, SSAA|Robert Disney
+Ride The Railroad|TTBB|Robert Disney
+I Believe|TTBB|S.P. Ditchfield
+I Am Woman|TTBB|Judith Dixon
+Can't Help Falling In Love|SSAA|Joanne Dockrell
+I Remember You|SSAA|Joanne Dockrell
+I'll Always Be In Love With You|SSAA|Joanne Dockrell
+Memory|SSAA|Joanne Dockrell
+The Rose|SSAA|Joanne Dockrell
+Sentimental Journey|SSAA|Joanne Dockrell
+There Will Never Be Another You|SSAA|Joanne Dockrell
+The Very Thought Of You|SSAA|Joanne Dockrell
+You Light Up My Life|SSAA|Joanne Dockrell
+Old Toy Trains|SSAA|Gail Docktor
+In The Cool Cool Cool Of The Evening|TTBB|Jim Dodge
+Away In A Manger|SATB|Brian Doepke
+Carol Of The Bells|SATB|Brian Doepke
+Do You Hear What I Hear|SSAA|Brian Doepke
+Ghostbusters|TTBB|Brian Doepke
+Happy Birthday To You|SATB|Brian Doepke
+Holiday Piece (Carol of the Bells)|SATB|Brian Doepke
+On Broadway|SATB|Brian Doepke
+The Rose|TTBB|Brian Doepke
+Stormy Weather|TTBB|Brian Doepke
+'C' is for cookie|TTBB, SSAA, SATB|Jay Dougherty
+All Sing Hail|SATB|Jay Dougherty
+Anti-Hero|SATB|Jay Dougherty
+Baby Blue|SATB|Jay Dougherty
+Bad Day|TTBB, SATB|Jay Dougherty
+Birdland|TTBB|Jay Dougherty
+Closer To Fine|SSAA, SATB|Jay Dougherty
+Coconut Nut, The (Coconut Song)|SSAA|Jay Dougherty
+Deep River|TTBB|Jay Dougherty
+Despondency|SATB|Jay Dougherty
+Express Yourself|SSAA|Jay Dougherty
+Forever And Ever, Amen|SSAA|Jay Dougherty
+From The Start|SATB|Jay Dougherty
+Haunted House|SSAA|Jay Dougherty
+Hey Jude|TTBB, SSAA, SATB|Jay Dougherty
+I Don't Want To Set The World On Fire|TTBB, SSAA, SATB|Jay Dougherty
+I Felt a Funeral in My Brain|SATB|Jay Dougherty
+Killing Me Softly|TTBB, SSAA, SATB|Jay Dougherty
+Lagrimas Negras|TTBB|Jay Dougherty
+Let It Be|TTBB, SSAA, SATB|Jay Dougherty
+Linger|SSAA, SATB|Jay Dougherty
+Mack The Knife|TTBB, SSAA, SATB|Jay Dougherty
+Man! I Feel Like A Woman|SSAA|Jay Dougherty
+Mary Did You Know|SATB|Jay Dougherty
+Merry Christmas Darling|SATB|Jay Dougherty
+Monsters|TTBB, SSAA, SATB|Jay Dougherty
+The Nearness Of You|TTBB|Jay Dougherty
+O Holy Night|SSAA, SATB|Jay Dougherty
+Once Upon A Dream|TTBB, SATB|Jay Dougherty
+Perfect|SATB|Jay Dougherty
+Please Come Home For Christmas|TTBB, SSAA, SATB|Jay Dougherty
+Please Don't Talk About Me When I'm Gone|SATB|Jay Dougherty
+Que Sera, Sera (whatever will be, will be)|SSAA|Jay Dougherty
+Re Your Brains|TTBB|Jay Dougherty
+Redemption Song|SSAA|Jay Dougherty
+Se Me Esta Escapando|SSAA|Jay Dougherty
+Slipping Through My Fingers|SSAA|Jay Dougherty
+Star Spangled Banner|TTBB|Jay Dougherty
+Take The Moon|SATB|Jay Dougherty
+Teddy Bears' Picnic|TTBB, SSAA|Jay Dougherty
+This Is The Moment|TTBB, SSAA, SATB|Jay Dougherty
+Ubi Caritas|SATB|Jay Dougherty
+Ukrainian National Anthem|TTBB, SSAA, SATB|Jay Dougherty
+Until I Found You|SATB|Jay Dougherty
+What Is This Feeling?|SSAA|Jay Dougherty
+Winter Song|SATB|Jay Dougherty
+Yakety Yak|SATB|Jay Dougherty
+You Make It Feel Like Christmas|TTBB, SSAA, SATB|Jay Dougherty
+You're My Best Friend|TTBB, SSAA, SATB|Jay Dougherty
+A G-Nu|TTBB|Bob Dowma
+Brother Can You Spare A Dime|TTBB|Bob Dowma
+Dakota|TTBB|Bob Dowma
+Hey Look Me Over|TTBB|Bob Dowma
+It's A Good Day|TTBB|Bob Dowma
+Run, Run, Run|SSAA|Bob Dowma
+Run, Run, Run|TTBB|Bob Dowma
+Show Me Where The Good Times Are|TTBB|Bob Dowma
+Does The Spearmint Lose Its Flavor On The Bedpost Overnight|TTBB|Al Downey
+Don't Get Around Much Anymore|TTBB|Al Downey
+My Little Buckaroo|TTBB|Al Downey
+Tiger Rag|TTBB|Al Downey
+A, You're Adorable|TTBB|Dennis Driscoll
+Abide With Me|TTBB|Dennis Driscoll
+After You've Gone|TTBB|Dennis Driscoll
+All Alone|TTBB|Dennis Driscoll
+All By Myself|TTBB|Dennis Driscoll
+Almost Like Being In Love|TTBB|Dennis Driscoll
+Am I Wasting My Time On You|TTBB|Dennis Driscoll
+Anniversary Song|TTBB|Dennis Driscoll
+Anything Goes|TTBB|Dennis Driscoll
+April Showers|TTBB|Dennis Driscoll
+Auction Song|TTBB|Dennis Driscoll
+Be A Clown|TTBB|Dennis Driscoll
+Because of You|TTBB|Dennis Driscoll
+Bigger Isn't Better|TTBB|Dennis Driscoll
+Billy-A-Dick|TTBB|Dennis Driscoll
+"Black Hills Of Dakota (Theme From ""Calamity Jane"")"|TTBB|Dennis Driscoll
+Black-Eyed Blues|TTBB|Dennis Driscoll
+Blue Jeans|TTBB|Dennis Driscoll
+Breezin' Along With The Breeze|TTBB|Dennis Driscoll
+Brown Eyes Why Are You Blue?|TTBB|Dennis Driscoll
+By My Side|TTBB|Dennis Driscoll
+By The Beautiful Sea|TTBB|Dennis Driscoll
+By The Time I Get To Phoenix|TTBB|Dennis Driscoll
+California And You|TTBB|Dennis Driscoll
+Candy|TTBB|Dennis Driscoll
+Carolina Moon|TTBB|Dennis Driscoll
+Charleston, Flappers And Razz-A-Ma-Tazz|TTBB|Dennis Driscoll
+Cheatin, On Me|TTBB|Dennis Driscoll
+Climb Ev'ry Mountain|TTBB|Dennis Driscoll
+Close As Pages In A Book|TTBB|Dennis Driscoll
+Collegiate Love|TTBB|Dennis Driscoll
+Congratulate Me|TTBB|Dennis Driscoll
+Consider Yourself|TTBB|Dennis Driscoll
+Count Your Blessings Instead Of Sheep|TTBB|Dennis Driscoll
+Dance Of The Grizzly Bear|TTBB|Dennis Driscoll
+Dancin' Dan|TTBB|Dennis Driscoll
+Dear Heart|TTBB|Dennis Driscoll
+Don't Think You'll Be Missed|TTBB|Dennis Driscoll
+Down By The O-hi-o|TTBB|Dennis Driscoll
+Down The Old Ox Road|TTBB|Dennis Driscoll
+Dream A Little Dream Of Me|TTBB|Dennis Driscoll
+Dreamsville|SSATB|Dennis Driscoll
+The Entertainer|TTBB|Dennis Driscoll
+Everybody Step|TTBB|Dennis Driscoll
+Everything's Comin' Up Roses|TTBB|Dennis Driscoll
+The Exodus Song|TTBB|Dennis Driscoll
+Finger Prints|TTBB|Dennis Driscoll
+Footloose And Fancy-Free|TTBB|Dennis Driscoll
+Forest Lawn|TTBB|Dennis Driscoll
+Free For All|TTBB|Dennis Driscoll
+The Gal That Was Stolen From Me|TTBB|Dennis Driscoll
+Galway Bay|TTBB|Dennis Driscoll
+Gee But There's Class To A Girl Like You|TTBB|Dennis Driscoll
+Gee! But I Hate To Go Home Alone|TTBB|Dennis Driscoll
+The Girl That I Marry|TTBB|Dennis Driscoll
+Give It Away|TTBB|Dennis Driscoll
+Give Me The Moonlight, Give Me The Girl|TTBB|Dennis Driscoll
+Give Me The Simple Life|TTBB|Dennis Driscoll
+Glory Of Love|TTBB|Dennis Driscoll
+Go With A Song In Your Heart|TTBB|Dennis Driscoll
+God Bless The Human Elbow|TTBB|Dennis Driscoll
+Golden Barefoot Days|TTBB|Dennis Driscoll
+Goody Goody|TTBB|Dennis Driscoll
+Goofus|TTBB|Dennis Driscoll
+Gotta Be This Or That|TTBB|Dennis Driscoll
+Great Day Medley|TTBB|Dennis Driscoll
+Green Bay Packer Polka|TTBB|Dennis Driscoll
+Growin' Old Can Be Fun|TTBB|Dennis Driscoll
+Guys And Dolls|TTBB|Dennis Driscoll
+Half-Way To Heaven|TTBB|Dennis Driscoll
+Hand Medley|TTBB|Dennis Driscoll
+Happy Anniversary|TTBB|Dennis Driscoll
+Hard Hearted Hannah|TTBB|Dennis Driscoll
+Have You Even Been In Heaven?|TTBB|Dennis Driscoll
+Here's That Rainy Day|TTBB|Dennis Driscoll
+High Cost Of Lovin'|TTBB|Dennis Driscoll
+High Hopes|TTBB|Dennis Driscoll
+Honey Bun|TTBB|Dennis Driscoll
+Honey's Arms Medley|TTBB|Dennis Driscoll
+Hooray For Hollywood|TTBB|Dennis Driscoll
+Hour-Day-Month Medley|TTBB|Dennis Driscoll
+Hour-Month-Day Medley|TTBB|Dennis Driscoll
+How Many Hearts Have You Broken?|TTBB|Dennis Driscoll
+I Don't Want To Walk Without You|TTBB|Dennis Driscoll
+I Got Rhythm|TTBB|Dennis Driscoll
+I Hear Music|TTBB|Dennis Driscoll
+I Love To Go Swimmin' With Wimmen|TTBB|Dennis Driscoll
+I Love You Just The Same Sweet Adeline|TTBB|Dennis Driscoll
+I Miss That Mississippi Miss That Misses Me|TTBB|Dennis Driscoll
+I Miss You Most Of All|TTBB|Dennis Driscoll
+I Only Have Eyes For You|TTBB|Dennis Driscoll
+I Walk With Music|TTBB|Dennis Driscoll
+I Wish You Love|TTBB|Dennis Driscoll
+I'll Fly Away|TTBB|Dennis Driscoll
+I'll Say She Does!|TTBB|Dennis Driscoll
+I'm Making A Study Of Beautiful Girls (And I'm Still In My Abc's)|TTBB|Dennis Driscoll
+I've Seen My Baby (And It Won't Be Long Now)|TTBB|Dennis Driscoll
+If I Could Only Make You Care|TTBB|Dennis Driscoll
+If I Had You|TTBB|Dennis Driscoll
+If There's Anybody Here From My Home Town|TTBB|Dennis Driscoll
+In My Harem|TTBB|Dennis Driscoll
+Ireland Must Be Heaven|TTBB|Dennis Driscoll
+Irish Blessing|TTBB|Dennis Driscoll
+It Could Happen To You|TTBB|Dennis Driscoll
+It Had To Be You|TTBB|Dennis Driscoll
+It's A Beautiful Day For A Ball Game|TTBB|Dennis Driscoll
+It's A Sin To Tell A Lie|TTBB|Dennis Driscoll
+It's Goin' To Be A Cold, Cold Winter|TTBB|Dennis Driscoll
+Johnny's In Town|TTBB|Dennis Driscoll
+Josephine|TTBB|Dennis Driscoll
+June Medley|TTBB|Dennis Driscoll
+Just A Dream Of You Dear|TTBB|Dennis Driscoll
+Just A Little Longer|TTBB|Dennis Driscoll
+Just When The Lights Are Low|TTBB|Dennis Driscoll
+King Of The Road|TTBB|Dennis Driscoll
+The Last Dance|TTBB|Dennis Driscoll
+Last Night On The Back Porch|TTBB|Dennis Driscoll
+Last Night When We Were Young|SSATB|Dennis Driscoll
+Lazy Afternoon|SSATB|Dennis Driscoll
+Let Me Be There|TTBB|Dennis Driscoll
+Let The Rest Of The World Go By|TTBB|Dennis Driscoll
+Let There Be Peace On Earth|TTBB|Dennis Driscoll
+Let's Get Away From It All|TTBB|Dennis Driscoll
+Let's Harmonize|TTBB|Dennis Driscoll
+Life Is Just A Bowl of Cherries|TTBB|Dennis Driscoll
+Listen Here|SSATB|Dennis Driscoll
+Listening|TTBB|Dennis Driscoll
+Little Man You've Had A Busy Day|TTBB|Dennis Driscoll
+Little Patch Of Heaven|TTBB|Dennis Driscoll
+Little Things Mean A Lot|TTBB|Dennis Driscoll
+Loading Up The Mandy Lee|TTBB|Dennis Driscoll
+Lost In The Stars|TTBB|Dennis Driscoll
+Love Letters In The Sand|TTBB|Dennis Driscoll
+Love Locked Out|SSATB|Dennis Driscoll
+Love Story (Where Do I Begin)|TTBB|Dennis Driscoll
+Love Walked In|SSATB|Dennis Driscoll
+M-O-T-H-E-R|TTBB|Dennis Driscoll
+Maggie Blues|TTBB|Dennis Driscoll
+Maharajah Of Magador|TTBB|Dennis Driscoll
+Make America Proud Of You|TTBB|Dennis Driscoll
+Makin' Love Ukelele Style|TTBB|Dennis Driscoll
+Man On The Flying Trapeze|TTBB|Dennis Driscoll
+Mandy|TTBB|Dennis Driscoll
+May The Good Lord Bless And Keep You|TTBB|Dennis Driscoll
+May You Always|TTBB|Dennis Driscoll
+Maybe|TTBB|Dennis Driscoll
+Me And My Shadow|TTBB|Dennis Driscoll
+Mean To Me|TTBB|Dennis Driscoll
+Memphis In June|TTBB|Dennis Driscoll
+Mickey Pretty Mickey|TTBB|Dennis Driscoll
+Milwaukee's Finest|TTBB|Dennis Driscoll
+Minnie The Mermaid|TTBB|Dennis Driscoll
+Mistaken In You|TTBB|Dennis Driscoll
+Mobile|TTBB|Dennis Driscoll
+Moon River|SSATB|Dennis Driscoll
+Moonlight in Vermont|SSATB|Dennis Driscoll
+The Muppet Show Theme|TTBB|Dennis Driscoll
+My Baby Just Cares For Me|TTBB|Dennis Driscoll
+My Book Of Broken Dreams|TTBB|Dennis Driscoll
+My Dreams Are Getting Better All The Time|TTBB|Dennis Driscoll
+My Gal Sal|TTBB|Dennis Driscoll
+My Honey's Lovin' Arms|TTBB|Dennis Driscoll
+My Mother's Rosary|TTBB|Dennis Driscoll
+My Sugar Is So Refined|TTBB|Dennis Driscoll
+My Yiddishe Momma|TTBB|Dennis Driscoll
+Naughty Lady Of Shady Lane|TTBB|Dennis Driscoll
+Nobody Knows What A Red-Head Mamma Can Do|SSAA|Dennis Driscoll
+Nobody Knows What A Red-Head Mamma Can Do|TTBB|Dennis Driscoll
+Nobody Knows You When You're Down And Out|TTBB|Dennis Driscoll
+Nothing Seems The Same Anymore|TTBB|Dennis Driscoll
+Oklahoma Medley|TTBB|Dennis Driscoll
+Old Familiar Faces|TTBB|Dennis Driscoll
+Old Fashioned Locket And A Curl|TTBB|Dennis Driscoll
+On The Bark Of An Old Cherry Tree|TTBB|Dennis Driscoll
+On The Mississippi Queen|TTBB|Dennis Driscoll
+Once In A While|SSATB|Dennis Driscoll
+Pal Of Mine|TTBB|Dennis Driscoll
+The Pal That I Loved Stole The Gal That I Loved|TTBB|Dennis Driscoll
+Parkin' In The Moonlight|TTBB|Dennis Driscoll
+The Picture That I Love the Best of All|TTBB|Dennis Driscoll
+Play Ball!|TTBB|Dennis Driscoll
+Portrait Of My Love|TTBB|Dennis Driscoll
+Pretty Baby|TTBB|Dennis Driscoll
+A Quiet Girl|TTBB|Dennis Driscoll
+Recipe For Love|TTBB|Dennis Driscoll
+Remembering Time Medley|TTBB|Dennis Driscoll
+Ring, Telephone Ring|TTBB|Dennis Driscoll
+River, Stay 'Way from My Door|TTBB|Dennis Driscoll
+Roll Out Of Bed With A Smile|TTBB|Dennis Driscoll
+Rosanne|TTBB|Dennis Driscoll
+A Rose And A Prayer|TTBB|Dennis Driscoll
+Rosemary|TTBB|Dennis Driscoll
+Sailing Down The Chesapeake Bay|TTBB|Dennis Driscoll
+San Francisco|TTBB|Dennis Driscoll
+The Shadow Of Your Smile|SSATB|Dennis Driscoll
+Silver Threads Among The Gold|TTBB|Dennis Driscoll
+Sleepy Time Gal|TTBB|Dennis Driscoll
+Sleigh Ride|TTBB|Dennis Driscoll
+Smile Will Go A Long Long Way|TTBB|Dennis Driscoll
+Smiles|TTBB|Dennis Driscoll
+Softly|SATB|Dennis Driscoll
+Something To Write The Folks About|TTBB|Dennis Driscoll
+Somewhere|TTBB|Dennis Driscoll
+Standing On The Corner|SSAA|Dennis Driscoll
+Stella By Starlight|SSATB|Dennis Driscoll
+Strip Polka|TTBB|Dennis Driscoll
+Stuff Like That There|TTBB|Dennis Driscoll
+Sweet Little Mother Of Mine|TTBB|Dennis Driscoll
+The Sweetest Song In The World|TTBB|Dennis Driscoll
+Tain't No Sin|TTBB|Dennis Driscoll
+Take Me Out To The Ball Game|TTBB|Dennis Driscoll
+Tell Me Why|TTBB|Dennis Driscoll
+Tenderly|SSATB|Dennis Driscoll
+Thank You Very Much|TTBB|Dennis Driscoll
+Thank You World|TTBB|Dennis Driscoll
+That Brown-Eyed Baby Of Mine|TTBB|Dennis Driscoll
+That Old Feeling|TTBB|Dennis Driscoll
+That's What Friends Are For|TTBB|Dennis Driscoll
+The Rose of Tralee|TTBB|Dennis Driscoll
+There's A Long, Long Trail|TTBB|Dennis Driscoll
+There's No Business Like Show Business|TTBB|Dennis Driscoll
+There's No You|TTBB|Dennis Driscoll
+There's Something About A Soldier|TTBB|Dennis Driscoll
+They Say It's Wonderful|TTBB|Dennis Driscoll
+This Is All I Ask|TTBB|Dennis Driscoll
+This Little Light Of Mine|TTBB|Dennis Driscoll
+Tie Me To Your Apron Strings Again|TTBB|Dennis Driscoll
+Tired Hands|TTBB|Dennis Driscoll
+Tired Of Me|TTBB|Dennis Driscoll
+Together Wherever We Go|TTBB|Dennis Driscoll
+True Love|TTBB|Dennis Driscoll
+The Twelve Days After Christmas|TTBB|Dennis Driscoll
+Undecided|TTBB|Dennis Driscoll
+Was There Ever A Pal Like You?|TTBB|Dennis Driscoll
+We'll be together again|SSATB|Dennis Driscoll
+What Do You Want To Make Those Eyes At Me For|TTBB|Dennis Driscoll
+What'll I Do?|TTBB|Dennis Driscoll
+When A Rambling Rose Goes Rambling Home Again|TTBB|Dennis Driscoll
+When I Lost You|TTBB|Dennis Driscoll
+When The Bell In The Lighthouse Rings|TTBB|Dennis Driscoll
+When Your Lover Has Gone|TTBB|Dennis Driscoll
+When Your Old Wedding Ring Was New|TTBB|Dennis Driscoll
+Where Do You Start?|TTBB|Dennis Driscoll
+Where Is Love?|TTBB|Dennis Driscoll
+Where The Blue Of The Night Meets The Gold Of The Day|TTBB|Dennis Driscoll
+Where The River Shannon Flows|TTBB|Dennis Driscoll
+Who'll Dry Your Tears When You Cry?|TTBB|Dennis Driscoll
+Who's In The Strawberry Patch With Sally?|TTBB|Dennis Driscoll
+Who?|TTBB|Dennis Driscoll
+Why Don't We Do This More Often|TTBB|Dennis Driscoll
+The Windmills of your Mind|SATB|Dennis Driscoll
+Wishing|TTBB|Dennis Driscoll
+The World is Waiting For The Sunrise|TTBB|Dennis Driscoll
+You Brought Ireland Right Over To Me|TTBB|Dennis Driscoll
+You don't know what love is|SSATB|Dennis Driscoll
+You Gotta Have Skin|TTBB|Dennis Driscoll
+You Grow Sweeter As The Years Go By|TTBB|Dennis Driscoll
+You Needed Me|TTBB|Dennis Driscoll
+You're My Thrill|TTBB|Dennis Driscoll
+Young At Heart|TTBB|Dennis Driscoll
+Your Eyes Have Told Me So|TTBB|Dennis Driscoll
+Don't Ask Me Why|TTBB|Darin Drown
+I'm Gonna Sing 'Til The Spirit Moves My Heart|TTBB|Darin Drown
+Peace On Earth/Little Drummer Boy medley|TTBB|Gil Dubray
+Lonesome - That's All|TTBB|Norm Duggan
+That Wonderful Mother Of Mine|TTBB|Norm Duggan
+As A Porcupine Pines For Its Pork|TTBB|Toban Dvoretsky
+Brother Noah Gave Out Checks for Rain|TTBB|Toban Dvoretsky
+Charmaine|TTBB|Toban Dvoretsky
+Curse Of An Aching Heart|TTBB|Toban Dvoretsky
+Dapper Dan|TTBB|Toban Dvoretsky
+Fiji (Ne'e Zulu) Hall Of Fame|TTBB|Toban Dvoretsky
+Flower Garden Ball|TTBB|Toban Dvoretsky
+Freckles|TTBB|Toban Dvoretsky
+Give Me A Kiss By The Number|TTBB|Toban Dvoretsky
+Give My Regards To Broadway|TTBB|Toban Dvoretsky
+Grandmother's Love Letters|TTBB|Toban Dvoretsky
+High Cost Of Lovin'|TTBB|Toban Dvoretsky
+I Always Knew The Girl I'd Love Would Be A Girl Like You|TTBB|Toban Dvoretsky
+I Love The Whole United States Medley|TTBB|Toban Dvoretsky
+I Tried To Forget You (In Vain)|TTBB|Toban Dvoretsky
+I Wish I Had A Girl|TTBB|Toban Dvoretsky
+In The Good Old Summertime|TTBB|Toban Dvoretsky
+It's Goin' To Be A Cold, Cold Winter|TTBB|Toban Dvoretsky
+Just For A Girl|TTBB|Toban Dvoretsky
+Little Bunch Of Shamrocks|TTBB|Toban Dvoretsky
+Moon Has His Eyes On You|TTBB|Toban Dvoretsky
+My Barney Lies Over The Ocean|TTBB|Toban Dvoretsky
+My Little Girlie Medley|TTBB|Toban Dvoretsky
+The Night Before Christmas|TTBB|Toban Dvoretsky
+Oh Helen!|TTBB|Toban Dvoretsky
+Oh How We Roared In The Twenties|TTBB|Toban Dvoretsky
+Out Among The Black Hills and the Pines|TTBB|Toban Dvoretsky
+Pat Your Foot|TTBB|Toban Dvoretsky
+Saturday Night|TTBB|Toban Dvoretsky
+She's So Much Like You, Mother|TTBB|Toban Dvoretsky
+Slide, Bill, Slide|TTBB|Toban Dvoretsky
+Sunshine And Roses|TTBB|Toban Dvoretsky
+Teasing|TTBB|Toban Dvoretsky
+Tell Her You Love Her Today|TTBB|Toban Dvoretsky
+They Needed A Songbird In Heaven|TTBB|Toban Dvoretsky
+Wait Till The Sun Shines, Nellie|TTBB|Toban Dvoretsky
+When I Sang The Tenor In That Old Quartet|TTBB|Toban Dvoretsky
+Will You Love Me In December As You Do In May|TTBB|Toban Dvoretsky
+You Brought Ireland Right Over To Me|TTBB|Toban Dvoretsky
+You Only Want Me When You're Lonesome|TTBB|Toban Dvoretsky
+My Barney Lies Over The Ocean|TTBB|Chuck Eaker
+Silent E|TTBB|Chuck Eaker
+Little Drummer Boy|TTBB|Bruce Early
+Delta Dawn|TTBB|R. B. Easterlin
+One Of Those Songs|TTBB|R. B. Easterlin
+Somebody Stole My Gal|TTBB|R. B. Easterlin
+Because He Lives|TTBB|Bill Eberius
+A Capital Ship (The Walloping Window Blind)|TTBB|David Ebersole
+I'm Just Simply Full of Jazz|TTBB|David Ebersole
+Let Yourself Go/Crazy Rhythm Medley|TTBB|David Ebersole
+My Special Angel|TTBB|David Ebersole
+Three Coins In The Fountain|TTBB|David Ebersole
+Heartaches|TTBB|John Eby
+This Could be the Start of Something Big|TTBB|Daniel Eckhart
+Circle Of Friends|SSAA|Gloria Eddy
+Don't Forget The Pal You Left At Home|SSAA|Linda Edmondson
+Doodle Doo Doo|SSAA|Linda Edmondson
+Everybody Step|SSAA|Linda Edmondson
+Hard Hearted Hannah|SSAA|Linda Edmondson
+I'll Forget You|SSAA|Linda Edmondson
+Longer|SSAA|Linda Edmondson
+Lost In My Dreams|SSAA|Linda Edmondson
+My Cutey's Due At Two-To-Two To-day|SSAA|Linda Edmondson
+Remember|SSAA|Linda Edmondson
+Say It With Music|SSAA|Linda Edmondson
+Silver Bells|SSAA|Linda Edmondson
+Sing An Old Fashioned Song|SSAA|Linda Edmondson
+Sweet Talkin' Guy|SSAA|Linda Edmondson
+What A Wonderful World|SSAA|Linda Edmondson
+Kiss That Made Me Cry|TTBB|Gary Eliason
+I Wish I Had A Sweetheart Like That Old Sweetheart of Mine|TTBB|Dick Ellenberger
+I Wonder What's Become Of Sally|TTBB|Dick Ellenberger
+My Little Girl|TTBB|Dick Ellenberger
+Smiles|TTBB|Dick Ellenberger
+There's A Long, Long Trail|TTBB|Dick Ellenberger
+There's A Rose That Is Blooming In Ireland|TTBB|Dick Ellenberger
+Thanks For The Memory|TTBB|I.I. Ellis
+It Is No Secret|TTBB|R. Ellwanger
+Blue Christmas|SSAA|Jeanne Elmuccio
+A Bushel And A Peck|SSAA|Jeanne Elmuccio
+Charleston|SSAA|Jeanne Elmuccio
+Christmas Lullaby|SSAA|Jeanne Elmuccio
+Count Your Blessings Instead Of Sheep|SSAA|Jeanne Elmuccio
+The Dance|SSAA|Jeanne Elmuccio
+Five Minutes More|SSAA|Jeanne Elmuccio
+Flirty Eyes/Jeepers Creepers Medley|SSAA|Jeanne Elmuccio
+Gay Nineties Medley|SSAA|Jeanne Elmuccio
+Happy Hanukkah, My Friend|SSAA|Jeanne Elmuccio
+It's Beginning To Look A Lot Like Christmas|SSAA|Jeanne Elmuccio
+Let's Light The Candles Again|SSAA|Jeanne Elmuccio
+My Tribute|SSAA|Jeanne Elmuccio
+One Little Candle|SSAA|Jeanne Elmuccio
+Pressed Roses|SSAA|Jeanne Elmuccio
+Put A Little Holiday InYour Heart|SSAA|Jeanne Elmuccio
+Somewhere Along The Way|SSAA|Jeanne Elmuccio
+Welcome Christmas|SSAA|Jeanne Elmuccio
+You Light Up My Life|SSAA|Jeanne Elmuccio
+You're The Cream In My Coffee|SSAA|Jeanne Elmuccio
+Let There Be Peace On Earth|TTBB|Wilburn Elrod
+Girl Of My Dreams|TTBB|Phil Embury
+I'm Sorry I Made You Cry|TTBB|Phil Embury
+It's You|TTBB|Phil Embury
+The Maple Leaf Forever|TTBB|Phil Embury
+My Bonnie|TTBB|Phil Embury
+Silver Threads Among The Gold|TTBB|Phil Embury
+Sincere|TTBB|Phil Embury
+Stephen Foster Medley|TTBB|Phil Embury
+Wagon Medley|TTBB|Phil Embury
+Where The Sunset Turns The Ocean's Blue To Gold|TTBB|Phil Embury
+You Tell Me Your Dream|TTBB|Phil Embury
+From This Moment On|TTBB|Jim Emery
+I Love To See You Smile|TTBB|Jim Emery
+I've Got A Feeling I'm Falling|TTBB|Jim Emery
+Keep America Singing|TTBB|Jim Emery
+Limerick Song|TTBB|Jim Emery
+My Wild Irish Chrysanthemum|TTBB|Jim Emery
+Second Time Around|TTBB|Jim Emery
+The Song that Doesn't End|TTBB|Jim Emery
+Taking A Chance On Love|TTBB|Jim Emery
+Wagon Wheels|TTBB|Jim Emery
+You've Got A Friend In Me|TTBB|Jim Emery
+Angels Among Us|SSAA|Donna Emfield
+A Teenager In Love|TTBB|Duane Enders
+Ballad Of The Green Beret|SSAA|Duane Enders
+Great Is Thy Faithfulness|TTBB|Duane Enders
+Heart Of A Clown|TTBB|Duane Enders
+I Can't Begin To Tell You|TTBB|Duane Enders
+Lydia (The Tattooed Lady)|TTBB|Duane Enders
+Return To Sender|TTBB|Duane Enders
+George M. Cohan Medley|TTBB|Paul Engel
+Goodbye|TTBB|Paul Engel
+Hen And The Cow|TTBB|Paul Engel
+Henpecked Sam|TTBB|Paul Engel
+I Love You California|TTBB|Paul Engel
+I'm Gonna Buy A One-Way Ticket To A Little One-Horse Town|TTBB|Paul Engel
+I'm Making Believe That I Don't Care|TTBB|Paul Engel
+"If I Knock The ""L"" Out Of Kelly"|TTBB|Paul Engel
+If War Is What Sherman Said It Was|TTBB|Paul Engel
+Land Of Hope And Glory|TTBB|Paul Engel
+They Were All Out Of Step But Jim|TTBB|Paul Engel
+They're Wearing 'Em Higher In Hawaii|TTBB|Paul Engel
+Too Many Kisses In The Summer|TTBB|Paul Engel
+The Twelve Days After Christmas|TTBB|Paul Engel
+When You Ring Some Chords With Your Newest Friends|SSAA|Paul Engel
+You Can't Take My Harem Away|TTBB|Paul Engel
+You Made Me Forget How To Cry|TTBB|Paul Engel
+Bright College Days|TTBB|W. Engelke
+Cruisin' Down The River|TTBB|Leif Erickson
+Abilene|TTBB|Mason Eubank
+After You Get What You Want You Don't Want It|TTBB|Mason Eubank
+Angelo State University Fight Song|TTBB|Mason Eubank
+Ben 10 Theme Song|TTBB|Mason Eubank
+Curious George Theme Song|TTBB|Mason Eubank
+Girl, Can I Kiss You With Tongue?|TTBB|Mason Eubank
+Hello Darlin'|TTBB|Mason Eubank
+Hibernate With Me|TTBB|Mason Eubank
+I'd Like To Buy The World A Coke|TTBB|Mason Eubank
+Looking For A City|TTBB|Mason Eubank
+Sharp Dressed Man|TTBB|Mason Eubank
+Sing|TTBB|Mason Eubank
+Suzy Snowflake|TTBB|Mason Eubank
+Tennessee River Runs Low|SSAA|Mason Eubank
+Ticklish Reuben (The Laughing Song)|TTBB|Mason Eubank
+West Texas Town|TTBB|Mason Eubank
+Wrapped In Red|TTBB|Mason Eubank
+It Had To Be You|TTBB|Bruce Evans
+Lullaby Of Broadway|TTBB|Craig Ewing
+New York, New York|TTBB|Craig Ewing
+Lonesome - That's All|TTBB|Wes Farmer
+Meet Me At Twilight|TTBB|Wes Farmer
+When Mother Played The Organ|TTBB|Wes Farmer
+How Lucky You Are|TTBB|Katie Farrell
+If I Love Again|TTBB, SSAA|Katie Farrell
+They Say It's Wonderful|TTBB, SSAA, SATB|Katie Farrell
+Angel Eyes|SSAA|Avis Fellows
+Bring Back The Music|SSAA|Avis Fellows
+Butter|SSAA|Avis Fellows
+Celebrity|SSAA|Avis Fellows
+Crazy|SSAA|Avis Fellows
+Give It Away|SSAA|Avis Fellows
+Have Yourself A Merry Little Christmas|SSAA|Avis Fellows
+Hooray For Christmas|SSAA|Avis Fellows
+How Do You Open A Show|SSAA|Avis Fellows
+I Had Someone Else Before I Had You|SSAA|Avis Fellows
+I Tore Up Your Picture When You Said Goodbye|SSAA|Avis Fellows
+I Want A Girl Medley|SSAA|Avis Fellows
+I'd Love You All Over Again|SSAA|Avis Fellows
+I'm Gonna Steal Somebody Else's Baby|SSAA|Avis Fellows
+I'm Making Believe That I Don't Care|SSAA|Avis Fellows
+If I Loved You More|SSAA|Avis Fellows
+If You Can't Land Er On The Old Veranda|SSAA|Avis Fellows
+Intermission|SSAA|Avis Fellows
+It's A Pity To Say Goodnight|SSAA|Avis Fellows
+Little Grey Donkey|SSAA|Avis Fellows
+Lord Bless You And Keep You|SSAA|Avis Fellows
+Love In Any Language|SSAA|Avis Fellows
+Luck Be A Lady|SSAA|Avis Fellows
+Married Medley|SSAA|Avis Fellows
+Minneapolis/St. Paul Theme|SSAA|Avis Fellows
+Mother's Hands|SSAA|Avis Fellows
+No One's Fool|SSAA|Avis Fellows
+Nobody's Lonesome But Me|SSAA|Avis Fellows
+O Holy Night|SSAA|Avis Fellows
+Pop, Pop, Popin, Popcorn|SSAA|Avis Fellows
+Sally Wont You Come Back?|SSAA|Avis Fellows
+Silent Night|SSAA|Avis Fellows
+Star Of Bethlehem|SSAA|Avis Fellows
+Take Me Out To The Ball Game|SSAA|Avis Fellows
+Taking A Chance On Love|SSAA|Avis Fellows
+Testify To Love|SSAA|Avis Fellows
+Thank God I'm Old|SSAA|Avis Fellows
+That Sunday, That Summer|SSAA|Avis Fellows
+That's What I Want For Christmas|SSAA|Avis Fellows
+That's What We Love About Christmas|SSAA|Avis Fellows
+When A Rambling Rose Goes Rambling Home Again|SSAA|Avis Fellows
+Where Do I Go From You?|SSAA|Avis Fellows
+Who Cares|SSAA|Avis Fellows
+Why We Sing|SSAA|Avis Fellows
+Wishing|SSAA|Avis Fellows
+You Made Me Love You|SSAA|Avis Fellows
+Another Christmas Song|TTBB|Dom Finetti
+Blue Shadows On The Trail|TTBB|Dom Finetti
+But I Do - You Know I Do!|TTBB, SATB|Dom Finetti
+Can I Interest You In Hannukah?|TTBB|Dom Finetti
+Cleanin' Up The Town|TTBB|Dom Finetti
+Comfortable|TTBB|Dom Finetti
+Favourite Pair of Pants|TTBB|Dom Finetti
+I'm Just Ken|TTBB|Dom Finetti
+I've Got The World On A String|TTBB|Dom Finetti
+It Takes Two|TTBB, SSAA|Dom Finetti
+Mango Tree|TTBB|Dom Finetti
+Nothing But The Best|TTBB|Dom Finetti
+Peaches|TTBB|Dom Finetti
+Places We Won't Walk|TTBB|Dom Finetti
+Please Come Home For Christmas|TTBB|Dom Finetti
+Reindeer(s) Are Better Than People|SATB|Dom Finetti
+So Close|TTBB|Dom Finetti
+Some Nights|TTBB|Dom Finetti
+That Christmas Morning Feelin'|TTBB|Dom Finetti
+Timeless To Me|TTBB|Dom Finetti
+Unredeemable|TTBB|Dom Finetti
+Vienna|TTBB|Dom Finetti
+We Could Be Falling In Love|TTBB|Dom Finetti
+Detour|TTBB|Jud Finley
+Feeling Blue|TTBB|Jud Finley
+Hit The Road Jack|TTBB|Jud Finley
+I Don't Know Why|TTBB|Jud Finley
+Rogue River Valley|TTBB|Jud Finley
+Sentimental Journey|TTBB|Jud Finley
+The Shadow Of Your Smile|TTBB|Jud Finley
+Smoke! Smoke! Smoke That Cigarette|TTBB|Jud Finley
+Blue Hours|TTBB|Bernie Fischer
+I Never Knew|TTBB|Bernie Fischer
+Sometime|TTBB|Bernie Fischer
+Broadway Rose|TTBB|Ken Fisher
+All By Myself|TTBB|Lance Fisher
+Anywhere I Wander|TTBB|Lance Fisher
+Back At One|TTBB|Lance Fisher
+Back Where I Come From|TTBB|Lance Fisher
+Being Alive|TTBB|Lance Fisher
+Friend Like Me|TTBB|Lance Fisher
+Give A Little Whistle|TTBB|Lance Fisher
+I Feel A Song Comin' On|SATB|Lance Fisher
+I'm Just A Bill|TTBB|Lance Fisher
+The Night We Met|SATB|Lance Fisher
+One Jump Ahead|TTBB|Lance Fisher
+One Last Cry|TTBB|Lance Fisher
+Perfect|TTBB|Lance Fisher
+Screw Loose|SATB|Lance Fisher
+September|SATB|Lance Fisher
+Steppin' Out With My Baby|TTBB|Lance Fisher
+What Is It About Her?|TTBB|Lance Fisher
+You're Nobody 'Til Somebody Loves You|TTBB|Lance Fisher
+Goodbye Boys|TTBB|William Fisher
+In The Land Of Wedding Bells|TTBB|William Fisher
+What Word Is Sweeter Than Sweetheart|TTBB|William Fisher
+The Christmas Song|TTBB|Al Fisk
+Christmas Time Is Here|TTBB|Al Fisk
+After The Lovin'|SSAA|Jean Flinn
+Humbug!|SSAA|Jean Flinn
+My Daddy Is Only A Picture|SSAA|Jean Flinn
+Friendship|TTBB|Richard Floersheimer
+Man On The Flying Trapeze|TTBB|Richard Floersheimer
+Most Wonderful Time Of The Year|TTBB|Richard Floersheimer
+Over The Sea Let's Go Men|TTBB|Richard Floersheimer
+Peggy O'Neil|TTBB|Richard Floersheimer
+Sit Down You're Rockin' The Boat|TTBB|Richard Floersheimer
+Sway|TTBB|Richard Floersheimer
+That's Amore|TTBB|Richard Floersheimer
+Chattanoogie Shoe Shine Boy|SSAA|Ed FLynn
+Chattanoogie Shoe Shine Boy|TTBB|Ed FLynn
+Pennies from Heaven|TTBB|Bruce Foreman
+The County Fair|TTBB|Russ Foris
+Deep River|SSAA|Russ Foris
+Fortuosity|TTBB|Russ Foris
+Home For The Holidays|TTBB, SSAA, SATB|Russ Foris
+I Stayed Too Long At The Fair|TTBB|Russ Foris
+I Want Somebody To Play With|SSAA|Russ Foris
+I'll Build A Stairway To Paradise|TTBB|Russ Foris
+I'll Build A Stairway To Paradise|SSAA|Russ Foris
+I'm Knee Deep In Daisies|SSAA|Russ Foris
+I'm Knee Deep In Daisies|TTBB|Russ Foris
+If He Can Fight Like He Can Love, Good Night Germany|SSAA|Russ Foris
+If I Could Write A Song|TTBB|Russ Foris
+Johnny Doughboy Found A Rose In Ireland|SSAA|Russ Foris
+Just A Baby's Prayer At Twilight|SSAA|Russ Foris
+Lucky Day|TTBB|Russ Foris
+Mardi Gras March|TTBB|Russ Foris
+Mary You're A Little Bit Old Fashioned|TTBB|Russ Foris
+Merry Heart, A (Finiculi, Finicula)|SSAA|Russ Foris
+Merry Heart, A (Finiculi, Finicula)|TTBB|Russ Foris
+Mickey|TTBB|Russ Foris
+Now Is The Hour|SSAA|Russ Foris
+Old Cape Cod|TTBB|Russ Foris
+Pal Of My Cradle Days|TTBB|Russ Foris
+Play A Simple Melody|TTBB|Russ Foris
+Polka Medley|TTBB|Russ Foris
+Polka Medley|SSAA|Russ Foris
+Powder Your Face With Sunshine|SSAA|Russ Foris
+Put On Your Old Grey Bonnet|TTBB|Russ Foris
+Ro-Ro-Rollin' Along|TTBB|Russ Foris
+The Secret Of Christmas|SSAA|Russ Foris
+The Secret Of Christmas|TTBB|Russ Foris
+Sister Susie's Sewing Shirts For Soldiers|TTBB|Russ Foris
+The Song Is Ended|TTBB|Russ Foris
+A Spoonful Of Sugar|TTBB|Russ Foris
+Sunny Southern Smiles|TTBB|Russ Foris
+There's No Business Like Show Business|TTBB|Russ Foris
+When I Carried Your Books Home from School|SSAA|Russ Foris
+When The Old Oaken Bucket Was New|TTBB|Russ Foris
+When The Saints Go Marching In|SSAA|Russ Foris
+When The Saints Go Marching In|TTBB|Russ Foris
+With A Smile And A Song|TTBB|Russ Foris
+Wonderful One|TTBB|Russ Foris
+I Feel A Song Comin' On|TTBB|John Fortino
+I'm Into Something Good|TTBB|John Fortino
+Sunny Side Up/When You're Smiling Medley|TTBB|John Fortino
+Tell Me With Your Eyes|TTBB|John Fortino
+That's Amore|TTBB|John Fortino
+September In The Rain|SSAA|Clarice Fowler
+Fun And Fancy Free|SSAA|Diana Franceschi
+I Asked The Lord|SSAA|Diana Franceschi
+Somebody Lied About Me|SSAA|Diana Franceschi
+Somebody Loves You|SSAA|Diana Franceschi
+Sposin|SSAA|Diana Franceschi
+There'll Be Jubilation Bye And Bye|SSAA|Diana Franceschi
+Brave|SSAA|Kari Francis
+I've Got My Love To Keep Me Warm|SATB|Kari Francis
+The Impression That I Get|TTBB|Kari Francis
+Up the Ladder to the Roof|SATB|Kari Francis
+Wildflowers|SATB|Kari Francis
+I Thrill When They Mention Your Name|TTBB|Jim Franklin
+I'm So Glad We Had This Time Together|TTBB|Jim Franklin
+Animal Fair|TTBB|Don Fraser
+Doin' The Raccoon|TTBB|Don Fraser
+Iowa|TTBB|Don Fraser
+My Dreams Are Getting Better All The Time|TTBB|Don Fraser
+When I Grow Too Old To Dream|TTBB|Don Fraser
+When Your Old Wedding Ring Was New|TTBB|Don Fraser
+Looking At The World Through Rose Colored Glasses|TTBB|Mark Freedkin
+Book Of Love|SSAA|Rosemary Frerking
+All You Need Is Love|SSAA|Takako Fuke
+Another Hallelujah|SSAA|Takako Fuke
+Beyond the Sea|SSAA|Takako Fuke
+Can't Take My Eyes Off Of You|SSAA|Takako Fuke
+Carol Of The Bells|SSAA|Takako Fuke
+Come Dance With Me|SSAA|Takako Fuke
+Dancing Queen|SSAA|Takako Fuke
+Ebony And Ivory|SSAA|Takako Fuke
+Everything|SSAA|Takako Fuke
+Fantasy|SSAA|Takako Fuke
+Happy Together|SSAA|Takako Fuke
+Heal The World|SSAA|Takako Fuke
+Holding Out For A Hero|SSAA|Takako Fuke
+I Love A Piano|SSAA|Takako Fuke
+I Love Being Here With You|SSAA|Takako Fuke
+I Need to be in Love|SSAA|Takako Fuke
+I Wonder Where My Baby Is Tonight|SSAA|Takako Fuke
+I Write The Songs|SSAA|Takako Fuke
+I've Told Ev'ry Little Star|SSAA|Takako Fuke
+It Is Well With My Soul|SSAA|Takako Fuke
+Jamaica Farewell|SSAA|Takako Fuke
+Let's Twist Again|SSAA|Takako Fuke
+The Loco-motion|SSAA|Takako Fuke
+May Each Day|SSAA|Takako Fuke
+Mister Sandman|SSAA|Takako Fuke
+My Blue Heaven|SSAA|Takako Fuke
+My Way|SSAA|Takako Fuke
+A Nightingale Sang In Berkeley Square|SSAA|Takako Fuke
+One Way Ticket|SSAA|Takako Fuke
+Sakura Sakura|SSAA|Takako Fuke
+Save The Last Dance For Me|SSAA|Takako Fuke
+Skidamarink|SSAA|Takako Fuke
+Sukiyaki|SSAA|Takako Fuke
+Super Trouper|SSAA|Takako Fuke
+Supercalifragilisticexpialidocious|SSAA|Takako Fuke
+Sway|SSAA|Takako Fuke
+Thank You For The Music|SSAA|Takako Fuke
+We're All Alone|SSAA|Takako Fuke
+What Would I Do Without You|SSAA|Takako Fuke
+When I'm Sixty Four|SSAA|Takako Fuke
+White Winter Hymnal|SSAA|Takako Fuke
+Why We Sing|SSAA|Takako Fuke
+You Raise Me Up|SSAA|Takako Fuke
+Your Song|SSAA|Takako Fuke
+Coney Island Washboard|SSAA|Ardeth Fullmer
+I Believed It All|SSAA|Ardeth Fullmer
+If There's Anybody Here|TTBB|Ardeth Fullmer
+My Cup Runneth Over With Love|TTBB|Ardeth Fullmer
+Route 66|SSAA|Ardeth Fullmer
+Ahead By A Century|SSAA|Elaine Gain
+All About That Bass|SSAA|Elaine Gain
+All Of Me|SSAA|Elaine Gain
+All The Things You Are|SSAA|Elaine Gain
+Any Man Of Mine|SSAA|Elaine Gain
+As Long as I'm Singin' My Song/Sing|SSAA|Elaine Gain
+As Long As I'm Singing|SSAA|Elaine Gain
+Bad Romance|SSAA|Elaine Gain
+Because You Loved Me|SSAA|Elaine Gain
+Can't Stop the Feeling!|SSAA|Elaine Gain
+Can't Take My Eyes Off Of You|SSAA|Elaine Gain
+Cheek To Cheek|SSAA|Elaine Gain
+Fight Song|SSAA|Elaine Gain
+Good Vibrations|SSAA|Elaine Gain
+Grown-Up Christmas List|SSAA|Elaine Gain
+Hallelujah|SSAA|Elaine Gain
+Happy|SSAA|Elaine Gain
+Hey, Soul Sister|SSAA|Elaine Gain
+Hold On Tight|SSAA|Elaine Gain
+Home|SSAA|Elaine Gain
+I Want You Back|SSAA|Elaine Gain
+Mamma Mia|SSAA|Elaine Gain
+My Baby Just Cares For Me|SSAA|Elaine Gain
+Rolling In The Deep|SSAA|Elaine Gain
+Where The Boys Are|SSAA|Elaine Gain
+Wherever You Are|SSAA|Elaine Gain
+Who I Am|SSAA|Elaine Gain
+Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|SSAA|Elaine Gain
+With Bells On|SSAA|Elaine Gain
+You Are My Sunshine|SSAA|Elaine Gain
+Charade|TTBB|Matthew Gallagher
+Corner Of The Sky|TTBB|Matthew Gallagher
+Destination Moon|TTBB|Matthew Gallagher
+Don't Speak|TTBB|Matthew Gallagher
+Fugue for Tinhorns|TTBB|Matthew Gallagher
+The Greatest Gift of All|TTBB|Matthew Gallagher
+How Could I Ever Know?|TTBB|Matthew Gallagher
+How Far I'll Go|TTBB, SSAA|Matthew Gallagher
+I Ain't Gonna Play No Second Fiddle|SSAA|Matthew Gallagher
+I Get Along Without You Very Well|TTBB|Matthew Gallagher
+Lately|TTBB, SSAA|Matthew Gallagher
+Let's Do It (Let's Fall In Love) / Let's Misbehave Medley|TTBB|Matthew Gallagher
+Photograph|TTBB|Matthew Gallagher
+Pure Imagination|TTBB, SSAA|Matthew Gallagher
+Saving All My Love For You|TTBB|Matthew Gallagher
+Someone Like You|SSAA|Matthew Gallagher
+The Song Is You|TTBB|Matthew Gallagher
+Sweet Roses Of Morn|TTBB|Matthew Gallagher
+When You Wish Upon A Star|TTBB|Matthew Gallagher
+You're Cheatin Yourself When You're Cheatin On Me|TTBB|Matthew Gallagher
+High Cost Of Lovin'|TTBB|Richard Gallagher
+Rhythm Of The Rain|TTBB|Fred Ganter
+In The Little Red Schoolhouse|SSAA|Ronaleen Gapetz
+Button Up Your Overcoat|TTBB|Bill Gard
+A Hard Days Night|TTBB|Liz Garnett
+A Million Dreams|TTBB|Liz Garnett
+Africa|SSAA|Liz Garnett
+Against All Odds|SSAA|Liz Garnett
+All About That Bass|SSAA|Liz Garnett
+All The Things You Are|SSAA|Liz Garnett
+And I Love You So|SSAA|Liz Garnett
+Around the World|TTBB|Liz Garnett
+Bad Day|TTBB|Liz Garnett
+Bad Guys/Down and Out Medley|TTBB|Liz Garnett
+Be My Christmas Number One|TTBB, SSAA|Liz Garnett
+Before The Parade Passes By|SSAA|Liz Garnett
+Beg, Steal Or Borrow|SATB|Liz Garnett
+Bein' Green|SSAA|Liz Garnett
+Blue Christmas|SSAA|Liz Garnett
+Born This Way|SSAA|Liz Garnett
+Bring Me Sunshine|SSAA, SATB|Liz Garnett
+Bugsy Malone|TTBB|Liz Garnett
+Cabaret|TTBB|Liz Garnett
+Candy Man|SSAA|Liz Garnett
+Carol Of The Bells|SSAA|Liz Garnett
+City of Stars|SSAA|Liz Garnett
+Coming Back as a Man|SSAA|Liz Garnett
+Completely|SSAA|Liz Garnett
+Coventry Carol|SSAA|Liz Garnett
+Crazy for You|SSAA|Liz Garnett
+Cry Me A River|SSAA|Liz Garnett
+Dance The Night Away|TTBB|Liz Garnett
+Dance With Me Tonight|SSAA|Liz Garnett
+Deck The Halls|SSAA|Liz Garnett
+Diamond's Are A Girls Best Friend|SSAA|Liz Garnett
+Diamonds are Forever|TTBB, SSAA|Liz Garnett
+Don't Give Up|SSAA|Liz Garnett
+Don't Know Why|SSAA, SATB|Liz Garnett
+Don't Stop Me Now|SSAA|Liz Garnett
+Don't Stop Me Now|TTBB|Liz Garnett
+Everything Is Awesome|SATB|Liz Garnett
+Feed The Birds|TTBB|Liz Garnett
+Feeling Good|SSAA|Liz Garnett
+Ferry Cross the Mersey|SATB|Liz Garnett
+Fields Of Gold|SSAA|Liz Garnett
+Fill, Fill a Run o|SSAA|Liz Garnett
+Flowers|SSAA|Liz Garnett
+For All We Know|TTBB|Liz Garnett
+Gaudete|SSAA|Liz Garnett
+Ghosts (How Can I Move On)|SSAA|Liz Garnett
+Girls Just Wanna Have Fun|SSAA|Liz Garnett
+Give Me The Simple Life|TTBB|Liz Garnett
+God Only Knows|SSAA|Liz Garnett
+Gortnamona|SSAA|Liz Garnett
+Grace Kelly|SSAA|Liz Garnett
+Happy Together|TTBB, SSAA, SATB|Liz Garnett
+Have Yourself A Merry Little Christmas|SSAA|Liz Garnett
+Haven't Met You Yet|TTBB|Liz Garnett
+Here Comes The Sun|SSAA|Liz Garnett
+Hit Me With a Hot Note/Too Darn Hot Medley|SSAA|Liz Garnett
+Holding Out For A Hero|SSAA|Liz Garnett
+I Am What I Am/I Will Survive Medley|SSAA|Liz Garnett
+I Don't Want to Miss a Thing|SSAA|Liz Garnett
+I Find Your Love|SSAA|Liz Garnett
+I Tell Me Ma|SSAA|Liz Garnett
+I Will Survive|SSAA|Liz Garnett
+I Wish I Was a Punk Rocker|SSAA|Liz Garnett
+I Won't Dance|TTBB, SSAA|Liz Garnett
+I'm Into Something Good|TTBB|Liz Garnett
+I'm Just a Gigolo/I Ain't Got Nobody|TTBB|Liz Garnett
+I'm Just Ken|SATB|Liz Garnett
+I'm So Excited|SSAA|Liz Garnett
+If I Were a Boy/Girls Medley|SSAA, SATB|Liz Garnett
+If You're Not the One|SSAA|Liz Garnett
+Impossible|TTBB|Liz Garnett
+The Internationale for Remainers|SATB|Liz Garnett
+It Must Be Love|TTBB, SSAA|Liz Garnett
+It's Christmas 1973!|TTBB|Liz Garnett
+It's D'Lovely|SSAA|Liz Garnett
+It's Still Rock and Roll to Me|TTBB|Liz Garnett
+The Jogging Song|SSAA|Liz Garnett
+Kiss From A Rose|TTBB|Liz Garnett
+Landslide|SSAA|Liz Garnett
+Let Me Be There|SSAA|Liz Garnett
+Let The River Run|SSAA|Liz Garnett
+Let There Be Love|SSAA|Liz Garnett
+Let's Face The Music And Dance|TTBB, SSAA|Liz Garnett
+Let's Go Fly a Kite|TTBB|Liz Garnett
+Linger Awhile|SSAA|Liz Garnett
+Listen|SSAA|Liz Garnett
+Listen To The Music|SSAA|Liz Garnett
+Live and Let Die|TTBB|Liz Garnett
+Long As I'm Here With You|SSAA|Liz Garnett
+Look For The Silver Lining|SSAA|Liz Garnett
+Love You Anymore|TTBB|Liz Garnett
+Ma! (He's Making Eyes At Me)|SSAA|Liz Garnett
+Madonna Medley|SSAA|Liz Garnett
+Mama's Shoes|SSAA|Liz Garnett
+Mamma Mia|SSAA|Liz Garnett
+Manhattan|SSAA|Liz Garnett
+Mary Poppins Medley|TTBB|Liz Garnett
+Medley: Bat Out Of Hell, All Revved Up, Dead Ringer For Love, You Took...|TTBB|Liz Garnett
+Medley: I Am What I Am with I Will Survive|SSAA|Liz Garnett
+Medley: Merry Christmas Everybody, I Wish It Could Be Christmas Every Day, Lonely This Christmas|TTBB|Liz Garnett
+Medley: Mr Bassman, Mah-Na Mah-Na|SSAA|Liz Garnett
+Medley: Music To Watch Girls By, Can't Take My eyes Off Of You|TTBB|Liz Garnett
+Medley: Pink, Dance The Night|SATB|Liz Garnett
+Medley: Play The Game with Killer Queen|SSAA|Liz Garnett
+Medley: Superwoman with Change|SSAA|Liz Garnett
+Medley: Vogue with Holiday, Material Girl, Into The Groove|SSAA|Liz Garnett
+Medley: What Was I Made For? with Corner Of The Sky|SSAA|Liz Garnett
+Meet You at the Moon|SSAA|Liz Garnett
+Mercy|SSAA|Liz Garnett
+Merry Christmas Everyone|SSAA|Liz Garnett
+Messin' with Fire|SSAA|Liz Garnett
+Monsters|TTBB|Liz Garnett
+Moondance|SSAA|Liz Garnett
+More|SSAA|Liz Garnett
+Mr. Blue Sky|TTBB, SSAA, SATB|Liz Garnett
+My Life|TTBB|Liz Garnett
+A New Ode to Joy|TTBB, SATB|Liz Garnett
+A Night Like This|SSAA|Liz Garnett
+Nine To Five|SSAA|Liz Garnett
+No One Is Alone|TTBB|Liz Garnett
+O Little Town Of Bethlehem|SSAA|Liz Garnett
+O Waly Waly|SSAA|Liz Garnett
+Oliver Medley|SSAA|Liz Garnett
+On the 25th of the 12th|TTBB|Liz Garnett
+On The Street Where You Live|SSAA|Liz Garnett
+One|SSAA|Liz Garnett
+One Day Like This|TTBB, SSAA|Liz Garnett
+One Love|SSAA|Liz Garnett
+Pack Up|SSAA|Liz Garnett
+Paradise by the Dashboard Light|TTBB|Liz Garnett
+The Parting Glass|TTBB, SSAA, SATB|Liz Garnett
+Perhaps, Perhaps, Perhaps|TTBB|Liz Garnett
+Piece of My Heart|SSAA|Liz Garnett
+Pink|SATB|Liz Garnett
+Place in the Choir|TTBB|Liz Garnett
+Play The Game|SSAA|Liz Garnett
+Play the Game/Killer Queen Medley|SSAA|Liz Garnett
+Price Tag|SSAA|Liz Garnett
+Right Here Right Now|SATB|Liz Garnett
+Rule the World|SSAA|Liz Garnett
+Russian Roulette|SSAA|Liz Garnett
+Saltwater|TTBB|Liz Garnett
+Seasons of Love|SSAA|Liz Garnett
+She Moved Through the Fair|SSAA|Liz Garnett
+She's Leaving Home|SSAA|Liz Garnett
+Shine|SSAA|Liz Garnett
+Shine Silently|SATB|Liz Garnett
+Sit Down You're Rockin' The Boat|SSAA|Liz Garnett
+Somebody to Love|SSAA|Liz Garnett
+Someone To Watch Over Me|SSAA|Liz Garnett
+Somewhere Only We Know|SSAA|Liz Garnett
+Song for Ireland|SSAA|Liz Garnett
+The Sound Of Silence|SSAA|Liz Garnett
+Speak/Sing Medley|TTBB|Liz Garnett
+Spoonful of Sugar/Jolly Holiday Medley|TTBB|Liz Garnett
+Stayin' Home|TTBB|Liz Garnett
+Straighten Up And Fly Right|TTBB, SSAA|Liz Garnett
+Streets Of Edinburgh|SSAA|Liz Garnett
+Summer Nights|SATB|Liz Garnett
+Superwoman/Change|SSAA|Liz Garnett
+Sway|SSAA|Liz Garnett
+Texas Hold 'em|SSAA|Liz Garnett
+That Don't Impress Me Much|SSAA|Liz Garnett
+These Are the Days of Our Lives|SATB|Liz Garnett
+These Boots Are Made For Walkin'|SSAA|Liz Garnett
+They Remind Me Too Much of You|TTBB|Liz Garnett
+This Is Me|TTBB, SSAA|Liz Garnett
+Three Lions (Football's Coming Home)|TTBB|Liz Garnett
+Time Of My Life|SATB|Liz Garnett
+To Make You Feel My Love|SSAA|Liz Garnett
+Tonight I Celebrate My Love|SATB|Liz Garnett
+Top Of The World|TTBB|Liz Garnett
+Try Everything|TTBB|Liz Garnett
+Two Out of Three Ain't Bad|TTBB|Liz Garnett
+Upside Down|SSAA|Liz Garnett
+Valerie|SSAA|Liz Garnett
+Walking On Sunshine|SSAA|Liz Garnett
+We Are Family|SSAA|Liz Garnett
+We Wish You A Merry Christmas|TTBB, SSAA|Liz Garnett
+We're Gonna Change the World|SSAA|Liz Garnett
+What About Us|SSAA|Liz Garnett
+What The World Needs Now Is Love|SSAA|Liz Garnett
+What Was I Made For?|SSAA|Liz Garnett
+When I Fall In Love|SSAA|Liz Garnett
+White Christmas|SSAA|Liz Garnett
+Who Can I Turn To? (When Nobody Needs Me)|TTBB|Liz Garnett
+Who Do You Think You Are Kidding Mr. Hit|TTBB|Liz Garnett
+Who Loves You|SSAA|Liz Garnett
+Witchy Woman|SSAA|Liz Garnett
+Wizard Of Oz Medley|SSAA|Liz Garnett
+Wonderful Baby|SSAA|Liz Garnett
+Writing's On the Wall|SSAA|Liz Garnett
+You Can't Hurry Love|SSAA|Liz Garnett
+You Can't Stop The Beat|SSAA|Liz Garnett
+You Do Something To Me|TTBB|Liz Garnett
+You Don't Own Me|SSAA|Liz Garnett
+You Got a Friend|SSAA|Liz Garnett
+You Made Me Love You|SSAA|Liz Garnett
+You're My World|SSAA|Liz Garnett
+You've Got A Friend In Me|TTBB|Liz Garnett
+Canadian Man|SSAA|Corinna Garriock
+Cover Me In Sunshine|SSAA|Corinna Garriock
+Fix You|SSAA|Corinna Garriock
+Honey, I'm Home|SSAA|Corinna Garriock
+Hooked On A Feeling|SSAA|Corinna Garriock
+Mr. Blue Sky|SSAA|Corinna Garriock
+Name Droppings|SSAA|Corinna Garriock
+Still The One|SSAA|Corinna Garriock
+Takin' Care of Business|SSAA|Corinna Garriock
+This Is It!|SSAA|Corinna Garriock
+Walking On Sunshine|SSAA|Corinna Garriock
+You Can't Make Old Friends|TTBB|Corinna Garriock
+Corabelle|TTBB|Roberta Garrison
+Sweetheart Tree|TTBB|Alan C. Gasper
+The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Julie Gaulke
+California Here I Come|TTBB|Jim Gay
+All The Things You Are|SSAA|Michael Gellert
+Almost Like Being In Love|SSAA|Michael Gellert
+Being Alive|SSAA|Michael Gellert
+The Big Parade|SSAA|Michael Gellert
+Break It To Me Gently|SSAA|Michael Gellert
+Cabaret|SSAA|Michael Gellert
+California Dreamin'|SSAA|Michael Gellert
+Darn That Dream|SSAA|Michael Gellert
+Daybreak|SSAA|Michael Gellert
+Drive My Car|SSAA|Michael Gellert
+The End of the World|SSAA|Michael Gellert
+Fly Me To The Moon|SSAA|Michael Gellert
+For Good|SSAA|Michael Gellert
+The Girl in 14G|SSAA|Michael Gellert
+Gonna Build A Mountain|SSAA|Michael Gellert
+Good Morning Baltimore|SSAA|Michael Gellert
+Hairspray|SSAA|Michael Gellert
+Happy Days Are Here Again|SSAA|Michael Gellert
+Hard Hearted Hannah|SSAA|Michael Gellert
+Help Is On The Way|SSAA|Michael Gellert
+Hit Me With A Hot Note|SSAA|Michael Gellert
+Hit The Road To Dreamland|SSAA|Michael Gellert
+Home|TTBB|Michael Gellert
+I Am What I Am|SSAA|Michael Gellert
+I Don't Care If The Sun Don't Shine|SSAA|Michael Gellert
+In His Eyes|SSAA|Michael Gellert
+It's The Hard-Knock Life|SSAA|Michael Gellert
+The Lady Down the Hall|SSAA|Michael Gellert
+Lean On Me|TTBB|Michael Gellert
+Let Me Be Your Star|SSAA|Michael Gellert
+Listen To My Heart|SSAA|Michael Gellert
+Little Boy|SSAA|Michael Gellert
+Little Patch Of Heaven|SSAA|Michael Gellert
+Make Your Own Kind of Music|SSAA|Michael Gellert
+Maybe|SSAA|Michael Gellert
+Mr. Mom|SSAA|Michael Gellert
+My Favorite Things|SSAA|Michael Gellert
+My Foolish Heart|SSAA|Michael Gellert
+A New Life|SSAA|Michael Gellert
+New Words|SSAA|Michael Gellert
+New York State of Mind|SSAA|Michael Gellert
+Open Arms|SSAA|Michael Gellert
+Opening Night|SSAA|Michael Gellert
+Over The Rainbow|SSAA|Michael Gellert
+Popular|SSAA|Michael Gellert
+Rolling In The Deep|SSAA|Michael Gellert
+She's Gonna Fly|SSAA|Michael Gellert
+She's Got A Way|SSAA|Michael Gellert
+A Shine On Your Shoes|SSAA|Michael Gellert
+Singin' In The Rain|SSAA|Michael Gellert
+Someone Like You|SSAA|Michael Gellert
+Something in the Water|SSAA|Michael Gellert
+Spread The Love Around|SSAA|Michael Gellert
+Take It Up A Step|SSAA|Michael Gellert
+Taylor The Latte Boy|SSAA|Michael Gellert
+That Cat Is High|SSAA|Michael Gellert
+That Old Feeling|SSAA|Michael Gellert
+They Just Keep Moving the Line|SSAA|Michael Gellert
+This Land Is Your Land|SSAA|Michael Gellert
+Tomorrow|SSAA|Michael Gellert
+Too Many Fish in the Sea|SSAA|Michael Gellert
+Up the Ladder to the Roof|SSAA|Michael Gellert
+We Can Be Kind|SSAA|Michael Gellert
+What A Wonderful World|SSAA|Michael Gellert
+Where Do You Start?|SSAA|Michael Gellert
+Wings|SSAA|Michael Gellert
+A Wink And A Smile|SSAA|Michael Gellert
+You're A Mean One, Mr. Grinch|SSAA|Michael Gellert
+You're Still You|SSAA|Michael Gellert
+You're The One|SSAA|Michael Gellert
+I Double Dare You|SSAA|Tom Gentil
+I'm Alone Because I Love You|TTBB|Tom Gentil
+Just A Cottage Small|SSAA|Tom Gentil
+Just A Cottage Small|TTBB|Tom Gentil
+Where The Black Eyed Susans Grow|TTBB|Tom Gentil
+Gee What A Wonderful Day|TTBB|Ed Gentry
+I'm Sorry I Answered The Phone|TTBB|Ed Gentry
+The Sunshine Of Your Smile|TTBB|Ed Gentry
+Just In Time|SSAA|Stephanie G. Gentry
+Once Upon A Time|SSAA|Stephanie G. Gentry
+Till Then|SSAA|Stephanie G. Gentry
+50,000 Names|TTBB|Tom Gentry
+99 Bottles of Beer|TTBB|Tom Gentry
+A Dream Is A Wish Your Heart Makes|TTBB, SSAA|Tom Gentry
+A Thousand Thoughts Of You|TTBB, SSAA|Tom Gentry
+A, You're Adorable|TTBB|Tom Gentry
+Ac-cent-tchu-ate The Positive|TTBB|Tom Gentry
+Ac-cent-tchu-ate The Positive|SSAA|Tom Gentry
+Across the Alley from the Alamo|TTBB|Tom Gentry
+Africa|TTBB, SSAA, SATB|Tom Gentry
+After Dark|SSAA|Tom Gentry
+After Dark|TTBB|Tom Gentry
+After The Ball|SSAA|Tom Gentry
+After The Ball|TTBB|Tom Gentry
+After The Lovin'|TTBB|Tom Gentry
+Aging Superheroes Medley|TTBB|Tom Gentry
+Alabama Jubilee|TTBB|Tom Gentry
+Alabama Medley|TTBB|Tom Gentry
+Alarm Clock Blues|TTBB, SSAA|Tom Gentry
+Alaska Medley|TTBB|Tom Gentry
+All Aboard For Slumberland|TTBB|Tom Gentry
+All Alone|TTBB|Tom Gentry
+All Alone|SSAA|Tom Gentry
+All Dressed Up With A Broken Heart|TTBB|Tom Gentry
+All Dressed Up With A Broken Heart|SATB|Tom Gentry
+All I Have To Do Is Dream|SATB|Tom Gentry
+All I Have To Do Is Dream|TTBB, SSAA, SATB|Tom Gentry
+All Night Long|TTBB, SSAA|Tom Gentry
+All That She Wants|TTBB|Tom Gentry
+All The Way|TTBB, SSAA|Tom Gentry
+Along Came Jones|TTBB|Tom Gentry
+Along The Road To Gundagai|TTBB|Tom Gentry
+Amazing Grace|SSAA, SATB|Tom Gentry
+Amazing Grace|SSAA|Tom Gentry
+America|TTBB, SSAA|Tom Gentry
+America The Beautiful|TTBB, SSAA|Tom Gentry
+An American Hymn|TTBB|Tom Gentry
+Among My Souvenirs|TTBB, SSAA|Tom Gentry
+Animal Crackers In My Soup|TTBB, SSAA|Tom Gentry
+Annie's Song|TTBB, SSAA|Tom Gentry
+Anniversary Song|TTBB|Tom Gentry
+Another Op'ning, Another Show|TTBB, SSAA|Tom Gentry
+Anti-Marriage Medley|TTBB|Tom Gentry
+Anything Goes|TTBB|Tom Gentry
+Anything You Can Do I Can Do Better|TTBB, SATB|Tom Gentry
+Aquarius|TTBB|Tom Gentry
+Are You Havin' Any Fun|TTBB|Tom Gentry
+Are You Lonesome Tonight?|TTBB, SSAA|Tom Gentry
+Art Is Calling for Me|TTBB, SSAA|Tom Gentry
+As Long As I'm Singing|TTBB, SSAA|Tom Gentry
+Assholujah Chorus|TTBB|Tom Gentry
+Aura Lee / Love Me Tender Medley|TTBB|Tom Gentry
+Aussie Road Medley|TTBB|Tom Gentry
+Ave Maria|TTBB, SSAA|Tom Gentry
+B-I-R-D-I-E|TTBB|Tom Gentry
+Baby on Board|TTBB|Tom Gentry
+Baby Song Medley|TTBB, SSAA|Tom Gentry
+Back to the River St. John|TTBB, SSAA|Tom Gentry
+Ballad of the Smog|TTBB|Tom Gentry
+Banjo Medley|TTBB|Tom Gentry
+Banjo's Back In Town|TTBB|Tom Gentry
+Bare Necessities|TTBB, SSAA, SATB|Tom Gentry
+Basin Street Blues|TTBB|Tom Gentry
+Be My Life's Companion|TTBB|Tom Gentry
+Beach Boys Medley|TTBB, SSAA|Tom Gentry
+Beautiful Ohio|TTBB|Tom Gentry
+Beautiful Savior|TTBB|Tom Gentry
+Because You Loved Me|TTBB, SSAA|Tom Gentry
+Beer Medley|TTBB|Tom Gentry
+Beethoven's Fifth|SSAA|Tom Gentry
+Beethoven's Fifth|TTBB|Tom Gentry
+Believe It Or Not|TTBB|Tom Gentry
+The Best Things Happen While You're Dancing|TTBB, SSAA|Tom Gentry
+Better Than I|TTBB, SSAA|Tom Gentry
+Bewitched|SSAA|Tom Gentry
+Bewitched|TTBB, SSAA|Tom Gentry
+Big Ten Fight Song Medley|TTBB|Tom Gentry
+The Biggest Parakeets in Town|TTBB|Tom Gentry
+Bill|TTBB, SSAA|Tom Gentry
+Bill|SSAA|Tom Gentry
+Birds Medley|TTBB|Tom Gentry
+Blackbird Parody|TTBB, SSAA|Tom Gentry
+Bless Us All|TTBB|Tom Gentry
+Blew by You|TTBB|Tom Gentry
+Blue Bayou|TTBB, SSAA|Tom Gentry
+Blue Moon|TTBB|Tom Gentry
+Blue Skies|TTBB|Tom Gentry
+Blue Suede Shoes|TTBB|Tom Gentry
+Blue Suede Shoes|SSAA|Tom Gentry
+Blues Brothers Medley|TTBB|Tom Gentry
+Blues In The Night|TTBB, SSAA|Tom Gentry
+Bon Soir, Herr Kommissar|TTBB|Tom Gentry
+Boogie Woogie Bugle Boy|TTBB, SSAA|Tom Gentry
+Book Of Love|TTBB|Tom Gentry
+Bourke Street on Saturday Night|TTBB|Tom Gentry
+Breaking Up Is Hard To Do|SSAA|Tom Gentry
+Bring Back Those Wonderful Days|SSAA|Tom Gentry
+Bring Back Those Wonderful Days|TTBB|Tom Gentry
+Broadway On Opening Night|TTBB|Tom Gentry
+Broadway Rose|TTBB|Tom Gentry
+Broken|TTBB|Tom Gentry
+Broken Hearted|SSAA|Tom Gentry
+Brown Eyed Girl|TTBB|Tom Gentry
+Bubble Wrap Medley|TTBB|Tom Gentry
+Butterfly Kisses|TTBB|Tom Gentry
+Button Up Your Overcoat|SSAA|Tom Gentry
+Button Up Your Overcoat|TTBB|Tom Gentry
+Bye Bye Love|TTBB, SSAA, SATB|Tom Gentry
+Bye, Bye My Love|TTBB|Tom Gentry
+Calendar Girl|TTBB|Tom Gentry
+Call Me Irresponsible|TTBB, SSAA|Tom Gentry
+Can You Tame Wild Wimmen|TTBB|Tom Gentry
+Can't Buy Me Love|TTBB, SSAA|Tom Gentry
+Can't Help Falling In Love|TTBB, SSAA|Tom Gentry
+Candle in the Wind|TTBB|Tom Gentry
+Candle in the Wind|SSAA|Tom Gentry
+Candle On The Water|SSAA|Tom Gentry
+Candle On The Water|TTBB|Tom Gentry
+Candlelight And Gold|TTBB|Tom Gentry
+Capri Fischer|TTBB|Tom Gentry
+Censorship Aggravation|TTBB|Tom Gentry
+Champion's Knack|TTBB, SSAA|Tom Gentry
+Change My Heart, Oh God|TTBB, SSAA|Tom Gentry
+Chitty Car Medley|SSAA|Tom Gentry
+Chitty Chitty Bang Bang|TTBB, SSAA|Tom Gentry
+Chitty Chitty Bang Bang|SSAA|Tom Gentry
+Chocolate Ice Cream Cone|TTBB|Tom Gentry
+Christmas Dinner|TTBB|Tom Gentry
+Christmas Fun Medley|TTBB|Tom Gentry
+Christmas in Three Minutes|TTBB|Tom Gentry
+Christmas Medley|TTBB|Tom Gentry
+The Christmas Shoes|TTBB|Tom Gentry
+The Christmas Shoes|TTBB, SSAA|Tom Gentry
+The Church Bells' Song|TTBB, SSAA|Tom Gentry
+Civil War Medley|TTBB|Tom Gentry
+Climb Ev'ry Mountain|TTBB, SSAA|Tom Gentry
+Clown Medley|TTBB|Tom Gentry
+College Years|TTBB|Tom Gentry
+Come Go With Me|TTBB, SSAA, SATB|Tom Gentry
+Come Rain Or Come Shine|TTBB, SSAA|Tom Gentry
+Consider Yourself|TTBB, SSAA|Tom Gentry
+Copacabana|TTBB, SSAA|Tom Gentry
+Cotton Club Medley|TTBB|Tom Gentry
+Crinoline Days|TTBB|Tom Gentry
+Crying|TTBB|Tom Gentry
+Crying|TTBB, SSAA|Tom Gentry
+Crying in the Rain|TTBB|Tom Gentry
+Crying in the Rain|TTBB, SSAA|Tom Gentry
+The Curtain Falls|TTBB, SSAA|Tom Gentry
+Cycles|TTBB|Tom Gentry
+Daddy, You've Been a Mother To Me|TTBB|Tom Gentry
+Dancing Frankie Medley|TTBB|Tom Gentry
+Dangerous Dan McGrew|TTBB|Tom Gentry
+Dapper Dan/Two-Time Dan|TTBB|Tom Gentry
+Darktown Strutters' Ball|TTBB|Tom Gentry
+Daydream|TTBB, SSAA|Tom Gentry
+Daydream|TTBB|Tom Gentry
+De Colores|TTBB|Tom Gentry
+Dentist Medley|TTBB|Tom Gentry
+Desperado|TTBB|Tom Gentry
+Desperado|TTBB, SSAA, SATB|Tom Gentry
+Devoted to You|TTBB, SSAA|Tom Gentry
+Diddly Squat (You Ain't Gettin')|SSAA|Tom Gentry
+Diddly Squat (You Ain't Gettin')|TTBB|Tom Gentry
+Diddly Squat (You Ain't Gettin')|TTBB, SSAA|Tom Gentry
+Do You Hear The People Sing?|TTBB, SSAA, SATB|Tom Gentry
+Do You Remember These?|TTBB|Tom Gentry
+Does Your Chewing Gum Lost It's Flavor|TTBB|Tom Gentry
+The Dogs|TTBB|Tom Gentry
+Don't Be Cruel (To A Heart That's True)|TTBB|Tom Gentry
+Don't Cry Little Girl|TTBB|Tom Gentry
+Don't Put A Tax On The Beautiful Girls|TTBB|Tom Gentry
+Don't Worry 'Bout Me|TTBB|Tom Gentry
+Donna Medley|TTBB|Tom Gentry
+Doo Wacka Doo|TTBB|Tom Gentry
+Doris|TTBB|Tom Gentry
+Down By The O-hi-o|TTBB|Tom Gentry
+Down By The Riverside|TTBB, SSAA, SATB|Tom Gentry
+Dream A Little Dream Of Me|TTBB, SSAA, SATB|Tom Gentry
+A Dream Come True|TTBB, SSAA|Tom Gentry
+Dreamer with a Penny|TTBB|Tom Gentry
+Du Gamla, Du Fria|TTBB|Tom Gentry
+Eighteen Wheels On A Big Rig|TTBB|Tom Gentry
+Eleanor Rigby|TTBB|Tom Gentry
+Elvis Medley|TTBB|Tom Gentry
+Enter Sandman|TTBB, SSAA|Tom Gentry
+Enter Sandman|TTBB|Tom Gentry
+The Entertainer|TTBB|Tom Gentry
+Everything's Comin' Up Roses|TTBB, SSAA|Tom Gentry
+Fa-La-La|TTBB|Tom Gentry
+Fabricating Frankie Medley|TTBB|Tom Gentry
+The Farmer And The Cowman|TTBB|Tom Gentry
+Feed The Birds|TTBB|Tom Gentry
+Feliz Navidad|TTBB, SSAA|Tom Gentry
+Fight the Team|TTBB|Tom Gentry
+The First Time Ever I Saw Your Face|TTBB, SSAA|Tom Gentry
+Fishy Medley|TTBB|Tom Gentry
+Five Minutes More|TTBB, SSAA|Tom Gentry
+Flowers on the Wall|TTBB|Tom Gentry
+Fly's Eyes|TTBB|Tom Gentry
+Folsom Prison Blues|TTBB|Tom Gentry
+Football Medley|TTBB, SSAA|Tom Gentry
+For Good|TTBB, SSAA|Tom Gentry
+For Once In My Life|TTBB, SSAA|Tom Gentry
+For the Good Times|TTBB|Tom Gentry
+Forest Lawn|TTBB|Tom Gentry
+Forest Lawn|TTBB, SSAA|Tom Gentry
+Forever And A Day|TTBB, SSAA|Tom Gentry
+Forever And A Day|TTBB|Tom Gentry
+Four Foot Two|TTBB, SSAA|Tom Gentry
+Four Seasons Medley|TTBB, SSAA|Tom Gentry
+Four Walls|TTBB|Tom Gentry
+Freckles / Peck's Bad Boy Medley|SSAA|Tom Gentry
+French Medley|TTBB|Tom Gentry
+Friends in Low Places|TTBB|Tom Gentry
+Frog Kissin'|TTBB|Tom Gentry
+Fun Fun Fun|SSAA|Tom Gentry
+Gee, I Wish I Was Back in the Army|TTBB|Tom Gentry
+Georgia Medley|TTBB|Tom Gentry
+Get Me To The Church On Time|SSAA|Tom Gentry
+Get Me To The Church On Time|TTBB|Tom Gentry
+Get Me to the Girl Medley|TTBB|Tom Gentry
+The Girl from Kodak Town|TTBB, SSAA|Tom Gentry
+The Girl in 14G|TTBB, SSAA|Tom Gentry
+Glory Of Love|TTBB, SSAA|Tom Gentry
+God Bless Our Senior Citizens|TTBB, SSAA|Tom Gentry
+God Bless The Child|TTBB|Tom Gentry
+God Put a Rainbow|TTBB|Tom Gentry
+Going Home|TTBB, SSAA|Tom Gentry
+Golf Medley|TTBB|Tom Gentry
+Gone|TTBB, SSAA|Tom Gentry
+Gonna Get a Girl|TTBB|Tom Gentry
+The Good Book Song|TTBB|Tom Gentry
+Good Enough for Now|TTBB, SSAA|Tom Gentry
+Good Old-fashioned Lover Boy|TTBB|Tom Gentry
+Goodbye Medley|TTBB, SSAA|Tom Gentry
+Goodbye Rose|TTBB|Tom Gentry
+Goodbye, Rose|TTBB|Tom Gentry
+Goodnight Saigon|TTBB|Tom Gentry
+Goodnight, Sweetheart, Goodnight|TTBB, SSAA|Tom Gentry
+Gospel Home Medley|TTBB|Tom Gentry
+Graduation Day|TTBB, SSAA|Tom Gentry
+Granada|TTBB|Tom Gentry
+Grandmas Feather Bed|TTBB|Tom Gentry
+Gravity Blues|TTBB, SSAA|Tom Gentry
+Grease Medley|TTBB|Tom Gentry
+Great Lakes Song|TTBB|Tom Gentry
+The Greatest Gift of All|TTBB, SSAA|Tom Gentry
+The Greatest Gift of All|SSAA|Tom Gentry
+The Greatest|TTBB|Tom Gentry
+Green Green Grass Of Home|TTBB|Tom Gentry
+Groovy Kind Of Love|TTBB, SSAA|Tom Gentry
+Groovy Kind Of Love|SATB|Tom Gentry
+Grown-Up Christmas List|TTBB, SATB|Tom Gentry
+Hab'n Sie nicht 'ne Frau ('nen Mann) fuer mich|TTBB|Tom Gentry
+Hallelujah, I Love Her So|TTBB|Tom Gentry
+Hang On Sloopy|TTBB|Tom Gentry
+Happy|TTBB|Tom Gentry
+Happy Birthday To You|TTBB|Tom Gentry
+Happy Trails|TTBB, SSAA|Tom Gentry
+Happy Trails|TTBB|Tom Gentry
+Harmonisch im Abgang|TTBB|Tom Gentry
+Harmony Joe|TTBB, SSAA|Tom Gentry
+Have A Nice Day|TTBB|Tom Gentry
+Hawaiian Wedding Song|TTBB, SSAA|Tom Gentry
+He|TTBB|Tom Gentry
+The Heart of a Girl|TTBB, SSAA|Tom Gentry
+Hell Froze Over|TTBB|Tom Gentry
+Hello Mary Lou|TTBB|Tom Gentry
+Hello Muddah, Hello Faddah|TTBB, SSAA|Tom Gentry
+Hello Young Lovers|TTBB|Tom Gentry
+Hello Young Lovers|TTBB, SSAA|Tom Gentry
+Hello, Detective Joe|TTBB|Tom Gentry
+Here Comes Santa Claus|TTBB|Tom Gentry
+Here We Have Idaho|TTBB|Tom Gentry
+Here's To My Lady|TTBB|Tom Gentry
+Here, There And Everywhere|TTBB|Tom Gentry
+Hey Good Lookin'|SSAA|Tom Gentry
+Hey Good Lookin'|TTBB|Tom Gentry
+Hey Look Me Over|TTBB, SSAA|Tom Gentry
+Hey Look Me Over / If My Friends Could See Me Now Medley|TTBB|Tom Gentry
+Hey!|TTBB|Tom Gentry
+Hickey|TTBB, SSAA|Tom Gentry
+High Hopes|TTBB|Tom Gentry
+Hit The Road Jack|TTBB, SSAA, SATB|Tom Gentry
+Holly Jolly Christmas|TTBB|Tom Gentry
+Holly Jolly Christmas|TTBB, SSAA|Tom Gentry
+Honey Medley|TTBB|Tom Gentry
+Honey, That I Love So Well|TTBB|Tom Gentry
+Hooey|TTBB|Tom Gentry
+House I Live In|TTBB, SSAA|Tom Gentry
+How Are You Goin' To Wet Your Whistle|TTBB|Tom Gentry
+How D'Ya Like Your Eggs in the Morning|TTBB, SSAA|Tom Gentry
+How Wonderful to Know|SSAA|Tom Gentry
+How Wonderful to Know|TTBB, SSAA|Tom Gentry
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|Tom Gentry
+Huckleberry Finn|TTBB|Tom Gentry
+I Believe|TTBB, SSAA|Tom Gentry
+I Believe In You|SSAA|Tom Gentry
+I Can't Give You Anything But Love|SSAA|Tom Gentry
+I Can't Give You Anything but Love/Cuddle Up a Little Closer|TTBB|Tom Gentry
+I Didn't Raise My Boy To Be A Soldier|SSAA|Tom Gentry
+I Didn't Raise My Boy To Be A Soldier|TTBB|Tom Gentry
+I Don't Care|TTBB, SSAA|Tom Gentry
+I Don't Know Enough About You/I Don't Know Why|TTBB, SSAA|Tom Gentry
+I Don't Want To Set The World On Fire|TTBB|Tom Gentry
+I Fall To Pieces|TTBB|Tom Gentry
+I Fall To Pieces|TTBB, SSAA|Tom Gentry
+I Get A Kick Out Of You|TTBB, SSAA|Tom Gentry
+I Got Rhythm|TTBB, SSAA|Tom Gentry
+I Guess He'd Rather Be In Colorado|TTBB|Tom Gentry
+I Had Someone Else Before I Had You / Who's Sorry Now Medley|TTBB, SSAA|Tom Gentry
+I Have a Love|TTBB, SSAA|Tom Gentry
+I Know An Old Lady Who Swallowed A Fly|TTBB|Tom Gentry
+I Like Beer|TTBB|Tom Gentry
+I Love A Parade / Strike Up The Band Medley|TTBB|Tom Gentry
+I Love My Baby|TTBB, SSAA|Tom Gentry
+I Never Miss The Sunshine|SSAA|Tom Gentry
+I Never Miss The Sunshine|TTBB|Tom Gentry
+I Only Have Eyes For You|TTBB, SSAA|Tom Gentry
+I Only Have Eyes For You|TTBB, SSAA, SATB|Tom Gentry
+I Only Want to Be with You|TTBB, SSAA|Tom Gentry
+I Pledge My Allegiance|TTBB|Tom Gentry
+I Say A Little Prayer For You|SSAA|Tom Gentry
+I Think You're Wonderful|TTBB, SSAA|Tom Gentry
+I Told Them All About You|TTBB|Tom Gentry
+I Used To Call Her Baby|TTBB|Tom Gentry
+I Wanna Be Like You|TTBB|Tom Gentry
+I Wanna Go Back to Ohio State|TTBB|Tom Gentry
+I Wanna Go Back to West Virginia|TTBB|Tom Gentry
+I Wanna Hear a Barbershop Song|TTBB|Tom Gentry
+I Wanna Marry Harry|SSAA|Tom Gentry
+I Wanna Marry Mary|TTBB|Tom Gentry
+I Want A Hippopotamus For Christmas|TTBB, SSAA|Tom Gentry
+I Want You, I Need You, I Love You|TTBB|Tom Gentry
+I Was Married Up in the Air/When You're Married|TTBB|Tom Gentry
+I Will|TTBB|Tom Gentry
+I Will Never Pass This Way Again|TTBB, SSAA|Tom Gentry
+I Will Sing Hallelujah|TTBB|Tom Gentry
+I Will Sing Hallelujah|SSAA|Tom Gentry
+I Wish I Had Died in My Cradle|TTBB|Tom Gentry
+I Wish That I'd Been Satisfied With Mary|TTBB|Tom Gentry
+I Wish You Love|SSAA|Tom Gentry
+I Wish You Were Jealous Of Me|TTBB|Tom Gentry
+I Wonder What You're Doing for Christmas|TTBB, SSAA, SATB|Tom Gentry
+I'd Give A Million Tomorrows|SSAA|Tom Gentry
+I'd Give A Million Tomorrows|TTBB|Tom Gentry
+I'd Rather Be The Girl In Your Arms|TTBB|Tom Gentry
+I'll Be Home For Christmas|TTBB|Tom Gentry
+I'll Be Home For Christmas|SSAA|Tom Gentry
+I'll Never Fall in Love Again|TTBB|Tom Gentry
+I'll Never Fall in Love Again|SSAA|Tom Gentry
+I'll Never Say Never Again Again|TTBB, SSAA|Tom Gentry
+I'll String Along with You|TTBB|Tom Gentry
+I'm a Middle-Aged Man|TTBB|Tom Gentry
+I'm a Middle-Aged Woman|TTBB, SSAA|Tom Gentry
+I'm Always Chasing Rainbows|TTBB|Tom Gentry
+I'm Beginning To Like It|TTBB, SSAA|Tom Gentry
+I'm Forever Blowing Bubbles|TTBB|Tom Gentry
+I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Tom Gentry
+I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tom Gentry
+I'm Henry VIII I Am|TTBB|Tom Gentry
+I'm Nobody's Baby|TTBB|Tom Gentry
+I'm Returning Everything|TTBB, SSAA|Tom Gentry
+I've Been Workin' on My Golf Game|TTBB|Tom Gentry
+I've Got A Pain In My Sawdust|TTBB|Tom Gentry
+I've Got The World On A String|SSAA|Tom Gentry
+I've Got The World On A String|TTBB|Tom Gentry
+Ich will keine Schokolade|TTBB, SSAA|Tom Gentry
+If|TTBB|Tom Gentry
+If|SSAA|Tom Gentry
+If Anything Happened to You|TTBB|Tom Gentry
+If I Can Dream|SSAA, SATB|Tom Gentry
+If I Can Dream|TTBB|Tom Gentry
+If I Didn't Have You|TTBB, SSAA|Tom Gentry
+If I Find Another Boy Like You|TTBB|Tom Gentry
+If I Had A Bulldozer|TTBB|Tom Gentry
+If I Had a Hammer|SSAA|Tom Gentry
+If I Had a Hammer|TTBB|Tom Gentry
+If I Had My Life To Live Over|TTBB|Tom Gentry
+If I Had My Way|TTBB|Tom Gentry
+"If I Knock The ""L"" Out Of Kelly"|TTBB|Tom Gentry
+If I Loved You|TTBB, SSAA|Tom Gentry
+If I Loved You|SSAA|Tom Gentry
+If I Stay Away Too Long from Carolina|TTBB|Tom Gentry
+If We Ever Needed the Lord Before|TTBB, SSAA|Tom Gentry
+If You Believe|TTBB, SSAA|Tom Gentry
+If You've Only Got A Moustache|TTBB|Tom Gentry
+In My Album of Memories|TTBB, SSAA|Tom Gentry
+In My Life|TTBB, SSAA, SATB|Tom Gentry
+In My Room|TTBB, SSAA|Tom Gentry
+In The Evening By The Moonlight|TTBB|Tom Gentry
+In The Heart Of The City That Has No Heart|TTBB|Tom Gentry
+In The Shade Of The Old Apple Tree|TTBB|Tom Gentry
+In The Still Of The Night|TTBB, SSAA, SATB|Tom Gentry
+Instrument of Peace|TTBB|Tom Gentry
+Instrument of Peace|SSAA|Tom Gentry
+Irene|TTBB|Tom Gentry
+Island of Dreams|TTBB, SSAA, SATB|Tom Gentry
+The Isle of Inisfree|TTBB, SSAA|Tom Gentry
+It Is Well With My Soul|TTBB, SATB|Tom Gentry
+It Was Almost Like A Song|SSAA|Tom Gentry
+It Was Almost Like A Song|TTBB|Tom Gentry
+It's a Man, Every Time, It's a Man|TTBB, SSAA|Tom Gentry
+It's Late|TTBB|Tom Gentry
+It's Magic|TTBB|Tom Gentry
+It's Magic|TTBB, SSAA|Tom Gentry
+It's Only a Wee-Wee|TTBB|Tom Gentry
+It's So Hard To Say Goodbye To Yesterday|SATB|Tom Gentry
+It's The Girl|TTBB, SSAA|Tom Gentry
+It's Today|TTBB, SSAA|Tom Gentry
+Ja-Da|TTBB|Tom Gentry
+Jamaican Noel|SSAA|Tom Gentry
+Jamaican Noel|TTBB|Tom Gentry
+Jenny Rebecca|SSAA|Tom Gentry
+Jenny Rebecca|TTBB|Tom Gentry
+Jesus Loves Me|TTBB|Tom Gentry
+Johnny Appleseed District Theme Song|TTBB|Tom Gentry
+Joint Is Jumpin'/Truckin'|TTBB, SSAA|Tom Gentry
+Jolene|SATB|Tom Gentry
+The Jones Boy|TTBB|Tom Gentry
+Josephine, Please Don't Lean On The Bell|TTBB|Tom Gentry
+Just A Baby's Prayer At Twilight|TTBB|Tom Gentry
+Just A Girl That Men Forget|TTBB|Tom Gentry
+Just A Letter From Ohio|TTBB|Tom Gentry
+Just A-Sittin' and A-Rockin'|TTBB|Tom Gentry
+Kazoo Koncerto|TTBB, SSAA|Tom Gentry
+Keep Cool with Coolidge|TTBB|Tom Gentry
+Killing Me Softly|TTBB, SSAA|Tom Gentry
+King Of The Road|TTBB|Tom Gentry
+Knight School Medley|TTBB|Tom Gentry
+Knighthood Quest Medley|TTBB|Tom Gentry
+Knighthood Rhythm Medley|TTBB|Tom Gentry
+Knock Knock Song|TTBB, SSAA|Tom Gentry
+Komm Trink Aus, Jack|TTBB|Tom Gentry
+Kriminal Tango|TTBB|Tom Gentry
+Last Night On The Back Porch|TTBB|Tom Gentry
+Laughter In The Rain|TTBB|Tom Gentry
+Lazy River|SSAA|Tom Gentry
+Lazy River|TTBB|Tom Gentry
+Le Regiment|TTBB|Tom Gentry
+The Leader Of The German Band|TTBB|Tom Gentry
+Lean On Me|TTBB|Tom Gentry
+Lean On Me|SATB|Tom Gentry
+Learnin' The Blues|TTBB|Tom Gentry
+Let It Be Me|TTBB, SSAA|Tom Gentry
+Let It Rain Let It Pour|TTBB|Tom Gentry
+Let Me Be Your Wings|TTBB|Tom Gentry
+Let Them Be Little|TTBB|Tom Gentry
+Let Them Be Little|TTBB, SSAA|Tom Gentry
+Let There Be Peace On Earth|SSAA, SATB|Tom Gentry
+Let There Be Peace On Earth|TTBB|Tom Gentry
+Let's All Go Down to the Old Barber Shop|TTBB|Tom Gentry
+Let's Do It Again|TTBB|Tom Gentry
+Let's Go to the Movies|SSAA|Tom Gentry
+Let's Go to the Movies|TTBB, SSAA|Tom Gentry
+Let's Sing Again Medley|SSAA|Tom Gentry
+Lili Marlene|TTBB|Tom Gentry
+Little Baby on my Shoulder|TTBB, SSAA|Tom Gentry
+Little Boy In Blue|TTBB|Tom Gentry
+Little Boy In Blue|TTBB, SSAA|Tom Gentry
+The Little Boy|TTBB|Tom Gentry
+The Little Boy|SSAA|Tom Gentry
+Little Darlin'|TTBB|Tom Gentry
+Little Girl|TTBB, SSAA|Tom Gentry
+Little Lady Make Believe|TTBB|Tom Gentry
+Little Lady Make Believe|SSAA|Tom Gentry
+Little Old Lady|TTBB, SSAA|Tom Gentry
+Little Old Lady|TTBB|Tom Gentry
+Little Pal|TTBB|Tom Gentry
+Little Red Riding Hood|TTBB|Tom Gentry
+Live Like an Angel|TTBB|Tom Gentry
+The Long Word Song|TTBB|Tom Gentry
+The Longest Time|TTBB, SSAA, SATB|Tom Gentry
+The Lord's Prayer|TTBB, SATB|Tom Gentry
+The Lord's Prayer|SATB|Tom Gentry
+Lost In The Stars|TTBB, SATB|Tom Gentry
+Love Changes Everything|TTBB, SSAA|Tom Gentry
+Love Me Tender|SSAA|Tom Gentry
+Love's Old Sweet Song|TTBB|Tom Gentry
+Lovesick Blues|TTBB, SSAA|Tom Gentry
+Lullaby In Ragtime|TTBB, SSAA|Tom Gentry
+The Lunatic's Lullaby|TTBB|Tom Gentry
+Lyin' Eyes|SATB|Tom Gentry
+made You Look|SSAA|Tom Gentry
+Maenner|TTBB|Tom Gentry
+Maggie Blues|TTBB|Tom Gentry
+Make You Feel My Love/Chasing Cars|TTBB|Tom Gentry
+Makin' Whoopee|TTBB|Tom Gentry
+Mammas, Don't Let Your Babies Grow Up to Be Cowboys|TTBB|Tom Gentry
+Man On The Flying Trapeze|TTBB|Tom Gentry
+Man With The Bag|TTBB, SSAA, SATB|Tom Gentry
+Man With The Bag|TTBB, SATB|Tom Gentry
+Mandy Lee|TTBB|Tom Gentry
+Margie|TTBB|Tom Gentry
+Marks Medley|TTBB|Tom Gentry
+Mary Did You Know|SATB|Tom Gentry
+Mary Did You Know|SSAA|Tom Gentry
+Mary In The Morning|TTBB|Tom Gentry
+Mary Poppins Medley|TTBB, SSAA|Tom Gentry
+Mary Tyler Moore Theme Song|TTBB, SSAA|Tom Gentry
+Mary Tyler Moore Theme Song|SSAA|Tom Gentry
+Mary You're A Little Bit Old Fashioned|TTBB|Tom Gentry
+May You Always|TTBB, SSAA|Tom Gentry
+Meet Me Tonight In Dreamland|TTBB|Tom Gentry
+Merry Christmas Darling|SATB|Tom Gentry
+Merry Christmas Darling|TTBB, SSAA|Tom Gentry
+The Merry Christmas Polka|SATB|Tom Gentry
+The Merry Christmas Polka|TTBB|Tom Gentry
+Mexicali Rose|TTBB|Tom Gentry
+Mexican National Anthem|TTBB|Tom Gentry
+Michigan Rag|TTBB|Tom Gentry
+Midnight Rose|TTBB|Tom Gentry
+Military Medley|TTBB|Tom Gentry
+Mischief Medley|SSAA|Tom Gentry
+Miss Celie's Blues|TTBB, SSAA|Tom Gentry
+Mississippi Squirrel Revival|TTBB|Tom Gentry
+Missouri Love Song|TTBB|Tom Gentry
+Mood Indigo|TTBB, SSAA|Tom Gentry
+Moon Medley|TTBB|Tom Gentry
+Moonlight And Roses|TTBB, SSAA|Tom Gentry
+Moonlight Brings Memories / Moonlight and Roses|TTBB, SSAA|Tom Gentry
+Moonshine Lullaby|TTBB, SSAA|Tom Gentry
+More|TTBB|Tom Gentry
+Mother Machree|TTBB|Tom Gentry
+Mother, I'm Dreaming Of You|TTBB|Tom Gentry
+Motown Medley|TTBB, SSAA|Tom Gentry
+Moving Picture Hero Of My Heart|SSAA|Tom Gentry
+Music Man Ballad Medley|TTBB|Tom Gentry
+Music Music Music|TTBB|Tom Gentry
+Music, Magic and Harmony|TTBB, SSAA|Tom Gentry
+Muskrat Ramble|TTBB|Tom Gentry
+My Boyfriends Back|TTBB, SSAA|Tom Gentry
+My Coloring Book|TTBB, SSAA|Tom Gentry
+My Fair Lady Medley|TTBB, SSAA|Tom Gentry
+My Favorite Things Parody|TTBB, SSAA|Tom Gentry
+My Foolish Heart|TTBB, SSAA|Tom Gentry
+My Fraternity Pin|TTBB|Tom Gentry
+My Golden Baby|TTBB, SSAA|Tom Gentry
+My Guy|SATB|Tom Gentry
+My Heroes Have Always Been Cowboys|TTBB|Tom Gentry
+My Life Flows On (How Can I Keep from Singing)|TTBB, SSAA|Tom Gentry
+My Little Girl|TTBB|Tom Gentry
+My Prayer|TTBB|Tom Gentry
+My Romance|TTBB, SSAA|Tom Gentry
+My Sally|TTBB|Tom Gentry
+My Uncultivated Irish Genus Rosa|TTBB|Tom Gentry
+My Wife Is On A Diet|TTBB|Tom Gentry
+My Wild Irish Rose|TTBB|Tom Gentry
+Nancy Lee|TTBB|Tom Gentry
+National Anthem of Barbados|TTBB|Tom Gentry
+Naughty Lady Of Shady Lane|TTBB|Tom Gentry
+Neutron Dance|TTBB|Tom Gentry
+A Nightingale Sang In Berkeley Square|TTBB, SSAA|Tom Gentry
+No No Never|TTBB, SSAA|Tom Gentry
+Nobody's Sweetheart|TTBB|Tom Gentry
+Now Is The Hour|TTBB|Tom Gentry
+Now Is The Hour|TTBB, SSAA|Tom Gentry
+Nowhere to Go but Up|TTBB, SSAA|Tom Gentry
+Nur Getraeumt|TTBB|Tom Gentry
+O, America|TTBB, SSAA|Tom Gentry
+Oh! My Love Is Like A Red, Red Rose|TTBB|Tom Gentry
+Oh! What A Pal Was Mary|TTBB|Tom Gentry
+Ohio State University Alma Mater|TTBB|Tom Gentry
+Old Cape Cod|TTBB, SSAA|Tom Gentry
+Old Cape Cod|TTBB|Tom Gentry
+Old Fashioned Love Song|TTBB, SSAA|Tom Gentry
+Old Fashioned Love Song|TTBB|Tom Gentry
+Old Folks|TTBB, SSAA|Tom Gentry
+Old Friends Medley|TTBB, SSAA|Tom Gentry
+The Old Lamplighter|TTBB|Tom Gentry
+Old Shep|TTBB|Tom Gentry
+The Old Spinning Wheel|TTBB|Tom Gentry
+The Old Spinning Wheel|TTBB, SSAA|Tom Gentry
+Oliver Medley|TTBB, SSAA|Tom Gentry
+Once Upon A Time|TTBB, SSAA|Tom Gentry
+One Tin Soldier|TTBB|Tom Gentry
+Ones Left Standing|TTBB|Tom Gentry
+Only A Voice On The Air|SSAA|Tom Gentry
+Operator|TTBB|Tom Gentry
+Operator|SSAA|Tom Gentry
+Orange Colored Sky|SSAA, SATB|Tom Gentry
+Orange Colored Sky|TTBB|Tom Gentry
+Oshkosh, Wisconsin|TTBB|Tom Gentry
+Paging Mr. Sousa|TTBB|Tom Gentry
+Pal Of My Dreams|TTBB|Tom Gentry
+Pals Of The Little Red School|TTBB|Tom Gentry
+Papa Oom Mow Mow|TTBB|Tom Gentry
+Papa Oom Mow Mow|SSAA|Tom Gentry
+Pass That Peacepipe / I'm an Indian, Too|TTBB, SSAA|Tom Gentry
+Peg O' My Heart|TTBB|Tom Gentry
+Pennies from Heaven|TTBB, SSAA|Tom Gentry
+Perfect Day|TTBB, SSAA|Tom Gentry
+Perfect Story|SSAA|Tom Gentry
+Peter Pan Medley|TTBB|Tom Gentry
+Pistol Packin' Mamma|TTBB|Tom Gentry
+Place in the Choir|TTBB, SSAA|Tom Gentry
+Plain|TTBB|Tom Gentry
+Playing Right Field|TTBB|Tom Gentry
+Please Don't Talk About Me When I'm Gone|TTBB|Tom Gentry
+Pokare Kare Ana|TTBB|Tom Gentry
+Popeye Medley|TTBB|Tom Gentry
+Pray For Sunshine|TTBB|Tom Gentry
+Precious Friends|TTBB, SSAA|Tom Gentry
+Precious Lord Take My Hand|TTBB|Tom Gentry
+Precious Lord Take My Hand|TTBB, SSAA, SATB|Tom Gentry
+Pretty Baby|TTBB|Tom Gentry
+Prison Medley|TTBB|Tom Gentry
+Professional Pirate|TTBB|Tom Gentry
+Puff The Magic Dragon|SSAA|Tom Gentry
+Raindrops Keep Falling On My Head|TTBB, SSAA|Tom Gentry
+Razzapple Medley|TTBB|Tom Gentry
+Razzle Dazzle|TTBB, SSAA|Tom Gentry
+Red Solo Cup|TTBB|Tom Gentry
+Redneck Kind of Guy|TTBB|Tom Gentry
+River of Song|TTBB, SSAA|Tom Gentry
+Rock and Rock Medley|TTBB|Tom Gentry
+Rock And Roll Is Here To Stay|TTBB|Tom Gentry
+Rock And Roll Medley|SSAA|Tom Gentry
+Rock And Roll Medley|TTBB|Tom Gentry
+Rock Around The Clock|TTBB|Tom Gentry
+Rock Of Ages, Let Our Song|TTBB|Tom Gentry
+Rock-a-bye Baby|TTBB|Tom Gentry
+Rock-a-bye Baby|SSAA|Tom Gentry
+Rocky Top|TTBB|Tom Gentry
+Rose Medley|TTBB, SSAA|Tom Gentry
+Roses Bring Dreams of You|TTBB|Tom Gentry
+Roses Of Picardy|TTBB|Tom Gentry
+Royal Garden Blues|TTBB, SSAA|Tom Gentry
+Run for the Roses|SSAA|Tom Gentry
+Run for the Roses|TTBB|Tom Gentry
+Sammy Put the Paper on the Wall|TTBB, SSAA|Tom Gentry
+Sanctuary|TTBB|Tom Gentry
+Santa Baby|TTBB, SSAA|Tom Gentry
+Santa Claus Parade|TTBB|Tom Gentry
+Saturday Night in Toledo, Ohio|TTBB, SSAA|Tom Gentry
+Saved|TTBB|Tom Gentry
+Say Hello to Pittsburgh|TTBB|Tom Gentry
+Sea Medley|TTBB|Tom Gentry
+Second Star to the Right|TTBB, SSAA|Tom Gentry
+Secret Love|TTBB, SSAA|Tom Gentry
+See Saw|TTBB|Tom Gentry
+Seeds and Stems Again|TTBB|Tom Gentry
+Send In The Clowns|TTBB, SSAA|Tom Gentry
+Senior Moments|TTBB|Tom Gentry
+Seventy Six Percent|TTBB|Tom Gentry
+Seventy-Six Trombones|SSAA|Tom Gentry
+Seventy-Six Trombones|TTBB|Tom Gentry
+Shall We Gather at the River|TTBB|Tom Gentry
+She Believes in Me|TTBB|Tom Gentry
+She Had to Go and Lose It at the Astor|TTBB, SSAA|Tom Gentry
+She Had to Go and Lose It at the Astor|TTBB|Tom Gentry
+She Is More To Be Pitied Than Censured|TTBB|Tom Gentry
+Shop-Vac|TTBB|Tom Gentry
+Side by Side|TTBB, SSAA, SATB|Tom Gentry
+Silhouettes|TTBB|Tom Gentry
+Silhouettes|SSAA, SATB|Tom Gentry
+Silhouettes|TTBB, SSAA, SATB|Tom Gentry
+Silver Threads Among The Gold|TTBB|Tom Gentry
+Sinatra Medley|TTBB|Tom Gentry
+Sing It A Cappella|TTBB, SSAA|Tom Gentry
+Sing Lullaby|TTBB, SSAA, SATB|Tom Gentry
+Sing Lullaby|TTBB, SSAA|Tom Gentry
+Skylark|TTBB|Tom Gentry
+Skylark|TTBB, SSAA|Tom Gentry
+Sleigh Ride|TTBB, SSAA|Tom Gentry
+Sleigh Ride|TTBB|Tom Gentry
+Slumber My Darling|TTBB|Tom Gentry
+Smell the Flowers|TTBB|Tom Gentry
+Smile|TTBB|Tom Gentry
+Smokerings|TTBB|Tom Gentry
+So Long, Mother|TTBB|Tom Gentry
+So Many Voices Sing America's Song|TTBB|Tom Gentry
+Solitaire|TTBB, SSAA|Tom Gentry
+Somebody's Darlin'|TTBB|Tom Gentry
+Someone Is Waiting At Home, Sweet Home|TTBB|Tom Gentry
+Something|TTBB|Tom Gentry
+Something Inside So Strong|TTBB, SSAA, SATB|Tom Gentry
+Sommersprossen|TTBB|Tom Gentry
+Song's Gotta Come From The Heart|TTBB, SSAA|Tom Gentry
+Sonny Boy|TTBB|Tom Gentry
+Sound Celebration|TTBB|Tom Gentry
+Sound Celebration|SSAA|Tom Gentry
+Sound Off|TTBB|Tom Gentry
+Spaceman Medley|TTBB|Tom Gentry
+Splish Splash|SSAA|Tom Gentry
+Spreadin' Rhythm Around|SSAA|Tom Gentry
+Spreadin' Rhythm Around|TTBB|Tom Gentry
+Standing/Leaning Medley|TTBB|Tom Gentry
+Steam Heat|SSAA|Tom Gentry
+Steam Heat|TTBB, SSAA|Tom Gentry
+Sudbury Saturday Night|TTBB|Tom Gentry
+Sugartime|TTBB, SSAA|Tom Gentry
+Sukiyaki|TTBB|Tom Gentry
+Sukiyaki|SSAA|Tom Gentry
+Summer Holiday|TTBB, SSAA|Tom Gentry
+Summer Holiday|SSAA|Tom Gentry
+Summer Sunshine Medley|TTBB, SSAA|Tom Gentry
+Sunday Night in Sydney|TTBB|Tom Gentry
+The Sunshine Of Your Smile|TTBB, SSAA|Tom Gentry
+Sweet Charity Medley|TTBB, SSAA|Tom Gentry
+Sweet She (He) Ain't|TTBB, SSAA|Tom Gentry
+Sweet Violets|SSAA|Tom Gentry
+Sweet Violets|TTBB|Tom Gentry
+Sweetheart, I'm Sorry|TTBB, SSAA|Tom Gentry
+Swingin' On A Star|TTBB, SSAA, SATB|Tom Gentry
+Taboo|TTBB, SSAA|Tom Gentry
+Tage wie diese|TTBB|Tom Gentry
+Take Me Out To The Ball Game|TTBB|Tom Gentry
+Take Me There|TTBB, SSAA|Tom Gentry
+Taking A Chance On Love|TTBB, SSAA, SATB|Tom Gentry
+TAPS|TTBB|Tom Gentry
+Taylor The Latte Boy|TTBB|Tom Gentry
+Tears (For Souvenirs)|TTBB|Tom Gentry
+Tell My Father|TTBB|Tom Gentry
+Ten Million Reasons|TTBB|Tom Gentry
+Thank God I'm a Country Boy|TTBB|Tom Gentry
+Thank You For The Music|TTBB, SSAA|Tom Gentry
+Thank You Very Much|TTBB, SSAA|Tom Gentry
+Thank You World|TTBB|Tom Gentry
+Thanks For The Memory|TTBB, SSAA|Tom Gentry
+That Charlie Chaplin Walk|TTBB|Tom Gentry
+That Lovely Weekend|TTBB, SSAA|Tom Gentry
+That Silver Haired Daddy Of Mine|TTBB|Tom Gentry
+That Song My Mother Sang|TTBB|Tom Gentry
+That Wonderful Mother Of Mine|TTBB|Tom Gentry
+That'll Be The Day|TTBB|Tom Gentry
+That's Entertainment|TTBB, SSAA|Tom Gentry
+That's My Weakness Now|SSAA|Tom Gentry
+That's My Weakness Now|TTBB|Tom Gentry
+That's My Weakness Now/That Certain Party|TTBB, SSAA|Tom Gentry
+The Virgin Mary Had A Baby Boy|TTBB, SSAA|Tom Gentry
+The Virgin Mary Had A Baby Boy|TTBB|Tom Gentry
+The Way You Look Tonight|TTBB, SSAA|Tom Gentry
+Their Hearts Were Full Of Spring|TTBB|Tom Gentry
+Their Hearts Were Full Of Spring|TTBB, SSAA|Tom Gentry
+Theme from Ice Castles|TTBB, SSAA|Tom Gentry
+There I've Said It Again|TTBB, SSAA|Tom Gentry
+There Is Only One of You|TTBB|Tom Gentry
+There'll Be No New Tunes On This Old Piano|TTBB|Tom Gentry
+There's A Little Spark Of Love Still Burning|TTBB|Tom Gentry
+There's a Rose On Your Cheek|TTBB|Tom Gentry
+They Are Gone|TTBB|Tom Gentry
+They Call It Dancing|TTBB|Tom Gentry
+They Go Wild, Simply Wild Over Me|TTBB|Tom Gentry
+They Go Wild, Simply Wild Over Me|TTBB, SSAA|Tom Gentry
+This Is All I Ask|TTBB|Tom Gentry
+This Train/When the Saints Go Marching In|TTBB|Tom Gentry
+Those Old-Time Sing-Along Songs|TTBB|Tom Gentry
+Thousand Thoughts of You|TTBB|Tom Gentry
+Three Birds Medley|TTBB|Tom Gentry
+Throne of Grace|TTBB|Tom Gentry
+Tie Me To Your Apron Strings Again|TTBB|Tom Gentry
+Til We Meet Again|TTBB|Tom Gentry
+Time After Time|TTBB|Tom Gentry
+To Know Him Is To Love Him|TTBB, SSAA|Tom Gentry
+To Morrow|TTBB|Tom Gentry
+To Where You Are|TTBB, SSAA|Tom Gentry
+Too Many Parties And Too Many Pals|TTBB|Tom Gentry
+Too Marvelous|TTBB, SSAA|Tom Gentry
+Too Young|TTBB, SSAA|Tom Gentry
+Tough Broads Medley|TTBB|Tom Gentry
+Transport of Delight|TTBB|Tom Gentry
+Treat Me Nice|TTBB, SSAA|Tom Gentry
+Treat Me Nice|TTBB|Tom Gentry
+Triplets|TTBB|Tom Gentry
+Try A Little Tenderness|TTBB, SSAA|Tom Gentry
+Try It On My Own|SSAA|Tom Gentry
+Tuxedo Junction|TTBB, SSAA|Tom Gentry
+Twenties Dance Medley|TTBB, SSAA|Tom Gentry
+Twinkle Twinkle Little Star|TTBB, SSAA|Tom Gentry
+Twisted|TTBB, SSAA|Tom Gentry
+Two Kinds of Seagulls|TTBB|Tom Gentry
+Ukulele Lady|TTBB|Tom Gentry
+Unchained Melody|TTBB|Tom Gentry
+Uncle Watt's Original Fantascinatin' Roadside Stand|SSAA|Tom Gentry
+Uncle Watt's Original Fantascinatin' Roadside Stand|TTBB|Tom Gentry
+Under The Boardwalk|TTBB, SSAA|Tom Gentry
+Vegemite|TTBB|Tom Gentry
+The Victors|TTBB|Tom Gentry
+Vincent (Starry Starry Night)|SSAA|Tom Gentry
+Vincent (Starry Starry Night)|TTBB|Tom Gentry
+VMbarrassment|TTBB|Tom Gentry
+Walk Away|TTBB, SSAA|Tom Gentry
+Walk Away|TTBB|Tom Gentry
+Waltz Me Around Again, Willie|TTBB|Tom Gentry
+Waltzing Matilda|TTBB|Tom Gentry
+Wang Wang Blues|TTBB|Tom Gentry
+Way You Look Tonight|TTBB, SSAA|Tom Gentry
+We Don't Give a Damn for the Whole State of Michigan|TTBB|Tom Gentry
+We Rise Again|TTBB, SSAA|Tom Gentry
+We'll Meet Again|SSAA|Tom Gentry
+We're Number One|TTBB, SSAA|Tom Gentry
+We're on Our Way|TTBB, SSAA|Tom Gentry
+Wedding Bells Are Ringing For Sally|TTBB|Tom Gentry
+Wedding of Mr. and Mrs. Swing|TTBB, SSAA|Tom Gentry
+Wedding of the Painted Doll|TTBB, SSAA|Tom Gentry
+Wedding Song|TTBB, SSAA|Tom Gentry
+West Virginia University Alma Mater|TTBB|Tom Gentry
+West Virginia University March Medley|TTBB|Tom Gentry
+West Virginia's Home to Me|TTBB|Tom Gentry
+Western medley|TTBB|Tom Gentry
+What Are You Doing New Year's Eve?|TTBB|Tom Gentry
+What Do You Do with Your Arms?|TTBB|Tom Gentry
+What Is This Thing Called Love|TTBB, SSAA|Tom Gentry
+What Is This Thing Called Love|SSAA|Tom Gentry
+What Would I Do Without My Music|TTBB|Tom Gentry
+What Would I Do Without My Music|SSAA|Tom Gentry
+Whatever Happened To Randolph Scott|TTBB|Tom Gentry
+Whatever Happened To The Old Songs|TTBB, SSAA|Tom Gentry
+When a Boy from Alabama (Meets a Girl from Gundagai)|TTBB|Tom Gentry
+When I Get You Alone Tonight|SSAA|Tom Gentry
+When I Grow Too Old To Dream|TTBB|Tom Gentry
+When I Just Wear My Smile|TTBB, SSAA|Tom Gentry
+When I Lost You|TTBB|Tom Gentry
+When I Lost You (Aging Superheroes Parody)|TTBB|Tom Gentry
+When I Sing|TTBB, SSAA|Tom Gentry
+When I'm Sixty Four|TTBB, SSAA, SATB|Tom Gentry
+When Sammy Put the Paper on the Wall|TTBB, SSAA|Tom Gentry
+When The Meadow Was Bloomin'|TTBB|Tom Gentry
+When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Tom Gentry
+When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Tom Gentry
+When the River Meets the Sea|TTBB, SSAA|Tom Gentry
+When There's Love At Home|TTBB, SSAA|Tom Gentry
+When They're Old Enough To Know Better|TTBB|Tom Gentry
+When You And I Were Young Maggie|TTBB|Tom Gentry
+When Your Old Wedding Ring Was New/Dear Old Sue|TTBB|Tom Gentry
+Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Tom Gentry
+Where Do They Go When They Row Row Row|TTBB|Tom Gentry
+Where Is Love?|TTBB, SSAA|Tom Gentry
+Where Is Your Heart At|TTBB|Tom Gentry
+Where The Blue Of The Night Meets The Gold Of The Day|TTBB|Tom Gentry
+Wherever There's Me, There's You|TTBB, SSAA|Tom Gentry
+Whispering|SSAA|Tom Gentry
+Whispering|TTBB|Tom Gentry
+White Christmas|TTBB|Tom Gentry
+Who Put The Bomp|TTBB, SSAA|Tom Gentry
+Who'll Be The Next One|TTBB|Tom Gentry
+Who's Going To Love You When I'm Gone|SSAA|Tom Gentry
+Who's Going To Love You When I'm Gone|TTBB|Tom Gentry
+Who's In The Strawberry Patch With Sally?|TTBB|Tom Gentry
+Who's Sorry Now|TTBB|Tom Gentry
+A Whole New World|TTBB|Tom Gentry
+A Whole New World|SSAA|Tom Gentry
+Why Doesn't Santa Claus Go Next Door|TTBB|Tom Gentry
+Wiegenlied|TTBB, SSAA|Tom Gentry
+Winchester Cathedral|TTBB|Tom Gentry
+Winchester Cathedral|SSAA|Tom Gentry
+Wind Beneath My Wings|SSAA|Tom Gentry
+Wind Beneath My Wings|TTBB|Tom Gentry
+With Two Wings|TTBB|Tom Gentry
+Would Jesus Wear a Rolex|TTBB|Tom Gentry
+WWI Smile Medley|TTBB, SSAA|Tom Gentry
+Y-you Tell Her-I S-stutter|TTBB|Tom Gentry
+Y.M.C.A.|TTBB, SSAA|Tom Gentry
+Yes, Still the Starry Banner Waves|TTBB|Tom Gentry
+Yesterday|TTBB, SSAA, SATB|Tom Gentry
+Yesterday's Roses Medley|TTBB|Tom Gentry
+Yesterday, When I Was Young|TTBB, SSAA|Tom Gentry
+You Ain't Heard Nothing Yet|TTBB|Tom Gentry
+You and Me (We Wanted It All)|TTBB|Tom Gentry
+You and Me (We Wanted It All)|TTBB, SSAA|Tom Gentry
+You Can't Get A Man With A Gun|SSAA|Tom Gentry
+You Know You Belong To Somebody Else|TTBB|Tom Gentry
+You Medley|TTBB|Tom Gentry
+You Meet the Nicest People|TTBB, SSAA, SATB|Tom Gentry
+You Must Come In at the Bottom|TTBB|Tom Gentry
+You Walk With Me|TTBB|Tom Gentry
+You're Just in Love|SATB|Tom Gentry
+You're The Flower Of My Heart, Sweet Adeline|TTBB|Tom Gentry
+You've Got A Friend|TTBB, SSAA|Tom Gentry
+You've Got To See Mamma Ev'ry Night|TTBB|Tom Gentry
+Young And Foolish|SSAA|Tom Gentry
+Young At Heart|TTBB|Tom Gentry
+Your Horoscope for Today|TTBB|Tom Gentry
+Your Tattoo|TTBB, SSAA|Tom Gentry
+Rock And Roll Is Here To Stay|TTBB|Brent Gerber
+Somewhere Out There|TTBB|Brent Gerber
+Show Me Where The Good Times Are|TTBB|C. C. Gerheim
+1927 Kansas City|TTBB, SSAA|Jay Giallombardo
+A Tree In The Meadow|TTBB, SSAA|Jay Giallombardo
+Across The Universe|TTBB|Jay Giallombardo
+After The Roses Have Faded Away|TTBB, SSAA|Jay Giallombardo
+After Today|TTBB, SSAA|Jay Giallombardo
+Ain't Misbehavin'|TTBB, SSAA|Jay Giallombardo
+Alabama Jazzbo Band|TTBB, SSAA|Jay Giallombardo
+Alabama Medley|TTBB, SSAA|Jay Giallombardo
+Aladdin Medley|TTBB|Jay Giallombardo
+Alice Blue Gown|TTBB, SSAA, SATB|Jay Giallombardo
+All American Girl|SSAA|Jay Giallombardo
+All For The Love Of Mike|SSAA|Jay Giallombardo
+All I Need is Just a Girl Like You|TTBB|Jay Giallombardo
+All Nations Rise|TTBB, SSAA|Jay Giallombardo
+All the Little Toy Soldiers|TTBB|Jay Giallombardo
+All The Time|TTBB, SSAA|Jay Giallombardo
+Almost Christmas Time|TTBB, SSAA|Jay Giallombardo
+Amazing Grace|TTBB, SSAA|Jay Giallombardo
+Amazing Grace/My Chains Are Broken|TTBB, SSAA|Jay Giallombardo
+American/Canadian Anthems-Ode to Joy|TTBB|Jay Giallombardo
+Angelic Anthem|TTBB, SSAA|Jay Giallombardo
+Angelic Carols|TTBB|Jay Giallombardo
+Angels Blush|TTBB|Jay Giallombardo
+Another Op'ning, Another Show|TTBB|Jay Giallombardo
+Anything Goes|TTBB, SSAA|Jay Giallombardo
+Anything You Can Do I Can Do Better|TTBB|Jay Giallombardo
+Applause|TTBB, SSAA|Jay Giallombardo
+Apple Blossom Medley|SSAA|Jay Giallombardo
+April Love|SSAA|Jay Giallombardo
+Armed Forces Medley|TTBB|Jay Giallombardo
+Around the World in Song Montage|TTBB, SSAA|Jay Giallombardo
+As If We Never Said Goodbye|TTBB, SSAA|Jay Giallombardo
+As Long As He/She Needs Me|TTBB, SSAA|Jay Giallombardo
+As Long As He/She Needs Me|TTBB|Jay Giallombardo
+Away In A Manger/Amazing Grace Medley|TTBB, SSAA|Jay Giallombardo
+Baby Medley 1|TTBB, SSAA|Jay Giallombardo
+Back in '76|TTBB|Jay Giallombardo
+Bandstand Boogie|TTBB, SSAA|Jay Giallombardo
+Banjo's Back In Town|TTBB, SSAA|Jay Giallombardo
+Barbershopper of Seville|TTBB, SSAA|Jay Giallombardo
+Bare Necessities|TTBB, SSAA|Jay Giallombardo
+Be A Clown / Make 'Em Laugh Medley|TTBB, SSAA|Jay Giallombardo
+Be Our Guest|TTBB, SSAA|Jay Giallombardo
+Before The Parade Passes By|SSAA|Jay Giallombardo
+Believe It Or Not|TTBB, SSAA|Jay Giallombardo
+Bell Carols Medley|TTBB|Jay Giallombardo
+Beyond the Sea|TTBB, SSAA|Jay Giallombardo
+Big Band Days Medley|TTBB, SSAA|Jay Giallombardo
+Big Girls Don't Cry|TTBB|Jay Giallombardo
+Bill Bailey/Big Bad Bill is Sweet William Now Medley|TTBB, SSAA|Jay Giallombardo
+Bill Grogan's Goat|TTBB|Jay Giallombardo
+Bill Medley (Keep Your Eye on the Girlie You Love/Bill Bailey)|SSAA|Jay Giallombardo
+Billy (I Always Dream of Bill)|TTBB, SSAA|Jay Giallombardo
+The Birthday Of A King|TTBB, SSAA|Jay Giallombardo
+Blow Gabriel Blow|TTBB, SSAA|Jay Giallombardo
+Blue Shadows On The Trail|TTBB, SSAA|Jay Giallombardo
+Bohemian Rhapsody|TTBB, SSAA|Jay Giallombardo
+Breaking Up Is Hard To Do|TTBB, SSAA|Jay Giallombardo
+Bring A Torch, Jeanette, Isabella|TTBB, SSAA|Jay Giallombardo
+Broadway Medley|SSAA|Jay Giallombardo
+Broadway Rose|TTBB, SSAA|Jay Giallombardo
+Broadway USA/Razzle Dazzle Medley|TTBB, SSAA|Jay Giallombardo
+Brotherhood of Man|TTBB, SSAA|Jay Giallombardo
+Brown Eyes Why Are You Blue?|TTBB, SSAA|Jay Giallombardo
+Buglers Holiday|TTBB|Jay Giallombardo
+A Bushel And A Peck|TTBB, SSAA|Jay Giallombardo
+Butterscotch Castle|TTBB|Jay Giallombardo
+By The Sea/Minnie The Mermaid Medley|TTBB, SATB|Jay Giallombardo
+California Dreamin'|TTBB, SSAA|Jay Giallombardo
+Calypso Medley|TTBB, SSAA|Jay Giallombardo
+Calypso Medley|TTBB|Jay Giallombardo
+Camptown Races Medley|TTBB, SSAA, SATB|Jay Giallombardo
+Can't We Talk It Over|TTBB, SSAA|Jay Giallombardo
+The Captain Of The Toy Brigade|TTBB, SSAA|Jay Giallombardo
+Carol Classics Medley|TTBB|Jay Giallombardo
+Carolina Medley|TTBB|Jay Giallombardo
+Carols of the Angels Medley|TTBB, SSAA|Jay Giallombardo
+Chicago Medley|TTBB, SSAA|Jay Giallombardo
+Christ Child Carols Medley|TTBB|Jay Giallombardo
+Christmas Folly|TTBB, SSAA|Jay Giallombardo
+The Christmas Rag|TTBB|Jay Giallombardo
+The Christmas Song|TTBB, SSAA|Jay Giallombardo
+The Circle Of Life|TTBB|Jay Giallombardo
+Cities Medley|TTBB|Jay Giallombardo
+Civil War Medley|TTBB|Jay Giallombardo
+Climb Ev'ry Mountain|TTBB, SSAA|Jay Giallombardo
+Clown Medley|TTBB, SSAA|Jay Giallombardo
+Collegiate Love|TTBB|Jay Giallombardo
+Collegiate Sam|TTBB, SSAA|Jay Giallombardo
+Colorado Christmas|TTBB|Jay Giallombardo
+Come Live with Me|TTBB, SSAA|Jay Giallombardo
+Come See What's Happenin' in the Barn|TTBB, SSAA|Jay Giallombardo
+Commerical Medley|TTBB, SSAA|Jay Giallombardo
+Coney Island Medley|TTBB, SSAA|Jay Giallombardo
+Consider Yourself|TTBB, SSAA|Jay Giallombardo
+Crazy Little Thing Called Love|TTBB, SSAA|Jay Giallombardo
+Daddy Sang Bass|TTBB, SSAA|Jay Giallombardo
+Daddy, You've Been a Mother To Me|TTBB, SSAA|Jay Giallombardo
+Daisy/Summer Time Medley|TTBB, SSAA|Jay Giallombardo
+Dancing In The Street|TTBB, SSAA|Jay Giallombardo
+Danny Boy|TTBB, SSAA|Jay Giallombardo
+Daybreak|TTBB|Jay Giallombardo
+Dayton, Ohio 1903|TTBB|Jay Giallombardo
+Dear Little Boy Of Mine|TTBB|Jay Giallombardo
+Dear Old Girl|TTBB, SSAA|Jay Giallombardo
+Dear Old Sweetheart Days, In The|TTBB|Jay Giallombardo
+December 1963 (Oh, What A Night)|TTBB|Jay Giallombardo
+Deck The Halls|TTBB|Jay Giallombardo
+Deep In My Heart, Dear|TTBB, SSAA|Jay Giallombardo
+Didn't We|TTBB|Jay Giallombardo
+Ding Dong Merrily On High|TTBB|Jay Giallombardo
+Dirty Hands! Dirty Face!|TTBB|Jay Giallombardo
+Do Nothing Til You Hear From Me|TTBB|Jay Giallombardo
+Do You Hear What I Hear|TTBB|Jay Giallombardo
+Doggone I've Done It/It's You Medley|TTBB|Jay Giallombardo
+Don't Cry Little Girl|SSAA|Jay Giallombardo
+Don't Stop Me Now|TTBB, SSAA|Jay Giallombardo
+Down in the Glen|TTBB, SSAA|Jay Giallombardo
+Down the Lane and Home Again|TTBB, SSAA|Jay Giallombardo
+Dream Days (Take Me Back to Those)|TTBB, SSAA|Jay Giallombardo
+The Dream Is Carried On|TTBB, SSAA|Jay Giallombardo
+Dreamland Brings Memories of You|TTBB, SSAA|Jay Giallombardo
+Drive My Car|TTBB, SSAA|Jay Giallombardo
+Dueling Banjos|TTBB|Jay Giallombardo
+Early American Medley|TTBB, SSAA|Jay Giallombardo
+Eleanor Rigby|TTBB|Jay Giallombardo
+Eliza|TTBB, SSAA|Jay Giallombardo
+Embraceable You|TTBB, SSAA|Jay Giallombardo
+Even Now|TTBB, SSAA|Jay Giallombardo
+Every Day Of My Life|TTBB, SSAA|Jay Giallombardo
+Everybody's Buddy|TTBB|Jay Giallombardo
+Eye Of The Tiger|TTBB, SSAA|Jay Giallombardo
+Eyes Medley|TTBB, SSAA|Jay Giallombardo
+Fairest Lord Jesus|TTBB|Jay Giallombardo
+Fare Thee Well|TTBB|Jay Giallombardo
+Fascinating Rhythm|TTBB, SSAA|Jay Giallombardo
+Festive Carol Medley|TTBB, SSAA|Jay Giallombardo
+Fifties Medley|TTBB, SSAA|Jay Giallombardo
+Fool On The Hill|TTBB, SSAA|Jay Giallombardo
+Football Hero Medley|TTBB, SSAA|Jay Giallombardo
+For All Your Miracles|TTBB, SSAA|Jay Giallombardo
+For Me And My Gal|TTBB, SSAA|Jay Giallombardo
+For The Sake Of Auld Lang Syne|TTBB|Jay Giallombardo
+Forever Young|TTBB|Jay Giallombardo
+Forgive Me|TTBB, SSAA|Jay Giallombardo
+Forties Medley|TTBB, SSAA|Jay Giallombardo
+Freddie Feelgood|SATB|Jay Giallombardo
+A Gathering Montage|SSAA|Jay Giallombardo
+Gee, I Wish I Was Back in the Army|TTBB|Jay Giallombardo
+Georgia On My Mind|SATB|Jay Giallombardo
+Gershwin Medley|SATB|Jay Giallombardo
+Gershwin Montage|TTBB|Jay Giallombardo
+Get Me To The Church On Time|TTBB, SSAA|Jay Giallombardo
+Girl Of My Dreams|TTBB|Jay Giallombardo
+Give Me Your Tired, Your Poor|TTBB, SSAA|Jay Giallombardo
+Give My Regards To Broadway|TTBB, SSAA|Jay Giallombardo
+Gloria|TTBB, SSAA|Jay Giallombardo
+Glue|TTBB|Jay Giallombardo
+God Bless America|TTBB, SSAA|Jay Giallombardo
+God Only Knows|TTBB|Jay Giallombardo
+GodSpeed|TTBB|Jay Giallombardo
+Golden Dreams|TTBB|Jay Giallombardo
+Good Day Opener|TTBB|Jay Giallombardo
+Good King Wenceslas|TTBB, SSAA|Jay Giallombardo
+Good/Wonderful Day Medley|TTBB, SSAA|Jay Giallombardo
+Goodbye Dear, I'll Be Back in a Year|TTBB, SSAA, SATB|Jay Giallombardo
+Goodbye World Goodbye|TTBB, SSAA|Jay Giallombardo
+Gospel Medley|TTBB|Jay Giallombardo
+Grandma's Boy|TTBB, SSAA|Jay Giallombardo
+Great Big Blue-Eyed Baby, You're A|TTBB, SSAA|Jay Giallombardo
+Hallelujah|TTBB, SSAA|Jay Giallombardo
+Hallelujah Chorus|TTBB, SSAA|Jay Giallombardo
+Halls Of Ivy|TTBB, SSAA|Jay Giallombardo
+Happy Days Are Here/Get Happy Medley|TTBB, SSAA|Jay Giallombardo
+Happy Go Lucky Lane|TTBB|Jay Giallombardo
+Happy Holiday|TTBB, SSAA|Jay Giallombardo
+Happy Holiday Medley|TTBB|Jay Giallombardo
+Hark the Herald Angels Sing/Angels We Have Heard on High|TTBB|Jay Giallombardo
+Have to Say I Love You in a Song, I'll|SATB|Jay Giallombardo
+Have You Seen The Child|TTBB|Jay Giallombardo
+Have Yourself A Merry Little Christmas|TTBB|Jay Giallombardo
+Haven't Met You Yet|TTBB|Jay Giallombardo
+He Ain't Heavy, He's My Brother|TTBB, SSAA|Jay Giallombardo
+Hello Ma Baby|TTBB, SSAA|Jay Giallombardo
+Here Comes Santa Claus|TTBB, SSAA|Jay Giallombardo
+Here Comes The Sun|TTBB, SSAA|Jay Giallombardo
+Here's That Rainy Day|TTBB, SSAA|Jay Giallombardo
+Here's To The Heroes|TTBB, SSAA|Jay Giallombardo
+Here, There And Everywhere|TTBB, SSAA, SATB|Jay Giallombardo
+Hero|TTBB|Jay Giallombardo
+Hey Jude|TTBB, SSAA|Jay Giallombardo
+Hey Look Me Over|TTBB, SSAA|Jay Giallombardo
+Higher Ground|SSAA|Jay Giallombardo
+Holly Jolly Christmas|TTBB, SSAA|Jay Giallombardo
+Home For The Holidays|TTBB, SSAA|Jay Giallombardo
+Home On The Range|TTBB, SSAA|Jay Giallombardo
+Hooray For Hollywood|TTBB|Jay Giallombardo
+House I Live In|TTBB, SSAA|Jay Giallombardo
+How Can You Buy Killarney|TTBB|Jay Giallombardo
+How Deep Is The Ocean|TTBB|Jay Giallombardo
+Huggin' And A-Chalkin|TTBB|Jay Giallombardo
+Humble and Kind|TTBB|Jay Giallombardo
+I Am The Man|TTBB, SSAA|Jay Giallombardo
+I Can See Clearly Now|TTBB, SSAA|Jay Giallombardo
+I Can't Give You Anything But Love|TTBB|Jay Giallombardo
+I Could Have Danced All Night|TTBB, SSAA|Jay Giallombardo
+I Don't Know How To Say Goodbye|TTBB, SSAA|Jay Giallombardo
+I Found A Rose (in the Devil's Garden)|TTBB, SSAA|Jay Giallombardo
+I Found The End Of The Rainbow|TTBB, SSAA|Jay Giallombardo
+I Got Plenty Of Nothing|TTBB|Jay Giallombardo
+I Got Rhythm|TTBB, SSAA|Jay Giallombardo
+I Had A Dream, Dear Montage|TTBB|Jay Giallombardo
+I Have Seen The Light|TTBB|Jay Giallombardo
+I Heard The Bells On Christmas Day|TTBB, SSAA|Jay Giallombardo
+I Heard You Singing|TTBB, SSAA|Jay Giallombardo
+I Love A Piano|TTBB, SSAA|Jay Giallombardo
+I Love Me (I'm Wild About Myself)|TTBB, SSAA|Jay Giallombardo
+I Thought About You|TTBB, SSAA|Jay Giallombardo
+I Used to Call Her/Him Baby Medley|TTBB, SSAA|Jay Giallombardo
+I Wanna Be Around|TTBB, SSAA|Jay Giallombardo
+I Was Here|TTBB, SSAA, SATB|Jay Giallombardo
+I Will|TTBB|Jay Giallombardo
+I Wish I Had My Old Pal Back Again|TTBB, SSAA|Jay Giallombardo
+I Wish You Love|TTBB, SSAA|Jay Giallombardo
+I Won't Give Up|TTBB|Jay Giallombardo
+I Won't Let Go|TTBB, SSAA|Jay Giallombardo
+I Wonder As I Wander|TTBB|Jay Giallombardo
+I Work 8 Hours I Sleep 8 Hours (8 Hours for Love)|TTBB, SSAA|Jay Giallombardo
+I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jay Giallombardo
+I Write The Songs|TTBB, SSAA|Jay Giallombardo
+I Yust Go Nuts at Christmas|TTBB, SSAA|Jay Giallombardo
+I'd Love to Be in Chicago on Good Ol' St. Valentine's Day|TTBB|Jay Giallombardo
+I'd Love to Play the Palace Once Again|SSAA|Jay Giallombardo
+I'll Be Home For Christmas|TTBB, SSAA|Jay Giallombardo
+I'll Be Home for Christmas/Have Yourself a Merry Little Christmas|SSAA|Jay Giallombardo
+I'll Follow The Sun|TTBB|Jay Giallombardo
+I'll Forget You|TTBB|Jay Giallombardo
+I'll Take You Home Again, Kathleen|TTBB|Jay Giallombardo
+I'm Gonna Make Hay While the Sun Shines in Virginia|TTBB, SSAA|Jay Giallombardo
+I'm Headin' South|TTBB|Jay Giallombardo
+I'm In Love With The Mother Of My Best Girl|SSAA|Jay Giallombardo
+I'm Just Singing Your Love Songs to Somebody Else|TTBB, SSAA|Jay Giallombardo
+I'm Sitting On Top Of The World|TTBB|Jay Giallombardo
+I'm Somebody Else's Now/Who's Sorry Now Medley|TTBB|Jay Giallombardo
+I'm Sorry I Made You Cry|TTBB, SSAA|Jay Giallombardo
+I'm Spending Hanukkah In Santa Monica|TTBB|Jay Giallombardo
+I've Got a Cross-Eyed Papa But He Looks Straight to Me|SSAA|Jay Giallombardo
+I've Got a Cross-Eyed Papa But He Looks Straight to Me|TTBB|Jay Giallombardo
+If|TTBB, SSAA|Jay Giallombardo
+If He Fights for His Country|TTBB, SSAA|Jay Giallombardo
+If I Can't Have You|TTBB|Jay Giallombardo
+If I Give My Heart To You|TTBB|Jay Giallombardo
+If I Give Up The Saxophone (Will You Come Back to Me)|TTBB|Jay Giallombardo
+If I Loved You|SSAA|Jay Giallombardo
+If I Ruled The World|SSAA|Jay Giallombardo
+If It Doesn't Snow On Christmas|TTBB|Jay Giallombardo
+If The Lord Be Willin'|TTBB, SSAA|Jay Giallombardo
+If There'd Never Been An Ireland|TTBB, SSAA|Jay Giallombardo
+If They String Me Up, I'll Never Live It Down|TTBB, SSAA|Jay Giallombardo
+If We Can't Be The Same Old Sweethearts|TTBB|Jay Giallombardo
+If You Had All The World And Its Gold|SSAA|Jay Giallombardo
+If You Want the Rainbow/April Showers|TTBB, SSAA|Jay Giallombardo
+Imagination|TTBB, SSAA|Jay Giallombardo
+The Impossible Dream|TTBB, SSAA|Jay Giallombardo
+In The Arms Of Love|SSAA|Jay Giallombardo
+In The Good Old Summertime|TTBB, SSAA|Jay Giallombardo
+In the Hills of Shiloh|TTBB|Jay Giallombardo
+Irish Blessing|SSAA|Jay Giallombardo
+Irish Medley|TTBB, SSAA|Jay Giallombardo
+Irish Montage|TTBB, SSAA|Jay Giallombardo
+It Came Upon A Midnight Clear|TTBB, SSAA|Jay Giallombardo
+It Don't Mean A Thing/Classical Music Parody|TTBB|Jay Giallombardo
+It's A Beautiful Day For A Ball Game|TTBB, SSAA|Jay Giallombardo
+It's A Good Day|TTBB, SSAA|Jay Giallombardo
+It's A Grand Night For Singing|TTBB|Jay Giallombardo
+It's Beginning to Look Like Christmas/Pine Cones and Holly Berries|TTBB|Jay Giallombardo
+It's Ragtime (That I Love)|TTBB|Jay Giallombardo
+It's The Most Wonderful Time Of The Year|TTBB|Jay Giallombardo
+It's The Same Old Shillelagh|TTBB, SSAA|Jay Giallombardo
+James Bond Medley|TTBB|Jay Giallombardo
+Jazz Baby|TTBB, SSAA|Jay Giallombardo
+Jeepers Creepers|TTBB, SSAA|Jay Giallombardo
+Jersey Boys Medley|TTBB|Jay Giallombardo
+Joint is Jumping/That's A Plenty|TTBB|Jay Giallombardo
+Josephine, Please Don't Lean On The Bell|TTBB|Jay Giallombardo
+Joy To The World|TTBB, SSAA|Jay Giallombardo
+Joy to the World/O Come All Ye Faithful|TTBB|Jay Giallombardo
+Jump Shout Boogie|SSAA|Jay Giallombardo
+June Is Bustin' Out All Over|TTBB|Jay Giallombardo
+Just A Baby's Prayer At Twilight|TTBB|Jay Giallombardo
+Just a Little Street/I'd Give the World|TTBB|Jay Giallombardo
+Just An Old Time Love Song|TTBB, SSAA|Jay Giallombardo
+Just When The Lights Are Low|TTBB|Jay Giallombardo
+Kansas City|TTBB, SSAA|Jay Giallombardo
+Kansas City Here I Come|TTBB, SSAA|Jay Giallombardo
+Kansas City Star|TTBB, SSAA|Jay Giallombardo
+Keep Yourself Alive|TTBB|Jay Giallombardo
+Keystone Cops|TTBB|Jay Giallombardo
+King Of The Road|TTBB|Jay Giallombardo
+Kissing A Fool|TTBB|Jay Giallombardo
+Lady Madonna|TTBB, SSAA|Jay Giallombardo
+Lady Of Spain|TTBB|Jay Giallombardo
+Let A Smile Be Your Umbrella|TTBB, SSAA|Jay Giallombardo
+Let It Rain Let It Pour|TTBB|Jay Giallombardo
+Let It Snow Let It Snow Let It Snow|TTBB, SSAA|Jay Giallombardo
+Let's Hang On|TTBB|Jay Giallombardo
+Light One Candle|TTBB, SSAA|Jay Giallombardo
+Light The Legend|TTBB, SSAA|Jay Giallombardo
+Lindbergh the Eagle of the U.S.A.|TTBB|Jay Giallombardo
+Little Bit Of Heaven|TTBB, SSAA|Jay Giallombardo
+Little Home Sweet Home of Mine|TTBB|Jay Giallombardo
+Little Man You've Had A Busy Day|TTBB, SSAA|Jay Giallombardo
+Little Mary Brown (Loves Me)|TTBB|Jay Giallombardo
+Little Street Where Old Friends Meet|TTBB|Jay Giallombardo
+The Little White House|TTBB|Jay Giallombardo
+Lo! How A Rose|TTBB, SSAA|Jay Giallombardo
+Lonesomest Girl In Town|SSAA|Jay Giallombardo
+The Long and Winding Road|TTBB|Jay Giallombardo
+A Long, Long Time|TTBB, SSAA|Jay Giallombardo
+Lord Bless You And Keep You|TTBB, SSAA|Jay Giallombardo
+Losing My Mind|TTBB|Jay Giallombardo
+Louisville Lou|TTBB, SSAA|Jay Giallombardo
+Love in a Home (You Can Tell When There's)|TTBB, SSAA|Jay Giallombardo
+Love Is A Many Splendored Thing|TTBB, SSAA|Jay Giallombardo
+Love is Sweepin' the Country|TTBB, SSAA|Jay Giallombardo
+Love Me And The World Is Mine|TTBB, SSAA|Jay Giallombardo
+Love Me in December/September Song Medley|TTBB, SSAA|Jay Giallombardo
+Love Of My Life|TTBB|Jay Giallombardo
+Lover Come Back To Me|TTBB, SSAA|Jay Giallombardo
+M-O-T-H-E-R|TTBB|Jay Giallombardo
+Mad Dogs and Englishmen|TTBB|Jay Giallombardo
+Magnificent Flying Medley|TTBB|Jay Giallombardo
+Man With The Bag|TTBB|Jay Giallombardo
+Mandy|TTBB|Jay Giallombardo
+Mandy Lee|TTBB|Jay Giallombardo
+Manilow Medley|TTBB, SSAA|Jay Giallombardo
+March of the Toys|TTBB, SSAA|Jay Giallombardo
+March of the Wooden Soldiers|TTBB, SSAA|Jay Giallombardo
+Marvelous Toy|TTBB|Jay Giallombardo
+The Marx Brothers Opener|TTBB|Jay Giallombardo
+The Masquerade Is Over|TTBB, SSAA|Jay Giallombardo
+Maybe This Time|SSAA|Jay Giallombardo
+Mean, Mean Mama|TTBB, SSAA|Jay Giallombardo
+Medley: This Old House/When the Saints Go Marching In Medley|TTBB|Jay Giallombardo
+Meetin' Here Tonight/Old Time Religion Medley|TTBB, SSAA|Jay Giallombardo
+Memory|TTBB|Jay Giallombardo
+Michigan Morn|TTBB|Jay Giallombardo
+Mississippi Medley (Roll On, Mississippi/On the Mississippi)|TTBB, SSAA|Jay Giallombardo
+Monday, Monday|TTBB, SSAA|Jay Giallombardo
+Moonlight Brings Memories|TTBB, SSAA|Jay Giallombardo
+More Than You Know|TTBB|Jay Giallombardo
+More Than You Need To Know|TTBB|Jay Giallombardo
+Mother Of Mine|TTBB, SSAA|Jay Giallombardo
+Music Of The Night|TTBB|Jay Giallombardo
+My Boy Bill - My Little Girl Medley|TTBB|Jay Giallombardo
+My Foolish Heart|TTBB|Jay Giallombardo
+My Melancholy Baby|TTBB, SSAA|Jay Giallombardo
+My Old Kentucky Home|TTBB|Jay Giallombardo
+My Old Kentucky Home/Jeanie|TTBB|Jay Giallombardo
+My Romance|TTBB|Jay Giallombardo
+My Way|TTBB|Jay Giallombardo
+My Wild Irish Rose|TTBB, SSAA|Jay Giallombardo
+Nashville Cats|TTBB|Jay Giallombardo
+Never-Never Land|TTBB, SSAA|Jay Giallombardo
+New York Ain't New York Anymore|TTBB, SSAA|Jay Giallombardo
+New York Medley|TTBB|Jay Giallombardo
+New York, New York|TTBB|Jay Giallombardo
+Nice People|TTBB|Jay Giallombardo
+No Wonder I'm Happy|TTBB|Jay Giallombardo
+Norwegian Wood|TTBB|Jay Giallombardo
+Nothing Like a Dame/Honey Bun Medley|TTBB|Jay Giallombardo
+O Breath Of Early Spring (Pourquoi Me Reveiller)|TTBB|Jay Giallombardo
+O Canada!|TTBB|Jay Giallombardo
+O Christmas Tree|TTBB|Jay Giallombardo
+O Holy Night|TTBB, SSAA|Jay Giallombardo
+Of Thee I Sing, America!|TTBB|Jay Giallombardo
+Oh Johnny|SSAA|Jay Giallombardo
+Oh, Come All Ye Faithful / Joy To The World Medley|TTBB, SSAA|Jay Giallombardo
+Oh, How I Miss You Tonight/When I Lost Medley|TTBB, SSAA|Jay Giallombardo
+Oh, You Beautiful Doll|TTBB, SSAA|Jay Giallombardo
+Oklahoma|TTBB|Jay Giallombardo
+Oklahoma Medley|TTBB|Jay Giallombardo
+The Old Man|TTBB|Jay Giallombardo
+The Old Songs|TTBB|Jay Giallombardo
+Old Time Religion|TTBB|Jay Giallombardo
+Oliver Medley|TTBB|Jay Giallombardo
+On A Slow Boat To China/Shanghai Medley|TTBB, SSAA|Jay Giallombardo
+On the Arms of the Old Armchair|TTBB|Jay Giallombardo
+On The Atchison, Topeka And The Santa Fe|TTBB|Jay Giallombardo
+On The Street Where You Live|TTBB, SSAA|Jay Giallombardo
+One By One|TTBB|Jay Giallombardo
+One Voice|SSAA|Jay Giallombardo
+Over The Rainbow|TTBB, SSAA|Jay Giallombardo
+Pal Of My Cradle Days|TTBB|Jay Giallombardo
+Pal Of My Dreams|TTBB|Jay Giallombardo
+Paperback Writer|TTBB, SSAA|Jay Giallombardo
+Parade Medley|TTBB|Jay Giallombardo
+Patriotic Medley|TTBB, SSAA|Jay Giallombardo
+Peace On Earth/Little Drummer Boy medley|TTBB, SSAA|Jay Giallombardo
+Pirates Who Don't Do Anything|TTBB, SSAA|Jay Giallombardo
+Please Don't Talk About Me When I'm Gone|TTBB, SSAA|Jay Giallombardo
+Poisoning Pigeons In The Park|TTBB, SSAA|Jay Giallombardo
+The Prayer|TTBB, SSAA|Jay Giallombardo
+Precious Child|TTBB, SSAA|Jay Giallombardo
+Pretty Girl Is Like A Melody/With A Song In My Heart|TTBB|Jay Giallombardo
+Pure Imagination|TTBB, SSAA|Jay Giallombardo
+Put On A Happy Face|TTBB|Jay Giallombardo
+Put On Your Old Grey Bonnet|TTBB|Jay Giallombardo
+Queen Montage|TTBB|Jay Giallombardo
+Rachel Was Here|TTBB|Jay Giallombardo
+Ragtime Drafted Man|TTBB|Jay Giallombardo
+Remind Me|SATB|Jay Giallombardo
+The River Of Dreams|TTBB|Jay Giallombardo
+Rock Me to Sleep In An Old Rocking Chair|TTBB, SSAA|Jay Giallombardo
+Rocky Raccoon|TTBB, SSAA|Jay Giallombardo
+Roll Out the Barrel/Zip-A-Dee-Doo-Dah Medley|TTBB|Jay Giallombardo
+Rosie, You Are My Posie/You Made Me Love You|TTBB|Jay Giallombardo
+Route 66|TTBB|Jay Giallombardo
+Rudolph The Red Nosed Reindeer|TTBB, SSAA|Jay Giallombardo
+San Francisco Medley|TTBB|Jay Giallombardo
+Santa Claus Is Comin' To Town|TTBB, SSAA|Jay Giallombardo
+School House Medley|TTBB, SSAA|Jay Giallombardo
+Scottish Tribute|TTBB, SSAA|Jay Giallombardo
+Secret Love|TTBB|Jay Giallombardo
+Send In The Clowns|TTBB|Jay Giallombardo
+Sentimental Journey|TTBB, SSAA|Jay Giallombardo
+Seventy-Six Trombones|TTBB, SSAA|Jay Giallombardo
+Shaking The Blues Away|TTBB|Jay Giallombardo
+She's Leaving Home|TTBB|Jay Giallombardo
+Shenandoah|TTBB|Jay Giallombardo
+Short People|TTBB, SSAA|Jay Giallombardo
+Show Business Medley|TTBB|Jay Giallombardo
+Silent Night|TTBB, SSAA|Jay Giallombardo
+Silver Bells|TTBB, SSAA|Jay Giallombardo
+Sincere|TTBB|Jay Giallombardo
+Sing|TTBB|Jay Giallombardo
+Sing An Old Fashioned Song|TTBB|Jay Giallombardo
+Singin' In The Rain|TTBB, SSAA|Jay Giallombardo
+Sister Hasn't Got a Chance Since Mother Bobbed Her Hair|SSAA|Jay Giallombardo
+Sleigh Ride|TTBB, SSAA|Jay Giallombardo
+Smile Medley|TTBB, SSAA|Jay Giallombardo
+Smooth Sailing (We're Gonna Have)|TTBB|Jay Giallombardo
+Snow|TTBB|Jay Giallombardo
+Somebody Else Took You Out of My Arms|TTBB|Jay Giallombardo
+Somebody to Love|TTBB, SSAA|Jay Giallombardo
+Someone To Watch Over Me|TTBB, SSAA|Jay Giallombardo
+Somewhere Down The Road|TTBB, SSAA|Jay Giallombardo
+Song For Mary|TTBB|Jay Giallombardo
+Song of America|TTBB|Jay Giallombardo
+Song's Gotta Come From The Heart|TTBB, SSAA|Jay Giallombardo
+Soul Man|TTBB|Jay Giallombardo
+South Pacific Medley|TTBB|Jay Giallombardo
+The Spinning Song|TTBB|Jay Giallombardo
+Star Spangled Banner|TTBB|Jay Giallombardo
+The Story of the Sparrows|TTBB|Jay Giallombardo
+Strike Up The Band|TTBB|Jay Giallombardo
+Stuff Like That There|TTBB|Jay Giallombardo
+Stumblin' All Around|TTBB|Jay Giallombardo
+A Summer Place|TTBB|Jay Giallombardo
+Summertime|TTBB|Jay Giallombardo
+Sunshine Lollipops And Rainbows|TTBB|Jay Giallombardo
+The Sunshine Of Your Smile|TTBB|Jay Giallombardo
+Sure On This Shining Night|TTBB|Jay Giallombardo
+Surrey with the Fringe On the Top|TTBB|Jay Giallombardo
+Suzanna Pianna Medley|TTBB, SSAA|Jay Giallombardo
+Sweet 16 Medley|TTBB|Jay Giallombardo
+The Sweetheart Of Sigma Chi|TTBB|Jay Giallombardo
+Take Me Out To The Ball Game|TTBB, SSAA|Jay Giallombardo
+Taking A Chance On Love|TTBB, SSAA|Jay Giallombardo
+That's Entertainment|TTBB, SSAA|Jay Giallombardo
+That's What Dreams Are For|TTBB|Jay Giallombardo
+That's What God Made Mothers For|TTBB|Jay Giallombardo
+There Is Nothing Like A Dame|TTBB|Jay Giallombardo
+There Used To Be A Ball Park|TTBB, SSAA|Jay Giallombardo
+There's a Boat That's Leaving Soon/Bess You Is Ma Woman Now|TTBB, SSAA|Jay Giallombardo
+There's Something About A Soldier|TTBB, SSAA|Jay Giallombardo
+They All Laughed|TTBB, SSAA|Jay Giallombardo
+They Call The Wind Maria|TTBB|Jay Giallombardo
+They Didn't Believe Me|TTBB, SSAA|Jay Giallombardo
+They Go Wild, Simply Wild Over Me|SSAA|Jay Giallombardo
+They Were All Out Of Step But Jim|TTBB|Jay Giallombardo
+This Is My Lucky Day/Sing Hallelujah|TTBB|Jay Giallombardo
+This Land Is Your Land|TTBB|Jay Giallombardo
+This Land Is Your Land|TTBB, SSAA|Jay Giallombardo
+This Nearly Was Mine|TTBB|Jay Giallombardo
+Through the Eyes of Love|TTBB|Jay Giallombardo
+Through The Years|TTBB|Jay Giallombardo
+Til Tomorrow Comes|TTBB, SSAA|Jay Giallombardo
+To Be Loved|TTBB, SSAA|Jay Giallombardo
+Tonight|TTBB|Jay Giallombardo
+Tonight We Love|TTBB, SSAA|Jay Giallombardo
+Too Darn Hot|TTBB|Jay Giallombardo
+Too Marvelous For Words|TTBB|Jay Giallombardo
+Top Of The World|TTBB|Jay Giallombardo
+Toyland|TTBB|Jay Giallombardo
+Tradition|TTBB|Jay Giallombardo
+Travelling Home|TTBB|Jay Giallombardo
+A Tree in the Meadow|TTBB|Jay Giallombardo
+A Tribute to World Peace|TTBB, SSAA|Jay Giallombardo
+Tulip Medley|TTBB, SSAA|Jay Giallombardo
+Turn Around|TTBB, SSAA|Jay Giallombardo
+Turn Back The Universe|TTBB|Jay Giallombardo
+Tuxedo Junction|TTBB|Jay Giallombardo
+Twentieth Century Baby's Lullaby, That's the|SSAA|Jay Giallombardo
+Unchained Melody|TTBB|Jay Giallombardo
+Under The Sea|TTBB, SSAA|Jay Giallombardo
+Until The Real Thing Comes Along|TTBB|Jay Giallombardo
+Up in the Air Medley|TTBB|Jay Giallombardo
+Up On the House Top|TTBB, SSAA|Jay Giallombardo
+Up, Up And Away (My Beautiful Balloon)|TTBB|Jay Giallombardo
+Walk Like a Man|TTBB|Jay Giallombardo
+Warm And Fuzzy|TTBB, SSAA|Jay Giallombardo
+Watch, Hope and Wait, Little Girl|TTBB|Jay Giallombardo
+The Way We Were|TTBB|Jay Giallombardo
+We Are The Champions|TTBB, SSAA|Jay Giallombardo
+We Can Work It Out|TTBB, SSAA|Jay Giallombardo
+We Couldn't Say Goodbye|TTBB|Jay Giallombardo
+We Three Kings|TTBB, SSAA|Jay Giallombardo
+We Will Rock You|TTBB|Jay Giallombardo
+We'll have to Pass the Apples/Little Bit of Bad Medley|TTBB|Jay Giallombardo
+Wedding Processional|TTBB, SSAA|Jay Giallombardo
+Weekend In New England|TTBB|Jay Giallombardo
+A Whale Of A Tale|TTBB|Jay Giallombardo
+What A Wonderful World|TTBB|Jay Giallombardo
+What Child Is This|TTBB, SSAA|Jay Giallombardo
+What Do You Mean By Loving Somebody Else|SSAA|Jay Giallombardo
+What Kind Of Fool Am I|TTBB|Jay Giallombardo
+What Wondrous Love/O Sacred Head|TTBB|Jay Giallombardo
+Whatever Happened to the Old Songs?/Yes Sir, That's My Baby|TTBB, SSAA|Jay Giallombardo
+When Autumn Comes|TTBB, SSAA|Jay Giallombardo
+When I Dream in Dreamland|TTBB|Jay Giallombardo
+When I Dream Of Old Erin|SSAA|Jay Giallombardo
+When I Fall In Love|TTBB, SSAA|Jay Giallombardo
+When I Fall In Love|TTBB|Jay Giallombardo
+When I Get You Alone Tonight|TTBB, SSAA|Jay Giallombardo
+When It's Sleepy Time Down South|TTBB|Jay Giallombardo
+When Johnny Comes Marching Home|TTBB|Jay Giallombardo
+When Lindy Comes Home|TTBB|Jay Giallombardo
+When The Gold Turns To Gray|TTBB|Jay Giallombardo
+When the Maple Leaves Were Falling|TTBB|Jay Giallombardo
+When The Midnight Choo Choo Leaves For Alabam'|TTBB, SSAA|Jay Giallombardo
+When the Toy Soldiers March on Parade|TTBB, SSAA|Jay Giallombardo
+When You Look In The Heart Of A Rose|SSAA|Jay Giallombardo
+When You Sang Soprano|TTBB|Jay Giallombardo
+White Cliffs Of Dover|TTBB, SSAA|Jay Giallombardo
+Who I Am|SSAA|Jay Giallombardo
+Who'll Take My Place When I'm Gone|TTBB|Jay Giallombardo
+Who'll Take The Place Of Mary|TTBB|Jay Giallombardo
+William Tell Overture|TTBB, SSAA|Jay Giallombardo
+Wind Beneath My Wings|SSAA|Jay Giallombardo
+Wind Beneath My Wings/You Raise Me Up Medley|TTBB|Jay Giallombardo
+With These Hands|SATB|Jay Giallombardo
+Without A Song|SSAA|Jay Giallombardo
+Wonderful To Be a Toy/Toy Soldier March Medley, It's|TTBB, SSAA|Jay Giallombardo
+Working My Way Back to You|TTBB|Jay Giallombardo
+Wouldn't It Be Loverly|SSAA|Jay Giallombardo
+Wouldn't It Be Nice|TTBB|Jay Giallombardo
+WWI Medley|TTBB, SSAA|Jay Giallombardo
+Yankee Doodle|TTBB|Jay Giallombardo
+Yesterday|TTBB|Jay Giallombardo
+You And I|TTBB, SSAA|Jay Giallombardo
+You Better Keep Babying Baby|SSAA|Jay Giallombardo
+You Can Never Be Too Sure About the Girls/There's a Little B|TTBB|Jay Giallombardo
+You Don't Love Me Anymore|TTBB, SSAA|Jay Giallombardo
+You Gotta Be A Football Hero|TTBB, SSAA|Jay Giallombardo
+You Light Up My Life|SSAA|Jay Giallombardo
+You Make My Dreams|TTBB|Jay Giallombardo
+You Took Advantage Of Me|TTBB|Jay Giallombardo
+You'd Better Be Nice to Them Now|TTBB|Jay Giallombardo
+You're in Wrong /How Come You Do Me|SSAA|Jay Giallombardo
+You're Nobody Til Somebody Loves You/Ain't That A Kick|TTBB, SSAA|Jay Giallombardo
+You're the Boy I Love|SSAA|Jay Giallombardo
+You're The Flower Of My Heart, Sweet Adeline|TTBB, SSAA|Jay Giallombardo
+You're the Girl I Love|TTBB|Jay Giallombardo
+You've Got A Friend In Me|TTBB, SSAA|Jay Giallombardo
+Yours is My Heart Alone|TTBB|Jay Giallombardo
+Zuckerman's Famous Pig|TTBB|Jay Giallombardo
+Makin' Whoopee|TTBB|Craig Gibbins
+Nancy (With The Laughing Face)|TTBB|Craig Gibbins
+Lulu's Back In Town|TTBB|Derek Gilbert
+Sweet Georgia Brown|TTBB|Derek Gilbert
+Blue Christmas|TTBB, SATB|M. Gill
+Have Yourself a Mary Little Christmas|TTBB|M. Gill
+Let There Be Peace On Earth|TTBB|M. Gill
+Little Drummer Boy|TTBB|M. Gill
+One Voice|TTBB|M. Gill
+Crazy 'Bout Ya Baby|TTBB|Don Gillespie
+Too Many Years Have Gone By|TTBB|David Gillingham
+War Eagle|SSAA|Joyce Glover
+The Big Bang Theory|SSAA|Patricia Godfrey
+Break My Stride|SSAA|Patricia Godfrey
+Buckeye Battle Cry|SSAA|Patricia Godfrey
+Carmen Ohio|SSAA|Patricia Godfrey
+Christmas Is|SSAA|Patricia Godfrey
+A Christmas Love Song|SSAA|Patricia Godfrey
+Christmas Magic|SSAA|Patricia Godfrey
+Don't Stop Me Now|SSAA|Patricia Godfrey
+Happiness|SSAA|Patricia Godfrey
+Holiday Road|SSAA|Patricia Godfrey
+I've Got My Love To Keep Me Warm|SSAA|Patricia Godfrey
+Lord Bless You And Keep You|SSAA|Patricia Godfrey
+Magic Moments|SSAA|Patricia Godfrey
+Merrily We Roll Along|SSAA|Patricia Godfrey
+No Time At All|SSAA|Patricia Godfrey
+Skye Boat Song|SSAA|Patricia Godfrey
+This Is It!|SSAA|Patricia Godfrey
+The Time Warp|SSAA|Patricia Godfrey
+Wasted On The Way|SSAA|Patricia Godfrey
+Welcome Christmas|SSAA|Patricia Godfrey
+White Christmas (doo wop)|SSAA|Patricia Godfrey
+You're A Grand Old Flag|SSAA|Patricia Godfrey
+Africa|TTBB, SSAA|Dianne Goldrick
+All I Have To Do Is Dream|TTBB, SSAA|Dianne Goldrick
+Almost Like Being In Love|TTBB, SSAA|Dianne Goldrick
+America The Beautiful|TTBB, SSAA|Dianne Goldrick
+And So It Goes|TTBB, SSAA|Dianne Goldrick
+Auld Lang Syne|TTBB, SSAA|Dianne Goldrick
+Be My Friend The Facebook Song|TTBB, SSAA|Dianne Goldrick
+Be Thou My Vision|TTBB, SSAA|Dianne Goldrick
+Bethlehem Joy|TTBB, SSAA|Dianne Goldrick
+Blackbird|TTBB, SSAA|Dianne Goldrick
+Blue Christmas|SSAA, SATB|Dianne Goldrick
+Blue Shadows On The Trail|TTBB, SSAA|Dianne Goldrick
+Bring Me Sunshine|TTBB, SSAA|Dianne Goldrick
+By Strauss|SSAA|Dianne Goldrick
+Can't Help Falling In Love|SSAA|Dianne Goldrick
+Christmas Island|TTBB, SSAA|Dianne Goldrick
+Come Thou Fount of Every Blessing|SSAA|Dianne Goldrick
+Count On Me|SSAA, SATB|Dianne Goldrick
+Coventry Carol|TTBB, SSAA|Dianne Goldrick
+Cow-cow Boogie|SSAA|Dianne Goldrick
+Deck The Halls|SSAA|Dianne Goldrick
+Dona Nobis Pacem|SSAA|Dianne Goldrick
+El Shaddai|TTBB, SSAA|Dianne Goldrick
+Everything Happens To Me|TTBB, SSAA|Dianne Goldrick
+Feliz Navidad|SSAA|Dianne Goldrick
+Forever Young|SSAA|Dianne Goldrick
+God Bless America|SSAA|Dianne Goldrick
+Grouch Anthem|TTBB, SSAA|Dianne Goldrick
+Happy Birthday To You|TTBB, SSAA, SATB|Dianne Goldrick
+Hark! The Herald Angels Sing|TTBB, SSAA|Dianne Goldrick
+Have I Told You Lately|SSAA|Dianne Goldrick
+His Eye Is On The Sparrow|TTBB|Dianne Goldrick
+Holly Jolly Christmas|TTBB, SSAA|Dianne Goldrick
+Hopelessly Devoted To You|SSAA|Dianne Goldrick
+How Lucky You Are|SSAA|Dianne Goldrick
+Hush, Little Baby|SSAA|Dianne Goldrick
+I Believe|TTBB, SSAA|Dianne Goldrick
+I Can't Get Started with You|SSAA|Dianne Goldrick
+I Don't Know Why|TTBB, SSAA|Dianne Goldrick
+I Say A Little Prayer For You|SSAA|Dianne Goldrick
+I Sing Because I'm Happy|TTBB, SSAA|Dianne Goldrick
+I Want To Stare At My Phone With You|SSAA|Dianne Goldrick
+I'm Glad There Is You|SATB|Dianne Goldrick
+Let The Rest Of The World Go By|SSAA|Dianne Goldrick
+Let's Get Away From It All|SSAA|Dianne Goldrick
+Little Saint Nick|SSAA|Dianne Goldrick
+Lord's My Shepherd|SSAA|Dianne Goldrick
+Love Is Here To Stay|SSAA|Dianne Goldrick
+Merry Christmas Darling|SSAA|Dianne Goldrick
+Moon River|SSAA|Dianne Goldrick
+My Favorite Things|TTBB, SSAA|Dianne Goldrick
+My Song in the Night|TTBB, SSAA, SATB|Dianne Goldrick
+O Come, All Ye Faithful|TTBB, SSAA|Dianne Goldrick
+O Little Town Of Bethlehem|TTBB, SSAA|Dianne Goldrick
+Place in the Choir|SSAA|Dianne Goldrick
+Popular|SSAA|Dianne Goldrick
+Recipe For Love|TTBB|Dianne Goldrick
+Royals|SSAA|Dianne Goldrick
+Run To You|SSAA|Dianne Goldrick
+Runnin' Home To You|TTBB, SSAA|Dianne Goldrick
+The Secret Of Christmas|TTBB, SSAA|Dianne Goldrick
+Shallow|SSAA|Dianne Goldrick
+Silent Night|TTBB, SSAA|Dianne Goldrick
+Simple Gifts|SSAA|Dianne Goldrick
+Singin' In The Rain|TTBB, SSAA|Dianne Goldrick
+Stand By Me|TTBB, SSAA|Dianne Goldrick
+Star Spangled Banner|SSAA, SATB|Dianne Goldrick
+The Sweetest Sounds|SSAA|Dianne Goldrick
+Sweetest Thing, The (I've Ever Known)|SSAA|Dianne Goldrick
+There's Nothing I Wouldn't Do|SSAA|Dianne Goldrick
+This Is Me|TTBB, SSAA, SATB|Dianne Goldrick
+This Kiss|SSAA|Dianne Goldrick
+To Make You Feel My Love|SSAA|Dianne Goldrick
+Until The Real Thing Comes Along|TTBB, SSAA|Dianne Goldrick
+Video Killed The Radio Star|SSAA|Dianne Goldrick
+We Wish You A Merry Christmas|SSAA|Dianne Goldrick
+We Wish You The Merriest|TTBB, SSAA|Dianne Goldrick
+Where In The World Is Carmen Sandiego?|TTBB, SSAA|Dianne Goldrick
+Why Do Fools Fall In Love|SSAA|Dianne Goldrick
+Love Me With All Your Heart|SSAA|Mary Lou Gomez-Leon
+Seventy-Six Trombones|SSAA|Mary Lou Gomez-Leon
+(Hey Won't You Play) Another Somebody Done Somebody Wrong Song|TTBB|Mark Goodney
+Aba Daba Honeymoon|TTBB|Mark Goodney
+Across the Alley from the Alamo|TTBB|Mark Goodney
+After You've Gone|TTBB|Mark Goodney
+Ain't Nobody Here But Us Chickens|TTBB|Mark Goodney
+Aspenglow|TTBB|Mark Goodney
+At The Ball, That's All|TTBB|Mark Goodney
+Beer Barrel Polka|TTBB|Mark Goodney
+The Begat|TTBB|Mark Goodney
+Believe|TTBB|Mark Goodney
+Beyond the Sea|TTBB|Mark Goodney
+Blue And Sentimental|TTBB|Mark Goodney
+Blue Velvet|TTBB|Mark Goodney
+A Bushel And A Peck|TTBB|Mark Goodney
+By The Light Of The Silvery Moon|TTBB|Mark Goodney
+Cab Driver|TTBB|Mark Goodney
+Cheek To Cheek|TTBB|Mark Goodney
+Chinatown My Chinatown|TTBB|Mark Goodney
+Chitty Chitty Bang Bang|TTBB|Mark Goodney
+Christmas Island|TTBB|Mark Goodney
+Christmas Waltz|TTBB|Mark Goodney
+Consider Yourself|TTBB|Mark Goodney
+Cool Yule|TTBB|Mark Goodney
+A Cover Is Not The Book|TTBB|Mark Goodney
+Doll On A Music Box|SATB|Mark Goodney
+Dominick, The Donkey|TTBB|Mark Goodney
+Don't Be A Do-Badder|TTBB|Mark Goodney
+Dream, Dream, Dream|TTBB|Mark Goodney
+Dreamer's Holiday|TTBB|Mark Goodney
+Ev'ry Day Of My Life|TTBB|Mark Goodney
+Feliz Navidad|TTBB|Mark Goodney
+Follow Me|TTBB|Mark Goodney
+For Once In My Life|TTBB|Mark Goodney
+For Sentimental Reasons|TTBB|Mark Goodney
+Fugue for Tinhorns|TTBB|Mark Goodney
+Grandmas Feather Bed|TTBB|Mark Goodney
+The Great Come-And-Get-It-Day|TTBB|Mark Goodney
+Hallelujah Chorus|TTBB|Mark Goodney
+Hanukkah In Santa Monica|TTBB|Mark Goodney
+Holly Jolly Christmas|TTBB|Mark Goodney
+Home For The Holidays|TTBB|Mark Goodney
+How Are Things In Glocca Morra|TTBB|Mark Goodney
+How Could You Believe Me|TTBB|Mark Goodney
+I Can't Give You Anything But Love|TTBB|Mark Goodney
+I Don't Want To Walk Without You|TTBB|Mark Goodney
+I MIss You So|TTBB|Mark Goodney
+I Wanna Be Around|TTBB|Mark Goodney
+I Want A Hippopotamus For Christmas|TTBB|Mark Goodney
+I'll Be Around|TTBB|Mark Goodney
+I'm Always Chasing Rainbows|TTBB|Mark Goodney
+I've Got My Love To Keep Me Warm|TTBB|Mark Goodney
+If I Had My Druthers|TTBB|Mark Goodney
+If My Friends Could See Me Now|TTBB|Mark Goodney
+If This Isn't Love|TTBB|Mark Goodney
+In The Mood|TTBB|Mark Goodney
+It Don't Mean A Thing|TTBB|Mark Goodney
+It's Not For Me To Say|TTBB|Mark Goodney
+The Japanese Sandman|TTBB|Mark Goodney
+L-O-V-E|TTBB|Mark Goodney
+Les Poissons|TTBB|Mark Goodney
+Let's Get Away From It All|TTBB|Mark Goodney
+Little On The Lonely Side|TTBB|Mark Goodney
+Little Patch Of Heaven|TTBB|Mark Goodney
+Look To The Rainbow|TTBB|Mark Goodney
+Love Won't Let You Get Away|TTBB|Mark Goodney
+Lovely Lonely Man|SATB|Mark Goodney
+Lullaby For Christmas Eve|TTBB|Mark Goodney
+Mah-na Mah-na|TTBB|Mark Goodney
+Mairzy Doats|TTBB|Mark Goodney
+Make 'Em Laugh|TTBB|Mark Goodney
+Man With The Bag|TTBB|Mark Goodney
+Mele Kalikimaka|TTBB|Mark Goodney
+The Most Wonderful Day Of The Year|TTBB|Mark Goodney
+The Movies|TTBB|Mark Goodney
+My Christmas Song For You|TTBB|Mark Goodney
+My Funny Valentine|TTBB|Mark Goodney
+My Little Grass Shack In Kealakekua, Hawaii|TTBB|Mark Goodney
+My Sweet Lady|TTBB|Mark Goodney
+Necessity|TTBB|Mark Goodney
+Nevertheless|TTBB|Mark Goodney
+Oh! What It Seemed To Be|TTBB|Mark Goodney
+Oh, You Beautiful Doll|TTBB|Mark Goodney
+The Ol' Insomniac Blues|TTBB|Mark Goodney
+Old Devil Moon|TTBB|Mark Goodney
+On A Slow Boat To China|TTBB|Mark Goodney
+One For My Baby (And One More For The Road)|TTBB|Mark Goodney
+Oom Pah Pah|TTBB|Mark Goodney
+Orange Colored Sky|TTBB|Mark Goodney
+Over The River And Through The Woods|TTBB|Mark Goodney
+Peaceful Easy Feeling|TTBB|Mark Goodney
+Pine Cones And Holly Berries|TTBB|Mark Goodney
+The Place Where the Lost Things Go|TTBB|Mark Goodney
+Play A Simple Melody|TTBB|Mark Goodney
+Posh|SATB|Mark Goodney
+Puff The Magic Dragon|TTBB|Mark Goodney
+Put Another Chair At The Table|TTBB|Mark Goodney
+Raindrops Keep Falling On My Head|TTBB|Mark Goodney
+Roses Of Success|TTBB|Mark Goodney
+Round and Round|TTBB|Mark Goodney
+Say, Has Anybody Seen My Sweet Gypsy Rose|TTBB|Mark Goodney
+See You In September|TTBB|Mark Goodney
+Sh Boom|TTBB|Mark Goodney
+Smile Away Each Rainy Day|TTBB|Mark Goodney
+Snow|TTBB|Mark Goodney
+Somebody Else Is Taking My Place|TTBB|Mark Goodney
+Something Sort of Grandish|TTBB|Mark Goodney
+The Sound Of Silence|TTBB|Mark Goodney
+Standing On The Corner|TTBB|Mark Goodney
+Style|TTBB|Mark Goodney
+Sweet Caroline|TTBB|Mark Goodney
+Sweet Violets|TTBB|Mark Goodney
+Take Me Home, Country Roads|TTBB|Mark Goodney
+Taking A Chance On Love|TTBB|Mark Goodney
+Teach Your Children|TTBB|Mark Goodney
+The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Mark Goodney
+There I've Said It Again|TTBB|Mark Goodney
+There Is A Tavern In The Town|TTBB|Mark Goodney
+This Could be the Start of Something Big|TTBB|Mark Goodney
+Those Lazy Hazy Crazy Days Of Summer|TTBB|Mark Goodney
+Those Were The Days|TTBB|Mark Goodney
+Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Mark Goodney
+Till Then|TTBB|Mark Goodney
+Time After Time|TTBB|Mark Goodney
+Time In A Bottle|TTBB|Mark Goodney
+Too Young|TTBB|Mark Goodney
+Top Of The World|TTBB|Mark Goodney
+The Trolley Song|TTBB|Mark Goodney
+Truly Scrumptious|TTBB|Mark Goodney
+Twice As Much|TTBB|Mark Goodney
+The Very Thought Of You|TTBB|Mark Goodney
+Weekend In New England|TTBB|Mark Goodney
+Welcome To My World|TTBB|Mark Goodney
+What Are You Doing New Year's Eve?|TTBB|Mark Goodney
+When I'm Not Near The Girl I Love|TTBB|Mark Goodney
+When The Idle Poor Become The Idle Rich|TTBB|Mark Goodney
+Where Does The Time Go?|TTBB|Mark Goodney
+Who's In The Strawberry Patch With Sally?|TTBB|Mark Goodney
+Will The Sun Ever Shine Again|TTBB|Mark Goodney
+Won't You Play a Simple Melody|TTBB|Mark Goodney
+You Always Hurt the One You Love|TTBB|Mark Goodney
+You Made Me Love You|TTBB|Mark Goodney
+You're Nobody 'Til Somebody Loves You|TTBB|Mark Goodney
+All Or Nothing|TTBB|Grant Goulding
+Almost Is Never Enough|TTBB|Grant Goulding
+Cassiopeia|SATB|Grant Goulding
+Creep|TTBB|Grant Goulding
+December 1963 (Oh, What A Night)|TTBB|Grant Goulding
+Devil May Care|TTBB|Grant Goulding
+The Light|SATB|Grant Goulding
+Love On The Rocks|SATB|Grant Goulding
+One More Minute|TTBB|Grant Goulding
+Walking On Sunshine|TTBB|Grant Goulding
+When God Dips His Love In My Heart|SSAA|Grant Goulding
+I Wish I Had Someone To Say Goodbye To|TTBB|Bob Graham
+Medley In The Rain|TTBB|Bob Graham
+Over The Rainbow|TTBB|Bob Graham
+Pal Of My Cradle Days|TTBB|Bob Graham
+Put On Your Old Grey Bonnet|TTBB|Bob Graham
+Sioux City Sue|TTBB|Bob Graham
+That Wonderful Mother Of Mine|TTBB|Bob Graham
+When Your Old Wedding Ring Was New|TTBB|Bob Graham
+A Kiss To Build A Dream On|TTBB|Brent Graham
+All The Things You Are|TTBB, SSAA|Brent Graham
+All The Way|TTBB, SSAA|Brent Graham
+Always On My Mind|TTBB|Brent Graham
+April Showers|TTBB|Brent Graham
+Are You Lonesome Tonight?|SSAA|Brent Graham
+Are You Lonesome Tonight?|TTBB|Brent Graham
+Barbershop in History|TTBB|Brent Graham
+The Best Is Yet To Come|TTBB|Brent Graham
+Big Spender|SSAA|Brent Graham
+Bill Bailey, Won't You Please Come Home?|TTBB|Brent Graham
+Blame It On My Youth|TTBB, SSAA|Brent Graham
+Boy of Mine|TTBB|Brent Graham
+Bridge Over Troubled Water|TTBB, SSAA|Brent Graham
+Broadway Medley|TTBB, SSAA|Brent Graham
+Broken Vow|TTBB|Brent Graham
+By The Sea / In The Good Old Summertime Medley|TTBB, SSAA|Brent Graham
+Bygone Memories|TTBB|Brent Graham
+Cheer Up, Charlie|TTBB, SSAA|Brent Graham
+The Christmas Song|TTBB, SSAA|Brent Graham
+Christmas Was Meant For Children|SSAA|Brent Graham
+Christmastime is here|TTBB, SSAA|Brent Graham
+Cottage For Sale|TTBB|Brent Graham
+Count your blessings|TTBB|Brent Graham
+Crazy World|TTBB, SSAA|Brent Graham
+Cry Me A River|TTBB, SSAA|Brent Graham
+Do I Love You?|TTBB, SSAA|Brent Graham
+Don't Go to Strangers|TTBB|Brent Graham
+Dream A Little Dream Of Me|TTBB|Brent Graham
+East Of The Sun (and West of the Moon)|TTBB|Brent Graham
+Edelweiss|TTBB|Brent Graham
+Embraceable You|TTBB|Brent Graham
+Family Guy Theme Song|TTBB|Brent Graham
+First Day In Heaven|TTBB|Brent Graham
+Forgiven Says It All|TTBB|Brent Graham
+From The First Hello To The Last Goodbye|TTBB, SSAA|Brent Graham
+Getting To Know You|SSAA|Brent Graham
+Grim Grinning Ghosts|TTBB|Brent Graham
+Hallelujah|SATB|Brent Graham
+Happy Birthday To You|TTBB|Brent Graham
+Happy Birthday To You|SSAA|Brent Graham
+Happy Trails|TTBB|Brent Graham
+Have Yourself A Merry Little Christmas|TTBB|Brent Graham
+Heart of My Heart|TTBB|Brent Graham
+Here Am I, Brokenhearted|TTBB, SSAA|Brent Graham
+How Many Hearts Have You Broken? / Them There Eyes Medley|TTBB, SSAA|Brent Graham
+How Sweet It Is To Be Loved By You|TTBB|Brent Graham
+I Can Dream, Can't I?|TTBB|Brent Graham
+I Could Have Danced All Night|TTBB|Brent Graham
+I Had The Craziest Dream|SSAA|Brent Graham
+I Have Dreamed|SSAA|Brent Graham
+I Heard You Cried Last Night|TTBB|Brent Graham
+I Left My Heart At The Stage Door Canteen|TTBB|Brent Graham
+I Never Knew What I Was Missin'|TTBB, SSAA|Brent Graham
+I Remember You|TTBB|Brent Graham
+I Say A Little Prayer For You|SSAA|Brent Graham
+I Wish I Could Shimmy Like My Sister Kate|TTBB, SSAA|Brent Graham
+I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Brent Graham
+I'll Be Here With You|TTBB, SSAA|Brent Graham
+I'll Be Home For Christmas|TTBB, SSAA|Brent Graham
+I'll Never Stop Loving You|TTBB|Brent Graham
+I'll See You In My Dreams|TTBB|Brent Graham
+I'm Gonna Miss Her|TTBB|Brent Graham
+I'm Old Fashioned|TTBB|Brent Graham
+I'm So Glad We Had This Time Together|SSAA|Brent Graham
+I've Grown Accustomed To Her Face|SSAA|Brent Graham
+If|TTBB|Brent Graham
+If Ever I Would Leave You|TTBB, SSAA|Brent Graham
+If I Didn't Care|TTBB|Brent Graham
+If I Ever Say I'm Over You|TTBB, SSAA|Brent Graham
+Invocation|TTBB|Brent Graham
+It Was Almost Like A Song|TTBB|Brent Graham
+It's A Beautiful Day For A Ball Game|TTBB, SSAA|Brent Graham
+It's Been A Long, Long Time|TTBB|Brent Graham
+It's Your Song|TTBB, SSAA|Brent Graham
+Just Bring Tulips Along|TTBB|Brent Graham
+Kiss Me Goodnight!|TTBB, SSAA|Brent Graham
+Laddie|SSAA|Brent Graham
+Last Night Was The End Of The World|TTBB|Brent Graham
+Lavender Blue|TTBB|Brent Graham
+Let It Be|TTBB|Brent Graham
+Let Me Sing And I'm Happy|SSAA|Brent Graham
+Life Is A Highway|SSAA|Brent Graham
+Lili Marlene|TTBB|Brent Graham
+Little Man You've Had A Busy Day|TTBB, SSAA|Brent Graham
+Little On The Lonely Side|SSAA|Brent Graham
+Little On The Lonely Side|TTBB|Brent Graham
+Lonesomest Girl In Town|TTBB|Brent Graham
+Looking at You/I Love You Medley|TTBB|Brent Graham
+Love At Home|TTBB|Brent Graham
+Love Is A Many Splendored Thing|TTBB, SSAA|Brent Graham
+Luck Be A Lady|TTBB|Brent Graham
+The Lucky One|SSAA|Brent Graham
+Make 'Em Laugh|SSAA|Brent Graham
+Maybe This Time|TTBB, SSAA|Brent Graham
+Medley: Impossible Year, It's Impossible|TTBB|Brent Graham
+Moon River|TTBB, SSAA|Brent Graham
+Moonlight Cocktail|TTBB|Brent Graham
+The More I See You|TTBB, SSAA|Brent Graham
+More I See You/Never Be Another You|TTBB|Brent Graham
+Mr. Rogers Medley|TTBB|Brent Graham
+My Father, My Friend, My Dad|TTBB|Brent Graham
+My Foolish Heart|TTBB, SSAA|Brent Graham
+My Sin|TTBB|Brent Graham
+Never Enough|SSAA|Brent Graham
+Never Give All the Heart|TTBB|Brent Graham
+Never-Never Land|TTBB, SSAA|Brent Graham
+Nevertheless|TTBB|Brent Graham
+Night And Day|SSAA|Brent Graham
+On The Street Where You Live|SSAA|Brent Graham
+One Moment in Time|TTBB|Brent Graham
+Out There|TTBB|Brent Graham
+Over The Rainbow|SSAA|Brent Graham
+The Place Where the Lost Things Go|TTBB|Brent Graham
+Prisoner of Love|TTBB|Brent Graham
+Reading Rainbow Theme Song|SSAA|Brent Graham
+Red Head|TTBB, SSAA|Brent Graham
+Rhythm Of Love|SSAA|Brent Graham
+The Right Girl for Me|TTBB|Brent Graham
+Rubber Duckie|TTBB|Brent Graham
+Rudolph The Red Nosed Reindeer|SSAA|Brent Graham
+Scotch And Soda|TTBB|Brent Graham
+Seasons of Love|TTBB|Brent Graham
+See You In September|TTBB|Brent Graham
+September Song|TTBB, SSAA|Brent Graham
+Serenade In Blue|TTBB|Brent Graham
+The Shadow Of Your Smile|TTBB, SSAA|Brent Graham
+She Chose Me|TTBB|Brent Graham
+Shine On Me|TTBB|Brent Graham
+Side by Side|TTBB, SSAA|Brent Graham
+Silver Bells|TTBB, SSAA|Brent Graham
+Sing! (Sing A Song!)|TTBB, SSAA|Brent Graham
+So Long, Farewell, Goodbye|TTBB, SSAA|Brent Graham
+So Long, Sal|TTBB|Brent Graham
+Softly As I Leave You|TTBB, SSAA|Brent Graham
+Somebody Stole My Gal|TTBB|Brent Graham
+Someday|TTBB|Brent Graham
+Someday (You'll Want Me To Want You)|TTBB|Brent Graham
+Somewhere Out There|TTBB, SSAA|Brent Graham
+Spies in the Night|SSAA|Brent Graham
+Star Spangled Banner|TTBB, SSAA|Brent Graham
+Stars Fell On Alabama|TTBB|Brent Graham
+Stay Awake|TTBB|Brent Graham
+Story Of The Rose|TTBB, SSAA|Brent Graham
+The Story|SSAA|Brent Graham
+Sunday|TTBB|Brent Graham
+Swept Away|SSAA|Brent Graham
+Taking A Chance On Love|TTBB|Brent Graham
+Tears In Heaven|TTBB|Brent Graham
+Tell Me Why|SSAA|Brent Graham
+Ten Minutes Ago|TTBB, SSAA|Brent Graham
+That Summer When We Were Young|SSAA|Brent Graham
+That Tumble Down Shack In Athlone|TTBB|Brent Graham
+That's The One Thing That I Didn't Get From You|TTBB, SSAA|Brent Graham
+The Love I Meant To Say|TTBB|Brent Graham
+The Party's Over|TTBB|Brent Graham
+There Used To Be A Ball Park|TTBB, SSAA|Brent Graham
+This Heart of Mine|TTBB|Brent Graham
+This Is It!|TTBB, SSAA|Brent Graham
+This Is The Moment|TTBB, SSAA|Brent Graham
+Tie Me To Your Apron Strings Again|TTBB|Brent Graham
+Time Was|TTBB, SSAA|Brent Graham
+Tonight You Belong To Me|TTBB, SSAA|Brent Graham
+Too Young|TTBB|Brent Graham
+The Touch of Your Lips|SSAA|Brent Graham
+Turn Your Eyes Upon Jesus|TTBB|Brent Graham
+The Twelfth Of Never|TTBB, SSAA|Brent Graham
+Twilight Time|TTBB|Brent Graham
+Up On The Roof|TTBB, SSAA|Brent Graham
+The Very Thought Of You|SSAA|Brent Graham
+Vienna|TTBB|Brent Graham
+Wedding Bells Are Ringing For Sally|TTBB|Brent Graham
+What Are You Doing New Year's Eve?|TTBB, SSAA|Brent Graham
+What I Did For Love|TTBB|Brent Graham
+When Christmas Comes To Town|TTBB, SSAA|Brent Graham
+When Day Is Done|SSAA|Brent Graham
+When I Grow Too Old To Dream|TTBB|Brent Graham
+When I See An Elephant Fly|TTBB|Brent Graham
+When You Wish Upon A Star|TTBB|Brent Graham
+When You're Smiling|TTBB, SSAA|Brent Graham
+Where The Boys Are|SSAA|Brent Graham
+White Cliffs Of Dover|TTBB|Brent Graham
+Who Can I Turn To? (When Nobody Needs Me)|TTBB|Brent Graham
+Why Would A Fellow Want A Girl Like Her?|SSAA|Brent Graham
+With A Song In My Heart|TTBB, SSAA|Brent Graham
+With A Song In My Heart|TTBB|Brent Graham
+Yesterday I Heard The Rain|SSAA|Brent Graham
+Yesterday I Heard The Rain|TTBB, SSAA|Brent Graham
+You Brought A New Kind Of Love To Me|TTBB, SSAA|Brent Graham
+You Keep Coming Back Like A Song|TTBB, SSAA|Brent Graham
+You'll Never Know|SSAA|Brent Graham
+You'll Never Walk Alone|TTBB|Brent Graham
+You've Got a Lot to See|TTBB|Brent Graham
+You, My Love|TTBB|Brent Graham
+Young And Foolish|SSAA|Brent Graham
+Hawaiian War Chant|TTBB|James Graham
+All Dressed Up With A Broken Heart|SSAA|Betty Grant
+Beauty And The Beast|SSAA|Betty Grant
+For Sentimental Reasons|SSAA|Betty Grant
+Freedom|TTBB|Betty Grant
+The Frim Fram Sauce|SSAA|Betty Grant
+Just A Kid Named Joe|SSAA|Betty Grant
+The Ugly Bug Ball|SSAA|Betty Grant
+Blue Star|TTBB|John Grant
+Chinatown My Chinatown|TTBB|Ted Gratz
+After You've Gone|TTBB|Don Gray
+After You've Gone|SSAA|Don Gray
+Always|TTBB|Don Gray
+Anything Goes|TTBB|Don Gray
+Anything You Can Do I Can Do Better|TTBB|Don Gray
+The Banana Boat Song|TTBB|Don Gray
+Because of You|SSAA|Don Gray
+Biggest Aspidastra In The World|TTBB|Don Gray
+Bill Bailey, Won't You Please Come Home?|TTBB|Don Gray
+Birth Of The Blues|TTBB|Don Gray
+Blues In The Night|TTBB|Don Gray
+Comedy Tonight|TTBB|Don Gray
+Crazy 'Bout Ya Baby|TTBB|Don Gray
+Cry|TTBB|Don Gray
+Darktown Strutters' Ball|TTBB|Don Gray
+Darktown Strutters' Ball|SSAA|Don Gray
+Dearie|TTBB|Don Gray
+Deep In My Heart, Dear|TTBB|Don Gray
+Don't Fence Me In|TTBB|Don Gray
+Forgive Me|TTBB|Don Gray
+Halls Of Ivy|TTBB|Don Gray
+Happy Days Are Here Again|TTBB|Don Gray
+Happy Trails|TTBB|Don Gray
+Heigh-Ho|TTBB|Don Gray
+Hello Dolly|TTBB|Don Gray
+How Are Things In Glocca Morra|TTBB|Don Gray
+I Can Dream, Can't I?|SSAA|Don Gray
+I Miss You Most Of All|TTBB|Don Gray
+I Never See Maggie Alone|TTBB|Don Gray
+I Only Want A Buddy, Not A Sweetheart|TTBB|Don Gray
+I'll Fly Away|TTBB|Don Gray
+I'm Afraid Of The Beautiful Girls|TTBB|Don Gray
+I'm An Old Cowhand|TTBB|Don Gray
+I'm Wild About Horns On Automobiles That Go 'Ta-Ta-Ta-Ta'|TTBB|Don Gray
+If I Loved You|TTBB|Don Gray
+If I Ruled The World|TTBB|Don Gray
+If The Lord Be Willin'|TTBB|Don Gray
+If You're Crazy About The Women|TTBB|Don Gray
+Indiana|TTBB|Don Gray
+Irish Blessing|TTBB, SSAA, SATB|Don Gray
+It Had To Be You|TTBB|Don Gray
+It's A Sin To Tell A Lie|TTBB|Don Gray
+Jambalaya|TTBB|Don Gray
+Jolson Medley|TTBB|Don Gray
+Loading Up The Mandy Lee|TTBB|Don Gray
+Marching Along Together|TTBB|Don Gray
+My Best To You|TTBB|Don Gray
+My Honey's Lovin' Arms|TTBB|Don Gray
+My Wild Irish Rose|TTBB|Don Gray
+New Ashmolean Band|TTBB|Don Gray
+New Orleans Funeral Medley|TTBB|Don Gray
+One Alone|TTBB|Don Gray
+Paddlin' Madelin' Home|TTBB|Don Gray
+Please Mr. Columbus|TTBB|Don Gray
+Remember|TTBB|Don Gray
+Riverboat Days|TTBB|Don Gray
+Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Don Gray
+Roses Of Success|TTBB|Don Gray
+Row, Row, Row|TTBB|Don Gray
+Sailin' Away On The Henry Clay|TTBB|Don Gray
+Scarlet Ribbons (For Her Hair)|TTBB|Don Gray
+Serenade|TTBB|Don Gray
+A Shine On Your Shoes|TTBB|Don Gray
+Show Me Where The Good Times Are|TTBB|Don Gray
+So Long, Mother|TTBB|Don Gray
+South Rampart Street Parade|TTBB|Don Gray
+St. Patrick's Day Parade Medley|TTBB|Don Gray
+Stouthearted Men|TTBB|Don Gray
+Student Marching Song|TTBB|Don Gray
+Sweet Georgia Brown|TTBB|Don Gray
+That Tumble Down Shack In Athlone|TTBB|Don Gray
+There I've Said It Again|TTBB, SSAA, SATB|Don Gray
+They All Laughed|TTBB|Don Gray
+Tin Roof Blues|TTBB|Don Gray
+Too Old|TTBB|Don Gray
+Tootsie / Lady Love Medley|TTBB|Don Gray
+Two Ton Tessie|TTBB|Don Gray
+Wait Till You Get Them Up In The Air Boys|TTBB|Don Gray
+Way Down Yonder In New Orleans|TTBB|Don Gray
+Weekend In New England|TTBB|Don Gray
+When I Grow Too Old To Dream|TTBB|Don Gray
+When I Grow too Old to Sing|TTBB|Don Gray
+White Cliffs Of Dover|TTBB|Don Gray
+Who's Sorry Now|TTBB|Don Gray
+World War I Medley|TTBB|Don Gray
+You'll Have To Put A Nightie On Aphrodite|TTBB|Don Gray
+You'll Never Know|TTBB|Don Gray
+You'll Never Walk Alone|TTBB, SSAA, SATB|Don Gray
+You'll Never Walk Alone|TTBB|Don Gray
+Your Land And My Land|TTBB|Don Gray
+Hi Neighbor|TTBB|Richard Gray
+World War I Medley|TTBB|Richard Gray
+Rhythm In My Nursery Rhymes (If I Had)|SSAA|Kay Griffin
+Brahm's Lullaby|SSAA|Paul Grimm
+Finian's Rainbow Medley|SSAA|Paul Grimm
+Have Yourself A Merry Little Christmas|SSAA|Paul Grimm
+Irish Blessing|SSAA|Paul Grimm
+MacNamara's Band|SSAA|Paul Grimm
+Nobody Knows You When You're Down And Out|TTBB|Paul Grimm
+Pal Of My Cradle Days|TTBB|Paul Grimm
+Secret Love|TTBB|Paul Grimm
+Toyland|SSAA|Paul Grimm
+When Irish Eyes Are Smiling|SSAA|Paul Grimm
+With Summer Coming On|SSAA|Paul Grimm
+And I Love You So|TTBB|Joe Grimme
+The Best Is Yet To Come|TTBB|Joe Grimme
+Carol From An Irish Cabin|TTBB|Joe Grimme
+Creep|TTBB|Joe Grimme
+Don't Let Me Be Lonely Tonight|TTBB|Joe Grimme
+Have Yourself A Merry Little Christmas|TTBB|Joe Grimme
+Heaven|TTBB|Joe Grimme
+I'm Still Standing|TTBB|Joe Grimme
+In A Sentimental Mood|TTBB|Joe Grimme
+It Takes Two|TTBB|Joe Grimme
+It's You I Like|TTBB|Joe Grimme
+Itsy Bitsy Spider|TTBB|Joe Grimme
+Just The Way You Are|TTBB|Joe Grimme
+Kiss On My List|TTBB|Joe Grimme
+Like It's Christmas|TTBB|Joe Grimme
+Maneater|TTBB|Joe Grimme
+Nobody's Fool|TTBB|Joe Grimme
+One More Payment|TTBB|Joe Grimme
+Pachelbel's Noel|TTBB|Joe Grimme
+Save The Daylight For Somebody Else|TTBB|Joe Grimme
+Sea Of Love|TTBB|Joe Grimme
+Still The One|TTBB|Joe Grimme
+Twinkle Twinkle Little Me|TTBB|Joe Grimme
+What Are You Doing New Year's Eve?|TTBB|Joe Grimme
+White Christmas|TTBB|Joe Grimme
+'Round Midnight|TTBB|Wayne Grimmer
+A Child is Born|TTBB|Wayne Grimmer
+Ain't No Mountain High Enough|SSAA|Wayne Grimmer
+All About That Bass|SATB|Wayne Grimmer
+Am I Wasting My Time On You|TTBB|Wayne Grimmer
+Angel Eyes|TTBB|Wayne Grimmer
+Body & Soul|TTBB|Wayne Grimmer
+Bread And Gravy|TTBB|Wayne Grimmer
+Bring On The Men|SSAA|Wayne Grimmer
+Buddy Holly|TTBB|Wayne Grimmer
+Build Me Up Buttercup|TTBB|Wayne Grimmer
+Can I Steal A Little Love|TTBB|Wayne Grimmer
+Count Your Blessings Instead Of Sheep|SSAA|Wayne Grimmer
+Darkness Falls Across The Land|TTBB|Wayne Grimmer
+Drop Me Off In Harlem|TTBB|Wayne Grimmer
+Eternal Flame|SSAA|Wayne Grimmer
+F Sharp|TTBB|Wayne Grimmer
+Fight Song|TTBB, SSAA|Wayne Grimmer
+The First Noel|TTBB, SSAA, SATB|Wayne Grimmer
+Fugue for Tinhorns|TTBB|Wayne Grimmer
+Glory Of Love|TTBB|Wayne Grimmer
+I Adore Mi Amore|TTBB|Wayne Grimmer
+I'll Make Love To You|TTBB|Wayne Grimmer
+I'll Never Smile Again|TTBB|Wayne Grimmer
+I've Got My Love To Keep Me Warm|TTBB|Wayne Grimmer
+In Summer|TTBB|Wayne Grimmer
+It's Now Or Never|TTBB|Wayne Grimmer
+It's So Hard To Say Goodbye To Yesterday|TTBB|Wayne Grimmer
+Just Maybe|SATB|Wayne Grimmer
+Kiss To Build A Dream On|TTBB|Wayne Grimmer
+The Lady's In Love With You|TTBB|Wayne Grimmer
+Lean On Me|TTBB|Wayne Grimmer
+Let The Good Times Roll|TTBB|Wayne Grimmer
+Let's Live It Up|TTBB|Wayne Grimmer
+Lil Darlin'|TTBB|Wayne Grimmer
+Lily's Eyes|TTBB|Wayne Grimmer
+Lonely House|TTBB|Wayne Grimmer
+Manhattan|TTBB|Wayne Grimmer
+Medley: I Love Rock 'n Roll, Call ME, If I Could Turn Back Time, What About Love?|SSAA|Wayne Grimmer
+Medley: I'll Be There For You, Never Say Goodbye|TTBB|Wayne Grimmer
+New York State of Mind|TTBB|Wayne Grimmer
+Now We Sing|SATB|Wayne Grimmer
+One, Two, Three|SATB|Wayne Grimmer
+Operator|SSAA|Wayne Grimmer
+Paradise by the Dashboard Light|TTBB|Wayne Grimmer
+Rainbow|SSAA|Wayne Grimmer
+Reflection|SATB|Wayne Grimmer
+Satin Doll|TTBB|Wayne Grimmer
+Saving All My Love For You|TTBB|Wayne Grimmer
+Shut Up And Dance|TTBB|Wayne Grimmer
+Sing|TTBB, SSAA, SATB|Wayne Grimmer
+Sugar (That Sugar Baby O'Mine)|TTBB, SSAA, SATB|Wayne Grimmer
+Take A Bow|TTBB|Wayne Grimmer
+"Take The ""A"" Train"|TTBB|Wayne Grimmer
+Try A Little Tenderness|TTBB|Wayne Grimmer
+What I Did For Love|TTBB|Wayne Grimmer
+When I Take My Sugar To Tea|TTBB|Wayne Grimmer
+You Can't Stop the Sun|TTBB, SSAA, SATB|Wayne Grimmer
+You Can't Stop the Sun|SSAA|Wayne Grimmer
+Alexander's Ragtime Band|TTBB|S. K. Grundy
+Back In My Home Town|TTBB|S. K. Grundy
+Each Time I Fall In Love|TTBB, SSAA|S. K. Grundy
+Good Nght My Someone|TTBB|S. K. Grundy
+A Nightingale Sang In Berkeley Square|TTBB|S. K. Grundy
+Perfect Day|TTBB|S. K. Grundy
+After You've Gone|TTBB|Joel Guyer
+It's A Wonderful World (Loving Wonderful You)|TTBB|Joel Guyer
+Ac-cent-tchu-ate The Positive|TTBB|Warren 'Buzz' Haeger
+And So To Sleep Again|SATB|Warren 'Buzz' Haeger
+Cabaret|TTBB|Warren 'Buzz' Haeger
+Careless|TTBB|Warren 'Buzz' Haeger
+Dear Old Days|TTBB|Warren 'Buzz' Haeger
+Easy Street|TTBB|Warren 'Buzz' Haeger
+Hold Out Your Hand|TTBB|Warren 'Buzz' Haeger
+I Asked The Lord|TTBB|Warren 'Buzz' Haeger
+I Don't Know Why|SSAA, Young SSAA|Warren 'Buzz' Haeger
+I May Be Gone For A Long Long Time|TTBB|Warren 'Buzz' Haeger
+I'm A Wild And Wooly Son Of The West|TTBB|Warren 'Buzz' Haeger
+I'm Tying The Leaves|TTBB|Warren 'Buzz' Haeger
+If I Had A Girl Like You|TTBB|Warren 'Buzz' Haeger
+Just a Smile Just a Kiss from You|TTBB|Warren 'Buzz' Haeger
+Laugh Clown Laugh|TTBB|Warren 'Buzz' Haeger
+Man With The Ladder And The Hose|TTBB|Warren 'Buzz' Haeger
+My Heart Stood Still|TTBB|Warren 'Buzz' Haeger
+My Wife The Dancer|TTBB|Warren 'Buzz' Haeger
+Old Fashioned Locket And A Curl|TTBB|Warren 'Buzz' Haeger
+Old Folks|TTBB|Warren 'Buzz' Haeger
+Take My Hand, Precious Lord|TTBB|Warren 'Buzz' Haeger
+That's What God Made Mothers For|TTBB|Warren 'Buzz' Haeger
+There Never Was A Gang Like Mine|TTBB|Warren 'Buzz' Haeger
+This Is All I Ask|TTBB|Warren 'Buzz' Haeger
+Time After Time|TTBB|Warren 'Buzz' Haeger
+Wahoo|TTBB|Warren 'Buzz' Haeger
+Wait Till The Sun Shines, Nellie|TTBB|Warren 'Buzz' Haeger
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|Warren 'Buzz' Haeger
+When You Wore A Tulip|TTBB|Warren 'Buzz' Haeger
+Dancing In The Street|SSAA|Ã…se Hagerman
+Dancing Queen|SSAA|Ã…se Hagerman
+Sisters Are Doing It For Themselves|SSAA|Ã…se Hagerman
+Thunder And Lightning|SSAA|Ã…se Hagerman
+After You Get What You Want You Don't Want It|SSAA|Dawn Haggerty
+All Of Me|SSAA|Dawn Haggerty
+A Christmas Carol|SSAA|Dawn Haggerty
+Don't|SSAA|Dawn Haggerty
+Eternal Flame|SSAA|Dawn Haggerty
+Glad Rag Doll|SSAA|Dawn Haggerty
+God Only Knows|SSAA|Dawn Haggerty
+I Love To Have The Boys Around Me|SSAA|Dawn Haggerty
+Let It Rain|SSAA|Dawn Haggerty
+Like A Prayer|SSAA|Dawn Haggerty
+One Fine Day|SSAA|Dawn Haggerty
+That's Christmas To Me|SSAA|Dawn Haggerty
+The Vatican Rag|SSAA|Dawn Haggerty
+When I Get Low I Get High|SSAA|Dawn Haggerty
+Turn Around, Look At Me|TTBB|Gordon Haines
+New York Medley|SSAA|Lynn Haldeman
+New York Medley|TTBB|Lynn Haldeman
+Goodnight, Irene|TTBB|Jack Hale
+Beautiful Star of Bethlehem|TTBB|John Hale
+He Looked Beyond My Fault|TTBB|John Hale
+He Will Set Your Fields On Fire|TTBB|John Hale
+Sweet, Sweet Spirit|TTBB|John Hale
+There Will Be Peace In The Valley For Me|TTBB|John Hale
+There's Something About That Name|TTBB|John Hale
+All God's Chillun Got Rhythm/Clap Yo' Hands Medley|TTBB|Mark Hale
+Always|TTBB|Mark Hale
+Beatles Sunshine Medley|TTBB, SSAA, SATB|Mark Hale
+Christmas Eve In My Home Town|TTBB|Mark Hale
+Give Me A Night In June|TTBB|Mark Hale
+How High The Moon|TTBB, SSAA|Mark Hale
+Ob-La-Di, Ob-La-Da|TTBB|Mark Hale
+Singin' In The Rain Medley|TTBB|Mark Hale
+Tangerine|TTBB|Mark Hale
+The Way You Look Tonight|TTBB|Mark Hale
+Too Marvelous For Words|TTBB|Mark Hale
+Why Do I Love You|TTBB|Mark Hale
+Wrap Your Troubles In Dreams|TTBB|Mark Hale
+Hallelujah|SSAA|Gayle Haley
+Lean On Me|SSAA|Gayle Haley
+Once You Lose Your Heart|SSAA|Gayle Haley
+Give Me A Barbershop Song|TTBB, SSAA|Steve Hall
+Remember Pearl Harbor|TTBB|Don Hallock
+Five Hundred Guys|TTBB|James Halvorson
+Night And Day|TTBB|James Halvorson
+Summer Wind|TTBB|James Halvorson
+Two Hearts|TTBB|James Halvorson
+You Needed Me|TTBB|James Halvorson
+On The Bright Side of Life|TTBB|Will Hamblet
+Perfect Day|TTBB|Bill Hamilton
+Little Bit Of Heaven|TTBB|Keith Hamilton
+Your Eyes Have Told Me So|TTBB|Keith Hamilton
+Dancing In The Street|SSAA|Marie Hampton
+Here Comes Santa Claus|SSAA|Marie Hampton
+Hymn For A Sunday Evening (Ed Sullivan)|SSAA|Marie Hampton
+Occapella|SSAA|Marie Hampton
+Old Fashioned Wedding|SSAA|Marie Hampton
+All I Have To Do Is Dream|SSAA|Kathy Hanneson
+I'm Shooting High|SSAA|Kathy Hanneson
+Rhythm Of The Rain|SSAA|Kathy Hanneson
+Should I|SSAA|Kathy Hanneson
+Side by Side|SSAA|Kathy Hanneson
+Lullaby In Ragtime|TTBB|Dale Hanson
+One Fine Day|TTBB|Dale Hanson
+Book Of Love|SSAA|Katherine Hardie
+If I Fell|TTBB, SSAA|Brian Harding
+Ain't That A Kick In The Head|TTBB|Steve Hardy
+Cows May Come, Cows May Go|TTBB|Steve Hardy
+Ev'ry Morning She Makes Me Late|TTBB|Steve Hardy
+Goodnight, Little Girl Of My Dreams|TTBB|Steve Hardy
+Hungry Women|TTBB|Steve Hardy
+I Love The Way You're Breaking My Heart|TTBB|Steve Hardy
+I Thought About You|TTBB|Steve Hardy
+I Was Floating Down The Old Green River|TTBB|Steve Hardy
+I Yust Go Nuts at Christmas|TTBB|Steve Hardy
+If I Had Rhythm In My Nursery Rhymes|TTBB|Steve Hardy
+It All Depends On You|TTBB|Steve Hardy
+Just An Ivy Covered Shack|TTBB|Steve Hardy
+Just The Way You Are|TTBB|Steve Hardy
+Kiss To Build A Dream On|TTBB|Steve Hardy
+Little Curly Hair In A High Chair|TTBB|Steve Hardy
+Moonlight On The Ganges|TTBB|Steve Hardy
+Nellie Kelly, I Love You|TTBB|Steve Hardy
+Oh Mabel|TTBB|Steve Hardy
+On The Other End Of A Kiss|TTBB|Steve Hardy
+Saloon|TTBB|Steve Hardy
+She Believes in Me|TTBB|Steve Hardy
+She's The Daughter Of Mother Machree|TTBB|Steve Hardy
+Up In Mabel's Room|TTBB|Steve Hardy
+A Million Dreams|TTBB, SSAA|Rowena Harper
+Ain't That A Kick In The Head|TTBB|Rowena Harper
+As The World Caves In|SSAA|Rowena Harper
+Back To You|TTBB, SATB|Rowena Harper
+The Bell Carol|SSAA|Rowena Harper
+Candy Cane Lane|TTBB, SSAA|Rowena Harper
+Creep|TTBB|Rowena Harper
+Crocodile Rock|SSAA|Rowena Harper
+Cry Today, Smile Tomorrow|SSAA|Rowena Harper
+Dance The Night|SSAA|Rowena Harper
+Distant Sun|SATB|Rowena Harper
+Don't Dream It's Over|SSAA|Rowena Harper
+Don't Nobody Bring Me No Bad News|SSAA|Rowena Harper
+Dreamer|SSAA|Rowena Harper
+Easy|TTBB|Rowena Harper
+Ex's & Oh's|SSAA|Rowena Harper
+Fix You|TTBB, SATB|Rowena Harper
+Four Seasons In One Day|TTBB|Rowena Harper
+I Go To Rio|SSAA|Rowena Harper
+I Want It That Way|TTBB|Rowena Harper
+I Will Survive|SSAA|Rowena Harper
+Medley: Candyman, The Candy Man|SSAA|Rowena Harper
+Medley: This Is Me, Unstoppable|SSAA|Rowena Harper
+Money, Money, Money|SSAA|Rowena Harper
+Perfect|SSAA|Rowena Harper
+Perfect Duet|TTBB, SATB|Rowena Harper
+Rhiannon|SSAA|Rowena Harper
+See You Again|SSAA|Rowena Harper
+Snowman|SSAA|Rowena Harper
+Something in the Water|SSAA, SATB|Rowena Harper
+Somewhere Only We Know|SSAA, SATB|Rowena Harper
+A Thousand Years|SSAA|Rowena Harper
+The Tide is High|SSAA|Rowena Harper
+Under Pressure|SATB|Rowena Harper
+Welcome Home|TTBB|Rowena Harper
+You're The Inspiration|TTBB, SSAA|Rowena Harper
+A Garden In The Rain|TTBB, SSAA|David Harrington
+After Today|TTBB, SSAA|David Harrington
+All Alone|TTBB, SSAA|David Harrington
+Almost Like Being In Love|TTBB, SSAA|David Harrington
+Am I Blue?|TTBB, SSAA|David Harrington
+April Showers|TTBB, SSAA|David Harrington
+April Showers|SSAA|David Harrington
+Back Home Again In Indiana|TTBB|David Harrington
+Bill Bailey, Won't You Please Come Home?|TTBB|David Harrington
+Bill Bailey, Won't You Please Come Home? / The Man Song Medley|TTBB|David Harrington
+Bless This House|TTBB|David Harrington
+Daydream Believer|TTBB|David Harrington
+Death Of A Bachelor|TTBB|David Harrington
+Do - Re - Mi|TTBB|David Harrington
+Don't Rain on My Parade|TTBB, SSAA|David Harrington
+Don't Sit under The Apple Tree|TTBB, SSAA|David Harrington
+Dry Bones|TTBB, SSAA|David Harrington
+Eight Days a Week|TTBB, SSAA|David Harrington
+Feeling Good|TTBB, SSAA|David Harrington
+The First Noel|TTBB|David Harrington
+The First Noel|SATB|David Harrington
+Fly To Heaven Medley|TTBB|David Harrington
+Georgia On My Mind|TTBB, SSAA|David Harrington
+God Rest Ye Merry, Gentlemen|SATB|David Harrington
+Great Day|TTBB, SSAA|David Harrington
+Happy Birthday To You|TTBB, SSAA|David Harrington
+Hark! The Herald Angels Sing|TTBB|David Harrington
+Hark! The Herald Angels Sing|TTBB, SSAA|David Harrington
+Hark! The Herald Angels Sing|SATB|David Harrington
+Have Yourself A Merry Little Christmas|TTBB, SSAA|David Harrington
+Hello My Baby|TTBB, SSAA|David Harrington
+Honey That I Love So Well / My Honey's Lovin' Arms Medley|TTBB, SSAA|David Harrington
+I Believe|TTBB|David Harrington
+I Can't Give You Anything But Love|TTBB, SSAA|David Harrington
+I Get The Blues When It Rains|TTBB, SSAA|David Harrington
+I Have A Feeling For You|TTBB, SSAA|David Harrington
+I Want To Hold Your Hand|TTBB, SSAA|David Harrington
+I Will|TTBB, SSAA|David Harrington
+I'm In The Mood For Love|TTBB|David Harrington
+I'm In The Mood For Love|TTBB, SSAA|David Harrington
+If I Had My Way|TTBB, SSAA|David Harrington
+It Came Upon A Midnight Clear|SATB|David Harrington
+It Came Upon A Midnight Clear|TTBB|David Harrington
+It Is Well With My Soul|TTBB, SSAA|David Harrington
+It's Foxy|TTBB|David Harrington
+Jingle Bells|SATB|David Harrington
+Jingle Bells|TTBB|David Harrington
+Jingle Bells|TTBB, SSAA|David Harrington
+Joy To The World|SATB|David Harrington
+Joy To The World|TTBB|David Harrington
+Just A Little Talk With Jesus|TTBB, SSAA|David Harrington
+Let There Be Peace On Earth|SATB|David Harrington
+Lonesomest Girl In Town|TTBB|David Harrington
+Looking For A Boy|SSAA|David Harrington
+Luck Be A Lady|TTBB, SSAA|David Harrington
+Margie|TTBB|David Harrington
+My Honey's Lovin' Arms|TTBB, SSAA|David Harrington
+Nearer, My God, To Thee|TTBB|David Harrington
+A Nightingale Sang In Berkeley Square|TTBB, SSAA|David Harrington
+No, No, Nora / I know that you know Medley|TTBB|David Harrington
+O Little Town Of Bethlehem|SATB|David Harrington
+O Little Town Of Bethlehem|TTBB|David Harrington
+Oh! Darling|TTBB, SSAA|David Harrington
+Only You (And You Alone)|TTBB, SSAA|David Harrington
+Orange Colored Sky|TTBB, SSAA|David Harrington
+Paper Doll|TTBB|David Harrington
+Pennies from Heaven|TTBB, SSAA|David Harrington
+Pick Yourself Up|TTBB, SSAA|David Harrington
+Pick Yourself Up|SSAA|David Harrington
+She's Out Of My Life|TTBB|David Harrington
+Side by Side|SSAA|David Harrington
+Silent Night|SATB|David Harrington
+Silent Night|TTBB|David Harrington
+So Much In Love|TTBB, SSAA|David Harrington
+Star Spangled Banner|TTBB, SSAA|David Harrington
+Strike Up The Band / Alexander's Ragtime Band Medley|TTBB, SSAA|David Harrington
+Sunrise, Sunset|TTBB|David Harrington
+Swingin' On A Star|TTBB|David Harrington
+That's Life|TTBB, SSAA|David Harrington
+This Boy|TTBB, SSAA|David Harrington
+This Heart of Mine|TTBB, SSAA|David Harrington
+The Twelve Days Of Christmas|SATB|David Harrington
+The Twelve Days Of Christmas|TTBB|David Harrington
+We Wish You A Merry Christmas|TTBB, SSAA|David Harrington
+We Wish You A Merry Christmas|SATB|David Harrington
+We Wish You A Merry Christmas|TTBB|David Harrington
+What Kind Of Fool Am I|TTBB, SSAA|David Harrington
+When I Lost You|TTBB|David Harrington
+When My Sugar Walks Down The Street|TTBB, SSAA|David Harrington
+When You're Smiling|TTBB, SSAA|David Harrington
+You And I|TTBB|David Harrington
+You And I|TTBB, SSAA|David Harrington
+You Don't Know Me|TTBB, SSAA|David Harrington
+You've Got A Friend In Me|TTBB, SSAA|David Harrington
+The Nearness Of You|TTBB|Andrew Harris
+Over The Rainbow|TTBB|Cliff Harris
+Aquarius/Let The Sunshine Medley|TTBB|Keith Harris
+Still The One|TTBB, SSAA, SATB|Scott Harris
+Tiger Rag|TTBB|Stan Harris
+Embraceable You|SSAA|Rudy Hart
+Little Lady Make Believe|SSAA|Rudy Hart
+Near To The Heart Of God|TTBB|Rudy Hart
+Nearer, My God, To Thee|TTBB|Rudy Hart
+Parade Of The Wooden Soldiers|SSAA|Penny Hartmann
+Ain't That A Kick In The Head|TTBB, SSAA|Richard Hasty
+Bring Him Home|SSAA|Richard Hasty
+I Will Go Sailing No More|TTBB, SSAA, SATB|Richard Hasty
+My Romance|TTBB|Richard Hasty
+Old Fashioned Girl/Sweet And Lovely Medley|TTBB|Richard Hasty
+With A Little Help From My Friends|TTBB, SSAA|Richard Hasty
+Bell-Chord Blues|TTBB|Derek Hatley
+Black Water|TTBB|Derek Hatley
+Hold Me Thrill Me Kiss Me|TTBB|Derek Hatley
+Men|TTBB|Derek Hatley
+Moonlight Serenade|TTBB|Derek Hatley
+Sally|TTBB|Derek Hatley
+Makin' Whoopee|SSAA|Jeanette Hawkenson
+Stolen Moments|SSAA|Jeanette Hawkenson
+Sweet Adelines Tapestry|SSAA|Jeanette Hawkenson
+Rubber Duckie|TTBB|Ben Hawker
+What Are You Doing New Year's Eve?|SATB|Ben Hawker
+As Long As You're Not In Love|SSAA|Carolyn Healey
+Bare Necessities|SSAA|Carolyn Healey
+Beep Beep|SSAA|Carolyn Healey
+Boogie Woogie Bugle Boy|SSAA|Carolyn Healey
+The Boy From New York City|SSAA|Carolyn Healey
+Chances Are|SSAA|Carolyn Healey
+Cry Me A River|SSAA|Carolyn Healey
+Don't Blame Me|SSAA|Carolyn Healey
+Don't Nobody Bring Me No Bad News|SSAA|Carolyn Healey
+Embraceable You|SSAA|Carolyn Healey
+Everything|SSAA|Carolyn Healey
+Georgia Cabin Door|SSAA|Carolyn Healey
+Give A Little Love|SSAA|Carolyn Healey
+God Bless The U.S.A.|SSAA|Carolyn Healey
+Grandma Got Run Over By A Reindeer|SSAA|Carolyn Healey
+I Wanna Be Around|SSAA|Carolyn Healey
+Love Letters|SSAA|Carolyn Healey
+Make Believe|SSAA|Carolyn Healey
+Moonlight Serenade|SSAA|Carolyn Healey
+The Nearness Of You|SSAA|Carolyn Healey
+Put Your Head On My Shoulder|SSAA|Carolyn Healey
+Saturday Night in Toledo, Ohio|SSAA|Carolyn Healey
+Scotch And Soda|SSAA|Carolyn Healey
+Song's Gotta Come From The Heart|SSAA|Carolyn Healey
+Summertime, Summertime|SSAA|Carolyn Healey
+This Ole House|SSAA|Carolyn Healey
+Tuxedo Junction|SSAA|Carolyn Healey
+Who Put The Bomp|SSAA|Carolyn Healey
+Ballad Of Gilligan's Isle Parody|TTBB|Chris Hebert
+Powder Your Face With Sunshine|TTBB|Chris Hebert
+Yo-Ho A Pirate's Life For Me|TTBB|Chris Hebert
+One Voice|SSAA|Susan Heimburger
+Phfft! You Were Gone Parody|SSAA|Susan Heimburger
+Red Sails In The Sunset|SSAA|Susan Heimburger
+I Love Lucy Theme Song|SSAA|Ryan Heller
+Whatever Lola Wants|SSAA|Ryan Heller
+Bill Grogan's Goat|SSAA|Michael Hengelsberg
+I Can Dream, Can't I?|SSAA|Michael Hengelsberg
+Let's Gather Round The Parlor Piano|SSAA|Michael Hengelsberg
+Mood Indigo|SSAA|Michael Hengelsberg
+Pirates Who Don't Do Anything|SATB|Michael Hengelsberg
+Stay Awake|SSAA|Michael Hengelsberg
+Alleluia|TTBB|James Henry
+Because|TTBB|James Henry
+Cheer Up, Charlie|TTBB, SSAA|James Henry
+Drive My Car|TTBB|James Henry
+Get Ready|TTBB|James Henry
+I Still Can't Say Goodbye|TTBB|James Henry
+My Old Man's A Sailor|TTBB|James Henry
+Paperback Writer|TTBB|James Henry
+Revolting Children|SATB|James Henry
+Some Children See Him|TTBB|James Henry
+Sometimes|TTBB|James Henry
+Beauty And The Beast|SSAA|Nina Herdes
+All The Things You Are|SSAA|Dorothy Herivel
+Man I Love|SSAA|Dorothy Herivel
+Route 66|SSAA|Dorothy Herivel
+Waitin' For The Train To Come In|SSAA|Dorothy Herivel
+Where Did The Circus Go?|SSAA|Dorothy Herivel
+Chicago Medley|TTBB|Don Hewey
+For Me And My Gal|TTBB|Don Hewey
+For The Sake Of Auld Lang Syne|TTBB|Don Hewey
+I'm Sittin' Pretty In A Pretty Little City|TTBB|Don Hewey
+Hometown Band|TTBB|Jim Hickman
+I Wanna Be A Front Row Man|TTBB|Jim Hickman
+Sioux City Sue|TTBB|Jim Hickman
+Stars Are The Windows Of Heaven|TTBB|Jim Hickman
+Tumbling Tumbleweeds|TTBB|Jim Hickman
+Utah Trail|TTBB|Jim Hickman
+When Your Old Wedding Ring Was New|TTBB|Jim Hickman
+'Til I Hear You Sing|TTBB, SSAA, SATB|Theodore Hicks
+All Is Well|SATB|Theodore Hicks
+Another You|TTBB|Theodore Hicks
+Anything Can Happen|TTBB|Theodore Hicks
+As Long As You're Mine|TTBB, SATB|Theodore Hicks
+Being Alive|TTBB|Theodore Hicks
+A Bit of Earth|TTBB|Theodore Hicks
+Born To Be Blue|TTBB|Theodore Hicks
+Bring Me Sunshine|TTBB, SSAA|Theodore Hicks
+Butterfly Kisses|TTBB|Theodore Hicks
+Cleanin' Up The Town|TTBB|Theodore Hicks
+Come What May|SATB|Theodore Hicks
+Cottage For Sale|TTBB|Theodore Hicks
+Dance With My Father|TTBB|Theodore Hicks
+The Days Back When|TTBB|Theodore Hicks
+Die A Happy Man|TTBB|Theodore Hicks
+Do You Love Me|TTBB|Theodore Hicks
+Evermore|TTBB|Theodore Hicks
+Fallen Angel|TTBB|Theodore Hicks
+For Forever|TTBB|Theodore Hicks
+Forever Now|TTBB|Theodore Hicks
+Gimme Some Lovin'|TTBB|Theodore Hicks
+Gran Torino|TTBB|Theodore Hicks
+The Greatest Show|SATB|Theodore Hicks
+Guys And Dolls|TTBB|Theodore Hicks
+Hold You A Little Too Long|TTBB, SSAA, SATB|Theodore Hicks
+How Am I Supposed To Live Without You|TTBB|Theodore Hicks
+How Could I Ever Know?|TTBB, SSAA, SATB|Theodore Hicks
+I Don't Know How To Say Goodbye|TTBB, SATB|Theodore Hicks
+I Have Nothing|TTBB|Theodore Hicks
+I Know Where I've Been|TTBB|Theodore Hicks
+I See The Light|TTBB, SSAA, SATB|Theodore Hicks
+I Think, I Love|TTBB|Theodore Hicks
+I Thought She Knew|TTBB, SSAA|Theodore Hicks
+I Want You Back|TTBB|Theodore Hicks
+I Won't Send Roses|TTBB|Theodore Hicks
+I'll Be Home For Christmas|TTBB|Theodore Hicks
+I've Gotta Be Me|TTBB|Theodore Hicks
+I've Never Been In Love Before|TTBB|Theodore Hicks
+If I Can't Love Her|TTBB|Theodore Hicks
+If I Never Knew You|TTBB, SSAA, SATB|Theodore Hicks
+The Impossible Dream|TTBB|Theodore Hicks
+It's Been A Long, Long Time|TTBB|Theodore Hicks
+It's Not Where You Start It's Where You Finish|TTBB, SSAA|Theodore Hicks
+It's Over Isn't It|TTBB, SSAA|Theodore Hicks
+Jack's Lament|TTBB|Theodore Hicks
+Jealous|SSAA|Theodore Hicks
+Kiss The Girl|TTBB|Theodore Hicks
+Knights Of The Round Table|TTBB|Theodore Hicks
+Let's Start Tomorrow Tonight|TTBB|Theodore Hicks
+Listen|TTBB|Theodore Hicks
+Losing My Mind|TTBB|Theodore Hicks
+Love Story|TTBB|Theodore Hicks
+The Mad Hatter|SSAA|Theodore Hicks
+Man With The Bag|TTBB|Theodore Hicks
+Mary Did You Know|TTBB, SSAA|Theodore Hicks
+Maybe This Time|SSAA|Theodore Hicks
+Medley: Knights of the Round Table, Men in Tights|TTBB|Theodore Hicks
+My Best Girl|TTBB|Theodore Hicks
+My Way|TTBB|Theodore Hicks
+Never Too Late|TTBB|Theodore Hicks
+Once More I Can See|TTBB|Theodore Hicks
+Perfect|TTBB|Theodore Hicks
+The Perfect Fan|TTBB|Theodore Hicks
+The Place Where the Lost Things Go|TTBB|Theodore Hicks
+Practical arrangement|TTBB|Theodore Hicks
+Reflection|TTBB, SSAA|Theodore Hicks
+Run, Freedom Run!|TTBB|Theodore Hicks
+Santa Fe|TTBB|Theodore Hicks
+Secondhand White Baby Grand|TTBB|Theodore Hicks
+Seize The Day|TTBB|Theodore Hicks
+She Chose Me|TTBB|Theodore Hicks
+She Used To Be Mine|TTBB, SSAA, SATB|Theodore Hicks
+She's Got A Way|TTBB|Theodore Hicks
+Sixty Seconds Got Together|TTBB|Theodore Hicks
+Skyfall|TTBB|Theodore Hicks
+So Big/So Small|TTBB|Theodore Hicks
+Someone's Waiting For You|SSAA|Theodore Hicks
+Something To Shout About|TTBB|Theodore Hicks
+Somewhere Out There|SATB|Theodore Hicks
+Supermarket Flowers|TTBB|Theodore Hicks
+Take Me As I Am|TTBB|Theodore Hicks
+Thank You For Being My Dad|TTBB|Theodore Hicks
+The Luckiest|TTBB|Theodore Hicks
+There's a Fine Fine Line|TTBB, SSAA|Theodore Hicks
+Under The Sea|TTBB|Theodore Hicks
+Waving Through A Window|TTBB, SSAA|Theodore Hicks
+What I Did For Love|TTBB|Theodore Hicks
+When I Grow Too Old To Dream|TTBB|Theodore Hicks
+When I Look At You|SSAA|Theodore Hicks
+When Your Feet Don't Touch The Ground|TTBB|Theodore Hicks
+A Whole New World|SATB|Theodore Hicks
+You're A Good Man, Charlie Brown|TTBB|Theodore Hicks
+You're Still You|TTBB|Theodore Hicks
+Yours is My Heart Alone|TTBB|Theodore Hicks
+By The Beautiful Sea|TTBB|Val Hicks
+By The Light Of The Silvery Moon|TTBB|Val Hicks
+Bye Bye Blues|TTBB|Val Hicks
+Cecilia|TTBB|Val Hicks
+College Medley|TTBB|Val Hicks
+Don't Cry Joe|TTBB|Val Hicks
+For Sale, One Broken Heart|SSAA|Val Hicks
+For Sale, One Broken Heart|TTBB|Val Hicks
+George M. Cohan Medley|TTBB|Val Hicks
+Good Night, Little Boy Of Mine|TTBB|Val Hicks
+Good Night, Little Boy Of Mine|SSAA|Val Hicks
+Hello My Baby|TTBB|Val Hicks
+How To Build A Chorus|TTBB|Val Hicks
+I Ain't Got No Body|TTBB|Val Hicks
+I Love To Hear That Old Barbershop Style|SSAA|Val Hicks
+I Love To Hear That Old Barbershop Style|TTBB|Val Hicks
+I Love To Laugh|TTBB|Val Hicks
+I Wrote The Book|TTBB|Val Hicks
+I'd Love To Live In Loveland|TTBB|Val Hicks
+I'll Be A Song And Dance Man Again|TTBB|Val Hicks
+I'll Take Her Back|TTBB|Val Hicks
+I've Grown Accustomed To Her Face|TTBB|Val Hicks
+It's A Good Day|TTBB|Val Hicks
+Jolly Holiday|TTBB|Val Hicks
+Let's Have An Old Fashioned Christmas|TTBB|Val Hicks
+Lord Bless You And Keep You|TTBB|Val Hicks
+Love's Old Sweet Song|TTBB, SSAA|Val Hicks
+Mandy Make Up Your Mind|TTBB|Val Hicks
+Memories|TTBB|Val Hicks
+Mister Sandman|TTBB, SSAA|Val Hicks
+Moments To Remember|TTBB|Val Hicks
+My Christmas Wish For You|SSAA|Val Hicks
+My Life, My Love, My Song|SSAA|Val Hicks
+My Life, My Love, My Song|TTBB|Val Hicks
+Now Is The Hour|TTBB|Val Hicks
+On A Sunday Afternoon|TTBB|Val Hicks
+One|TTBB|Val Hicks
+Peggy O'Neil|TTBB|Val Hicks
+A Pitchpipe, A Song, And A Smile|TTBB|Val Hicks
+Ring Out The Bells|SSAA|Val Hicks
+Ring Out The Bells|SATB|Val Hicks
+Row, Row, Row|TTBB|Val Hicks
+Senior Citizen Blues|TTBB|Val Hicks
+She Didn't Say No|TTBB|Val Hicks
+Shine On, Harvest Moon|TTBB|Val Hicks
+The Showboat Came to Town|TTBB|Val Hicks
+Singing Here With Dad|TTBB|Val Hicks
+Star Spangled Banner|TTBB|Val Hicks
+Star Spangled Banner|SSAA|Val Hicks
+Summer Sounds|TTBB|Val Hicks
+Ten Feet Off The Ground|SSAA|Val Hicks
+Ten Feet Off The Ground|TTBB|Val Hicks
+Thanks For The Buggy Ride|TTBB|Val Hicks
+There Used To Be A Ballpark Right Here|SSAA|Val Hicks
+There Used To Be A Ballpark Right Here|TTBB|Val Hicks
+This Little Light Of Mine|TTBB|Val Hicks
+This Little Light Of Mine / Do Lord Medley|SSAA|Val Hicks
+This Little Light Of Mine / Do Lord Medley|TTBB|Val Hicks
+True Love|TTBB|Val Hicks
+True Love|SSAA|Val Hicks
+Two Patriotic Classics|TTBB|Val Hicks
+When I Lost You|TTBB|Val Hicks
+When That Great Day Comes|TTBB|Val Hicks
+While Strolling Through The Park One Day|TTBB|Val Hicks
+Yes Sir, That's My Baby|TTBB|Val Hicks
+You Broke The Only Heart That Ever Loved You|TTBB|Val Hicks
+There's a Rose On Your Cheek|TTBB|John Hill
+At Last|TTBB|Clay Hine
+Blue Skies|SATB|Clay Hine
+Blue Skies|TTBB|Clay Hine
+Christmas Waltz|TTBB|Clay Hine
+Come Rain Or Come Shine|TTBB|Clay Hine
+Don't Get Around Much Anymore|TTBB|Clay Hine
+Down Yonder|TTBB|Clay Hine
+Dream A Little Dream Of Me|TTBB|Clay Hine
+Fit As A Fiddle|TTBB, SSAA|Clay Hine
+Five Foot Two|TTBB|Clay Hine
+Five Minutes More|SSAA|Clay Hine
+For All We Know|SSAA|Clay Hine
+God Only Knows|TTBB|Clay Hine
+Have Yourself A Merry Little Christmas|SATB|Clay Hine
+Help!|SATB|Clay Hine
+I Can't Give You Anything But Love|TTBB|Clay Hine
+I Will Never Pass This Way Again|TTBB|Clay Hine
+If I Only Had A Brain|SSAA|Clay Hine
+The Impossible Dream|SSAA|Clay Hine
+In My Daughter's Eyes|TTBB|Clay Hine
+It's A Great Day For The Irish|TTBB|Clay Hine
+It's Only A Paper Moon|TTBB|Clay Hine
+It's The Most Wonderful Time Of The Year|TTBB|Clay Hine
+It's the Music that Brings Us Together|TTBB, SSAA, SATB|Clay Hine
+Lazy River|TTBB|Clay Hine
+Lonesomest Girl In Town|TTBB|Clay Hine
+Look To The Rainbow|TTBB|Clay Hine
+Make 'Em Laugh|SSAA|Clay Hine
+Make You Feel My Love|TTBB|Clay Hine
+Maybe This Time|SSAA|Clay Hine
+Medley: A Wonderful Day Like Today, Nothing Can Stop Me Now!|SSAA|Clay Hine
+Most Wonderful Time Of The Year|TTBB|Clay Hine
+Oh! What A Pal Was Mary|TTBB|Clay Hine
+On The Sunny Side Of The Street|TTBB|Clay Hine
+Over The Rainbow|TTBB, SSAA|Clay Hine
+Please Don't Make Me Love You|TTBB|Clay Hine
+Sleigh Ride|TTBB|Clay Hine
+That Tumble Down Shack In Athlone|TTBB|Clay Hine
+White Christmas|TTBB|Clay Hine
+You Are The Sunshine Of My Life|SATB|Clay Hine
+You Can Fly|TTBB|Clay Hine
+You Tell Me Your Dream|TTBB|Clay Hine
+You're Nobody 'Til Somebody Loves You|TTBB|Clay Hine
+A Life That's Good|TTBB, SSAA, SATB|Melody Hine
+A Million Dreams|TTBB, SSAA, SATB|Melody Hine
+After You Get What You Want You Don't Want It|SSAA|Melody Hine
+Ain't We Got Fun|SSAA|Melody Hine
+Air Conditioner|SSAA, SATB|Melody Hine
+And The Angels Sing|TTBB|Melody Hine
+Anything is Possible|TTBB, SSAA, SATB|Melody Hine
+Are You Havin' Any Fun|TTBB, SSAA, SATB|Melody Hine
+Artificial Flowers|SSAA|Melody Hine
+As If We Never Said Goodbye|SSAA|Melody Hine
+Astonishing|SSAA, SATB|Melody Hine
+Beautiful Thang|TTBB|Melody Hine
+Beggin'|TTBB|Melody Hine
+The Best Is Yet To Come|SSAA|Melody Hine
+Better Days|SSAA|Melody Hine
+Born To Be Blue|TTBB|Melody Hine
+Brand New|TTBB|Melody Hine
+Brick House|SSAA|Melody Hine
+Build Me Up Buttercup|SSAA|Melody Hine
+Bury A Friend|TTBB|Melody Hine
+Can You Imagine That?|SSAA|Melody Hine
+Carolina In My Mind|TTBB|Melody Hine
+Chega De Saudade (No More Blues)|TTBB|Melody Hine
+Children Will Listen|SSAA|Melody Hine
+Chosen Family|SSAA|Melody Hine
+The Climb|TTBB|Melody Hine
+Colors Of The Wind|TTBB, SSAA, SATB|Melody Hine
+Corner Of The Sky|TTBB, SSAA|Melody Hine
+Count On Me|SSAA|Melody Hine
+Crabbuckit|TTBB, SSAA, SATB|Melody Hine
+Creep|TTBB, SSAA, SATB|Melody Hine
+Cruella De Vil|SSAA|Melody Hine
+Cups (When I'm Gone)|SSAA|Melody Hine
+Demon Kitty Rag|TTBB, SSAA|Melody Hine
+Disney Princess Medley|SSAA|Melody Hine
+Don't Do Something To Someone Else|SSAA|Melody Hine
+Don't Rain on My Parade|SSAA|Melody Hine
+Don't Stop Me Now|SATB|Melody Hine
+Dreamer|SSAA|Melody Hine
+Ev'rybody Wants To Be A Cat|SSAA|Melody Hine
+Everybody Eats When They Come to My House|TTBB|Melody Hine
+Extraordinary|TTBB|Melody Hine
+Extraordinary Magic|TTBB|Melody Hine
+Feed The Birds|TTBB|Melody Hine
+Feels Like Home|SATB|Melody Hine
+Fight Song|TTBB, SSAA, SATB|Melody Hine
+Fire And Rain|SSAA, SATB|Melody Hine
+Fixer Upper|SATB|Melody Hine
+Flowers|SSAA, SATB|Melody Hine
+For Good|SSAA|Melody Hine
+Forget About The Boy|SSAA|Melody Hine
+Frank Sinatra Medley|TTBB, SATB|Melody Hine
+Fresh Prince Of Bel-Air|TTBB|Melody Hine
+Friend Like Me|TTBB|Melody Hine
+From Now On|SSAA|Melody Hine
+From The Ground Up|SSAA|Melody Hine
+From This Moment On|SSAA|Melody Hine
+Gimme Gimme|SSAA|Melody Hine
+Girl on Fire|SSAA|Melody Hine
+God Only Knows|TTBB|Melody Hine
+Gone|SSAA|Melody Hine
+Gone, Gone, Gone|TTBB, SATB|Melody Hine
+Gonna Get Over You|SSAA|Melody Hine
+Good Job|SSAA|Melody Hine
+Good Morning Baltimore|TTBB, SSAA|Melody Hine
+Goodnight, My Love|SSAA|Melody Hine
+Greased Lightning|SATB|Melody Hine
+The Greatest Show|SSAA|Melody Hine
+Hakunah Matata|SATB|Melody Hine
+Happy Birthday To You|SSAA|Melody Hine
+Hard Candy Christmas|SSAA|Melody Hine
+Hawaiian Roller Coaster Ride|TTBB, SATB|Melody Hine
+His Cheeseburger|TTBB, SSAA, SATB|Melody Hine
+Hopelessly Devoted To You|TTBB, SSAA, SATB|Melody Hine
+Hot Dogs Or Legs|TTBB|Melody Hine
+How High The Moon|SSAA|Melody Hine
+I Can Dream, Can't I?|SSAA|Melody Hine
+I Can See Clearly Now|SSAA|Melody Hine
+I Could Write a Book|TTBB|Melody Hine
+I Don't Care About You|SSAA|Melody Hine
+I Don't Want To Set The World On Fire|TTBB|Melody Hine
+I Love Me (I'm Wild About Myself)|SSAA|Melody Hine
+I Put a Spell on You|TTBB|Melody Hine
+I See Stars|SSAA|Melody Hine
+I Will|TTBB, SSAA, SATB|Melody Hine
+I Won't Say I'm In Love|SSAA|Melody Hine
+I Write The Songs|SSAA|Melody Hine
+I'll Build A Stairway To Paradise|SSAA|Melody Hine
+I'll Never Be Free|TTBB|Melody Hine
+I'm Alive|SSAA|Melody Hine
+I'm Just Ken|SSAA|Melody Hine
+I'm Still Standing|TTBB, SSAA, SATB|Melody Hine
+If I Were A Fish|SATB|Melody Hine
+In My Daughter's Eyes|SSAA|Melody Hine
+In My Life|SSAA|Melody Hine
+In The Mood|SSAA|Melody Hine
+It's Raining|SATB|Melody Hine
+It's Today|SSAA|Melody Hine
+Jackson|TTBB|Melody Hine
+Jersey Bounce|SSAA|Melody Hine
+Kim Possible/Danny Phantom Medley|SATB|Melody Hine
+Kiss On My List|TTBB|Melody Hine
+Landslide|TTBB|Melody Hine
+Let's Be Bad|SATB|Melody Hine
+Like A Prayer|TTBB|Melody Hine
+Louder Than Words|SATB|Melody Hine
+Love is an Open Door|SATB|Melody Hine
+Love On Top|SSAA|Melody Hine
+Love You Anymore|TTBB|Melody Hine
+Luck Be A Lady|SSAA|Melody Hine
+Mama's Broken Heart|SSAA|Melody Hine
+Mambo Italiano|SSAA|Melody Hine
+Man! I Feel Like A Woman|SSAA|Melody Hine
+Maybe This Time|TTBB, SSAA, SATB|Melody Hine
+Me, too!|SSAA|Melody Hine
+Medley: A Foggy Day, Fly Me To The Moon, Come Fly With Me|SATB|Melody Hine
+Medley: Beautiful, I Am What I Am|SATB|Melody Hine
+Medley: Dancing In The Street, Dance The Night, I Wanna Dance With Somebody, Can't Stop The Feeling|SATB|Melody Hine
+Medley: Ease On Down The Road, Follow The Yellow Brick Road|SSAA|Melody Hine
+Medley: Gospel Truth, Go The Distance, One Last Hope, Zero To Hero|TTBB|Melody Hine
+Medley: I Will Survive with Survivor|SSAA|Melody Hine
+Medley: Respect, Proud Mary, Nine To Five, Born This Way|SSAA|Melody Hine
+"Medley: Take The ""A"" Train, Thomas Theme"|TTBB|Melody Hine
+Medley: The Greatest Show , Come Alive|SATB|Melody Hine
+Medley: Think, Respect|SSAA|Melody Hine
+Medley: When Will My Life Begin?, Just Around The Riverbend, God Help Outcasts|SSAA|Melody Hine
+Men In Tights|TTBB|Melody Hine
+Mighty Mouse|SSAA|Melody Hine
+Mom|SSAA|Melody Hine
+My One And Only Love|TTBB|Melody Hine
+Naughty|SSAA|Melody Hine
+Never Getting Rid Of Me|SSAA|Melody Hine
+O Pato (The Duck)|TTBB|Melody Hine
+One Heartbeat|SATB|Melody Hine
+Opening Up|TTBB|Melody Hine
+Over The Rainbow|SATB|Melody Hine
+Pancakes For Dinner|TTBB|Melody Hine
+Parked Out By The Lake|TTBB|Melody Hine
+Peel me a Grape|SSAA|Melody Hine
+The Place Where the Lost Things Go|SSAA|Melody Hine
+Please Don't Talk About Me When I'm Gone|TTBB|Melody Hine
+Rainbow|SSAA|Melody Hine
+Raise Your Glass|SSAA|Melody Hine
+Row Your Boat|TTBB|Melody Hine
+Rusty Old American Dream|TTBB|Melody Hine
+Same Boat|SATB|Melody Hine
+Santa Claus Is Comin' To Town|TTBB|Melody Hine
+Saturday Night Is The Loneliest Night Of The Week|TTBB, SSAA|Melody Hine
+Seaside Rendezvous|SSAA|Melody Hine
+She Blinded Me With Science|TTBB|Melody Hine
+She Used To Be Mine|SSAA|Melody Hine
+A Shine On Your Shoes|TTBB, SSAA, SATB|Melody Hine
+Shiny Teeth|SATB|Melody Hine
+Sing|SATB|Melody Hine
+Snowmiser/Heatmiser|SSAA|Melody Hine
+The Song Is You|SSAA|Melody Hine
+Soul Man|TTBB|Melody Hine
+Speechless|TTBB|Melody Hine
+Spinning Wheel|TTBB|Melody Hine
+Survivor/I Will Survive|SSAA|Melody Hine
+Tain't Nobody's Business If I Do|SSAA, SATB|Melody Hine
+Take It To The Limit|TTBB, SSAA, SATB|Melody Hine
+That Man|SSAA|Melody Hine
+That's What Friends Are For|TTBB|Melody Hine
+The Greatest Show/Come Alive Medley|SATB|Melody Hine
+These Foolish Things|TTBB|Melody Hine
+They Can't Take That Away From Me|SSAA|Melody Hine
+They Don't Let You In The Opera|SSAA|Melody Hine
+This Is Me|SATB|Melody Hine
+This Is Why I Sing|SATB|Melody Hine
+A Thousand Things|SSAA|Melody Hine
+A Thousand Things|TTBB|Melody Hine
+The Time Warp|TTBB|Melody Hine
+Traffic Jam|SSAA, SATB|Melody Hine
+Trashin' The Camp|SSAA|Melody Hine
+Try Everything|SSAA|Melody Hine
+Two Of A Kind|SSAA|Melody Hine
+Under The Sea|SATB|Melody Hine
+Unredeemable|SSAA|Melody Hine
+Wake Me Up!|SSAA|Melody Hine
+We Built This City|SSAA|Melody Hine
+We Need A Little Christmas|SATB|Melody Hine
+We've Got A World That Swings|TTBB|Melody Hine
+Welcome To My Nightmare|SSAA|Melody Hine
+What Do I Need With Love|SSAA|Melody Hine
+What Was I Made For?|SSAA|Melody Hine
+What's Going On|TTBB|Melody Hine
+When He Sees Me|TTBB|Melody Hine
+When You Come Back Down|SSAA|Melody Hine
+Where I Wanna Be|SATB|Melody Hine
+Winter Wonderland|TTBB|Melody Hine
+The World This Way|SATB|Melody Hine
+Wrapped Up In You|SATB|Melody Hine
+You And I|SSAA|Melody Hine
+You Didn't Want Me When You Had Me|TTBB|Melody Hine
+You Make Me Feel So Young|SSAA|Melody Hine
+You Will Be Found|SSAA|Melody Hine
+You're Nobody 'Til Somebody Loves You|SSAA|Melody Hine
+You're The One That I Want|SSAA|Melody Hine
+You've Got To Do It|TTBB|Melody Hine
+Because You're You|TTBB|Ed Hinkley
+Cuddle Up A Little Closer|SSAA|Ed Hinkley
+Embraceable You / You Do Something To Me|SSAA|Ed Hinkley
+If All My Dreams Were Made Of Gold|TTBB|Ed Hinkley
+It Had To Be You|TTBB|Ed Hinkley
+Just One Of Those Things|TTBB|Ed Hinkley
+Looking Through The Eyes Of Love|TTBB|Ed Hinkley
+Oh! What A Pal Was Mary|TTBB|Ed Hinkley
+Poor Butterfly|SSAA|Ed Hinkley
+Sweet Violets|TTBB|Ed Hinkley
+When It's Springtime In The Rockies|TTBB|Ed Hinkley
+After I've Called You Sweetheart|TTBB|Munson Hinman
+Bashful Baby|TTBB|Munson Hinman
+Brown Eyes Why Are You Blue?|TTBB|Munson Hinman
+Everything In America Is Ragtime|TTBB|Munson Hinman
+Gee But I'm Blue|TTBB|Munson Hinman
+Hello Boys I'm Back Again|TTBB|Munson Hinman
+I Want To Dream By The Old Mill Stream|TTBB|Munson Hinman
+I Wish You Were Jealous Of Me|TTBB|Munson Hinman
+I Wonder What's Become Of Sally|TTBB|Munson Hinman
+I'll Take Care Of Your Cares|TTBB|Munson Hinman
+I've Been Floating Down The Old Green River|TTBB|Munson Hinman
+Jeannine I Dream Of Lilac Time|TTBB|Munson Hinman
+Meet Me Tonight In Dreamland|TTBB|Munson Hinman
+Rock-a-bye Baby|TTBB|Munson Hinman
+Roll On, Missouri|TTBB|Munson Hinman
+Sweet Cider Time When You Were Mine|TTBB|Munson Hinman
+When I Take My Sugar To Tea|TTBB|Munson Hinman
+The Circle Of Life|SSAA|Penny Hock
+Go Tell It On The Mountain|TTBB|Wendy Hofmann
+Imagine|TTBB|Wendy Hofmann
+Let Me Call You Sweetheart|TTBB|Wendy Hofmann
+Patapan|TTBB|Wendy Hofmann
+Danny Boy|TTBB|Bob Hofstetter
+It's The Most Wonderful Time Of The Year|TTBB|Brian Hogan
+After You've Gone / Someday Medley|TTBB|John Hohl
+Cole Porter Love Songs Medley|TTBB|John Hohl
+Dream/Dream A Little Dream of Me - Medley|TTBB|John Hohl
+Elvis Medley|TTBB|John Hohl
+Embraceable You|TTBB|John Hohl
+The End of the Road|TTBB|John Hohl
+The End of the Road|SSAA|John Hohl
+Frog Kissin'|TTBB|John Hohl
+From This Moment On|TTBB|John Hohl
+Gee But I'm Lonesome Tonight|TTBB|John Hohl
+Happy Days Are Here Again|TTBB|John Hohl
+The Heather On The Hill|TTBB|John Hohl
+Hey Look Me Over|TTBB|John Hohl
+I Love My Baby|TTBB|John Hohl
+I Love You Just The Same Sweet Adeline|TTBB|John Hohl
+I Tore Up Your Picture When You Said Goodbye|TTBB|John Hohl
+I'm Beginning To See The Light|TTBB|John Hohl
+I'm Glad I'm Not Young Anymore|TTBB|John Hohl
+I'm Singing Your Love Song To Somebody Else|TTBB|John Hohl
+I'm Sitting On Top Of The World|TTBB|John Hohl
+I'm Sorry I Made You Cry|TTBB|John Hohl
+I'm Spending Hanukkah In Santa Monica|TTBB|John Hohl
+I'm Tickled Pink With A Blue Eyed Baby|TTBB|John Hohl
+If|TTBB|John Hohl
+It All Depends On You|TTBB|John Hohl
+Jukebox Baby|TTBB|John Hohl
+The Key To Success With The Beautiful Girls|TTBB|John Hohl
+Let's Talk About My Sweetie / Ain't She Sweet Medley|TTBB|John Hohl
+Looking Through The Eyes Of Love|TTBB|John Hohl
+Love Is A Many Splendored Thing|TTBB|John Hohl
+Manhattan|TTBB|John Hohl
+Miss Otis Regrets|TTBB|John Hohl
+My Heart Stood Still|TTBB|John Hohl
+My Name Is America|TTBB|John Hohl
+Never Too Old For Christmas|TTBB|John Hohl
+A Nightingale Sang In Berkeley Square|TTBB|John Hohl
+No Wonder I'm Happy|TTBB|John Hohl
+North To Alaska|TTBB|John Hohl
+Old Man Time|TTBB|John Hohl
+Once In A While|TTBB|John Hohl
+One God|TTBB|John Hohl
+Rhythm And Dance Medley|TTBB|John Hohl
+Sing A Song Medley|TTBB|John Hohl
+Some Day|TTBB|John Hohl
+Somebody Stole My Gal Medley|TTBB|John Hohl
+Sunday|TTBB|John Hohl
+Taking A Chance On Love|TTBB|John Hohl
+That Christmas Feeling|TTBB|John Hohl
+That Old Feeling|TTBB|John Hohl
+That'll Do|TTBB|John Hohl
+There Is No Greater Love|TTBB|John Hohl
+They Go Wild, Simply Wild Over Me|TTBB|John Hohl
+Those Were The Days|TTBB|John Hohl
+Top Of The World|TTBB|John Hohl
+Wait Till You Get Them Up In The Air Boys|TTBB|John Hohl
+When Sweet Susie Goes Steppin' By|TTBB|John Hohl
+White Cliffs Of Dover|TTBB|John Hohl
+Why Do They Always Say No / There's Yes Yes In Your Eyes Medley|TTBB|John Hohl
+Why Should I Cry Over You?|TTBB|John Hohl
+World War I Medley|TTBB|John Hohl
+You're Some Pretty Doll|TTBB|John Hohl
+On A Slow Boat To China|TTBB|Greg Hollander
+Come Softly To Me|TTBB|Michael Holmes
+Big Band Santa|SSAA|Sharon Holmes
+Chances Are|SSAA|Sharon Holmes
+Cheer Up, Charlie|SSAA|Sharon Holmes
+Christmas Time Is Here|SSAA|Sharon Holmes
+Cottage For Sale|SSAA|Sharon Holmes
+Don't Take Your Love From Me|SSAA|Sharon Holmes
+Good News|SSAA|Sharon Holmes
+I Will Never Leave You|SSAA|Sharon Holmes
+I Wish I Didn't Love You So|SSAA|Sharon Holmes
+The Lord's Prayer|SSAA|Sharon Holmes
+Misty|SSAA|Sharon Holmes
+Please Come Home For Christmas|SSAA|Sharon Holmes
+Say It Isn't So|SSAA|Sharon Holmes
+So Long, Dearie|SSAA|Sharon Holmes
+The Song Is You|SSAA|Sharon Holmes
+Songbird|SSAA|Sharon Holmes
+Still, Still, Still|SSAA|Sharon Holmes
+This Is My Country|SSAA|Sharon Holmes
+White Cliffs Of Dover|SSAA|Sharon Holmes
+You Dropped Me Like A Red Hot Penny|SSAA|Sharon Holmes
+You Want Lovin' But I Want Love/How Come You Do Me Like You Do?|SSAA|Sharon Holmes
+You Wanted Someone To Play With|SSAA|Sharon Holmes
+All 4 Love|TTBB|III Eddie Holmes
+Longer|TTBB|III Eddie Holmes
+Louisiana Fairy Tale|TTBB|III Eddie Holmes
+Stay With Me|TTBB|III Eddie Holmes
+Only Us|TTBB|David Holst
+Angry|SSAA|Norma Holzmeier
+Fifteen Minute Intermission|SSAA|Norma Holzmeier
+Irelands Loss Was Heavens Gain|SSAA|Norma Holzmeier
+Irish Farewell|SSAA|Norma Holzmeier
+Over The River And Through The Woods|SSAA|Norma Holzmeier
+When I Lost You|SSAA|Norma Holzmeier
+Bidi Bom|SSAA|Joan Homokay
+Dream|TTBB|Gerald Hooper
+Hi Neighbor|TTBB|Gerald Hooper
+Little Green Apples|TTBB|Gerald Hooper
+When My Baby Smiles At Me|TTBB|Gerald Hooper
+Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Gerald Hooper
+America The Beautiful|SATB|James Hoover
+This Christmastide|TTBB|James Hoover
+This Christmastide|SSAA, SATB|James Hoover
+America The Beautiful|TTBB, SSAA, SATB|Rob Hopkins
+Anything Goes|TTBB|Rob Hopkins
+April Showers|TTBB|Rob Hopkins
+As Time Goes By|TTBB|Rob Hopkins
+The Band Played On|TTBB|Rob Hopkins
+Believer|TTBB|Rob Hopkins
+Billionaire|TTBB, SSAA, SATB|Rob Hopkins
+Build Me Up Buttercup|TTBB|Rob Hopkins
+By The Light Of The Silvery Moon|TTBB|Rob Hopkins
+Bye Bye Blackbird|TTBB|Rob Hopkins
+Caroline|TTBB|Rob Hopkins
+Caroline, I'm Coming Back To You|TTBB|Rob Hopkins
+Daddy Get Your Baby Out Of Jail|TTBB|Rob Hopkins
+Dancing At The Moving Picture Ball|TTBB|Rob Hopkins
+Embraceable You|TTBB|Rob Hopkins
+Five Foot Two Parody|TTBB|Rob Hopkins
+For All We Know|TTBB|Rob Hopkins
+Forgive Me|TTBB|Rob Hopkins
+The Girl That I Marry|TTBB|Rob Hopkins
+A Girl Whose Name Begins With 'M'|TTBB|Rob Hopkins
+Good Thing Going|TTBB|Rob Hopkins
+Goodbye Boys|TTBB|Rob Hopkins
+Goody Goody|SSAA|Rob Hopkins
+Goody Goody|TTBB|Rob Hopkins
+Holly Jolly Christmas|TTBB|Rob Hopkins
+How Deep Is The Ocean|TTBB, SSAA, SATB|Rob Hopkins
+I Don't Want To Get Well|TTBB|Rob Hopkins
+I Don't Want To Walk Without You|TTBB|Rob Hopkins
+I Feel A Song Comin' On|TTBB|Rob Hopkins
+I Found A Million Dollar Baby|TTBB|Rob Hopkins
+I Never Knew / You Were Meant for Me Medley|TTBB|Rob Hopkins
+I Used To Call Her Baby|TTBB|Rob Hopkins
+I'd Like To Teach The World To Sing|TTBB|Rob Hopkins
+I'll Be Seeing You|TTBB, SSAA, SATB|Rob Hopkins
+I'll Be Seeing You/Once In A Lifetime Medley|TTBB, SSAA, SATB|Rob Hopkins
+I'm A Believer|TTBB|Rob Hopkins
+I'm Alone Because I Love You|TTBB|Rob Hopkins
+I'm Gonna Miss Her|TTBB|Rob Hopkins
+I'm Singing Your Love Song To Somebody Else|TTBB|Rob Hopkins
+I'm Sitting On Top Of The World|TTBB|Rob Hopkins
+If I Love Again|TTBB|Rob Hopkins
+If I Love Again|SSAA|Rob Hopkins
+If You Knew Susie / Say Mister Medley|TTBB|Rob Hopkins
+It's Been A Long, Long Time|TTBB, SSAA, SATB|Rob Hopkins
+It's Impossible|TTBB, SSAA|Rob Hopkins
+It's The Most Wonderful Time Of The Year|TTBB|Rob Hopkins
+Let Me Call You Sweetheart|TTBB|Rob Hopkins
+Let's Get Away From It All|TTBB|Rob Hopkins
+Louisville Lou|TTBB|Rob Hopkins
+Love Is Here To Stay|TTBB|Rob Hopkins
+Mansions Of The Lord|SATB|Rob Hopkins
+Memories|TTBB|Rob Hopkins
+My Cutey's Due At Two-To-Two To-day|TTBB|Rob Hopkins
+My Foolish Heart|TTBB|Rob Hopkins
+The Nearness Of You|TTBB|Rob Hopkins
+Never Hit Your Grandma With A Shovel|TTBB|Rob Hopkins
+Once In Love With Amy|TTBB|Rob Hopkins
+Over The Rainbow|TTBB|Rob Hopkins
+Piano Man|TTBB|Rob Hopkins
+Put On Your Old Grey Bonnet|TTBB|Rob Hopkins
+Roll On, Mississippi, Roll On|TTBB|Rob Hopkins
+Roll Out Of Bed With A Smile|TTBB|Rob Hopkins
+Runnin' Wild Medley|TTBB|Rob Hopkins
+Sailin' Away On The Henry Clay|TTBB|Rob Hopkins
+Saturday Night Is The Loneliest Night Of The Week|TTBB|Rob Hopkins
+Say Mister / If You Knew Susie Medley|TTBB|Rob Hopkins
+Somebody Stole My Gal|TTBB|Rob Hopkins
+Someone Like You|TTBB|Rob Hopkins
+Someone You Loved|TTBB|Rob Hopkins
+Spend My Life With You|TTBB|Rob Hopkins
+Steppin' Out With My Baby|TTBB|Rob Hopkins
+Still The One|TTBB|Rob Hopkins
+Summer Sounds|TTBB|Rob Hopkins
+That Old Irish Mother Of Mine|TTBB|Rob Hopkins
+They All Laughed|TTBB|Rob Hopkins
+This May Be The Night|TTBB|Rob Hopkins
+Three Times A Lady|TTBB|Rob Hopkins
+Too Marvelous For Words|TTBB|Rob Hopkins
+Wait Till You Get Them Up In The Air Boys|TTBB|Rob Hopkins
+What Do You Want To Make Those Eyes At Me For|TTBB|Rob Hopkins
+When I Look At You|TTBB|Rob Hopkins
+Who'll Dry Your Tears When You Cry?|TTBB|Rob Hopkins
+Whose Pretty Baby Are You Now|TTBB|Rob Hopkins
+Wonderful Day like Today|TTBB|Rob Hopkins
+You Do Something To Me|TTBB|Rob Hopkins
+You Must Have Been A Beautiful Baby|TTBB|Rob Hopkins
+Singin' In The Rain|TTBB|Charles Hornstein
+It's Christmas All Over Town|TTBB|Brian Horwath
+Yawning|TTBB|William Hotin
+Rainbow Connection|TTBB|Kyle Hottel
+Spooky Scary Skeletons|TTBB|Kyle Hottel
+Beautiful Savior|SSAA|Dotty Hougen
+Doggie In The Window (How Much Is That)|SSAA|Dotty Hougen
+Hold Me|SSAA|Dotty Hougen
+Let It Be Me|SSAA|Dotty Hougen
+Ain't Misbehavin'|TTBB|Ed Howard
+Friendly Giant Theme|TTBB|Ed Howard
+God Rest Ye Merry, Gentlemen|TTBB|Ed Howard
+Happy Together|TTBB|Ed Howard
+I Vow to Thee My Country|TTBB|Ed Howard
+People Get Ready|TTBB|Ed Howard
+Some Girls Do|TTBB|Ed Howard
+Take It On The Run|TTBB|Ed Howard
+Thank You for being a Friend|TTBB|Ed Howard
+Welcome To Duloc|TTBB|Ed Howard
+You Walk With Me|TTBB|Ed Howard
+Lulu's Back In Town|TTBB|Clifford Howe
+Feliz Navidad|SSAA|Valerie Hoy
+Morning Town Ride|SSAA|Valerie Hoy
+No Matter What|SSAA|Valerie Hoy
+Three Bells|SSAA|Valerie Hoy
+Peggy O'Neil|TTBB|Ed Hubbard
+Desperado|SSAA|Richard Hubbard
+All I Ask|SSAA|Sam Hubbard
+America|SATB|Sam Hubbard
+Baby's Request|TTBB, SSAA|Sam Hubbard
+Cabaret|TTBB, SSAA|Sam Hubbard
+Call Me|TTBB|Sam Hubbard
+Can't Help Lovin' Dat Man|TTBB, SSAA|Sam Hubbard
+Could It Be Magic|TTBB, SSAA|Sam Hubbard
+Don't Lose Sight|SSAA|Sam Hubbard
+Friends|TTBB, SSAA|Sam Hubbard
+Have Yourself A Merry Little Christmas|SSAA|Sam Hubbard
+Hopelessly Devoted To You|SSAA|Sam Hubbard
+I Can't Decide|TTBB, SATB|Sam Hubbard
+I Get Around|TTBB|Sam Hubbard
+I Want A Hippopotamus For Christmas|SSAA|Sam Hubbard
+I'm Not That Girl|SSAA|Sam Hubbard
+Isn't It Romantic|SATB|Sam Hubbard
+Keep The Customer Satisfied|TTBB, SSAA|Sam Hubbard
+Keeping The Dream Alive|TTBB, SSAA|Sam Hubbard
+Knocks Me Off My Feet|SSAA|Sam Hubbard
+Lately|TTBB|Sam Hubbard
+Laughter In The Rain|TTBB, SSAA|Sam Hubbard
+Maybe|TTBB, SSAA, SATB|Sam Hubbard
+Medley: I Wanna Dance with Somebody, I'm Your Baby Tonight, I Will Always|SSAA|Sam Hubbard
+My Neighbor Totoro|TTBB, SSAA|Sam Hubbard
+Never Ever|SSAA|Sam Hubbard
+The Next Right Thing|SSAA|Sam Hubbard
+Nine To Five|TTBB, SSAA|Sam Hubbard
+No More Tears (Enough Is Enough)|SSAA|Sam Hubbard
+Over The Rainbow|TTBB, SSAA|Sam Hubbard
+Part Of Your World|SSAA|Sam Hubbard
+Ring Of Fire|TTBB, SATB|Sam Hubbard
+Second Star to the Right|TTBB, SSAA|Sam Hubbard
+Shallow|TTBB, SSAA|Sam Hubbard
+Sister Act|SSAA|Sam Hubbard
+Sister Suffragette|SSAA|Sam Hubbard
+Somewhere Only We Know|TTBB, SSAA|Sam Hubbard
+Space Man|TTBB|Sam Hubbard
+Spiderman Theme|TTBB, SSAA|Sam Hubbard
+Sunny|TTBB, SSAA|Sam Hubbard
+Teach Me Tonight|SSAA|Sam Hubbard
+That's Enough|TTBB, SSAA|Sam Hubbard
+The Things We Did Last Summer|TTBB|Sam Hubbard
+Vienna|TTBB|Sam Hubbard
+Waiting For My Real Life To Begin|TTBB, SSAA|Sam Hubbard
+We'll Meet Again|TTBB, SSAA|Sam Hubbard
+Where Do I Begin|TTBB|Sam Hubbard
+Who Needs You|TTBB|Sam Hubbard
+Without A Song|SSAA|Sam Hubbard
+Wonderful|SSAA|Sam Hubbard
+A World Of Your Own|SSAA|Sam Hubbard
+Yellow Bird|SSAA|Sam Hubbard
+You Make My Dreams|TTBB, SSAA|Sam Hubbard
+You've Got A Friend|SSAA|Sam Hubbard
+Your Molecular Structure|SSAA|Sam Hubbard
+Edelweiss|TTBB|Mac Huff
+Every Time I See You, I Cry|TTBB|Mac Huff
+Have A Happy Day|TTBB|Mac Huff
+Huggin' And A-Chalkin|TTBB|Mac Huff
+Little Girl|SSAA|Mac Huff
+Little Girl|TTBB|Mac Huff
+Little Old Lady|TTBB|Mac Huff
+Nobody's Singing At The Old Barbershop|TTBB|Mac Huff
+Old Time Love Songs|TTBB|Mac Huff
+Strollin' Down Harmony Lane|TTBB|Mac Huff
+Sweet And Lovely|TTBB|Mac Huff
+Texas, My Texas Medley|TTBB|Mac Huff
+Waitin' For The Evening Train|TTBB|Mac Huff
+White Christmas|TTBB|Mac Huff
+If I Had My Life To Live Over|TTBB|Paul Huff
+Alfie|SSAA|Barbara Huffman
+Crazy|SSAA|Barbara Huffman
+Whoevers On Your Mind|SSAA|Barbara Huffman
+Lookout, Here Comes My Cookie|TTBB|Larry Hull
+All American Girl|TTBB|George Hulst
+April Showers|TTBB|George Hulst
+Colleen My Own|TTBB|George Hulst
+Feudin' And Fightin'|TTBB|George Hulst
+I Don't Mind Being All Alone|TTBB|George Hulst
+I Love The Whole United States|TTBB|George Hulst
+I Won't Tell A Soul|TTBB|George Hulst
+Just A Girl That Men Forget|TTBB|George Hulst
+Memories|TTBB|George Hulst
+Mister Sandman|TTBB|George Hulst
+Seventy-Six Trombones|TTBB|George Hulst
+Sleepyhead|TTBB|George Hulst
+Somebody Stole My Gal|TTBB|George Hulst
+Toyland|TTBB|George Hulst
+When I Grow Too Old To Dream|TTBB|George Hulst
+Bridge Over Troubled Water|SSAA|Asuka Ichikawa
+The Chicken Dance|SSAA|Asuka Ichikawa
+Happy|SSAA|Asuka Ichikawa
+If You Want The Rainbow|SSAA|Asuka Ichikawa
+Old Macdonald Had A Farm|SSAA|Asuka Ichikawa
+Shut Up And Dance|SSAA|Asuka Ichikawa
+Ain't We Got Fun|SSAA|Jo Anne Ingels
+Fair Is Fair|SSAA|Jo Anne Ingels
+I Ain't Down Yet|SSAA|Jo Anne Ingels
+I Found A Million Dollar Baby|SSAA|Jo Anne Ingels
+More Than A Name On A Wall|SSAA|Jo Anne Ingels
+Stormy Weather|SSAA|Jo Anne Ingels
+Don't You Remember The Time|TTBB|Walter Ingram
+I Don't Wanna Wake Up When I'm Dreaming|TTBB|Walter Ingram
+Blue Moon|TTBB|Andy Isbell
+409|TTBB|Marty Israel
+Buckle Down Winsocki|TTBB|Marty Israel
+Goodbye Broadway, Hello France|TTBB|Marty Israel
+Hard Boiled Rose|TTBB|Marty Israel
+Let It Be Me - 6-part arrangement|SATB|Marty Israel
+New York, New York|TTBB|Marty Israel
+Parade Of The Wooden Soldiers|TTBB|Marty Israel
+Three Plays For A Quarter Show Opener Medley|TTBB|Marty Israel
+A Tribute To The King|TTBB|Marty Israel
+Carolina In The Morning|TTBB|Eric Jackson
+Just Because / How Could You Believe Me (parody) Medley|TTBB|Larry Jackson
+This Is My Country|TTBB|Larry Jackson
+Varsity Drag|TTBB|Wesley Jackson
+The Circle Of Life|TTBB|Jake Jacobson
+As You Desire Me|SSAA|Ig Jakovac
+Baby's Request|SSAA|Ig Jakovac
+Don't Be So Mean To Baby|SSAA|Ig Jakovac
+I Know Why And So Do You|SSAA|Ig Jakovac
+I Waited Too Long|SSAA|Ig Jakovac
+Maybe This Time|SSAA|Ig Jakovac
+Nice 'n Easy|TTBB|Ig Jakovac
+Old Bones|TTBB|Ig Jakovac
+One Shalom|SSAA|Ig Jakovac
+Try a Little Kindness|TTBB, SATB|Ig Jakovac
+Waitin' For The Train To Come In|SSAA|Ig Jakovac
+After I've Called You Sweetheart|TTBB|J Rae Jamieson
+Alice Blue Gown|TTBB|J Rae Jamieson
+As Time Goes By|TTBB|J Rae Jamieson
+Birth Of The Blues|TTBB|J Rae Jamieson
+Breezin' Along With The Breeze|TTBB|J Rae Jamieson
+Broadway Show Opener|TTBB|J Rae Jamieson
+Casey Jones|TTBB|J Rae Jamieson
+Daddy's Little Girl|TTBB|J Rae Jamieson
+Dream Medley|TTBB|J Rae Jamieson
+Fats Waller Medley|TTBB|J Rae Jamieson
+Gospel Medley|TTBB|J Rae Jamieson
+Grand Knowing You|TTBB|J Rae Jamieson
+I'm Forever Blowing Bubbles|TTBB|J Rae Jamieson
+"If I Knock The ""L"" Out Of Kelly"|TTBB|J Rae Jamieson
+If You're Crazy About The Women|TTBB|J Rae Jamieson
+Lullaby Medley|TTBB|J Rae Jamieson
+The Nearness Of You|TTBB|J Rae Jamieson
+O'Brien To Ryan To Goldberg|TTBB|J Rae Jamieson
+Second Hand Rose|TTBB|J Rae Jamieson
+Somebody Stole My Gal Medley|TTBB|J Rae Jamieson
+Sweet Lorraine|TTBB|J Rae Jamieson
+Take Me To My Alabam'|TTBB|J Rae Jamieson
+That Tumble Down Shack In Athlone|TTBB|J Rae Jamieson
+Wand'rin' Star|TTBB|J Rae Jamieson
+When I Wore My Daddy's Brown Derby|TTBB|J Rae Jamieson
+When The Gold Turns To Gray|TTBB|J Rae Jamieson
+Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|J Rae Jamieson
+Who's Sorry Now|TTBB|J Rae Jamieson
+You Don't Need The Wine To Have A Wonderful Time|TTBB|J Rae Jamieson
+A Soldier's Medley|TTBB|Rex Jamieson
+Up Over The Hill|TTBB|Rex Jamieson
+After You've Gone|TTBB|Steve Jamison
+Amazed|SSAA|Steve Jamison
+Anchors Aweigh / Don't Sit Under The Apple Tree|TTBB|Steve Jamison
+Anything You Can Do I Can Do Better|TTBB|Steve Jamison
+Anyway|TTBB|Steve Jamison
+Are You Lonesome Tonight?|TTBB|Steve Jamison
+Auld Lang Syne|TTBB|Steve Jamison
+Ballad of Gilligan's Isle|TTBB|Steve Jamison
+Basin Street!|TTBB|Steve Jamison
+Beat Of The Future|TTBB|Steve Jamison
+Beautiful Eyes|TTBB|Steve Jamison
+Bewitched, Bothered, and Bewildered|TTBB|Steve Jamison
+Birth Of The Blues|TTBB|Steve Jamison
+Blues In The Night|TTBB|Steve Jamison
+Broadway Rose|TTBB|Steve Jamison
+Carol Of The Bells|TTBB|Steve Jamison
+Catch A Wave|TTBB|Steve Jamison
+Cattle Call|TTBB|Steve Jamison
+Chattanooga/Kalamazoo Medley|TTBB|Steve Jamison
+Clap Yo Hands|TTBB|Steve Jamison
+Coney Island Baby / Baby Face Medley|TTBB|Steve Jamison
+Cruisin' Down The River|TTBB|Steve Jamison
+Dance With A Dolly (With A Hole In Her Stocking)|SSAA|Steve Jamison
+Darktown Strutters' Ball|TTBB|Steve Jamison
+Dear Old Donegal|TTBB|Steve Jamison
+Do You Want To Know a Secret!|TTBB|Steve Jamison
+Embraceable You|TTBB|Steve Jamison
+Every Time We Say Goodbye|TTBB|Steve Jamison
+Fascinating Rhythm|TTBB|Steve Jamison
+Georgia On My Mind|TTBB, SSAA, SATB|Steve Jamison
+Give Me Forever (I Do)|TTBB|Steve Jamison
+Goofus|TTBB|Steve Jamison
+Grace|TTBB|Steve Jamison
+Great Day|TTBB|Steve Jamison
+Guess Who's In Town|TTBB|Steve Jamison
+He'd Keep On Saying Good Night|TTBB|Steve Jamison
+How Many Hearts Have You Broken?|TTBB|Steve Jamison
+I Got Plenty O' Nuttin'|SSAA|Steve Jamison
+I Only Have Eyes For You|TTBB|Steve Jamison
+I Want To Hold Your Hand|SSAA|Steve Jamison
+I'd Love To Live In Loveland|TTBB|Steve Jamison
+I'll Be Home For Christmas|TTBB|Steve Jamison
+I'm So Alone With The Crowd|TTBB|Steve Jamison
+I've Got A Crush On You|SSAA|Steve Jamison
+I've Heard/One of Those Songs Medley|TTBB|Steve Jamison
+If I Had A Girl Like You|TTBB|Steve Jamison
+If I Had The Last Dream Left In The World|TTBB|Steve Jamison
+It Had To Be You|TTBB|Steve Jamison
+It's Only Love|TTBB|Steve Jamison
+It's Time To Sing Sweet Adeline Again|TTBB|Steve Jamison
+Jersey Bounce|TTBB|Steve Jamison
+Laura|TTBB|Steve Jamison
+Let It Snow Let It Snow Let It Show|TTBB|Steve Jamison
+Let's Call The Whole Thing Off|TTBB|Steve Jamison
+Little Bit Of Heaven|TTBB|Steve Jamison
+Little Red Riding Hood|TTBB|Steve Jamison
+Little Saint Nick|TTBB|Steve Jamison
+Living A Ragtime Life|TTBB|Steve Jamison
+Lonesomest Girl In Town|TTBB|Steve Jamison
+Lorabelle Lee|TTBB|Steve Jamison
+Love Is Here To Stay|TTBB|Steve Jamison
+Love Potion No. 9|TTBB|Steve Jamison
+Luck Be A Lady|TTBB|Steve Jamison
+Lullaby Of Broadway|TTBB|Steve Jamison
+Mood Indigo|TTBB|Steve Jamison
+Mother Machree|TTBB|Steve Jamison
+My Funny Valentine|TTBB|Steve Jamison
+New York, New York|SSAA|Steve Jamison
+New York, New York|TTBB|Steve Jamison
+Nine To Five|SSAA|Steve Jamison
+Nine To Five|TTBB|Steve Jamison
+No Vacancy|TTBB|Steve Jamison
+Oh, What A Pal Was Whoozis|TTBB|Steve Jamison
+On My Own|TTBB|Steve Jamison
+On The Banks Of The Brandywine|TTBB|Steve Jamison
+One Of Those Songs|TTBB|Steve Jamison
+Our Love Is Here To Stay|TTBB|Steve Jamison
+Puff The Magic Dragon|SSAA|Steve Jamison
+Red Hot Mamma|TTBB|Steve Jamison
+Rosie Medley|TTBB|Steve Jamison
+Row, Row, Row|TTBB|Steve Jamison
+Satin Doll|TTBB|Steve Jamison
+Send Me Away With A Smile|TTBB|Steve Jamison
+She's All I Ever Had|TTBB|Steve Jamison
+Shipping Out Medley|TTBB|Steve Jamison
+Sing Me A Baby Song|TTBB|Steve Jamison
+Sit Down You're Rockin' The Boat|TTBB|Steve Jamison
+Some Girls Do And Some Girls Don't|TTBB|Steve Jamison
+Son of a Preacherman|TTBB|Steve Jamison
+Star Spangled Banner|TTBB|Steve Jamison
+Step Inside Love|TTBB|Steve Jamison
+Summertime|TTBB|Steve Jamison
+Sunshine On My Shoulders|TTBB|Steve Jamison
+The Sweetheart Of Sigma Chi|TTBB|Steve Jamison
+Take Me Out To The Ball Game|TTBB|Steve Jamison
+Taking A Chance On Love|TTBB|Steve Jamison
+Taking A Chance On Love|SATB|Steve Jamison
+Taking A Chance On Love|SSAA|Steve Jamison
+Tammy|SSAA|Steve Jamison
+Teddy Bears' Picnic|SSAA|Steve Jamison
+That Lonesome Road|TTBB|Steve Jamison
+This Is The Moment|TTBB|Steve Jamison
+Three Plays For A Quarter Medley|TTBB|Steve Jamison
+When Alexander Takes His Ragtime Band To France|TTBB|Steve Jamison
+Wide Open Spaces|TTBB|Steve Jamison
+Winter in America is Cold|TTBB|Steve Jamison
+Witch Doctor|TTBB|Steve Jamison
+With A Little Help From My Friends|TTBB|Steve Jamison
+Without You|TTBB|Steve Jamison
+You Can't Take My Memories from Me|TTBB|Steve Jamison
+You Gotta Be A Football Hero / Betty Coed Medley|TTBB|Steve Jamison
+You're Just in Love|TTBB|Steve Jamison
+Rudolph The Red Nosed Reindeer|TTBB|Ed Jarley
+All That Holiday Stuff!|TTBB|Mark Jennings
+Because You Loved Me|SSAA|Mark Jennings
+Cinderella Girl|TTBB|Mark Jennings
+From The Top Of Your Head (To The Tip Of Your Toes)|TTBB|Mark Jennings
+I Wanna Be Loved|SATB|Mark Jennings
+If He Walked Into My Life|SSAA|Mark Jennings
+Live To Tell|SSAA|Mark Jennings
+Louisiana Fairy Tale|TTBB|Mark Jennings
+Medley: Pennsylvania 65000, Is You Is Or Is You Ain't My Baby, Chattanooga Choo Choo|SATB|Mark Jennings
+Moonlight Savings Time|TTBB|Mark Jennings
+My Man|SSAA|Mark Jennings
+My One And Only Love|TTBB|Mark Jennings
+Near You|SSAA|Mark Jennings
+No Regrets|SSAA|Mark Jennings
+Oh Daddy Blues (You Won't Have No Mama At All)|SSAA|Mark Jennings
+Sailing|TTBB|Mark Jennings
+Scrooge|SATB|Mark Jennings
+Seventeen|SSAA|Mark Jennings
+Something To Believe In|TTBB|Mark Jennings
+Speak Low|TTBB|Mark Jennings
+Time After Time|SSAA|Mark Jennings
+Two Sleepy People|SATB|Mark Jennings
+Valentine|SATB|Mark Jennings
+Wave|TTBB|Mark Jennings
+You Didn't Know The Music|TTBB|Mark Jennings
+Look For The Silver Lining|TTBB|Dan Jimenez
+I Guess I'll Get The Papers (And Go Home)|TTBB|Ernie Johansen
+Those Old Fashioned Songs|TTBB|Ernie Johansen
+When The Organ Played At Twilight|TTBB|Ernie Johansen
+Just A Closer Walk With Thee|TTBB|Barney Johnson
+Act Naturally|SSAA|Carolyn Johnson
+Adios, Aurevoir, Auf Wiedersehn|SSAA|Carolyn Johnson
+After You've Gone|SSAA|Carolyn Johnson
+Ain't We Got Fun|SSAA|Carolyn Johnson
+All Beautiful The March Of Days|SSAA|Carolyn Johnson
+All My Loving|SSAA|Carolyn Johnson
+All Through The Night|SSAA|Carolyn Johnson
+Amazing Grace|SSAA|Carolyn Johnson
+America (My Country, 'Tis Of Thee)|SSAA|Carolyn Johnson
+America The Beautiful|SSAA|Carolyn Johnson
+And I Love Him|SSAA|Carolyn Johnson
+Angels From The Realms Of Glory|SSAA|Carolyn Johnson
+As With Gladness Men Of Old|SSAA|Carolyn Johnson
+Ash Grove|SSAA|Carolyn Johnson
+At the End of a Beautiful Day|SSAA|Carolyn Johnson
+Auld Lang Syne|SSAA|Carolyn Johnson
+Away In A Manger|SSAA|Carolyn Johnson
+Baby's In Black|SSAA|Carolyn Johnson
+Barbershop A Song With Me|SSAA|Carolyn Johnson
+Barbershop Buddies|SSAA|Carolyn Johnson
+Barbershoppin Cowgirl|SSAA|Carolyn Johnson
+Blackbird|SSAA|Carolyn Johnson
+Bring A Torch, Jeanette, Isabella|SSAA|Carolyn Johnson
+Broken Hearted (Here Am I)|SSAA|Carolyn Johnson
+Call Me Back Pal O' Mine|SSAA|Carolyn Johnson
+Cheek To Cheek|SSAA|Carolyn Johnson
+Deck The Halls|SSAA|Carolyn Johnson
+Direct Our Harmony|SSAA|Carolyn Johnson
+Don't Cry, Little Girl, Don't Cry|SSAA|Carolyn Johnson
+Don't Stop Me Now|SSAA|Carolyn Johnson
+Dream|SSAA|Carolyn Johnson
+Dreamland/Sweetheart Medley|SSAA|Carolyn Johnson
+Festival Of Lights|SSAA|Carolyn Johnson
+The First Noel|SSAA|Carolyn Johnson
+For The Beauty of the Earth|SSAA|Carolyn Johnson
+From This Moment On|SSAA|Carolyn Johnson
+Fum Fum Fum|SSAA|Carolyn Johnson
+Gentle Mary Laid Her Child|SSAA|Carolyn Johnson
+Gentlemen Medley|SSAA|Carolyn Johnson
+Glad Tidings All To You|SSAA|Carolyn Johnson
+God Bless America|SSAA|Carolyn Johnson
+God Rest Ye Frugal Shoppers|SSAA|Carolyn Johnson
+God Rest Ye Merry, Gentlemen|SSAA|Carolyn Johnson
+God Save The Queen/King|SSAA|Carolyn Johnson
+Good King Wenceslas|SSAA|Carolyn Johnson
+Good-Bye My Honey Love|SSAA|Carolyn Johnson
+Good-Bye My Treasure Chest|SSAA|Carolyn Johnson
+Heart And Soul|SSAA|Carolyn Johnson
+Here We Come A Wassailing|SSAA|Carolyn Johnson
+Here, There And Everywhere|SSAA|Carolyn Johnson
+The Holly And The Ivy|SSAA|Carolyn Johnson
+Holly Jolly Christmas|SSAA|Carolyn Johnson
+Honey-Love|SSAA|Carolyn Johnson
+I Ain't Got No Body|SSAA|Carolyn Johnson
+I Ain't Got No Sunshine|SSAA|Carolyn Johnson
+I Don't Know Where I'm Going But I'm On My Way|SSAA|Carolyn Johnson
+I Get A Kick Out Of You|SSAA|Carolyn Johnson
+I Saw Three Ships|SSAA|Carolyn Johnson
+I Will|SSAA|Carolyn Johnson
+I Wonder Who's Kissing Her Now|SSAA|Carolyn Johnson
+I'm A Lonesome Melody|SSAA|Carolyn Johnson
+I'm Gonna Marry Harry|SSAA|Carolyn Johnson
+I'm Waiting For Ships That Never Come In|SSAA|Carolyn Johnson
+In The Bleak Midwinter|SSAA|Carolyn Johnson
+Insomnia|SSAA|Carolyn Johnson
+It Came Upon A Midnight Clear / O Come All Ye Faithful Medley|SSAA|Carolyn Johnson
+Java Jive|SSAA|Carolyn Johnson
+Jeepers Creepers|SSAA|Carolyn Johnson
+Johnny Medley|SSAA|Carolyn Johnson
+Johnny's In Town|SSAA|Carolyn Johnson
+Joy Medley|SSAA|Carolyn Johnson
+Joy To The World|SSAA|Carolyn Johnson
+Just A Baby's Prayer At Twilight|SSAA|Carolyn Johnson
+Let Me Call You Sweetheart|SSAA|Carolyn Johnson
+Lo! How A Rose|SSAA|Carolyn Johnson
+Love Potion No. 9|SSAA|Carolyn Johnson
+Manager Medley: There's A Song In The Air / Away In A Manger|SSAA|Carolyn Johnson
+Manger in Bethlehem Medley|SSAA|Carolyn Johnson
+Mary's A Grand Old Name|SSAA|Carolyn Johnson
+Meet Me Tonight In Dreamland|SSAA|Carolyn Johnson
+Merry Christmas / Wassailing Medley|SSAA|Carolyn Johnson
+Morning Glories Twine|SSAA|Carolyn Johnson
+The Muppet Show Theme|SSAA|Carolyn Johnson
+My Little Diamonds|SSAA|Carolyn Johnson
+My Sweetheart's The Man In The Moon|SSAA|Carolyn Johnson
+My Wild Irish Rose|SSAA|Carolyn Johnson
+New Way to Walk|SSAA|Carolyn Johnson
+No Fancy Shoes|SSAA|Carolyn Johnson
+Nowadays|SSAA|Carolyn Johnson
+O Chanukah, O Chanukah|SSAA|Carolyn Johnson
+O Christmas Tree|SSAA|Carolyn Johnson
+O Little Town Of Bethlehem|SSAA|Carolyn Johnson
+Ode To Joy (Joyful, Joyful)|SSAA|Carolyn Johnson
+Oh Johnny, Oh Johnny, Oh!|SSAA|Carolyn Johnson
+Oh! Honey (Frenchy)|SSAA|Carolyn Johnson
+On Moonlight Bay|SSAA|Carolyn Johnson
+On My Way Over There Medley|SSAA|Carolyn Johnson
+Ooh! My Feet!|SSAA|Carolyn Johnson
+Pirate Parody On Moonlight Bay|SSAA|Carolyn Johnson
+Pirate Seaside Medley|SSAA|Carolyn Johnson
+Ragtime Cowboy Joe|SSAA|Carolyn Johnson
+Razzle Dazzle|SSAA|Carolyn Johnson
+Row, Row, Row|SSAA|Carolyn Johnson
+San Francisco Sadie|SSAA|Carolyn Johnson
+Santa Medley|SSAA|Carolyn Johnson
+Seasons Greetings|SSAA|Carolyn Johnson
+Sentimental Journey|SSAA|Carolyn Johnson
+Shall We Sing, Adeline|SSAA|Carolyn Johnson
+Shalom Chaverim|SSAA|Carolyn Johnson
+Shalom Chaverim - Round|SSAA|Carolyn Johnson
+Shenandoah|SSAA|Carolyn Johnson
+Shine On, Harvest Moon|SSAA|Carolyn Johnson
+Side by Side|SSAA|Carolyn Johnson
+Silver Bells|SSAA|Carolyn Johnson
+Sing An Old Time Melody|SSAA|Carolyn Johnson
+Sunrise, Sunset|SSAA|Carolyn Johnson
+Sweet And Low|SSAA|Carolyn Johnson
+Tell Me Why|SSAA|Carolyn Johnson
+That's An Irish Lullaby|SSAA|Carolyn Johnson
+The Only Guy Can Make Me Cry|SSAA|Carolyn Johnson
+There's A Beautiful Star|SSAA|Carolyn Johnson
+There's A Song In The Air|SSAA|Carolyn Johnson
+They Didn't Believe Me|SSAA|Carolyn Johnson
+Treasures that Gold Cannot Buy|SSAA|Carolyn Johnson
+We Three Kings|SSAA|Carolyn Johnson
+We Wish You A Merry Christmas|SSAA|Carolyn Johnson
+Wear A Corset (Parody)|SSAA|Carolyn Johnson
+What Child Is This|SSAA|Carolyn Johnson
+When I'm Sixty Four|SSAA|Carolyn Johnson
+When Irish Eyes Are Smiling|SSAA|Carolyn Johnson
+Whispering|SSAA|Carolyn Johnson
+Who's Sorry Now|SSAA|Carolyn Johnson
+Who's Sorry Now / Goody Goody Medley|SSAA|Carolyn Johnson
+Yes, We Have No Bananas|SSAA|Carolyn Johnson
+Yesterday|SSAA|Carolyn Johnson
+Yesterday I Heard The Rain|SSAA|Carolyn Johnson
+You're A Grand Old Flag|SSAA|Carolyn Johnson
+You've Got To Hide Your Love Away|SSAA|Carolyn Johnson
+Zing! Went The Strings Of My Heart|SSAA|Carolyn Johnson
+A Dream Is A Wish Your Heart Makes|TTBB|Derric Johnson
+A Mighty Fortress|TTBB|Derric Johnson
+A Starry Night|TTBB|Derric Johnson
+A Whole New World|TTBB|Derric Johnson
+All Creatures Of Our God And King|TTBB|Derric Johnson
+All Hail The Power Of Jesus' Name|TTBB|Derric Johnson
+Amazing Grace/Marvelous Grace|TTBB|Derric Johnson
+America The Beautiful|SATB|Derric Johnson
+Armed Forces Medley|TTBB|Derric Johnson
+Away In A Manger|SATB|Derric Johnson
+Back Home Again In Indiana|SATB|Derric Johnson
+Battle Hymn Of The Republic|SATB|Derric Johnson
+Better Day Medley|TTBB|Derric Johnson
+Beyond The Sunset/Sunrise|TTBB|Derric Johnson
+The Birthday Of A King|TTBB|Derric Johnson
+Bless This House|TTBB|Derric Johnson
+Blessed Be The Name|TTBB|Derric Johnson
+Brethren, We Have Met To Worship|TTBB|Derric Johnson
+C-H-R-I-S-T-M-A-S|TTBB|Derric Johnson
+Call Upon The Lord|TTBB|Derric Johnson
+Calypso Noel|TTBB|Derric Johnson
+Carol Of The Bells|TTBB|Derric Johnson
+Carol Of The Russian Children|SATB|Derric Johnson
+Carolina Moon|TTBB|Derric Johnson
+Cherish That Name|TTBB|Derric Johnson
+Christmas In The Air|TTBB|Derric Johnson
+The Christmas Song|TTBB|Derric Johnson
+Christmas Time Is Here|TTBB|Derric Johnson
+Consider Yourself|TTBB|Derric Johnson
+David And Goliath|TTBB|Derric Johnson
+Deck The Halls|SATB|Derric Johnson
+Do You Hear What I Hear|TTBB|Derric Johnson
+Down By The Old Mill Stream|TTBB|Derric Johnson
+Drink To Me Only With Thine Eyes|SATB|Derric Johnson
+Duke Ellington Medley|TTBB|Derric Johnson
+Every Time I Feel The Spririt|SATB|Derric Johnson
+Ezekiel Saw The Wheel|TTBB|Derric Johnson
+Fifty Nifty|TTBB|Derric Johnson
+The First Noel|SATB|Derric Johnson
+Folk Medley|TTBB|Derric Johnson
+Footsteps Of Jesus|TTBB|Derric Johnson
+French Chorale Of Praise|SATB|Derric Johnson
+Frosty The Snowman|TTBB|Derric Johnson
+Fum Fum Fum|SATB|Derric Johnson
+Gershwin Medley|TTBB|Derric Johnson
+Gesu Bambino|SATB|Derric Johnson
+Give Me Jesus|TTBB|Derric Johnson
+Give Me Your Tired, Your Poor|TTBB|Derric Johnson
+Glory To God (The Echo Carol)|TTBB|Derric Johnson
+Go Down Moses|TTBB|Derric Johnson
+Go Tell It On The Mountain|TTBB|Derric Johnson
+Go Where I Send Thee|TTBB|Derric Johnson
+God Bless America|TTBB|Derric Johnson
+God Bless The U.S.A.|TTBB|Derric Johnson
+God Rest Ye Merry, Gentlemen|TTBB|Derric Johnson
+Golden Dream|TTBB|Derric Johnson
+Great Is Thy Faithfulness|TTBB|Derric Johnson
+Hallelujah Chorus|TTBB|Derric Johnson
+Hanukkah|SATB|Derric Johnson
+Happy Birthday To You|SATB|Derric Johnson
+Hark! The Herald Angels Sing|TTBB|Derric Johnson
+Have A Little Talk With Jesus|TTBB|Derric Johnson
+Have Yourself A Merry Little Christmas|TTBB|Derric Johnson
+He Knows Just How Much You Can Bear|TTBB|Derric Johnson
+He Never Said A Mumblin' Word|TTBB|Derric Johnson
+He Never Sleeps|TTBB|Derric Johnson
+He's Gone|TTBB|Derric Johnson
+Holy Ground|TTBB|Derric Johnson
+How Great Thou Art|TTBB|Derric Johnson
+I Just Feel Like Something Good|TTBB|Derric Johnson
+I Know A Name|TTBB|Derric Johnson
+I Must Tell Jesus|TTBB|Derric Johnson
+I Walked Today Where Jesus Walked|TTBB|Derric Johnson
+I Wonder As I Wander|TTBB|Derric Johnson
+I'll Be Home For Christmas|TTBB|Derric Johnson
+In Moments Like These|TTBB|Derric Johnson
+It Came Upon A Midnight Clear|SATB|Derric Johnson
+It Is Well With My Soul|TTBB|Derric Johnson
+It's About Time|TTBB|Derric Johnson
+It's The Most Wonderful Time Of The Year|TTBB|Derric Johnson
+It's You I Like|SATB|Derric Johnson
+Ivory Palaces|TTBB|Derric Johnson
+Jesu Joy of Man's Desiring|TTBB|Derric Johnson
+Jesus Is His Name|TTBB|Derric Johnson
+Jesus, Lover Of My Soul|TTBB|Derric Johnson
+Jingle Bells|SATB|Derric Johnson
+Joshua|TTBB|Derric Johnson
+Joy To The World|SATB|Derric Johnson
+Joyful, Joyful, We Adore Thee|TTBB|Derric Johnson
+Just As I Am|TTBB|Derric Johnson
+Kentucky Babe|TTBB|Derric Johnson
+Leaning On The Everlasting Arms|TTBB|Derric Johnson
+Let It Snow Let It Snow Let It Snow|TTBB|Derric Johnson
+Let There Be Peace On Earth|TTBB|Derric Johnson
+Little Drummer Boy|TTBB|Derric Johnson
+The Lord's Prayer|TTBB|Derric Johnson
+Love (Jesu, Joy Of Man's Desiring)|TTBB|Derric Johnson
+Love In Any Language|TTBB|Derric Johnson
+Love's Old Sweet Song|SATB|Derric Johnson
+Mary's Boy Child|TTBB|Derric Johnson
+May The Road Rise Up To Meet You|SATB|Derric Johnson
+Midnight Cry|TTBB|Derric Johnson
+Mighty Spirit|TTBB|Derric Johnson
+Moment By Moment|TTBB|Derric Johnson
+Moon Beams, Moon Dreams|TTBB|Derric Johnson
+More Than Wonderful|TTBB|Derric Johnson
+My Country 'Tis Of Thee (The Penny)|TTBB|Derric Johnson
+My Jesus, I Love Thee|TTBB|Derric Johnson
+No Room|TTBB|Derric Johnson
+Nothing But The Blood/At The Cross|TTBB|Derric Johnson
+O Come, All Ye Faithful|SATB|Derric Johnson
+O Happy Day|TTBB|Derric Johnson
+O Holy Night|TTBB|Derric Johnson
+O How He Loves You and Me|TTBB|Derric Johnson
+O Little Town Of Bethlehem|TTBB|Derric Johnson
+O Love That Wilt Not Let Me Go|TTBB|Derric Johnson
+O Perfect Love|TTBB|Derric Johnson
+O Tannenbaum|TTBB|Derric Johnson
+O The Deep, Deep Love Of Jesus|TTBB|Derric Johnson
+O Worship The King|TTBB|Derric Johnson
+Old Macdonald Had A Farm|SATB|Derric Johnson
+One Moment in Time|TTBB|Derric Johnson
+One Solitary Life|TTBB|Derric Johnson
+One Song|TTBB|Derric Johnson
+One Voice|TTBB|Derric Johnson
+Only Jesus Can Satisfy Your Soul|TTBB|Derric Johnson
+Over The Sunset Mountains|TTBB|Derric Johnson
+Patapan|TTBB|Derric Johnson
+Railroad Medley|SATB|Derric Johnson
+Red, White and Blue|SATB|Derric Johnson
+Rejoice With Exceeding Great Joy|TTBB|Derric Johnson
+Rise Up Shepherd And Follow|TTBB|Derric Johnson
+Riverside Medley|TTBB|Derric Johnson
+Rocky Top|TTBB|Derric Johnson
+Rudolph The Red Nosed Reindeer|TTBB|Derric Johnson
+Santa Claus Is Comin' To Town|TTBB|Derric Johnson
+Shadrach|TTBB|Derric Johnson
+Shenandoah|SATB|Derric Johnson
+Silent Night|TTBB|Derric Johnson
+Silver Bells|TTBB|Derric Johnson
+Simple Gifts|SATB|Derric Johnson
+Sing Alleluia/In Excelsis Deo|TTBB|Derric Johnson
+Sing We Now of Christmas|TTBB|Derric Johnson
+Singin' About Love|TTBB|Derric Johnson
+Singin' About Singing|TTBB|Derric Johnson
+Some Children See Him|TTBB|Derric Johnson
+Songs Of The West|TTBB|Derric Johnson
+Soon And Very Soon|TTBB|Derric Johnson
+Spirit Of The Living God|TTBB|Derric Johnson
+Star Spangled Banner|TTBB|Derric Johnson
+Steal Away To Jesus|TTBB|Derric Johnson
+Stephen Foster Medley|TTBB|Derric Johnson
+Still, Still, Still|SATB|Derric Johnson
+Summertime Medley|TTBB|Derric Johnson
+Sweet Hour Of Prayer|TTBB|Derric Johnson
+Sweet Little Jesus Boy|TTBB|Derric Johnson
+TAPS|TTBB|Derric Johnson
+That Golden Stair|TTBB|Derric Johnson
+The Cross, The Crown, The Nail|TTBB|Derric Johnson
+The King Is Coming|TTBB|Derric Johnson
+The Little Bitty Baby|TTBB|Derric Johnson
+The Meeting In The Air|TTBB|Derric Johnson
+The Red, White And Blue|TTBB|Derric Johnson
+The Sleigh|TTBB|Derric Johnson
+The Touch Of The Master's Hand|TTBB|Derric Johnson
+There Is A Fountain|TTBB|Derric Johnson
+There's No Business Like Show Business|TTBB|Derric Johnson
+This Is My Country|TTBB|Derric Johnson
+This Land Is Your Land|TTBB|Derric Johnson
+Under His Wings|TTBB|Derric Johnson
+Walk Into The Closet|TTBB|Derric Johnson
+We The People|TTBB|Derric Johnson
+We Wish You A Merry Christmas|TTBB|Derric Johnson
+Were You There?|TTBB|Derric Johnson
+What A Merry Christmas Tree|TTBB|Derric Johnson
+When I Fall In Love|TTBB|Derric Johnson
+When Johnny Comes Marching Home|TTBB|Derric Johnson
+When The Lord Comes Knockin'|TTBB|Derric Johnson
+Whispering Hope|TTBB|Derric Johnson
+White Christmas|TTBB|Derric Johnson
+Wind Beneath My Wings|TTBB|Derric Johnson
+Winter Wonderland|TTBB|Derric Johnson
+Wise Men Still Seek Him|TTBB|Derric Johnson
+Wonderful Counselor|TTBB|Derric Johnson
+Wonderful, Wonderful Jesus|TTBB|Derric Johnson
+Yankee Doodle|TTBB|Derric Johnson
+You Are My Sunshine|TTBB|Derric Johnson
+You Can Build A Bridge|TTBB|Derric Johnson
+You Must Come In At The Door|TTBB|Derric Johnson
+You'll Never Walk Alone|TTBB|Derric Johnson
+(They Long To Be) Close To You|TTBB|Jeremey Johnson
+(This Is) Dedicated to The One I Love|TTBB|Jeremey Johnson
+50 States In Rhyme|TTBB|Jeremey Johnson
+A Chocolate Sundae on a Saturday Night|TTBB, SSAA|Jeremey Johnson
+A Matter of Policy|TTBB|Jeremey Johnson
+A Million Dreams|TTBB|Jeremey Johnson
+Ac-cent-tchu-ate The Positive|TTBB|Jeremey Johnson
+Angels Medley|TTBB|Jeremey Johnson
+Angels Medley|SSAA|Jeremey Johnson
+Because We're Kids|TTBB|Jeremey Johnson
+Bein' Green|TTBB|Jeremey Johnson
+Blackbird|SSAA|Jeremey Johnson
+Boy Band Medley|TTBB|Jeremey Johnson
+Call Me Maybe|TTBB|Jeremey Johnson
+Close To You|TTBB|Jeremey Johnson
+Come See What's Happenin' in the Barn|TTBB, SSAA|Jeremey Johnson
+Count On Me|TTBB, SSAA|Jeremey Johnson
+Crazy People|TTBB|Jeremey Johnson
+Day In, Day Out|TTBB|Jeremey Johnson
+Desperado|TTBB, SSAA|Jeremey Johnson
+Edelweis/Climb E'vry Mountain Medley|TTBB|Jeremey Johnson
+Everybody Needs a Best Friend|SATB|Jeremey Johnson
+Extraordinary|SSAA|Jeremey Johnson
+Five Pennies Medley|TTBB|Jeremey Johnson
+Gee, I'm Glad It's Rainin'|TTBB|Jeremey Johnson
+George Michael Medley|TTBB|Jeremey Johnson
+Happy|TTBB|Jeremey Johnson
+Have I Told You Lately|TTBB, SSAA|Jeremey Johnson
+His Grace Is Sufficient For me|TTBB|Jeremey Johnson
+Hold On|TTBB|Jeremey Johnson
+House At Pooh Corner|TTBB|Jeremey Johnson
+How Sweet It Is To Be Loved By You|TTBB, SSAA|Jeremey Johnson
+I Get Around|TTBB|Jeremey Johnson
+I Never Can Say Goodbye|TTBB|Jeremey Johnson
+I Only Wanna Laugh|TTBB|Jeremey Johnson
+I Put a Spell on You|TTBB|Jeremey Johnson
+I Saw Her Again|TTBB|Jeremey Johnson
+I'll Change The Shadows To Sunshine|TTBB|Jeremey Johnson
+I'll Walk With God|TTBB|Jeremey Johnson
+I've Got No Strings|TTBB|Jeremey Johnson
+Isle of Innisfree|TTBB|Jeremey Johnson
+It's All Right|TTBB, SSAA|Jeremey Johnson
+It's Not For Me To Say|TTBB|Jeremey Johnson
+It's Still Rock and Roll to Me|TTBB|Jeremey Johnson
+Joy To The World|TTBB, SSAA|Jeremey Johnson
+Lately|TTBB|Jeremey Johnson
+Let It Be|TTBB|Jeremey Johnson
+Like The Rain|TTBB|Jeremey Johnson
+Little Devil|TTBB|Jeremey Johnson
+The Little Toy Soldier|TTBB|Jeremey Johnson
+Lo! How A Rose|TTBB|Jeremey Johnson
+Love is an Open Door|SSAA|Jeremey Johnson
+Make an Omelette|TTBB|Jeremey Johnson
+May You Never Know Sadness|TTBB|Jeremey Johnson
+More Than Words|TTBB, SSAA|Jeremey Johnson
+Mother Mine|TTBB, SSAA|Jeremey Johnson
+Mr. Rogers Medley|TTBB|Jeremey Johnson
+My Eyes Adored You|TTBB, SSAA|Jeremey Johnson
+My Mom|TTBB|Jeremey Johnson
+Oh, Promise Me|TTBB, SSAA|Jeremey Johnson
+The Old North State|TTBB|Jeremey Johnson
+One Fine Day|TTBB|Jeremey Johnson
+Pass Me The Jazz|TTBB|Jeremey Johnson
+Philadelphia Freedom|TTBB|Jeremey Johnson
+Prime Time Blues|SSAA|Jeremey Johnson
+The Proposal Song|TTBB|Jeremey Johnson
+Rhythm Of Love|TTBB, SSAA|Jeremey Johnson
+Roll, Michigan Roll|TTBB|Jeremey Johnson
+Run To You|TTBB|Jeremey Johnson
+Seven Bridges Road|TTBB, SSAA|Jeremey Johnson
+Seven Bridges Road|TTBB, SSAA, SATB|Jeremey Johnson
+She Belongs to Me|TTBB|Jeremey Johnson
+Silent Night|TTBB, SSAA|Jeremey Johnson
+Sing A Song|TTBB|Jeremey Johnson
+Someone's Waiting For You|TTBB|Jeremey Johnson
+Sometimes It Snows In April|TTBB|Jeremey Johnson
+Sound of Music Medley|TTBB|Jeremey Johnson
+Stella By Starlight|TTBB|Jeremey Johnson
+Straight Street|TTBB|Jeremey Johnson
+Take a Step in the Right Direction|TTBB|Jeremey Johnson
+Totally|TTBB|Jeremey Johnson
+Turn Your Eyes Upon Jesus|TTBB|Jeremey Johnson
+Twisted|TTBB|Jeremey Johnson
+Uptown Funk!|TTBB|Jeremey Johnson
+We All Need Saving|TTBB|Jeremey Johnson
+We're Glad You're Here|TTBB|Jeremey Johnson
+Welcome to the 60's|SSAA|Jeremey Johnson
+You Are So Beautiful|TTBB, SATB|Jeremey Johnson
+You Are So Beautiful|SSAA|Jeremey Johnson
+You Are The Sunshine Of My Life|TTBB, SSAA|Jeremey Johnson
+You're The Best|TTBB|Jeremey Johnson
+Zuckerman's Famous Pig|TTBB|Jeremey Johnson
+A Hundred And Sixty Acres|TTBB|Jordan Johnson
+City Of New Orleans|TTBB|Jordan Johnson
+Lucky Day/Innocent When You Dream|TTBB|Jordan Johnson
+Picture In A Frame|TTBB|Jordan Johnson
+Poisoning Pigeons In The Park|TTBB|Jordan Johnson
+Achy Breaky Heart|SSAA|Marie Johnson
+Applause|SSAA|Marie Johnson
+Be My Springtime|SSAA|Marie Johnson
+Best Things In Life Are Free|TTBB|Marie Johnson
+The Best Time Of Your Life|SSAA|Marie Johnson
+Bring Back Those Minstrel Days|TTBB|Marie Johnson
+Bring Me Back My Lovin' Honey Boy|SSAA|Marie Johnson
+Climbin' Up The Mountain|SSAA|Marie Johnson
+Do You Hear What I Hear|SSAA|Marie Johnson
+Down At The Barbecue|SSAA|Marie Johnson
+Down By The Old Mill Stream|SSAA|Marie Johnson
+Fireman, Save My Child|TTBB|Marie Johnson
+First Class Private Mary Brown|TTBB|Marie Johnson
+Give Me Just One Minute More|SSAA|Marie Johnson
+Good Morning Theme|SSAA|Marie Johnson
+Good Night Theme|SSAA|Marie Johnson
+Green Green Grass Of Home|TTBB|Marie Johnson
+Green Leaves Of Summer|TTBB|Marie Johnson
+He May Be Old, But He's Got Young Ideas|SSAA|Marie Johnson
+How Many Hearts Have You Broken?|SSAA|Marie Johnson
+Hunting Song|TTBB|Marie Johnson
+I Don't Know Enough About You|SSAA|Marie Johnson
+I'll Be A Famous Lady Of The Stage|SSAA|Marie Johnson
+I'm Alone Because I Love You|SSAA|Marie Johnson
+I'm In Love With The Sound Effects Man|SSAA|Marie Johnson
+I'm Sending A Message To Daddy|SSAA|Marie Johnson
+I'm The One Your're Looking For|SSAA|Marie Johnson
+I've Got The Blues For Tennessee|SSAA|Marie Johnson
+If He Can Fight Like He Can Love, Good Night Germany|SSAA|Marie Johnson
+If I Could Write A Song|SSAA|Marie Johnson
+Irish Songs Give Me A Pain (Parody)|SSAA|Marie Johnson
+It's A Million To One You're In Love|SSAA|Marie Johnson
+It's Been A Long, Long Time|SSAA|Marie Johnson
+It's Time To Fall In Love|SSAA|Marie Johnson
+Ja-Da|SSAA|Marie Johnson
+Keep The Home Fires Burning|TTBB|Marie Johnson
+The Lady From 29 Palms|SSAA|Marie Johnson
+Let There Be Peace On Earth|SSAA|Marie Johnson
+Lime Jello Marshmallow Cottage Cheese Surprise|SSAA|Marie Johnson
+Little Boy Blue|SSAA|Marie Johnson
+Looking At The Rain And Missing You|SSAA|Marie Johnson
+The Lord's Prayer|SSAA|Marie Johnson
+Love Is Friendship Set To Music|SSAA|Marie Johnson
+Love Lifted Me|SSAA|Marie Johnson
+Masochism Tango|TTBB|Marie Johnson
+The Memory Of You Lives On|SSAA|Marie Johnson
+Music|SSAA|Marie Johnson
+My Melancholy Baby|SSAA|Marie Johnson
+Never Hit Your Grandma With A Shovel|TTBB|Marie Johnson
+Never Let The Same Bee|SSAA|Marie Johnson
+Ode To My Answering Machine|SSAA|Marie Johnson
+Oh! How I Laugh When I Think How I Cried About You|SSAA|Marie Johnson
+Older Women|TTBB|Marie Johnson
+On A Bicycle Built For Two (Daisy Bell)|SSAA|Marie Johnson
+One, Two, Button Your Shoe|TTBB|Marie Johnson
+Over There|TTBB|Marie Johnson
+River In Judea|SSAA|Marie Johnson
+Silver Medals And Sweet Memories|SSAA|Marie Johnson
+Singin' In The Rain|TTBB|Marie Johnson
+Singing In A Great Quartet|SSAA|Marie Johnson
+Smoke! Smoke! Smoke That Cigarette|TTBB|Marie Johnson
+Stars Are The Windows Of Heaven|SSAA|Marie Johnson
+Take Me Out To The Ball Game|SSAA|Marie Johnson
+Thanks For The Memory|SSAA|Marie Johnson
+That's What God Made Grandmas For|SSAA|Marie Johnson
+There's A Star Spangled Banner Waving Somewhere|TTBB|Marie Johnson
+This Is The Moment|SSAA|Marie Johnson
+Til We Meet Again|SSAA|Marie Johnson
+Vocal Production|SSAA|Marie Johnson
+Walk With Me (Goin' Home)|SSAA|Marie Johnson
+Way Down Yonder In New Orleans|SSAA|Marie Johnson
+We Are A Beauty Shoppe Quartette|SSAA|Marie Johnson
+We Wish You A Merry Christmas|SSAA|Marie Johnson
+Wha Do Ya Do|SSAA|Marie Johnson
+What Do They Mean By Love?|SSAA|Marie Johnson
+What Ever Happened To Mary?|SSAA|Marie Johnson
+When I Lost You|SSAA|Marie Johnson
+Who'll Take My Place When I'm Gone|SSAA|Marie Johnson
+Will I Ever Tell You|SSAA|Marie Johnson
+World War I Girls Medley|TTBB|Marie Johnson
+You Were Only Fooling|SSAA|Marie Johnson
+God Only Knows|TTBB|Rosalind Johnson
+Greatest Day|SSAA|Rosalind Johnson
+Hold My Hand|SSAA|Rosalind Johnson
+If I Ain't Got You|SSAA|Rosalind Johnson
+Most Wonderful Time Of The Year|TTBB|Rosalind Johnson
+Penny Lane|TTBB|Rosalind Johnson
+Climb Ev'ry Mountain|TTBB|Harold Johnston
+Sound Of Music|TTBB|Harold Johnston
+Alice Blue Gown|TTBB|Bob Jones
+Frog Kissin'|TTBB|Bob Jones
+Lulu's Back In Town|TTBB|Bob Jones
+New Orleans Post Parade|TTBB|Bob Jones
+Slippery Sal and Dirty Dan|TTBB|Bob Jones
+Sweet Mae|TTBB|Bob Jones
+Wells Fargo Wagon|TTBB|Howard Jones
+Will I Ever Tell You|TTBB|Howard Jones
+Hard Hearted Hannah|TTBB|Howard Jones Jr.
+Rural Rhythm|TTBB|Howard Jones Jr.
+Amazing Grace|TTBB|Paul Jorg
+Another Hallelujah|TTBB|Paul Jorg
+Ashokan Farewell|TTBB|Paul Jorg
+Away In A Manager / Cradle Song Medley|TTBB|Paul Jorg
+Away In A Manger|TTBB|Paul Jorg
+Battle Hymn Of The Republic|TTBB|Paul Jorg
+Be Thou My Vision|TTBB|Paul Jorg
+Beautiful Isle Of Somewhere|TTBB|Paul Jorg
+Beyond The Sunset/Sunrise|TTBB|Paul Jorg
+Blessed Assurance|TTBB|Paul Jorg
+Blessed Be The Name|TTBB|Paul Jorg
+Can He, Could He, Would He|TTBB|Paul Jorg
+Children Of The Heavenly Father|TTBB|Paul Jorg
+Columbia, The Gem of the Ocean Medley|TTBB|Paul Jorg
+Come On, Ring Those Bells|TTBB|Paul Jorg
+Count your blessings|TTBB|Paul Jorg
+Daniel Saw The Stone|TTBB|Paul Jorg
+Dear Heart|TTBB|Paul Jorg
+Do You Know You Are My Sunshine|TTBB|Paul Jorg
+Done In Black And White|TTBB|Paul Jorg
+Down To The River To Pray|TTBB|Paul Jorg
+Happy Rhythm|TTBB|Paul Jorg
+Harbor Lights|TTBB|Paul Jorg
+Hasta La Vista|TTBB|Paul Jorg
+Holy Highway|TTBB|Paul Jorg
+Honeycomb|TTBB|Paul Jorg
+How Great Thou Art|TTBB|Paul Jorg
+I Believe In Miracles|TTBB|Paul Jorg
+I Just Can't Make It By Myself|TTBB|Paul Jorg
+I Pledge My Allegiance|TTBB|Paul Jorg
+It Is Well With My Soul|TTBB|Paul Jorg
+Just A Closer Walk With Thee|TTBB|Paul Jorg
+Learning To Lean|TTBB|Paul Jorg
+Let Freedom Ring|TTBB|Paul Jorg
+Lord Bless You And Keep You|TTBB|Paul Jorg
+Lost In The Music|SSAA|Paul Jorg
+Lost In The Music|TTBB|Paul Jorg
+Lovely Way To Spend An Evening|SATB|Paul Jorg
+My Special Angel|TTBB|Paul Jorg
+Near The Cross|TTBB|Paul Jorg
+O Little Town Of Bethlehem|TTBB|Paul Jorg
+Pass Me By|TTBB|Paul Jorg
+The Shifting Whispering Sands|TTBB|Paul Jorg
+Somebody Touched Me|TTBB|Paul Jorg
+Swing Low, Swing Down Medley|TTBB|Paul Jorg
+Turn Your Radio On|TTBB|Paul Jorg
+Wayfaring Stranger|TTBB|Paul Jorg
+We Are Climbing Jacob's Ladder|TTBB|Paul Jorg
+We Three Kings / God Rest Ye Merry Medley|TTBB|Paul Jorg
+What A Friend We Have In Jesus|TTBB|Paul Jorg
+When The Saints Go Marching In|TTBB|Paul Jorg
+Why Me|TTBB|Paul Jorg
+Yellow Rose Of Texas|TTBB|Paul Jorg
+Everybody Loves A Lover|TTBB|Drayton Justus
+But Not For Me|TTBB|Walter Kaestner
+Feliz Navidad|TTBB|Walter Kaestner
+Ice Cream|TTBB|Walter Kaestner
+I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Jimbob Kahlke
+Only You (And You Alone)|SSAA|Jimbob Kahlke
+Only You (And You Alone)|TTBB|Jimbob Kahlke
+Something|TTBB|Jimbob Kahlke
+Air So Sweet|SSAA|Lauren Kahn
+All Of Me|SSAA|Lauren Kahn
+Annie's Song|SSAA|Lauren Kahn
+Coming Home|TTBB|Lauren Kahn
+Everywhere|SSAA|Lauren Kahn
+A Farewell To Kings|SSAA|Lauren Kahn
+Get Together|SSAA|Lauren Kahn
+Goodbye Yellow Brick Road|SSAA|Lauren Kahn
+Happy|SSAA|Lauren Kahn
+Have Yourself A Merry Little Christmas|SATB|Lauren Kahn
+Head Over Heels|SSAA|Lauren Kahn
+Here We Are|SSAA|Lauren Kahn
+The Hideaway|SATB|Lauren Kahn
+Holiday Road|SSAA|Lauren Kahn
+Home|SSAA|Lauren Kahn
+Hooray for Tom|SSAA|Lauren Kahn
+Humble and Kind|SSAA|Lauren Kahn
+If I Ain't Got You|SSAA|Lauren Kahn
+If You Don't Want My Love|SSAA|Lauren Kahn
+Jealousy|SSAA|Lauren Kahn
+The Joke|SSAA|Lauren Kahn
+Let It Snow Let It Snow Let It Snow|SATB|Lauren Kahn
+Make Your Own Kind of Music|SSAA|Lauren Kahn
+Mama, I'm Coming Home|SATB|Lauren Kahn
+Misty|SSAA|Lauren Kahn
+My Future|SSAA|Lauren Kahn
+New Romantics|SSAA|Lauren Kahn
+Old Friends|SSAA|Lauren Kahn
+One Day|SSAA|Lauren Kahn
+Past LIfe|SSAA|Lauren Kahn
+Remedy|SSAA|Lauren Kahn
+Right As Rain|SSAA|Lauren Kahn
+Rise|SSAA|Lauren Kahn
+Safe and Sound|SSAA|Lauren Kahn
+Secret For The Mad|SSAA|Lauren Kahn
+Sing|SSAA|Lauren Kahn
+Sometimes|SSAA|Lauren Kahn
+Step Into Christmas|SSAA|Lauren Kahn
+Take Me Home, Country Roads|SSAA|Lauren Kahn
+Team|SSAA|Lauren Kahn
+There's A Frost On The Moon|SSAA|Lauren Kahn
+Truly, Madly, Deeply|SATB|Lauren Kahn
+Up, Up And Away (My Beautiful Balloon)|SSAA|Lauren Kahn
+Vienna|SSAA|Lauren Kahn
+Yakko's Universe|SSAA|Lauren Kahn
+You've Got A Friend|SSAA|Lauren Kahn
+Come What May|SSAA|Alex Kaiserman
+Here, There And Everywhere|TTBB|Alex Kaiserman
+Lean On Me|TTBB|Alex Kaiserman
+Love Of My Life|SSAA|Alex Kaiserman
+Make You Feel My Love|TTBB|Alex Kaiserman
+Marry You|TTBB|Alex Kaiserman
+Price Tag|SATB|Alex Kaiserman
+Since You've Been Gone|SSAA|Alex Kaiserman
+Up On The Roof|SATB|Alex Kaiserman
+When You Say Nothing At All|TTBB|Alex Kaiserman
+Zoom|SSAA|Alex Kaiserman
+Alone|SATB|Julianne Kallman
+Bye Bye Bye|SSAA|Julianne Kallman
+Diamonds are Forever|SATB|Julianne Kallman
+Big Daddy|SSAA|Jean Kane
+Blame It On The Boogie|SSAA|Jean Kane
+Blue Hawaii|SSAA|Jean Kane
+I Enjoy Being A Girl|SSAA|Jean Kane
+I'm Knee Deep In Daisies|SSAA|Jean Kane
+It Looks Like Rain In Cherry Blossom Lane|SSAA|Jean Kane
+My Foolish Heart|SSAA|Jean Kane
+You Are The Sunshine Of My Life|SSAA|Jean Kane
+Blue Bayou|SSAA|Connie Kash
+Boogie Woogie Bugle Boy|SSAA|Connie Kash
+Broadway Baby|SSAA|Connie Kash
+Chiquita Banana|SSAA|Connie Kash
+Deed I Do|SSAA|Connie Kash
+Give Me The Simple Life|SSAA|Connie Kash
+Greenfields|SSAA|Connie Kash
+It Had To Be You|SSAA|Connie Kash
+It's Make Believe Ballroom Time|SSAA|Connie Kash
+A Straw Hat And A Cane|SSAA|Connie Kash
+Time In A Bottle|SSAA|Connie Kash
+What A Wonderful World|SSAA|Connie Kash
+What Can I Say After I Say I'm Sorry|SSAA|Connie Kash
+You Didn't Want Me When You Had Me|SSAA|Connie Kash
+Just As I Am|TTBB|Bob Kauflin
+What A Wonderful Day|TTBB|Mervin Keedy
+All The Time|SSAA|Susan Kegley
+Almost Like Being In Love|TTBB|Susan Kegley
+Be Our Guest|SSAA|Susan Kegley
+The Christmas Song|SSAA|Susan Kegley
+Cool Yule|SSAA|Susan Kegley
+Do You Hear What I Hear|SSAA|Susan Kegley
+Here Comes Santa Claus|SSAA|Susan Kegley
+In The Cool Cool Cool Of The Evening|SSAA|Susan Kegley
+Keep Christmas With You (All Through The Year)|SSAA|Susan Kegley
+Lullabye|SSAA|Susan Kegley
+Merry Christmas Darling|SSAA|Susan Kegley
+The Nearness Of You|SSAA|Susan Kegley
+One Short Day|SSAA|Susan Kegley
+One Voice|TTBB|Susan Kegley
+Pennies from Heaven|SSAA|Susan Kegley
+Sometimes|SSAA|Susan Kegley
+Taking A Chance On Love|SSAA|Susan Kegley
+That's Christmas To Me|TTBB|Susan Kegley
+Top Of The World|SSAA|Susan Kegley
+Uptempo Folksong (Generic)|SSAA|Susan Kegley
+What The World Needs Now Is Love|SSAA|Susan Kegley
+The Rose|SSAA|Dick Keirstead
+Bring Me To Life|SSAA|Erica Kelch-Slesnick
+Do You Know The Way To San Jose|SSAA|Erica Kelch-Slesnick
+Gaudete|SSAA|Erica Kelch-Slesnick
+A Hand For Mrs. Claus|TTBB, SSAA|Erica Kelch-Slesnick
+Hanukkah Medley|SSAA|Erica Kelch-Slesnick
+Helplessly Hoping|SSAA|Erica Kelch-Slesnick
+Here We Come A Wassailing|SSAA|Erica Kelch-Slesnick
+I Got You (I Feel Good)|SSAA|Erica Kelch-Slesnick
+Move Like That|SATB|Erica Kelch-Slesnick
+My Days|SSAA|Erica Kelch-Slesnick
+Rise Like A Phoenix|SSAA|Erica Kelch-Slesnick
+Shake It Off|SSAA|Erica Kelch-Slesnick
+Step Into Christmas|SSAA|Erica Kelch-Slesnick
+Stretchy Pants|SSAA|Erica Kelch-Slesnick
+Think|SSAA|Erica Kelch-Slesnick
+Walk Like an Egyptian|SSAA|Erica Kelch-Slesnick
+Wannabe|SSAA|Erica Kelch-Slesnick
+White Christmas|SSAA|Erica Kelch-Slesnick
+You Gotta Be|SSAA|Erica Kelch-Slesnick
+Cups (When I'm Gone)|SSAA|Jenna Kellas
+Time After Time|TTBB|Paul Kelleher
+Vacation|SSAA|Elizabeth Keller
+50's Rock and Roll Medley|TTBB|Kevin Keller
+A Kiss To Build A Dream On|TTBB, SSAA, SATB|Kevin Keller
+A Million Dreams|TTBB, SSAA|Kevin Keller
+Across the Field|TTBB, SSAA, SATB|Kevin Keller
+Africa|TTBB, SSAA, SATB|Kevin Keller
+After I've Called You Sweetheart|TTBB|Kevin Keller
+Ain't It The Truth|TTBB, SSAA, SATB|Kevin Keller
+Ain't We Got Fun|TTBB, SSAA, SATB|Kevin Keller
+All I Do Is Dream Of You|TTBB|Kevin Keller
+All I Do Is Dream Of You|SSAA|Kevin Keller
+All I Need Is The Girl|TTBB|Kevin Keller
+All The Things You Are|SATB|Kevin Keller
+Almost There|TTBB, SSAA|Kevin Keller
+Alto's Lament|SSAA|Kevin Keller
+Anything Goes|TTBB, SSAA|Kevin Keller
+Are You Havin' Any Fun|TTBB|Kevin Keller
+Are You Havin' Any Fun|SSAA, SATB|Kevin Keller
+As Long As I Live|TTBB, SSAA, SATB|Kevin Keller
+At The Mississippi Cabaret|TTBB, SSAA|Kevin Keller
+Ave Maria|SATB|Kevin Keller
+Baby Love|SSAA|Kevin Keller
+Back Home Again|TTBB, SSAA, SATB|Kevin Keller
+Bad, Bad Leroy Brown|TTBB, SSAA, SATB|Kevin Keller
+Barbershop Memories|TTBB|Kevin Keller
+Be A Clown|TTBB|Kevin Keller
+Be The Hero|TTBB|Kevin Keller
+Beautiful|SSAA|Kevin Keller
+Beautiful Boy|TTBB, SSAA, SATB|Kevin Keller
+Because My Baby Don't Mean 'Maybe' Now|TTBB, SSAA, SATB|Kevin Keller
+Being Alive|SSAA|Kevin Keller
+Being Good Isn't Good Enough|TTBB|Kevin Keller
+Believe|TTBB, SSAA, SATB|Kevin Keller
+Believe It Or Not|TTBB|Kevin Keller
+Both Sides Now|TTBB, SSAA, SATB|Kevin Keller
+Broken Hearted (Here Am I)|SSAA|Kevin Keller
+Broken Together|TTBB|Kevin Keller
+Brother, My Brother|TTBB|Kevin Keller
+Buckeye Battle Cry|TTBB, SSAA, SATB|Kevin Keller
+But The World Goes Around|TTBB|Kevin Keller
+Can He, Could He, Would He|TTBB, SSAA, SATB|Kevin Keller
+Can't Help Falling In Love|TTBB, SSAA|Kevin Keller
+Can't Take My Eyes Off Of You|SATB|Kevin Keller
+Can't Take My Eyes Off Of You|TTBB, SSAA|Kevin Keller
+Candy Man|TTBB, SSAA, SATB|Kevin Keller
+Carmen Ohio|TTBB, SSAA, SATB|Kevin Keller
+Cartoon Medley|TTBB|Kevin Keller
+Cell Block Tango|SSAA|Kevin Keller
+Chasin' the Blues|TTBB, SSAA|Kevin Keller
+Cheer Up, Charlie|TTBB, SSAA|Kevin Keller
+Cherish|TTBB, SSAA, SATB|Kevin Keller
+Chicken Fried|TTBB, SSAA, SATB|Kevin Keller
+Childhood|TTBB|Kevin Keller
+Chimney Medley|TTBB|Kevin Keller
+Come Dance With Me|SSAA|Kevin Keller
+Come Dance With Me / Come Fly With Me Medley|TTBB|Kevin Keller
+Come Fly With Me|TTBB, SSAA, SATB|Kevin Keller
+Come What May|TTBB, SSAA, SATB|Kevin Keller
+Crying My Heart Out For You|TTBB|Kevin Keller
+Daydream|TTBB, SSAA, SATB|Kevin Keller
+Deep In My Heart, Dear|TTBB|Kevin Keller
+Defying Gravity|TTBB|Kevin Keller
+Destination Moon|SSAA|Kevin Keller
+Diane (I'm In Heaven When I See You Smile)|TTBB|Kevin Keller
+Die Lorelei|TTBB, SSAA|Kevin Keller
+Ding-Dong! The Witch Is Dead|TTBB, SSAA, SATB|Kevin Keller
+Don't Let That Moon Get Away|TTBB, SSAA, SATB|Kevin Keller
+Don't Look At Me That Way|TTBB, SSAA|Kevin Keller
+Don't Put A Tax On The Beautiful Girls|TTBB|Kevin Keller
+Don't Take The Girl|TTBB|Kevin Keller
+Don't Worry Baby|TTBB|Kevin Keller
+Down In New Orleans|TTBB, SSAA, SATB|Kevin Keller
+Down With Love|TTBB, SSAA|Kevin Keller
+Doxology|TTBB, SSAA, SATB|Kevin Keller
+Dream On|TTBB, SSAA|Kevin Keller
+Drifting|SSAA|Kevin Keller
+Drifting|TTBB|Kevin Keller
+Evermore|TTBB|Kevin Keller
+Everybody Loves Somebody|TTBB|Kevin Keller
+Everyone's Wrong But Me|TTBB, SSAA, SATB|Kevin Keller
+Fantastic, That's You|TTBB|Kevin Keller
+Feed The Birds|TTBB, SSAA, SATB|Kevin Keller
+Forever And Ever, Amen|TTBB, SSAA|Kevin Keller
+Forty-Second Street|TTBB|Kevin Keller
+Georgia On My Mind|SATB|Kevin Keller
+Get Happy|TTBB|Kevin Keller
+Get Happy/Hallelujah|TTBB|Kevin Keller
+Get Up And Go|TTBB, SSAA|Kevin Keller
+Gnome Travelogue Medley|TTBB|Kevin Keller
+Go Rest High on that Mountain|TTBB|Kevin Keller
+Good Morning Life|TTBB, SSAA|Kevin Keller
+Goodbye My Lady Love|TTBB|Kevin Keller
+Gotta Go!|TTBB|Kevin Keller
+Gotta Lot Of Rhythm In My Soul|TTBB, SSAA, SATB|Kevin Keller
+Great Atomic Power|TTBB, SSAA, SATB|Kevin Keller
+Great Is Thy Faithfulness|TTBB|Kevin Keller
+Guilty|TTBB, SSAA, SATB|Kevin Keller
+Hail to the Chief|TTBB, SSAA, SATB|Kevin Keller
+Happy Days Are Here Again|TTBB|Kevin Keller
+Hard Times (No One Knows Better Than I)|TTBB|Kevin Keller
+Harmony|TTBB|Kevin Keller
+Heat Wave|SSAA|Kevin Keller
+Hello My Baby|TTBB, SSAA|Kevin Keller
+Here's To Love|TTBB|Kevin Keller
+Hero|TTBB, SSAA|Kevin Keller
+Hold On|TTBB, SSAA|Kevin Keller
+Hold On Tight|TTBB, SSAA|Kevin Keller
+Holly Jolly Christmas|TTBB, SSAA, SATB|Kevin Keller
+Homeward Bound|TTBB, SSAA, SATB|Kevin Keller
+How Are Things In Glocca Morra|SATB|Kevin Keller
+How Can You Mend a Broken Heart|SSAA|Kevin Keller
+How Deep Is The Ocean|TTBB, SSAA|Kevin Keller
+How It Ends|TTBB|Kevin Keller
+How Long Has This Been Going On?|TTBB, SSAA|Kevin Keller
+I Believe In You|TTBB|Kevin Keller
+I Can't Believe That You're In Love With Me|SSAA|Kevin Keller
+I Can't Believe That You're In Love With Me|TTBB|Kevin Keller
+I Can't Help Falling in Love with You|TTBB|Kevin Keller
+I Dig Rock And Roll Music|TTBB, SSAA|Kevin Keller
+I Dig Rock And Roll Music|TTBB|Kevin Keller
+I Double Dare You|TTBB|Kevin Keller
+I Fall To Pieces|TTBB, SSAA|Kevin Keller
+I Fall To Pieces/Crazy Medley|TTBB|Kevin Keller
+I Know Why And So Do You|TTBB, SSAA|Kevin Keller
+I Love Being Here With You|TTBB, SSAA|Kevin Keller
+I Love Being Here With You / On A Slow Boat To China Medley|SSAA|Kevin Keller
+I Love That We're Old Fashioned|SSAA|Kevin Keller
+I Love That We're Old Fashioned|TTBB|Kevin Keller
+I May Be Gone For A Long, Long Time/Yankee Boy|TTBB|Kevin Keller
+I Must Be Comin' Down with the Blues|TTBB|Kevin Keller
+I Saw Three Ships|TTBB|Kevin Keller
+I See The Light (from Walt Disney Pictures' TANGLED)|TTBB, SSAA|Kevin Keller
+I See Your Face Before Me|TTBB, SSAA, SATB|Kevin Keller
+I Sing You Sing|TTBB|Kevin Keller
+I Walk A Little Faster|TTBB, SSAA, SATB|Kevin Keller
+I Wish That I Could Hide Inside This Letter|TTBB, SSAA, SATB|Kevin Keller
+I'll Dream of You Again/And So To Sleep Again Medley|TTBB, SSAA|Kevin Keller
+I'm A Believer|TTBB, SATB|Kevin Keller
+I'm Glad There Is You|TTBB, SSAA, SATB|Kevin Keller
+I'm Not Gonna Worry|TTBB|Kevin Keller
+I'm Stone In Love With You|TTBB, SATB|Kevin Keller
+I'm Thru with Love|TTBB, SSAA, SATB|Kevin Keller
+I've Got A Crush On You|TTBB, SSAA|Kevin Keller
+I've Got A Golden Ticket|TTBB, SSAA|Kevin Keller
+If You Go Away|TTBB, SSAA, SATB|Kevin Keller
+Immanuel|TTBB|Kevin Keller
+In The Wee Small Hours Of The Morning|TTBB|Kevin Keller
+In This Heart|SSAA|Kevin Keller
+The International Rag|TTBB, SSAA|Kevin Keller
+It Had To Be You|TTBB, SSAA|Kevin Keller
+It Never Was You|TTBB, SSAA|Kevin Keller
+It's A Jungle Out There|TTBB, SSAA, SATB|Kevin Keller
+It's Time To Say So Long|TTBB|Kevin Keller
+Jingle Jingle Jingle|TTBB|Kevin Keller
+Joy|TTBB|Kevin Keller
+Just A Kid Named Joe|TTBB|Kevin Keller
+Just Give Me A Reason|TTBB, SSAA|Kevin Keller
+Just In Time|SATB|Kevin Keller
+Justin Timberlake Medley|SATB|Kevin Keller
+Kindred Spirits|TTBB|Kevin Keller
+King Of The Road|TTBB, SSAA, SATB|Kevin Keller
+Knee Deep|TTBB|Kevin Keller
+Last Night When We Were Young|TTBB, SATB|Kevin Keller
+Let Me Drown|TTBB|Kevin Keller
+Let Me Sing And I'm Happy|TTBB|Kevin Keller
+Let's Fall In Love|TTBB|Kevin Keller
+Let's Get Away From It All|TTBB, SSAA, SATB|Kevin Keller
+Let's Just Stay In|TTBB, SSAA, SATB|Kevin Keller
+Let's Love|TTBB|Kevin Keller
+Let's Start Tomorrow Tonight|TTBB, SSAA, SATB|Kevin Keller
+Little Saint Nick|TTBB, SSAA, SATB|Kevin Keller
+Lose That Long Face|TTBB, SSAA, SATB|Kevin Keller
+Lullaby for Baby Jesus|TTBB, SSAA|Kevin Keller
+Lullaby League And Lollypop Guild|SATB|Kevin Keller
+Make Them Hear You|TTBB|Kevin Keller
+Mean To Me|TTBB, SSAA|Kevin Keller
+Medley: They Just Keep Moving The Line, Almost There|TTBB, SATB|Kevin Keller
+Merry Old Land Of Oz|TTBB, SSAA, SATB|Kevin Keller
+Mirrors|SATB|Kevin Keller
+Misty|SATB|Kevin Keller
+More|TTBB|Kevin Keller
+More I Cannot Wish You|TTBB, SSAA, SATB|Kevin Keller
+Morning Side Of The Mountain|TTBB, SSAA, SATB|Kevin Keller
+Most Wonderful Time Of The Year|TTBB|Kevin Keller
+Munchkinland|TTBB, SSAA|Kevin Keller
+Music Man Medley|TTBB|Kevin Keller
+Music Of My Heart|TTBB|Kevin Keller
+My Diane|TTBB|Kevin Keller
+My Life for a Song|TTBB, SSAA|Kevin Keller
+My Lord and I|TTBB|Kevin Keller
+My Old Montana Home|TTBB|Kevin Keller
+My Special Angel|TTBB, SSAA|Kevin Keller
+My Tribute|TTBB, SSAA, SATB|Kevin Keller
+The Nearness Of You|SATB|Kevin Keller
+The Nearness Of You|TTBB|Kevin Keller
+Not A Bad Thing|SATB|Kevin Keller
+Not Gonna Worry|TTBB|Kevin Keller
+Notre Dame Victory March|TTBB, SSAA|Kevin Keller
+O Come O Come Emmanuel|TTBB, SSAA|Kevin Keller
+O Little Town Of Bethlehem|TTBB|Kevin Keller
+Oliver Medley|SSAA|Kevin Keller
+On A Clear Day|SATB|Kevin Keller
+On My Own|TTBB|Kevin Keller
+On Wisconsin|TTBB, SSAA, SATB|Kevin Keller
+Oompa-loomp-doompadee-doo|TTBB, SSAA|Kevin Keller
+Patapan|TTBB, SSAA|Kevin Keller
+Perfidia|SSAA, SATB|Kevin Keller
+Please Don't Forget Me|TTBB|Kevin Keller
+Proud of Your Boy|TTBB|Kevin Keller
+Puff The Magic Dragon|SATB|Kevin Keller
+Pure Imagination|TTBB, SSAA, SATB|Kevin Keller
+Put On A Happy Face|TTBB|Kevin Keller
+Rainbow Connection|TTBB, SSAA, SATB|Kevin Keller
+Rainy Night In Rio|TTBB, SSAA, SATB|Kevin Keller
+Red Hot Henry Brown|TTBB, SSAA|Kevin Keller
+Remembering You|TTBB, SSAA, SATB|Kevin Keller
+Rhode Island Is Famous For You|TTBB|Kevin Keller
+Ride, Red Ride|TTBB|Kevin Keller
+Ring Of Fire|TTBB, SSAA, SATB|Kevin Keller
+Ring Those Christmas Bells|TTBB|Kevin Keller
+Ring-A-Ding Ding|TTBB, SSAA, SATB|Kevin Keller
+Roll Out Of Bed With A Smile|TTBB|Kevin Keller
+Rudolph Montage|SATB|Kevin Keller
+Rudolph The Red Nosed Reindeer|TTBB|Kevin Keller
+Rumor Has It|SATB|Kevin Keller
+S Wonderful|TTBB, SATB|Kevin Keller
+Salty Dog|TTBB, SSAA, SATB|Kevin Keller
+Sam, The Old Accordion Man|TTBB, SSAA|Kevin Keller
+Satan's Li'l Lamb|TTBB|Kevin Keller
+Save Your Love for Me|TTBB|Kevin Keller
+Seventy-Six Trombones|TTBB, SATB|Kevin Keller
+The Shadow Of Your Smile|TTBB, SSAA|Kevin Keller
+She's Out Of My Life|TTBB, SSAA|Kevin Keller
+Silver And Gold|TTBB|Kevin Keller
+Sing It A Cappella|TTBB|Kevin Keller
+Sit Down You're Rockin' The Boat|TTBB, SSAA|Kevin Keller
+Slap That Bass|SSAA|Kevin Keller
+Smile|SSAA|Kevin Keller
+Some Nights|SSAA|Kevin Keller
+Some Things Are Meant To Be|TTBB, SSAA, SATB|Kevin Keller
+Somebody to Love|TTBB, SSAA, SATB|Kevin Keller
+Someone Like You|TTBB, SSAA|Kevin Keller
+Something Tells Me You're The Girl|TTBB|Kevin Keller
+Somewhere Out There|TTBB|Kevin Keller
+Somewhere That's Green|TTBB|Kevin Keller
+A Song For You|TTBB, SATB|Kevin Keller
+Songs|TTBB|Kevin Keller
+Speechless|SSAA|Kevin Keller
+Standing On The Corner|TTBB, SSAA|Kevin Keller
+Star Spangled Banner|TTBB|Kevin Keller
+Step In Time|TTBB|Kevin Keller
+Still, Still, Still|TTBB, SSAA, SATB|Kevin Keller
+Stompin' At The Savoy|TTBB|Kevin Keller
+Strangers Like Me|TTBB|Kevin Keller
+Strawberry Moon|TTBB, SSAA, SATB|Kevin Keller
+Stronger (What Doesn't Kill You)|SSAA|Kevin Keller
+Summer Love|SATB|Kevin Keller
+Sunday Morning|TTBB|Kevin Keller
+Supremes Medley|TTBB|Kevin Keller
+Swingin' On A Star|TTBB, SATB|Kevin Keller
+Take Back The Night|SATB|Kevin Keller
+Ten Thousand Men Of Harvard|TTBB|Kevin Keller
+Texas A&M Aggie War Hymn|TTBB, SSAA|Kevin Keller
+That Old Feeling|TTBB, SSAA, SATB|Kevin Keller
+That's All|SATB|Kevin Keller
+That's Life|TTBB, SSAA|Kevin Keller
+The Candy Man|TTBB|Kevin Keller
+The International Rag|TTBB|Kevin Keller
+The Lord Is Good To Me|TTBB, SSAA, SATB|Kevin Keller
+The More I See You|TTBB, SSAA|Kevin Keller
+Then|TTBB|Kevin Keller
+There Used To Be A Ball Park|TTBB|Kevin Keller
+There's A Long, Long Trail|TTBB|Kevin Keller
+There's Always Tomorrow|TTBB, SSAA|Kevin Keller
+They Call The Wind Maria|TTBB|Kevin Keller
+They Just Keep Moving the Line|TTBB, SSAA|Kevin Keller
+They Just Keep Moving The Line/Almost there|SSAA|Kevin Keller
+Things Are Looking Up|TTBB|Kevin Keller
+This Heart of Mine|TTBB, SSAA|Kevin Keller
+This Nearly Was Mine|TTBB|Kevin Keller
+This Ole House|TTBB|Kevin Keller
+This Time the Dream's on Me|SATB|Kevin Keller
+Through a Long and Sleepless Night|TTBB|Kevin Keller
+Ticket To Ride|SSAA|Kevin Keller
+To Love and to be Loved|TTBB|Kevin Keller
+Together Wherever We Go|TTBB, SSAA|Kevin Keller
+Tomorrow Tonight|SATB|Kevin Keller
+Too Darn Hot|TTBB, SSAA|Kevin Keller
+Too Much Love Will Kill You|TTBB|Kevin Keller
+Topsy Turvy Day|TTBB, SSAA|Kevin Keller
+Twenty-Third Psalm|TTBB|Kevin Keller
+Two Less Lonely People in the World|TTBB, SSAA|Kevin Keller
+Unchained Melody|TTBB, SSAA|Kevin Keller
+Unsaid Things|TTBB|Kevin Keller
+Vaya Con Dios|TTBB, SSAA, SATB|Kevin Keller
+Victors March, The (U of M fight Song)|TTBB, SSAA, SATB|Kevin Keller
+Victory for MSU (Michigan State Fight Song)|TTBB, SSAA, SATB|Kevin Keller
+The Voyage|TTBB, SSAA, SATB|Kevin Keller
+Wayfaring Stranger|TTBB, SSAA, SATB|Kevin Keller
+We Are Santa's Elves|TTBB|Kevin Keller
+We Are The World|SSAA, SATB|Kevin Keller
+We Got Us|TTBB, SSAA, SATB|Kevin Keller
+We're A Couple of Misfits|TTBB, SATB|Kevin Keller
+We're Off To See The Wizard|TTBB, SSAA|Kevin Keller
+What Are You Doing The Rest Of Your Life|SATB|Kevin Keller
+What Child is This/A Child of the Poor|TTBB, SSAA|Kevin Keller
+What Goes Around|SATB|Kevin Keller
+What Kind Of Fool Am I|TTBB, SSAA, SATB|Kevin Keller
+When I Survey the Wondrous Cross|TTBB, SSAA, SATB|Kevin Keller
+When October Goes|TTBB, SSAA, SATB|Kevin Keller
+When Santa Gets a Headcold|TTBB|Kevin Keller
+When She Loved Me|TTBB, SSAA|Kevin Keller
+When the Call is Rolled up Yonder|TTBB, SSAA|Kevin Keller
+When You Come Home|TTBB|Kevin Keller
+Where Everybody Knows Your Name|TTBB, SSAA|Kevin Keller
+Who Can I Turn To? (When Nobody Needs Me)|TTBB, SSAA|Kevin Keller
+"Who Could Ever Love You More? (Alt. title, ""Miracle"")"|TTBB|Kevin Keller
+A Whole New World|TTBB, SSAA|Kevin Keller
+Why Haven't I Heard From You|SSAA|Kevin Keller
+Will The Sun Ever Shine Again|TTBB, SSAA|Kevin Keller
+Willie Wonka Medley I|TTBB|Kevin Keller
+With You|TTBB, SSAA, SATB|Kevin Keller
+Wizard Of Oz Medley|TTBB, SSAA|Kevin Keller
+Y.M.C.A.|TTBB|Kevin Keller
+You And I|TTBB|Kevin Keller
+You Can't Hurry Love|SSAA|Kevin Keller
+You'll Be In My Heart|TTBB|Kevin Keller
+You're A Lady|TTBB|Kevin Keller
+Your Cheatin' Heart|TTBB, SSAA|Kevin Keller
+Yes, We Have No Bananas|TTBB|Bob Kelly
+Hatikva (National Anthem of Israel)|TTBB|Patrick Kelly
+They All Call It Canada|TTBB|Beverly Kennedy
+They All Call It Canada|SSAA, SATB|Beverly Kennedy
+When The Sun Says Good Night To The Mountain|SSAA|Beverly Kennedy
+The Dream Never Dies|SSAA|Fran Kerbs
+I Want To Be A Cowboys Sweetheart|SSAA|Fran Kerbs
+Ain't That A Kick In The Head|SSAA|Debbie Keretz
+California Dreamin'|SSAA|Debbie Keretz
+Can't Help Falling In Love|SSAA|Debbie Keretz
+The Chipmunk Song|SSAA|Debbie Keretz
+Fame|SSAA|Debbie Keretz
+Fly Me To The Moon|SSAA|Debbie Keretz
+Fun Fun Fun|SSAA|Debbie Keretz
+Grown-Up Christmas List|SSAA|Debbie Keretz
+Have Yourself A Merry Little Christmas|SSAA|Debbie Keretz
+It Feels Like Christmas|SSAA|Debbie Keretz
+It Had To Be You|SSAA|Debbie Keretz
+It Was Almost Like A Song|SSAA|Debbie Keretz
+Love Letters|SSAA|Debbie Keretz
+Magic To Do|SSAA|Debbie Keretz
+Make 'Em Laugh|SSAA|Debbie Keretz
+Merry Christmas Darling|SSAA|Debbie Keretz
+Mood Indigo|SSAA|Debbie Keretz
+Moonglow|SSAA|Debbie Keretz
+Most Wonderful Time Of The Year|SSAA|Debbie Keretz
+Pure Imagination|SSAA|Debbie Keretz
+Remember Me|SSAA|Debbie Keretz
+Snow|SSAA|Debbie Keretz
+They Say It's Wonderful|SSAA|Debbie Keretz
+This Is It!|SSAA|Debbie Keretz
+This Nearly Was Mine|SSAA|Debbie Keretz
+Till There Was You|SSAA|Debbie Keretz
+Time Of My Life|SSAA|Debbie Keretz
+Time Was|SSAA|Debbie Keretz
+Traces|SSAA|Debbie Keretz
+Underneath the Tree|SSAA|Debbie Keretz
+Where The Blue Of The Night Meets The Gold Of The Day|SSAA|Debbie Keretz
+Barney Google|TTBB|Roy Keys
+Beside An Open Fireplace|TTBB|Roy Keys
+Christmas Eve In My Home Town|TTBB|Roy Keys
+Cryin' for The Carolines|TTBB|Roy Keys
+Daddy's Little Girl|TTBB|Roy Keys
+Do Lord|TTBB|Roy Keys
+Drink To Me Only With Thine Eyes|TTBB|Roy Keys
+Everywhere You Go|TTBB|Roy Keys
+For Lovin' Me|TTBB|Roy Keys
+Gone|TTBB|Roy Keys
+Greatest Mistake Of My Life|TTBB|Roy Keys
+Home|TTBB|Roy Keys
+I Wonder What's Become Of Sally|TTBB|Roy Keys
+In The Garden|TTBB|Roy Keys
+Lucky Day|TTBB|Roy Keys
+Mistakes|TTBB, SSAA|Roy Keys
+Mother Of Mine|TTBB|Roy Keys
+Old Rugged Cross|TTBB|Roy Keys
+Pal Of My Cradle Days|TTBB|Roy Keys
+Powder Your Face With Sunshine|TTBB|Roy Keys
+Roses Of Picardy|TTBB|Roy Keys
+Sentimental Gentleman From Georgia|TTBB|Roy Keys
+September Song|TTBB|Roy Keys
+Smile, Darn Ya, Smile|TTBB|Roy Keys
+Sweet Georgia Brown|TTBB|Roy Keys
+Sweetheart Of All My Dreams|TTBB|Roy Keys
+That Lovely Weekend|TTBB|Roy Keys
+That Wonderful Mother Of Mine|TTBB|Roy Keys
+When He Gave Me You|TTBB|Roy Keys
+When Irish Eyes Are Smiling|TTBB|Roy Keys
+When You're Smiling|TTBB|Roy Keys
+No More Sorrow|TTBB|Shelton Kilby III
+Blue Velvet|TTBB|Curt Kimball
+Charade|TTBB|Curt Kimball
+Ev'ry Day Of My Life|TTBB|Curt Kimball
+Laugh Clown Laugh|TTBB|Curt Kimball
+Rocky Top|SSAA|Curt Kimball
+You Don't Know Me|TTBB|Curt Kimball
+He May Be Old, But He's Got Young Ideas|TTBB|Don King
+Sometime|TTBB|Don King
+When I Dream Of Old Erin|TTBB|Don King
+Almost Like Being In Love|TTBB|Erik King
+At the End of the Road|TTBB|Fred King
+Crying for You|TTBB|Fred King
+Didn't We|TTBB|Fred King
+Don't Fence Me In|TTBB|Fred King
+Ebb Tide|TTBB, SSAA|Fred King
+He's Got The Whole World|TTBB|Fred King
+Heart Of My Heart Medley|TTBB|Fred King
+Hi Neighbor|TTBB|Fred King
+I've Lost All My Love For You|TTBB|Fred King
+If I Ruled The World|TTBB|Fred King
+Jeepers Creepers|TTBB|Fred King
+Jeepers Creepers|SSAA|Fred King
+Just For Remembrance|TTBB|Fred King
+Little Man You've Had A Busy Day|TTBB|Fred King
+Love Letters|SSAA|Fred King
+Memories Of You|TTBB|Fred King
+My Friend|TTBB|Fred King
+Sailing Down The Chesapeake Bay|TTBB|Fred King
+So Long, Mother|TTBB|Fred King
+That Old Feeling|TTBB|Fred King
+Undecided|SSAA|Fred King
+When Irish Eyes Are Smiling|TTBB|Fred King
+Why Did I Choose You?|SSAA|Fred King
+Beauty And The Beast|TTBB|Carol Kingsbury
+A Dream Is A Wish Your Heart Makes|SSAA|Kohl Kitzmiller
+A Million Dreams|TTBB|Kohl Kitzmiller
+The Ace In The Hole|TTBB|Kohl Kitzmiller
+All By Myself|SSAA|Kohl Kitzmiller
+All I Ask|TTBB, SSAA|Kohl Kitzmiller
+All Over The World|TTBB, SSAA|Kohl Kitzmiller
+All The Gifts I Need|TTBB|Kohl Kitzmiller
+All The Way|TTBB|Kohl Kitzmiller
+Always On My Mind|TTBB|Kohl Kitzmiller
+Around the World|TTBB|Kohl Kitzmiller
+As Long As I'm Singing|TTBB, SSAA, SATB|Kohl Kitzmiller
+Autumn In New York|TTBB|Kohl Kitzmiller
+Bananaphone|TTBB, SSAA, SATB|Kohl Kitzmiller
+Bang Bang|SSAA|Kohl Kitzmiller
+Beautiful|SSAA, SATB|Kohl Kitzmiller
+Bella Notte|TTBB|Kohl Kitzmiller
+The Best Thing For You|TTBB, SSAA|Kohl Kitzmiller
+Beth|TTBB|Kohl Kitzmiller
+Better Man|TTBB|Kohl Kitzmiller
+Blame It On The Boogie|TTBB, SSAA, SATB|Kohl Kitzmiller
+Blue Smoke|SSAA|Kohl Kitzmiller
+Brave|SATB|Kohl Kitzmiller
+Busy Doing Nothing|SSAA|Kohl Kitzmiller
+Can't Buy Me Love|TTBB, SSAA, SATB|Kohl Kitzmiller
+Can't Help Falling In Love|SATB|Kohl Kitzmiller
+Caught A Touch Of Your Love|SSAA|Kohl Kitzmiller
+The Christmas Song|SSAA|Kohl Kitzmiller
+Christmas Time Is Here|TTBB, SSAA, SATB|Kohl Kitzmiller
+The Circle Of Life|SATB|Kohl Kitzmiller
+Cowboys and Angels|TTBB|Kohl Kitzmiller
+Crazy Little Thing Called Love|TTBB, SSAA|Kohl Kitzmiller
+Creep|TTBB|Kohl Kitzmiller
+Dancin' In The Moonlight|TTBB|Kohl Kitzmiller
+Danke Schoen|SSAA|Kohl Kitzmiller
+Days of Wine and Roses|TTBB|Kohl Kitzmiller
+Do - Re - Mi|TTBB|Kohl Kitzmiller
+Don't Know Why|TTBB, SSAA, SATB|Kohl Kitzmiller
+Don't Rain on My Parade|SATB|Kohl Kitzmiller
+Don't Speak|SSAA|Kohl Kitzmiller
+Dream A Little Dream Of Me|TTBB, SSAA, SATB|Kohl Kitzmiller
+Dream Lover|TTBB, SSAA, SATB|Kohl Kitzmiller
+Evermore|TTBB|Kohl Kitzmiller
+Everybody Loves Somebody|TTBB, SSAA, SATB|Kohl Kitzmiller
+Faith|TTBB, SSAA, SATB|Kohl Kitzmiller
+Feel It Still|TTBB|Kohl Kitzmiller
+Fly Me To The Moon|TTBB, SSAA, SATB|Kohl Kitzmiller
+Follow Me|TTBB, SSAA, SATB|Kohl Kitzmiller
+Fools Fall In Love|TTBB|Kohl Kitzmiller
+Footloose|SSAA|Kohl Kitzmiller
+For You|TTBB|Kohl Kitzmiller
+Fortuosity|TTBB|Kohl Kitzmiller
+Get Happy|TTBB, SSAA, SATB|Kohl Kitzmiller
+Get Me To The Church On Time|TTBB|Kohl Kitzmiller
+Go Rest High on that Mountain|SSAA|Kohl Kitzmiller
+Gonna Make You Happy Tonight|TTBB|Kohl Kitzmiller
+Good Time Tavern|TTBB, SSAA, SATB|Kohl Kitzmiller
+Good To Be Alive|SSAA|Kohl Kitzmiller
+Grace Kelly|TTBB|Kohl Kitzmiller
+Gravity|SATB|Kohl Kitzmiller
+The Greatest Show|SSAA|Kohl Kitzmiller
+Hallelujah, I Love Her So|TTBB|Kohl Kitzmiller
+Happy Time|SSAA|Kohl Kitzmiller
+Have Yourself A Merry Little Christmas|TTBB|Kohl Kitzmiller
+The Headless Horseman|SATB|Kohl Kitzmiller
+Heart And Soul|SATB|Kohl Kitzmiller
+Here Comes The Sun|TTBB|Kohl Kitzmiller
+Honesty|TTBB|Kohl Kitzmiller
+I (Who Have Nothing)|TTBB, SSAA, SATB|Kohl Kitzmiller
+I Can't Believe That You're In Love With Me|TTBB|Kohl Kitzmiller
+I Don't Dance|SSAA|Kohl Kitzmiller
+I Got Plenty O' Nuttin'|SSAA|Kohl Kitzmiller
+I Got You (I Feel Good)|TTBB|Kohl Kitzmiller
+I Put a Spell on You|TTBB, SSAA, SATB|Kohl Kitzmiller
+I Wanna Dance With Somebody|SSAA, SATB|Kohl Kitzmiller
+I'll Be Seeing You|SATB|Kohl Kitzmiller
+I've Got My Love To Keep Me Warm|TTBB, SSAA, SATB|Kohl Kitzmiller
+I've Got The World On A String|TTBB|Kohl Kitzmiller
+If I Loved You|SSAA|Kohl Kitzmiller
+In The Cool Cool Cool Of The Evening|TTBB|Kohl Kitzmiller
+Irgendwo Auf Der Welt|TTBB|Kohl Kitzmiller
+It's A Lovely Day Today|TTBB|Kohl Kitzmiller
+It's A Most Unusual Day|SSAA, SATB|Kohl Kitzmiller
+It's A Pity To Say Goodnight|TTBB, SSAA, SATB|Kohl Kitzmiller
+It's A Sin To Tell A Lie|TTBB|Kohl Kitzmiller
+It's D'Lovely|TTBB, SSAA, SATB|Kohl Kitzmiller
+It's Not Unusual|TTBB, SSAA, SATB|Kohl Kitzmiller
+It's Now Or Never|TTBB|Kohl Kitzmiller
+Joy|SSAA|Kohl Kitzmiller
+Jumpin' East Of Java|SSAA|Kohl Kitzmiller
+Just The Way You Are|TTBB|Kohl Kitzmiller
+The Lady In Red|SSAA|Kohl Kitzmiller
+Lava|SATB|Kohl Kitzmiller
+Lazy River|TTBB|Kohl Kitzmiller
+Let There Be Peace On Earth|TTBB|Kohl Kitzmiller
+Let's Face The Music And Dance|TTBB|Kohl Kitzmiller
+Light Of A Clear Blue Morning|SSAA|Kohl Kitzmiller
+Love|TTBB|Kohl Kitzmiller
+Luck Be A Lady|TTBB|Kohl Kitzmiller
+Maneater|TTBB|Kohl Kitzmiller
+Mango Tree|SATB|Kohl Kitzmiller
+Medley: Daydream Believer, I'm A Believer|SSAA|Kohl Kitzmiller
+Medley: Good To Be Alive (Hallelujah), Uptown Funk|SSAA|Kohl Kitzmiller
+Medley: I Feel Like Dancing, Gonna Make You Sweat, I Don't Dance, Shut Up..|SSAA|Kohl Kitzmiller
+Medley: Knights of the Round Table, Men in Tights|TTBB|Kohl Kitzmiller
+Medley: Route 66, Take The 'A' Train|TTBB, SSAA|Kohl Kitzmiller
+Medley: Won't You Be My Neighbor?, It's Such A Good Feeling, It's You I Like|SATB|Kohl Kitzmiller
+Meglio Stasera|SATB|Kohl Kitzmiller
+Memories|SSAA|Kohl Kitzmiller
+Midnight Train to Georgia|SSAA|Kohl Kitzmiller
+A Million Ways|TTBB|Kohl Kitzmiller
+Monsters|TTBB|Kohl Kitzmiller
+Moon River|TTBB, SSAA, SATB|Kohl Kitzmiller
+Mr. Blue Sky|TTBB, SSAA, SATB|Kohl Kitzmiller
+Never Gonna Not Dance Again|SSAA|Kohl Kitzmiller
+New York State of Mind|SSAA, SATB|Kohl Kitzmiller
+Nice Work If You Can Get It|SSAA|Kohl Kitzmiller
+Nine People's Favorite Thing|TTBB|Kohl Kitzmiller
+Nine To Five|SSAA, SATB|Kohl Kitzmiller
+One Mint Julep|SSAA|Kohl Kitzmiller
+Over The Rainbow|TTBB|Kohl Kitzmiller
+Please Come Home For Christmas|TTBB, SSAA, SATB|Kohl Kitzmiller
+Proud Mary|TTBB, SSAA|Kohl Kitzmiller
+Return To Sender|SSAA|Kohl Kitzmiller
+Save The Last Dance For Me|TTBB|Kohl Kitzmiller
+September|TTBB|Kohl Kitzmiller
+Someone Like You|SATB|Kohl Kitzmiller
+Somewhere Out There|TTBB, SSAA, SATB|Kohl Kitzmiller
+Stay|TTBB|Kohl Kitzmiller
+Stay Awake|TTBB, SSAA, SATB|Kohl Kitzmiller
+Still The One|TTBB|Kohl Kitzmiller
+Stronger (What Doesn't Kill You)|SSAA|Kohl Kitzmiller
+Sweet Child O' Mine|TTBB, SSAA, SATB|Kohl Kitzmiller
+Take A Look At Us Now|TTBB|Kohl Kitzmiller
+Take Me Or Leave Me|SATB|Kohl Kitzmiller
+Thankful|TTBB|Kohl Kitzmiller
+That's All|TTBB|Kohl Kitzmiller
+That's Christmas To Me|SSAA, SATB|Kohl Kitzmiller
+That's How You Know|SSAA|Kohl Kitzmiller
+There's A Boat Dat's Leavin' Soon for New York|TTBB, SSAA, SATB|Kohl Kitzmiller
+They Just Keep Moving the Line|TTBB, SSAA, SATB|Kohl Kitzmiller
+Things We Do For Love|TTBB|Kohl Kitzmiller
+This Is Me|SSAA|Kohl Kitzmiller
+This Time Around|SATB|Kohl Kitzmiller
+To Let A Good Thing Die|TTBB|Kohl Kitzmiller
+Together Wherever We Go|TTBB|Kohl Kitzmiller
+Tomorrow Never Dies|TTBB|Kohl Kitzmiller
+Too Close For Comfort|TTBB, SSAA, SATB|Kohl Kitzmiller
+The Trolley Song|TTBB|Kohl Kitzmiller
+Unredeemable|TTBB|Kohl Kitzmiller
+Uptown Funk!|SSAA|Kohl Kitzmiller
+Welcome To The Black Parade|TTBB|Kohl Kitzmiller
+What Christmas Means To Me|TTBB|Kohl Kitzmiller
+What Kind Of Fool Am I|SATB|Kohl Kitzmiller
+When She Loved Me|TTBB|Kohl Kitzmiller
+When Sunny Gets Blue|SSAA|Kohl Kitzmiller
+When You Believe|SSAA|Kohl Kitzmiller
+Without You|TTBB|Kohl Kitzmiller
+Writing's On the Wall|TTBB, SSAA|Kohl Kitzmiller
+You and Me (But Mostly Me)|SSAA|Kohl Kitzmiller
+You Can't Stop The Beat|SATB|Kohl Kitzmiller
+You'll Never Walk Alone|TTBB, SSAA|Kohl Kitzmiller
+You're The First, The Last, My Everything|TTBB|Kohl Kitzmiller
+You've Got A Friend In Me|TTBB|Kohl Kitzmiller
+Carry On Wayward Son|TTBB|Kyle Kitzmiller
+Chameleon|TTBB|Kyle Kitzmiller
+Cupid Shuffle|TTBB|Kyle Kitzmiller
+Here And Now|SSAA|Kyle Kitzmiller
+Hero|TTBB|Kyle Kitzmiller
+I Know Where I've Been|TTBB|Kyle Kitzmiller
+Livin' On A Prayer|TTBB|Kyle Kitzmiller
+No One Knows Who I Am|SSAA|Kyle Kitzmiller
+Spend My Life With You|TTBB, SSAA|Kyle Kitzmiller
+The Stars Will Remember|TTBB|Kyle Kitzmiller
+That's All|TTBB|Kyle Kitzmiller
+This Love|TTBB|Kyle Kitzmiller
+You And I|TTBB|Kyle Kitzmiller
+You And I|SATB|Kyle Kitzmiller
+All Dressed Up With A Broken Heart|TTBB|Scott Kitzmiller
+All Of Me|TTBB|Scott Kitzmiller
+All The Things You Are|TTBB|Scott Kitzmiller
+Bewitched|TTBB|Scott Kitzmiller
+Blue Velvet|TTBB|Scott Kitzmiller
+Caravan|TTBB|Scott Kitzmiller
+Carolina Moon|TTBB|Scott Kitzmiller
+Climb Ev'ry Mountain|TTBB|Scott Kitzmiller
+Come Rain Or Come Shine|SSAA|Scott Kitzmiller
+Crazy|TTBB, SSAA|Scott Kitzmiller
+Darn That Dream|SATB|Scott Kitzmiller
+Easy Living|TTBB|Scott Kitzmiller
+Exactly Like You|TTBB, SSAA|Scott Kitzmiller
+Fly Me To The Moon|TTBB|Scott Kitzmiller
+Georgia On My Mind|TTBB|Scott Kitzmiller
+Guilty|TTBB|Scott Kitzmiller
+I Left My Heart In San Francisco|TTBB|Scott Kitzmiller
+I Remember You|SATB|Scott Kitzmiller
+I Wanna Be Around|TTBB|Scott Kitzmiller
+I Wish You Love|SSAA|Scott Kitzmiller
+The Impossible Dream|TTBB|Scott Kitzmiller
+Indiana / Banks Of The Wabash Medley|TTBB|Scott Kitzmiller
+It Could Happen To You|TTBB|Scott Kitzmiller
+Just Friends|TTBB|Scott Kitzmiller
+King Of The Road|TTBB|Scott Kitzmiller
+Laura|SATB|Scott Kitzmiller
+Moonglow|TTBB, SSAA|Scott Kitzmiller
+Moonlight Becomes You|TTBB|Scott Kitzmiller
+My Funny Valentine|TTBB|Scott Kitzmiller
+On Green Dolphin Street|TTBB, SSAA|Scott Kitzmiller
+Once In A While|SATB|Scott Kitzmiller
+Rubber Duckie|TTBB|Scott Kitzmiller
+Satin Doll|TTBB|Scott Kitzmiller
+Scotch And Soda|SSAA|Scott Kitzmiller
+Skylark|SATB|Scott Kitzmiller
+Spring Can Really Hang You Up The Most|SATB|Scott Kitzmiller
+Stuff Like That There|SSAA|Scott Kitzmiller
+There Goes My Heart|TTBB|Scott Kitzmiller
+This Could be the Start of Something Big|TTBB, SSAA|Scott Kitzmiller
+Together On New Year's Eve|TTBB|Scott Kitzmiller
+Undecided|TTBB|Scott Kitzmiller
+We'll be together again|SATB|Scott Kitzmiller
+Who Can I Turn To? (When Nobody Needs Me)|SSAA|Scott Kitzmiller
+Smile Will Go A Long Long Way|TTBB|Vern Knapp
+Sweet Georgia Brown|TTBB|Vern Knapp
+Hush|SSAA|Dick Kneeland
+Hush|TTBB|Dick Kneeland
+Show Me Where The Good Times Are|TTBB|Dick Kneeland
+Black Eyed Susan Brown|TTBB|Mel Knight
+Daydream|TTBB, SSAA, SATB|Mel Knight
+Gimme A Little Kiss Will Ya Huh|SATB|Mel Knight
+Goodnight, Sweetheart, Goodnight|TTBB, SSAA, SATB|Mel Knight
+Harmony Rag|TTBB|Mel Knight
+Heart Of A Clown|TTBB|Mel Knight
+High Hopes|SATB|Mel Knight
+I Don't Know Why|TTBB|Mel Knight
+If My Friends Could See Me Now|TTBB|Mel Knight
+If You Were The Only Girl In The World|TTBB|Mel Knight
+Irish Blessing|TTBB|Mel Knight
+Joy To The World|SATB|Mel Knight
+Let There Be Peace On Earth|TTBB|Mel Knight
+Listen To That Dixie Band|TTBB|Mel Knight
+Look Out World / Powder Your Face With Sunshine Medley|TTBB|Mel Knight
+Look Out, World!|TTBB|Mel Knight
+O Holy Night|SATB|Mel Knight
+On The Sunny Side Of The Street|TTBB|Mel Knight
+Once In A While|TTBB|Mel Knight
+The Red Rose Rag|TTBB|Mel Knight
+Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Mel Knight
+Side By Side / Ain't We Got Fun Medley|TTBB|Mel Knight
+Since It Started To Rain on Lovers Lane|TTBB|Mel Knight
+Stop And Smell The Roses|TTBB|Mel Knight
+Strike Up The Band|TTBB|Mel Knight
+Toyland|SATB|Mel Knight
+We Wish You A Merry Christmas|TTBB|Mel Knight
+When I Sang The Tenor In That Old Quartet|TTBB|Mel Knight
+When It's Circus Day Back Home|TTBB|Mel Knight
+When There's Love At Home|TTBB|Mel Knight
+Why Not Say Goodbye The Way We Said Hello|TTBB|Mel Knight
+Why Not Say Goodbye The Way We Said Hello|SSAA|Mel Knight
+After The Gold Rush|SATB|Peter Knight
+Born on a New Day|SATB|Peter Knight
+Danny Boy|SATB|Peter Knight
+I'm A Train|TTBB|Peter Knight
+I'm A Train|SATB|Peter Knight
+Swing Low, Sweet Chariot|TTBB|Peter Knight
+You Are the New Day|SATB|Peter Knight
+I Want To Be Happy|TTBB|Ron Knight
+A Little Closer|TTBB|Kevin Koehl
+Ain't Misbehavin'|TTBB|Kevin Koehl
+Always On My Mind|TTBB|Kevin Koehl
+American Dad|TTBB|Kevin Koehl
+Answer Me, My Love|SATB|Kevin Koehl
+Bad Guy|TTBB|Kevin Koehl
+Book Of Love|TTBB, SSAA|Kevin Koehl
+Can You Feel The Love Tonight?|TTBB, SSAA, SATB|Kevin Koehl
+Can't Help Falling In Love|TTBB, SATB|Kevin Koehl
+Don't You Worry Bout A Thing|SATB|Kevin Koehl
+Escape|TTBB|Kevin Koehl
+Family Guy Theme Song|TTBB|Kevin Koehl
+Follow Me|TTBB, SSAA|Kevin Koehl
+Follow You|TTBB|Kevin Koehl
+The Fox|TTBB|Kevin Koehl
+Goodbye To Yesterday|SSAA|Kevin Koehl
+Goodnight, Sweetheart, Goodnight|TTBB, SATB|Kevin Koehl
+Grace Kelly|TTBB|Kevin Koehl
+Green Green Grass|TTBB, SATB|Kevin Koehl
+Holly Jolly Christmas|TTBB|Kevin Koehl
+I'm Having A Ball|TTBB|Kevin Koehl
+Ich will keine Schokolade|SSAA|Kevin Koehl
+If I Can Dream|SSAA|Kevin Koehl
+Jar Of Hearts|SSAA|Kevin Koehl
+Kiss|TTBB|Kevin Koehl
+Kiss Me|SATB|Kevin Koehl
+Let's Twist Again|TTBB|Kevin Koehl
+A Major Chord|SATB|Kevin Koehl
+Mean Ol' Moon|TTBB|Kevin Koehl
+Medley: Ain't Misbehavin', I'm Crazy 'bout My Baby|TTBB|Kevin Koehl
+Medley: Black Or White, Ebony And Ivory|SSAA|Kevin Koehl
+Medley: This Old House/When the Saints Go Marching In Medley|TTBB|Kevin Koehl
+Mother|SATB|Kevin Koehl
+My Way|TTBB|Kevin Koehl
+Nothing But The Best|TTBB|Kevin Koehl
+The Old Country Church|TTBB|Kevin Koehl
+Perfect|TTBB, SATB|Kevin Koehl
+Rockin' Around The Christmas Tree|TTBB|Kevin Koehl
+Rocky Raccoon|TTBB|Kevin Koehl
+Say Something|SSAA|Kevin Koehl
+Someday|SSAA, SATB|Kevin Koehl
+Somethin' Stupid|TTBB|Kevin Koehl
+Sun, Shine On Me Today|TTBB|Kevin Koehl
+Take Good Care Of My Baby|TTBB|Kevin Koehl
+Take Me Home, Country Roads|TTBB|Kevin Koehl
+Tequila|TTBB|Kevin Koehl
+There's No Business Like Show Business|TTBB|Kevin Koehl
+They Just Keep Moving the Line|TTBB|Kevin Koehl
+This Ole House|TTBB|Kevin Koehl
+Three Cigarettes In An Ashtray|SATB|Kevin Koehl
+Tribute|TTBB|Kevin Koehl
+Twistin' The Night Away|TTBB|Kevin Koehl
+Until I Found You|TTBB|Kevin Koehl
+Vampire|SSAA|Kevin Koehl
+Way To Your Heart|TTBB|Kevin Koehl
+Weekend In New England|SATB|Kevin Koehl
+What Does The Fox Say?|SATB|Kevin Koehl
+Whole Again|TTBB|Kevin Koehl
+Wonderful World|TTBB|Kevin Koehl
+You'll Be In My Heart|SSAA|Kevin Koehl
+Hi Neighbor|TTBB|G. J. Koning
+Call Me Back Pal O' Mine|TTBB|Jerry Koskela
+I Wish All My Children Were Babies Again|TTBB|Jerry Koskela
+Never Hit Your Grandma With A Shovel|TTBB|Jerry Koskela
+When I Dream Of My Ould Kerry Home|TTBB|Jerry Koskela
+Bye Bye Blackbird|TTBB|Brian Kotval
+Down By The Old Mill Stream/In The Good Old Summer Time|TTBB|Nick Kozel
+Kansas City|SSAA|Jo Kraut
+The Rhythm Of Life|SSAA|Jo Kraut
+They Go Wild, Simply Wild Over Me|SSAA|Jo Kraut
+Cryin'|TTBB|Rasmus Krigstrom
+Devil May Care|TTBB|Rasmus Krigstrom
+Goodbye Yellow Brick Road|TTBB|Rasmus Krigstrom
+Have You Met Miss Jones|TTBB|Rasmus Krigstrom
+It's A Pity To Say Goodnight|TTBB|Rasmus Krigstrom
+I Hold Your Hand In Mine|TTBB|Gerald Krumbholz
+Baby on Board|TTBB|Jay Krumbholz
+Goodbye Broadway, Hello France|TTBB, SSAA|Jay Krumbholz
+I See The Light|TTBB, SSAA|Jay Krumbholz
+Oh, How I Hate To Get Up In The Morning|TTBB|Jay Krumbholz
+Someone Like You|SATB|Jay Krumbholz
+You'll Be In My Heart|SSAA|Jay Krumbholz
+You're Still The One|SSAA|Jay Krumbholz
+The Girl From Ipanema|SSAA|Gloria Kuchenbecker
+That Old Gang Of Mine|SSAA|Val Robin Ladouceur
+Perhaps Love|TTBB|Bob Landry
+Treasure Untold|TTBB|Bob Landry
+Autumn Leaves|SSAA|Diane Landry
+Don't Blame Me|SSAA|Diane Landry
+Mary Was The First One To Carry The Gospel|SSAA|Diane Landry
+Reindeer Boogie|SSAA|Diane Landry
+When They Call My Name|SSAA|Diane Landry
+You've Got To See Mamma Ev'ry Night|SSAA|Janet Landstrom
+River Jordan|TTBB|Ken Lang
+Pal Of My Dreams|TTBB|Gordon Lankenau
+The Church Bells Are Ringing For Mary|TTBB|Greg Lapp
+20th Century Rag|TTBB|Walter Latzko
+A Cup Of Coffee A Sandwich And You|TTBB|Walter Latzko
+A Good Man Is Hard To Find|SSAA|Walter Latzko
+A Mighty Fortress|TTBB|Walter Latzko
+A, You're Adorable|TTBB, SSAA|Walter Latzko
+Aba Daba Honeymoon|TTBB|Walter Latzko
+Abide With Me|TTBB, SSAA|Walter Latzko
+About A Quarter To Nine|TTBB|Walter Latzko
+Ac-cent-tchu-ate The Positive|TTBB|Walter Latzko
+Ain't Misbehavin'|TTBB, SSAA|Walter Latzko
+Alabama Jubilee|TTBB, SSAA|Walter Latzko
+Alexander's Ragtime Band|TTBB|Walter Latzko
+Alice Blue Gown|SSAA|Walter Latzko
+All Hail The Power Of Jesus' Name|TTBB|Walter Latzko
+All I Do Is Dream Of You|TTBB|Walter Latzko
+All Or Nothing|TTBB|Walter Latzko
+All That Jazz|TTBB|Walter Latzko
+All The Things You Are|TTBB, SSAA|Walter Latzko
+Almost Like Being In Love|TTBB|Walter Latzko
+Alone|TTBB|Walter Latzko
+Always|TTBB, SSAA|Walter Latzko
+American Beauty Rose|TTBB|Walter Latzko
+An Affair To Remember|TTBB|Walter Latzko
+And I Love You So|TTBB|Walter Latzko
+And I'll Be There|TTBB, SSAA|Walter Latzko
+Any Place I Hang My Hat is Home|TTBB|Walter Latzko
+Anything You Can Do I Can Do Better|TTBB|Walter Latzko
+Anything You Can Do I Can Do Better|SATB|Walter Latzko
+Apple for The Teacher|TTBB|Walter Latzko
+Around the World|TTBB|Walter Latzko
+As Time Goes By|TTBB|Walter Latzko
+At Last|TTBB, SSAA|Walter Latzko
+At The Mississippi Cabaret|TTBB|Walter Latzko
+Autumn Leaves|TTBB|Walter Latzko
+Ave Verum|TTBB|Walter Latzko
+Away In A Manger|SSAA|Walter Latzko
+Baby Your Mother|TTBB|Walter Latzko
+Back Home Again In Indiana|SSAA|Walter Latzko
+Barney Google|TTBB|Walter Latzko
+Basin Street Blues|SSAA|Walter Latzko
+A Beautiful Friendship|SSAA|Walter Latzko
+Beep Beep|TTBB|Walter Latzko
+Begin The Beguine|TTBB|Walter Latzko
+Believe|TTBB|Walter Latzko
+The Bells Of St. Mary's|SSAA|Walter Latzko
+Bewitched|TTBB|Walter Latzko
+Beyond The Blue Horizon|TTBB|Walter Latzko
+Beyond the Sea|TTBB|Walter Latzko
+Bidin' My Time|SSAA|Walter Latzko
+Big Bad Bill from Louisville|TTBB|Walter Latzko
+Bill|SSAA|Walter Latzko
+Bill Bailey, Won't You Please Come Home?|TTBB|Walter Latzko
+Birth Of The Blues|TTBB|Walter Latzko
+Black Coffee|TTBB|Walter Latzko
+Blame It On The Summer Night|TTBB|Walter Latzko
+The Blue Room|TTBB|Walter Latzko
+Blues (Stay Away From Me)|SSAA|Walter Latzko
+Body & Soul|TTBB|Walter Latzko
+Born Free|TTBB|Walter Latzko
+Break Forth, O Beauteous Heavenly Light|TTBB|Walter Latzko
+Breezin' Along With The Breeze|TTBB|Walter Latzko
+Bridget|TTBB|Walter Latzko
+A Bushel And A Peck|TTBB|Walter Latzko
+Buttons And Bows|SSAA|Walter Latzko
+By Myself|TTBB|Walter Latzko
+By The Light Of The Silvery Moon|SSAA|Walter Latzko
+Bye Bye Blackbird|TTBB|Walter Latzko
+C'est Si Bon|TTBB|Walter Latzko
+Can't Take My Eyes Off Of You|TTBB|Walter Latzko
+Candle Light|TTBB|Walter Latzko
+Carolina Moon|SSAA|Walter Latzko
+Carolina Rolling Stone|TTBB|Walter Latzko
+Carry Me Back To Old Virginny|SSAA|Walter Latzko
+Chantez, Chantez|TTBB|Walter Latzko
+Chapters Of Life|TTBB|Walter Latzko
+Chargog-gagoog-manchaug-gagogg|TTBB|Walter Latzko
+Charleston|TTBB|Walter Latzko
+Charmaine|TTBB|Walter Latzko
+Chattanooga Choo Choo|TTBB|Walter Latzko
+Cheek To Cheek|SSAA|Walter Latzko
+Chicago Style|TTBB, SSAA|Walter Latzko
+Christmas Back Home|TTBB|Walter Latzko
+Christmas Island|SSAA|Walter Latzko
+The Christmas Song|TTBB|Walter Latzko
+The Church's One Foundation|TTBB, SSAA|Walter Latzko
+Clap Yo Hands|SSAA|Walter Latzko
+Climb Ev'ry Mountain|TTBB, SSAA|Walter Latzko
+Close As Pages In A Book|TTBB, SSAA|Walter Latzko
+Close Enough for Love|TTBB|Walter Latzko
+Come On-A My House|SSAA|Walter Latzko
+Come Rain Or Come Shine|TTBB|Walter Latzko
+Come Thou Fount of Every Blessing|TTBB|Walter Latzko
+Come To Me|TTBB|Walter Latzko
+Come To Me, Bend To Me|TTBB|Walter Latzko
+Come, Josephine, In My Flying Machine|TTBB|Walter Latzko
+Come, Thou Almighty King|TTBB, SSAA|Walter Latzko
+Crazy|TTBB|Walter Latzko
+The Croquet Song|TTBB|Walter Latzko
+Cruisin' Down The River|TTBB, SSAA|Walter Latzko
+Cry|TTBB, SSAA|Walter Latzko
+Cuddle Up A Little Closer|TTBB|Walter Latzko
+Cup Of Coffee, A Sandwich and You|TTBB|Walter Latzko
+DA, DA, DA, DA|TTBB|Walter Latzko
+Daddy's Little Girl|TTBB|Walter Latzko
+Dancing On The Ceiling|TTBB|Walter Latzko
+Darkness On The Delta|TTBB, SSAA|Walter Latzko
+Darktown Strutters' Ball|TTBB, SSAA|Walter Latzko
+Day By Day|TTBB|Walter Latzko
+Dear Lord And Father Of Mankind|TTBB|Walter Latzko
+Dearly Beloved|TTBB|Walter Latzko
+Deep Purple|TTBB|Walter Latzko
+Do I Hear a Waltz?|TTBB|Walter Latzko
+Do I Worry?|TTBB|Walter Latzko
+Do You Ever Think Of Me?|TTBB|Walter Latzko
+Does The Spearmint Lose Its Flavor On The Bedpost Overnight|TTBB|Walter Latzko
+Dolce Far Niente|TTBB|Walter Latzko
+Don't Blame Me|TTBB|Walter Latzko
+Don't Bring Lulu|TTBB|Walter Latzko
+Don't Ever Leave Me|SSAA|Walter Latzko
+Don't Get Around Much Anymore|TTBB|Walter Latzko
+Don't Go In The Lion's Cage Tonight|TTBB|Walter Latzko
+Don't Marry Me|TTBB|Walter Latzko
+Don't Sit under The Apple Tree|SSAA|Walter Latzko
+Don't Wait on Me|TTBB|Walter Latzko
+Doodle Doo Doo|SSAA|Walter Latzko
+Down Among The Sheltering Palms|SSAA|Walter Latzko
+Down By The Old Mill Stream|SSAA|Walter Latzko
+Down In New Orleans|TTBB|Walter Latzko
+Dream|TTBB, SSAA|Walter Latzko
+Dream A Little Dream Of Me|TTBB|Walter Latzko
+Drifting and Dreaming|SSAA|Walter Latzko
+The Duke Of Dubuque|TTBB|Walter Latzko
+Dungaree Doll|TTBB|Walter Latzko
+Easy Goin'|TTBB|Walter Latzko
+Easy on the Heart|SSAA|Walter Latzko
+Edelweiss|TTBB|Walter Latzko
+Eight More Miles to Louisville|SSAA|Walter Latzko
+Eloise|TTBB|Walter Latzko
+Emaline|TTBB|Walter Latzko
+End of a Love Affair|TTBB|Walter Latzko
+Erie Canal|TTBB|Walter Latzko
+Ev'ry Night I Cry Myself to Sleep Over You|TTBB|Walter Latzko
+Every Night|TTBB|Walter Latzko
+Everybody Loves My Baby|TTBB|Walter Latzko
+Everybody's Doin' It Now|TTBB|Walter Latzko
+The Face I Love|TTBB|Walter Latzko
+Fairest Lord Jesus|SSAA|Walter Latzko
+Faith of our Fathers|TTBB|Walter Latzko
+Family Man|TTBB|Walter Latzko
+Fascinating Rhythm|TTBB, SSAA|Walter Latzko
+Feels Like Home|TTBB|Walter Latzko
+Fit As A Fiddle|TTBB, SSAA|Walter Latzko
+The Flirt|TTBB|Walter Latzko
+Floatin' Down To Cotton Town|TTBB, SSAA|Walter Latzko
+A Foggy Day|TTBB, SSAA|Walter Latzko
+Follow the Fold|TTBB|Walter Latzko
+For Every Man There's a Woman|TTBB|Walter Latzko
+For Me And My Gal|TTBB, SSAA|Walter Latzko
+Forty-Five Minutes from Broadway|TTBB|Walter Latzko
+Forty-Second Street|SSAA|Walter Latzko
+French Foreign Legion|TTBB|Walter Latzko
+The Gambler|TTBB|Walter Latzko
+A Garden In The Rain|TTBB|Walter Latzko
+Gary, Indiana|TTBB|Walter Latzko
+Georgia On My Mind|SATB|Walter Latzko
+Get Out Those Old Records|SSAA|Walter Latzko
+Getting To Know You|SSAA|Walter Latzko
+Girl Of My Dreams|SSAA|Walter Latzko
+Glow Worm|TTBB|Walter Latzko
+God Be With You 'til We Meet Again|TTBB|Walter Latzko
+Good Night My Someone|TTBB|Walter Latzko
+Goofus|TTBB|Walter Latzko
+Greensleeves|SSAA|Walter Latzko
+Gypsy in my Soul|TTBB|Walter Latzko
+Gypsy Love Song|TTBB|Walter Latzko
+Hallelujah|TTBB|Walter Latzko
+A Handful Of Stars|SSAA|Walter Latzko
+Happy Days Are Here Again|TTBB|Walter Latzko
+Happy Together|SSAA|Walter Latzko
+Hard Hearted Hannah|TTBB|Walter Latzko
+Hark! The Herald Angels Sing|TTBB|Walter Latzko
+Haunted Heart|TTBB|Walter Latzko
+Have You Met Miss Jones|TTBB|Walter Latzko
+Have Yourself A Merry Little Christmas|TTBB|Walter Latzko
+He Touched Me|TTBB|Walter Latzko
+Heart (You Gotta Have)|TTBB|Walter Latzko
+The Heather On The Hill|TTBB|Walter Latzko
+Hello My Baby|TTBB, SSAA|Walter Latzko
+Hernando's Hideaway|TTBB|Walter Latzko
+Hero|TTBB|Walter Latzko
+Hey There|TTBB|Walter Latzko
+Hold Me|SSAA|Walter Latzko
+Hold My Hand|SSAA|Walter Latzko
+The Holy City|TTBB|Walter Latzko
+Holy, Holy, Holy|TTBB|Walter Latzko
+Home|TTBB|Walter Latzko
+Honey Boy|SSAA|Walter Latzko
+Honeymoon|TTBB|Walter Latzko
+Hooray For Love|TTBB|Walter Latzko
+Hortense|TTBB|Walter Latzko
+House I Live In|TTBB|Walter Latzko
+How Am I To Know|TTBB|Walter Latzko
+How Deep Is The Ocean/Remember|TTBB|Walter Latzko
+How Great Thou Art|TTBB|Walter Latzko
+How High The Moon|SSAA|Walter Latzko
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|Walter Latzko
+How'd You Like to Spoon With Me?|TTBB|Walter Latzko
+A Hundred Years From Today|TTBB|Walter Latzko
+I Ain't Down Yet|TTBB|Walter Latzko
+I Ain't Gonna Be Nobody's Fool|TTBB|Walter Latzko
+I Ain't Got Nothin' But The Blues|TTBB|Walter Latzko
+I Apologize|TTBB|Walter Latzko
+I Can Always Find A Little Sunshine At The Ymca|TTBB|Walter Latzko
+I Can't Believe That You're In Love With Me|TTBB|Walter Latzko
+I Can't Get Started with You|TTBB|Walter Latzko
+I Can't Give You Anything But Love|TTBB|Walter Latzko
+I Can't Run Away From You|TTBB|Walter Latzko
+I Cannot Sing The Old Songs|TTBB|Walter Latzko
+I Cried For You|TTBB|Walter Latzko
+I Don't Know Enough About You|TTBB|Walter Latzko
+I Don't Know Why|SSAA|Walter Latzko
+I Don't Want To Play In Your Yard|SSAA|Walter Latzko
+I Don't Want To Walk Without You|TTBB|Walter Latzko
+I Found A Million Dollar Baby|TTBB|Walter Latzko
+I Got Out Of Bed On The Right Side|TTBB|Walter Latzko
+I Got Rhythm|TTBB|Walter Latzko
+I Happen To Love You|SSAA|Walter Latzko
+I Hate To Lose You|TTBB|Walter Latzko
+I Have Dreamed|TTBB|Walter Latzko
+I Hear Music|TTBB|Walter Latzko
+I Know That You Know|TTBB|Walter Latzko
+I Know Why And So Do You|TTBB|Walter Latzko
+I Left My Heart In San Francisco|TTBB|Walter Latzko
+I Love A Piano|TTBB|Walter Latzko
+I Love My Baby|TTBB|Walter Latzko
+I Love To Tell The Story|TTBB, SSAA|Walter Latzko
+I Love You Truly|TTBB|Walter Latzko
+I Must Be Comin' Down with the Blues|TTBB|Walter Latzko
+I Need Thee Ev'ry Hour|TTBB|Walter Latzko
+I Only Have Eyes For You|SSAA|Walter Latzko
+I Only Want A Buddy, Not A Sweetheart|TTBB, SSAA|Walter Latzko
+I Remember You|TTBB|Walter Latzko
+I Thought She Knew|TTBB|Walter Latzko
+I Used To Love You But It's All Over|TTBB|Walter Latzko
+I Walked Today Where Jesus Walked|TTBB|Walter Latzko
+I Wanna Be Loved By You|TTBB|Walter Latzko
+I Want To Go Back To Dixieland|TTBB|Walter Latzko
+I Was Born In Hoboken|TTBB|Walter Latzko
+I Wish I Had A Girl|TTBB|Walter Latzko
+I Wish I Knew|TTBB|Walter Latzko
+I Won't Dance|TTBB|Walter Latzko
+I Wonder What's Become Of Sally|TTBB|Walter Latzko
+I Wonder Who's Kissing Her Now|SSAA|Walter Latzko
+I Wonder Why|TTBB|Walter Latzko
+I'd Love To Live In Loveland|SSAA|Walter Latzko
+I'd Rather Have Fingers Than Toes (Blest Be The Tie Parody)|SSAA|Walter Latzko
+I'll Be Seeing You|TTBB|Walter Latzko
+I'll Be With You In Apple Blossom Time|SSAA|Walter Latzko
+I'll Build A Stairway To Paradise|TTBB|Walter Latzko
+I'll Never Be The Same|TTBB|Walter Latzko
+I'll Never Smile Again|TTBB|Walter Latzko
+I'll String Along with You|TTBB|Walter Latzko
+I'm A Ding Dong Daddy from Dumas|TTBB|Walter Latzko
+I'm A Fool To Want You|TTBB, SSAA|Walter Latzko
+I'm Always Chasing Rainbows|TTBB, SSAA|Walter Latzko
+I'm Beginning To See The Light|TTBB, SSAA|Walter Latzko
+I'm Drifting Back To Dreamland|SSAA|Walter Latzko
+I'm Getting Sentimental Over You|TTBB|Walter Latzko
+I'm Glad I Waited For You|TTBB|Walter Latzko
+I'm Nobody's Baby|SSAA|Walter Latzko
+I'm Old Fashioned|TTBB|Walter Latzko
+I'm Shooting High|TTBB|Walter Latzko
+I'm Sitting On Top Of The World|SSAA|Walter Latzko
+I've Forgotten You|TTBB|Walter Latzko
+I've Found A New Baby (I Found A New Baby)|TTBB|Walter Latzko
+I've Got A Crush On You|TTBB|Walter Latzko
+I've Got A Feeling You'Re Foolin'|TTBB|Walter Latzko
+I've Got A Gal in Kalamazoo|TTBB|Walter Latzko
+I've Got My Love To Keep Me Warm|SSAA|Walter Latzko
+I've Got Rings On My Fingers|TTBB|Walter Latzko
+I've Got The World On A String|TTBB|Walter Latzko
+I've Got You Under My Skin|TTBB|Walter Latzko
+I've Heard That Song Before|TTBB|Walter Latzko
+I've Heard That Song Before/Sweet Adeline|TTBB|Walter Latzko
+Ice Cream/Sincere/It'S You Medley|TTBB|Walter Latzko
+Ida! Sweet As Apple Cider|TTBB|Walter Latzko
+If He Can Fight Like He Can Love, Good Night Germany|TTBB|Walter Latzko
+If I Had You|TTBB|Walter Latzko
+If I Loved You|TTBB, SSAA|Walter Latzko
+If I Never See You Again|TTBB|Walter Latzko
+If I Were A Rich Man|TTBB|Walter Latzko
+If Love Is Good To Me|TTBB|Walter Latzko
+If My Friends Could See Me Now|TTBB|Walter Latzko
+If You Were The Only Girl In The World|TTBB|Walter Latzko
+If You Were The Only Girl In The World|TTBB, SSAA|Walter Latzko
+In A Shanty In Old Shanty Town|TTBB|Walter Latzko
+In That Great Gettin' Up Mornin'|TTBB|Walter Latzko
+In The Arms Of Love|TTBB|Walter Latzko
+In The Good Old Summertime|TTBB|Walter Latzko
+In The Mood|TTBB|Walter Latzko
+In The Sweet Long Ago|SSAA|Walter Latzko
+The International Rag|TTBB|Walter Latzko
+Iowa Stubborn|TTBB|Walter Latzko
+Isn't It Romantic|TTBB|Walter Latzko
+It All Depends On You|TTBB|Walter Latzko
+It Could Happen To You|TTBB|Walter Latzko
+It Had To Be You|TTBB|Walter Latzko
+It Rained Last Night|TTBB|Walter Latzko
+It's A Grand Night For Singing|TTBB|Walter Latzko
+It's A Most Unusual Day|TTBB|Walter Latzko
+It's A Pity To Say Goodnight|TTBB|Walter Latzko
+It's A Sign Of Spring|TTBB|Walter Latzko
+It's A Sin To Tell A Lie|TTBB, SSAA|Walter Latzko
+It's A Wonderful Life|TTBB|Walter Latzko
+It's Almost Tomorrow|TTBB, SSAA|Walter Latzko
+It's beginning to look a lot like christmas|TTBB|Walter Latzko
+It's Midnight|TTBB|Walter Latzko
+It's Only A Paper Moon|TTBB|Walter Latzko
+It's Such A Good Feeling|SSAA|Walter Latzko
+It's The Hard-Knock Life|TTBB|Walter Latzko
+It's Time For You|TTBB|Walter Latzko
+Jazz Me Blues|TTBB|Walter Latzko
+Jealous|TTBB|Walter Latzko
+Jealousy|TTBB|Walter Latzko
+Jillian|TTBB|Walter Latzko
+Jingle Bells|TTBB, SSAA|Walter Latzko
+Johnny One Note|TTBB|Walter Latzko
+June Night|TTBB|Walter Latzko
+Just A Dream Of You Dear|TTBB|Walter Latzko
+Just A Girl That Men Forget|TTBB|Walter Latzko
+Just Walking In The Rain|SSAA|Walter Latzko
+Kalamazoo (I've Got A Gal In)|TTBB|Walter Latzko
+Keep Young and Beautiful|TTBB|Walter Latzko
+Kiss, Kiss, Kissin' In The Corn|SSAA|Walter Latzko
+Kisses Sweeter Than Wine|TTBB|Walter Latzko
+Kitten On The Keys|TTBB|Walter Latzko
+Last Time I Saw Paris|SSAA|Walter Latzko
+Let Me Call You Sweetheart|TTBB, SSAA|Walter Latzko
+Let Me Go, Lover|SSAA|Walter Latzko
+Let The Rest Of The World Go By|SSAA|Walter Latzko
+Let's Call The Whole Thing Off|TTBB|Walter Latzko
+Let's Face The Music And Dance|TTBB|Walter Latzko
+Let's Go To Church Next Sunday Morning|SSAA|Walter Latzko
+Let's Have An Old Fashioned Christmas|TTBB|Walter Latzko
+Let's Misbehave|TTBB|Walter Latzko
+Lida Rose|TTBB|Walter Latzko
+Life Upon The Wicked Stage-Ain't Nothing For A Girl|SSAA|Walter Latzko
+Linger Awhile|TTBB|Walter Latzko
+Little Girl From Little Rock|SSAA|Walter Latzko
+Little Man You've Had A Busy Day|TTBB|Walter Latzko
+Little Tin Box|TTBB|Walter Latzko
+Little White Lies|TTBB|Walter Latzko
+Lo How a Rose Ere Blooming|TTBB|Walter Latzko
+Long Ago (And Far Away)|SSAA|Walter Latzko
+Look For The Silver Lining|TTBB, SSAA|Walter Latzko
+Lord's My Shepherd|TTBB|Walter Latzko
+Lost In Loveliness|TTBB|Walter Latzko
+Love In Bloom|TTBB|Walter Latzko
+Love Is Here To Stay|TTBB|Walter Latzko
+Love is the Sweetest Thing|TTBB|Walter Latzko
+The Loveliest Night Of The Year|TTBB|Walter Latzko
+Lovely To Look At|TTBB|Walter Latzko
+Lovesick Blues|TTBB|Walter Latzko
+Lovingless Day|TTBB|Walter Latzko
+Luck Be A Lady|TTBB, SSAA|Walter Latzko
+Lullaby Of Broadway|TTBB|Walter Latzko
+Make Believe|TTBB|Walter Latzko
+Makin' Whoopee|TTBB|Walter Latzko
+Mandy|TTBB|Walter Latzko
+Margie|TTBB|Walter Latzko
+Marian|TTBB|Walter Latzko
+Mary Did You Know|TTBB|Walter Latzko
+Masters In This Hall|TTBB|Walter Latzko
+May Each Day|TTBB|Walter Latzko
+May You Always|TTBB, SSAA|Walter Latzko
+Maybe You'll Be There|TTBB|Walter Latzko
+Mean To Me|TTBB|Walter Latzko
+Meet Me In Dreamland|SSAA|Walter Latzko
+Memories|TTBB|Walter Latzko
+Memories|SSAA|Walter Latzko
+Mighty Like A Rose|SSAA|Walter Latzko
+Minnie The Moocher|TTBB, SSAA|Walter Latzko
+Miss You|TTBB|Walter Latzko
+Mister And Mississippi|SSAA|Walter Latzko
+Misty|TTBB|Walter Latzko
+Moments Like This|TTBB|Walter Latzko
+Mona Lisa|TTBB|Walter Latzko
+Money Burns A Hole In My Pocket`|TTBB|Walter Latzko
+Mood Indigo|TTBB, SSAA|Walter Latzko
+Moon Beams, Moon Dreams|SSAA|Walter Latzko
+Moon River|TTBB|Walter Latzko
+Moondance|TTBB|Walter Latzko
+Moonglow|TTBB, SSAA|Walter Latzko
+Moonlight Becomes You|TTBB|Walter Latzko
+Moonlight On The Ganges|SSAA|Walter Latzko
+More I Cannot Wish You|TTBB|Walter Latzko
+The More I See You|TTBB|Walter Latzko
+Mother In Ireland|TTBB|Walter Latzko
+Mountain Greenery|TTBB|Walter Latzko
+The Movies|TTBB|Walter Latzko
+Mr. Wonderful|SSAA|Walter Latzko
+My Baby Just Cares For Me|TTBB|Walter Latzko
+My Blue Heaven|TTBB|Walter Latzko
+My Buddy|TTBB, SSAA|Walter Latzko
+My Heart Stood Still|TTBB, SSAA|Walter Latzko
+My Honey's Lovin' Arms|TTBB|Walter Latzko
+My Little Dog Left Me Last Night|TTBB|Walter Latzko
+My Love Is Like a Red, Red Rose|TTBB, SSAA|Walter Latzko
+My Man|SSAA|Walter Latzko
+My Melancholy Baby|SSAA|Walter Latzko
+My Old Kentucky Home|TTBB|Walter Latzko
+My Wonderful One|SSAA|Walter Latzko
+Nearer, My God, To Thee|TTBB, SSAA|Walter Latzko
+The Nearness Of You|TTBB, SSAA|Walter Latzko
+Never Again|TTBB|Walter Latzko
+A Nightingale Sang In Berkeley Square|TTBB, SSAA|Walter Latzko
+Nina|TTBB|Walter Latzko
+No, No, Nora|TTBB|Walter Latzko
+Now The Day is Over|TTBB|Walter Latzko
+Now The Day is Over|TTBB, SSAA|Walter Latzko
+O Holy Night|TTBB|Walter Latzko
+O Little Town Of Bethlehem|TTBB|Walter Latzko
+O Master Let Me Walk With Thee|TTBB|Walter Latzko
+The Odd Couple|TTBB|Walter Latzko
+Oh Baby Mine|SSAA|Walter Latzko
+Oh You Crazy Moon|TTBB|Walter Latzko
+Oh! Baby|TTBB|Walter Latzko
+Oh! Look At Me Now|TTBB|Walter Latzko
+Oh, What A Beautiful Mornin'|TTBB|Walter Latzko
+Oh, You Beautiful Doll|TTBB|Walter Latzko
+Oh, You Million Dollar Doll|TTBB|Walter Latzko
+Old Is In|SSAA|Walter Latzko
+Old Rugged Cross|TTBB|Walter Latzko
+On A Chinese Honeymoon|SSAA|Walter Latzko
+On A Sunday By The Sea|SSAA|Walter Latzko
+On The Alamo|TTBB|Walter Latzko
+On The Atchison, Topeka And The Santa Fe|TTBB, SSAA|Walter Latzko
+On The Banks Of The Wabash|TTBB|Walter Latzko
+On The Street Where You Live|TTBB|Walter Latzko
+On The Sunny Side Of The Street|TTBB|Walter Latzko
+Once In Love With Amy|TTBB|Walter Latzko
+Once Upon A Summertime|TTBB|Walter Latzko
+One Cup Of Coffee|TTBB|Walter Latzko
+One Little Candle|SSAA|Walter Latzko
+One Of Those Songs|TTBB|Walter Latzko
+One Spring Day In Kentucky|TTBB|Walter Latzko
+One Voice|TTBB|Walter Latzko
+One, Two, Three|TTBB|Walter Latzko
+Only A Rose|TTBB, SSAA|Walter Latzko
+Our Song|TTBB|Walter Latzko
+Paper Doll|TTBB|Walter Latzko
+Pass Me By|TTBB|Walter Latzko
+Penthouse Serenade|TTBB|Walter Latzko
+Perfidia|TTBB|Walter Latzko
+Personality|TTBB|Walter Latzko
+Pick Yourself Up|TTBB|Walter Latzko
+Pick-A-Little, Talk-A-Little / Goodnight Ladies|TTBB|Walter Latzko
+Poor Butterfly|TTBB|Walter Latzko
+The Preacher And The Bear|TTBB, SSAA|Walter Latzko
+Pure Imagination|TTBB|Walter Latzko
+Put 'em In A Box, Tie 'em With A Ribbon|TTBB|Walter Latzko
+Put On A Happy Face|TTBB|Walter Latzko
+A Quiet Place|TTBB|Walter Latzko
+Rain|SSAA|Walter Latzko
+Raindrops Keep Falling On My Head|TTBB|Walter Latzko
+Ramona|TTBB|Walter Latzko
+Real American Folk Song, The (Is A Rag)|TTBB|Walter Latzko
+Red Sails In The Sunset|SSAA|Walter Latzko
+Remember Me|TTBB|Walter Latzko
+Remind Me|SSAA|Walter Latzko
+Rise Up Shepherd And Follow|TTBB|Walter Latzko
+The River Seine|SSAA|Walter Latzko
+Riverboat Shuffle|TTBB|Walter Latzko
+Rock Of Ages|TTBB, SSAA|Walter Latzko
+Rockin' Chair|TTBB|Walter Latzko
+Rose Of The Rio Grande|TTBB|Walter Latzko
+Rose Of Washington Square|TTBB|Walter Latzko
+Roses Of Picardy|SSAA|Walter Latzko
+Rudolph The Red Nosed Reindeer|SSAA|Walter Latzko
+Rum And Coca Cola|SSAA|Walter Latzko
+Runnin' Wild|TTBB, SSAA|Walter Latzko
+Sadder But Wiser Girl|TTBB|Walter Latzko
+Sam, You Made The Pants Too Long|TTBB|Walter Latzko
+Saturday Night Is The Loneliest Night Of The Week|TTBB|Walter Latzko
+Save Your Sorrow|TTBB|Walter Latzko
+Say Hello To Sally For Me|TTBB|Walter Latzko
+Seasons of Love|TTBB|Walter Latzko
+Second Hand Rose|SSAA|Walter Latzko
+Secret Love|SSAA|Walter Latzko
+See You In September|TTBB|Walter Latzko
+Sentimental Baby|TTBB|Walter Latzko
+Sentimental Journey|TTBB, SSAA|Walter Latzko
+Sentimental Journey|TTBB|Walter Latzko
+September In The Rain|TTBB|Walter Latzko
+September Song|TTBB|Walter Latzko
+Serenade In Blue|TTBB|Walter Latzko
+Seventy-Six Trombones|TTBB|Walter Latzko
+She Didn't Say 'Yes'|TTBB|Walter Latzko
+She's Funny That Way|TTBB|Walter Latzko
+She's Out Of My Life|TTBB|Walter Latzko
+Shine On, Harvest Moon|SSAA|Walter Latzko
+Shiny Stockings|TTBB, SSAA|Walter Latzko
+Shipoopi|TTBB|Walter Latzko
+Shut The Door (They'Re Coming Through The Window)|TTBB|Walter Latzko
+Silent Night|TTBB|Walter Latzko
+Sincere|TTBB|Walter Latzko
+Sincerely|TTBB|Walter Latzko
+Sing An Old Fashioned Song|TTBB|Walter Latzko
+Sir Duke|SSAA|Walter Latzko
+Sister Susie's Sewing Shirts For Soldiers|TTBB|Walter Latzko
+Sit Down You're Rockin' The Boat|TTBB|Walter Latzko
+Skylark|TTBB, SSAA|Walter Latzko
+Slap That Bass|TTBB, SSAA|Walter Latzko
+Slow Poke|TTBB|Walter Latzko
+Smoke Gets In Your Eyes|TTBB|Walter Latzko
+So High, So Low, So Wide|TTBB|Walter Latzko
+Some Of These Days|SSAA|Walter Latzko
+Somebody Else Is Taking My Place|TTBB, SSAA|Walter Latzko
+Somebody Loves Me|SSAA|Walter Latzko
+Someone To Watch Over Me|TTBB|Walter Latzko
+Something To Remember You By|TTBB|Walter Latzko
+Somewhere|TTBB|Walter Latzko
+The Song Is Ended|TTBB|Walter Latzko
+The Song Is You|TTBB|Walter Latzko
+Speak To Me Of Love|SSAA|Walter Latzko
+Springtime|TTBB|Walter Latzko
+St Louis Blues|SSAA|Walter Latzko
+Stairway To The Stars|TTBB|Walter Latzko
+Standing On The Corner|TTBB|Walter Latzko
+Stardust|TTBB|Walter Latzko
+Stars Fell On Alabama|TTBB, SSAA|Walter Latzko
+Still, Still, Still|TTBB|Walter Latzko
+Stouthearted Men|TTBB|Walter Latzko
+Stumbling|TTBB, SSAA|Walter Latzko
+Sugar (That Sugar Baby O'Mine)|TTBB|Walter Latzko
+Summer Night|TTBB|Walter Latzko
+Sunbonnet Sue|SSAA|Walter Latzko
+Sunny|TTBB|Walter Latzko
+Sunrise, Sunset|TTBB|Walter Latzko
+Sweet And Low|SSAA|Walter Latzko
+The Sweetheart Of Sigma Chi|TTBB|Walter Latzko
+The Syncopated Walk|TTBB|Walter Latzko
+Take Another Guess|TTBB|Walter Latzko
+Talk To The Animals|TTBB|Walter Latzko
+Tea For Two|TTBB|Walter Latzko
+Tell Me You'll Forgive Me|SSAA|Walter Latzko
+Telling It To The Daisies|SSAA|Walter Latzko
+Tennessee Waltz|SSAA|Walter Latzko
+Thank You For Letting Us Entertain You|TTBB|Walter Latzko
+Thank You For The Music|TTBB|Walter Latzko
+Thank You World|TTBB|Walter Latzko
+That Lucky Old Sun|TTBB|Walter Latzko
+That Old Feeling|TTBB|Walter Latzko
+That Old Gang Of Mine|SSAA|Walter Latzko
+That's My Weakness Now|SSAA|Walter Latzko
+The Chapters Of Life|TTBB|Walter Latzko
+The Things We Did Last Summer|TTBB|Walter Latzko
+The Way You Look Tonight|TTBB|Walter Latzko
+There He Goes|TTBB|Walter Latzko
+There Never Was A Girl Like You|TTBB|Walter Latzko
+There Will Always Be A Place For You|TTBB|Walter Latzko
+There Will Never Be Another You|TTBB|Walter Latzko
+There's A Full Moon Tonight|TTBB|Walter Latzko
+There's A Long, Long Trail|SSAA|Walter Latzko
+There's A Small Hotel|TTBB|Walter Latzko
+They All Laughed|TTBB, SSAA|Walter Latzko
+They Can't Take That Away From Me|TTBB|Walter Latzko
+They Didn't Believe Me|TTBB|Walter Latzko
+They Say It's Wonderful|SSAA|Walter Latzko
+This Could be the Start of Something Big|TTBB|Walter Latzko
+This Heart of Mine|SSAA|Walter Latzko
+This Ole House|TTBB|Walter Latzko
+Those Were The Days|TTBB|Walter Latzko
+Three Coins In The Fountain|TTBB, SSAA|Walter Latzko
+Three Little Words|TTBB|Walter Latzko
+Three O'Clock In The Morning|TTBB|Walter Latzko
+Til We Meet Again|TTBB, SSAA|Walter Latzko
+Till The Clouds Roll By|TTBB|Walter Latzko
+Till The End Of Time|TTBB|Walter Latzko
+Till Then|SSAA|Walter Latzko
+Time In A Bottle|TTBB|Walter Latzko
+Tomboy|SSAA|Walter Latzko
+Tonight You Belong To Me|TTBB|Walter Latzko
+Too Late Now (from ROYAL WEDDING)|TTBB|Walter Latzko
+Too Marvelous For Words|TTBB|Walter Latzko
+Too Young|TTBB, SSAA|Walter Latzko
+Toora Loora Loora|SSAA|Walter Latzko
+Toot, Toot, Tootsie|TTBB|Walter Latzko
+The Toy Trumpet|TTBB|Walter Latzko
+Truckin'|TTBB|Walter Latzko
+Try A Little Tenderness|TTBB, SSAA|Walter Latzko
+Tuxedo Junction|TTBB|Walter Latzko
+The Twelfth Of Never|TTBB|Walter Latzko
+Twilight Zone|TTBB|Walter Latzko
+Two Different Worlds|TTBB|Walter Latzko
+Undecided|TTBB|Walter Latzko
+Up On The Roof|TTBB|Walter Latzko
+Up Where We Belong|SSAA|Walter Latzko
+Wait Till The Sun Shines, Nellie|TTBB, SSAA|Walter Latzko
+Wake The Town And Tell The People|SSAA|Walter Latzko
+Way Down Yonder In New Orleans|SSAA|Walter Latzko
+Way Down Yonder In New Orleans|TTBB|Walter Latzko
+We'd Like To Thank You, Herbert Hoover|TTBB|Walter Latzko
+We'd Rather Be With You|TTBB|Walter Latzko
+We've Only Just Begun|TTBB|Walter Latzko
+Wedding Bells Are Breaking Up That Old Gang Of Mine|SSAA|Walter Latzko
+Wells Fargo Wagon|TTBB|Walter Latzko
+What I Did For Love|TTBB|Walter Latzko
+What Kind Of Fool Am I|TTBB|Walter Latzko
+When Day Is Done|TTBB, SSAA|Walter Latzko
+When Francis Dances With Me|TTBB, SSAA|Walter Latzko
+When I Lost You|TTBB, SSAA|Walter Latzko
+When My Baby Smiles At Me|TTBB|Walter Latzko
+When My Sugar Walks Down The Street|TTBB|Walter Latzko
+When The Circus Leaves Town|TTBB|Walter Latzko
+When The Lights Go On Again (All Over The World)|TTBB|Walter Latzko
+When You Say Nothing At All|TTBB|Walter Latzko
+When You're A Long, Long Way From Home|TTBB|Walter Latzko
+When Your Old Wedding Ring Was New|TTBB|Walter Latzko
+Where Are You|TTBB|Walter Latzko
+Where Can I Go Without You|TTBB|Walter Latzko
+Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Walter Latzko
+Where Is Love?|TTBB|Walter Latzko
+Where is the One?|TTBB|Walter Latzko
+Where Or When|TTBB|Walter Latzko
+Where The Blue Of The Night Meets The Gold Of The Day|TTBB, SSAA|Walter Latzko
+Where We Gonna' Put The Piano, And Who We Gonna' Get To Play|TTBB|Walter Latzko
+Whip-Poor-Will|TTBB|Walter Latzko
+Who Will Buy|TTBB|Walter Latzko
+Why Do I Love You|TTBB|Walter Latzko
+Why Don't We Do This More Often|TTBB|Walter Latzko
+Why Should I Cry Over You?|TTBB|Walter Latzko
+Why Was I Born?|TTBB|Walter Latzko
+Will You Love Me In December As You Do In May|TTBB|Walter Latzko
+Willow Weep For Me|TTBB|Walter Latzko
+Winter Wonderland|TTBB|Walter Latzko
+With A Song In My Heart|TTBB, SSAA|Walter Latzko
+With You So Far Away|TTBB|Walter Latzko
+Without A Song|TTBB, SSAA|Walter Latzko
+Wonderful Day like Today|TTBB, SSAA|Walter Latzko
+Wonderful Grace Of Jesus|TTBB|Walter Latzko
+Wonderful! Wonderful!|TTBB|Walter Latzko
+The World is Waiting For The Sunrise|TTBB, SSAA|Walter Latzko
+Would You Like To Take A Walk|TTBB|Walter Latzko
+Wrap Your Troubles In Dreams|TTBB|Walter Latzko
+Ya Got Trouble|TTBB|Walter Latzko
+Yellow Rose Of Texas|SSAA|Walter Latzko
+Yesterdays|TTBB|Walter Latzko
+You Are Love|TTBB|Walter Latzko
+You Are My Sunshine|SSAA|Walter Latzko
+You Belong To Me|SSAA|Walter Latzko
+You Broke My Heart In Three Places|TTBB|Walter Latzko
+You Didn't Want Me When You Had Me|TTBB|Walter Latzko
+You Forgot All The Words|SSAA|Walter Latzko
+You Light Up My Life|TTBB, SSAA|Walter Latzko
+You Made Me Love You|TTBB, SSAA|Walter Latzko
+You Make Me Feel So Young|TTBB, SSAA|Walter Latzko
+You Must Have Been A Beautiful Baby|TTBB|Walter Latzko
+You Never Miss The Water Till The Well Runs Dry|TTBB|Walter Latzko
+You Raise Me Up|TTBB|Walter Latzko
+You Stepped Out Of A Dream|TTBB|Walter Latzko
+You Tell Me Your Dream|SSAA|Walter Latzko
+You Were Meant For Me|TTBB|Walter Latzko
+You'll Never Know|TTBB|Walter Latzko
+You're An Old Smoothie|TTBB, SSAA|Walter Latzko
+You're Getting To Be A Habit With Me|TTBB|Walter Latzko
+You're Just in Love|TTBB|Walter Latzko
+You're My Everything|TTBB|Walter Latzko
+You're Never Fully Dressed Without A Smile|SSAA|Walter Latzko
+You're Nobody 'Til Somebody Loves You|TTBB, SSAA|Walter Latzko
+You're Some Pretty Doll|TTBB|Walter Latzko
+You've Changed|TTBB|Walter Latzko
+Your Eyes Have Told Me So|TTBB|Walter Latzko
+Zing! Went The Strings Of My Heart|TTBB, SSAA|Walter Latzko
+Zoot Suit Riot|TTBB|Walter Latzko
+You Are My Sunshine|TTBB|Barb Laukaitis
+Blue Moon|TTBB|Paul Laurenz
+In A Shanty In Old Shanty Town|TTBB|Graham Lawrence
+After The Disco|TTBB|Gabriel Lawson
+Ain't No Mountain High Enough|TTBB|Gabriel Lawson
+All I Want For Christmas Is You|TTBB|Gabriel Lawson
+And So It Goes|TTBB|Gabriel Lawson
+The Angel Gabriel From Heaven Came|TTBB|Gabriel Lawson
+At The Door|TTBB|Gabriel Lawson
+The Blessed Dawn Of Christmas Day|TTBB|Gabriel Lawson
+Candy Cane Lane|TTBB|Gabriel Lawson
+Choose Your Fighter|TTBB|Gabriel Lawson
+Christmas Holiday|TTBB|Gabriel Lawson
+Christmas Time Is Here|TTBB|Gabriel Lawson
+Christmas Waltz|TTBB|Gabriel Lawson
+Christmas Why Can't I Find You|TTBB|Gabriel Lawson
+Come and Get Your Love|TTBB|Gabriel Lawson
+Coventry Carol|TTBB|Gabriel Lawson
+Ding Dong Merrily On High|TTBB|Gabriel Lawson
+Every Second|TTBB|Gabriel Lawson
+Far From The Home I Love|TTBB|Gabriel Lawson
+Frozen Heart|TTBB|Gabriel Lawson
+Gesu Bambino|TTBB|Gabriel Lawson
+Good Christian Men, Rejoice|TTBB|Gabriel Lawson
+Gorgeous|TTBB|Gabriel Lawson
+Grown-Up Christmas List|TTBB|Gabriel Lawson
+Happy Birthday To You|TTBB|Gabriel Lawson
+Hark! The Herald Angels Sing|TTBB|Gabriel Lawson
+Hawaiian Roller Coaster Ride|TTBB|Gabriel Lawson
+Hey There Delilah|TTBB|Gabriel Lawson
+Hooked On A Feeling|TTBB|Gabriel Lawson
+I Ain't Worried|TTBB|Gabriel Lawson
+It Came Upon A Midnight Clear|TTBB|Gabriel Lawson
+Jingle Bells|TTBB|Gabriel Lawson
+Let It Go|TTBB|Gabriel Lawson
+Lo How a Rose Ere Blooming|TTBB|Gabriel Lawson
+Look For The Light|TTBB|Gabriel Lawson
+Lost In The Woods|TTBB|Gabriel Lawson
+Love is an Open Door|TTBB|Gabriel Lawson
+Ma Belle Evangeline|TTBB|Gabriel Lawson
+Merry Christmas Darling|TTBB|Gabriel Lawson
+Never Going Back Again|TTBB|Gabriel Lawson
+Never Gonna Give You Up|TTBB|Gabriel Lawson
+O Come O Come Emmanuel|TTBB|Gabriel Lawson
+Oo-de-lally|TTBB|Gabriel Lawson
+Out Of The East|TTBB|Gabriel Lawson
+Places We Won't Walk|TTBB|Gabriel Lawson
+Por Una Cabeza|TTBB|Gabriel Lawson
+Rainbow Connection|TTBB|Gabriel Lawson
+Remember Me|TTBB|Gabriel Lawson
+Rockin' Around The Christmas Tree|TTBB|Gabriel Lawson
+Santa Fe|TTBB|Gabriel Lawson
+Silent Night|TTBB|Gabriel Lawson
+Sing We Now of Christmas|TTBB|Gabriel Lawson
+Stop This Train|TTBB|Gabriel Lawson
+To Let A Good Thing Die|TTBB|Gabriel Lawson
+Underneath the Tree|TTBB|Gabriel Lawson
+Unredeemable|TTBB|Gabriel Lawson
+We Need A Little Christmas|TTBB|Gabriel Lawson
+What A Glorious Night|TTBB|Gabriel Lawson
+What I Did For Love|TTBB|Gabriel Lawson
+What Was I Made For?|TTBB|Gabriel Lawson
+When Christmas Comes To Town|TTBB|Gabriel Lawson
+When She Loved Me|TTBB|Gabriel Lawson
+You Are So Beautiful|TTBB|Gabriel Lawson
+You're The Best|TTBB|Gabriel Lawson
+You've Got A Friend In Me|TTBB|Gabriel Lawson
+The Preacher And The Bear|TTBB|Bud Leabo
+Since You've Been Gone|SSAA|Jen Lee
+It Had To Be You|SSAA|Eugene Lefkowitz
+Be Sweet To Me Kid|TTBB|Frank Leitnaker
+Bedelia|TTBB|Frank Leitnaker
+Elmer's Tune|TTBB|Frank Leitnaker
+The Fireman's Bride|TTBB|Frank Leitnaker
+Memories / Will You Remember|TTBB|Frank Leitnaker
+A Pony Shy Medley|TTBB|Frank Leitnaker
+Cocktails For Two|TTBB|Richard Lengel
+I'd Give A Million Tomorrows|TTBB|Richard Lengel
+Temptation (parody)|TTBB|Richard Lengel
+Beauty School Dropout|SSAA|Eileen Leotta
+For You|SSAA|Eileen Leotta
+I Caint Say No|SSAA|Eileen Leotta
+Honey's Arms Medley|TTBB|Al Leroy
+Alice Blue Gown|SSAA|Alice Lesniak
+Horace The Horse (on The Merry-go-round)|TTBB|Ben Lewin
+I Don't Want To Live On The Moon|TTBB|Ben Lewin
+Shiny Teeth|TTBB|Ben Lewin
+This Grill Is Not A Home|TTBB|Ben Lewin
+What If I Forget Your Face?|SSAA|Ben Lewin
+S'Vivon|TTBB|Gary Lewis
+(They Long To Be) Close To You|TTBB|Joe Liles
+Abide With Me|TTBB|Joe Liles
+All Hail Our Alma Mater|TTBB|Joe Liles
+All Hail The Power Of Jesus' Name|TTBB|Joe Liles
+A Barbershop Time Of Your Life|TTBB|Joe Liles
+Battle Hymn Of The Republic|TTBB|Joe Liles
+Beautiful Savior|TTBB|Joe Liles
+Bring Back Those Vaudeville Days|TTBB|Joe Liles
+Broadway On Opening Night|TTBB|Joe Liles
+Candle In The Window|SSAA|Joe Liles
+Candle In The Window|TTBB|Joe Liles
+Candlelight And Gold|TTBB|Joe Liles
+Celebrate Harmony (Show Opener / Closer)|TTBB|Joe Liles
+The Chordbuster March|SSAA|Joe Liles
+Christmas Island|TTBB|Joe Liles
+The Christmas Song|TTBB|Joe Liles
+Disney Song Medley|SSAA|Joe Liles
+Disney Song Medley|TTBB|Joe Liles
+Do You Hear What I Hear|TTBB|Joe Liles
+Down By The Riverside|TTBB|Joe Liles
+Five Foot Two|TTBB|Joe Liles
+Fun In Just One Lifetime|TTBB|Joe Liles
+Fun In Just One Lifetime|SSAA|Joe Liles
+Fun In Just One Lifetime|SATB|Joe Liles
+The Girl In My Fantasy|TTBB|Joe Liles
+Give Me A Girl|TTBB|Joe Liles
+Glory Of Love / Makin' Whoopee|TTBB|Joe Liles
+Go Tell It On The Mountain|TTBB|Joe Liles
+Goodbye Means The End Of My World|TTBB|Joe Liles
+Got My Thumb Out|TTBB|Joe Liles
+Harmony Collage|SSAA|Joe Liles
+Harmony Collage|TTBB|Joe Liles
+Harmony Leads The Way|TTBB|Joe Liles
+Hats Off to Barbershop|TTBB|Joe Liles
+Henry K. Holiday|TTBB|Joe Liles
+Hey Little Baby O' Mine|TTBB|Joe Liles
+I Believe In Music|SSAA|Joe Liles
+I Believe In Music|TTBB|Joe Liles
+I Can't Begin To Tell You|TTBB|Joe Liles
+I Can't Recall Her Name|TTBB|Joe Liles
+I Can't Recall His Name|SSAA|Joe Liles
+I Didn't Want To Fall|TTBB|Joe Liles
+I Didn't Want To Fall|SSAA|Joe Liles
+I Guess I Always Will|TTBB, SSAA|Joe Liles
+I Have A Song To Sing|TTBB|Joe Liles
+I Love A Jolson Song|TTBB|Joe Liles
+I Love Cholesterol|TTBB, SSAA|Joe Liles
+I Miss Mother Most Of All|TTBB|Joe Liles
+I Never Meant To Fall In Love|SSAA|Joe Liles
+I Never Meant To Fall In Love|TTBB|Joe Liles
+I Remember All The Songs We Sang|TTBB|Joe Liles
+I Wanna Sing Not Dance|TTBB|Joe Liles
+I'll Always Be In Love With You|TTBB|Joe Liles
+I'll Never Write A Love Song Any More|TTBB|Joe Liles
+I'm Feeling Fine|TTBB, SSAA, SATB|Joe Liles
+I'm Still Havin' Fun|TTBB|Joe Liles
+I've Got The Time, I've Got The Place|TTBB|Joe Liles
+If I Had The Last Dream Left In The World|TTBB|Joe Liles
+If I Had The Last Dream Left In The World|SSAA|Joe Liles
+In An Old Barbershop Chair|TTBB|Joe Liles
+In The Garden|SSAA|Joe Liles
+In The Garden|TTBB|Joe Liles
+In The Good Old Summertime|TTBB|Joe Liles
+It Is Well With My Soul|TTBB|Joe Liles
+It Is Well With My Soul|SSAA|Joe Liles
+It's A Brand New Day|SSAA|Joe Liles
+Jingle Bells|TTBB|Joe Liles
+Joy To The World|TTBB, SSAA, SATB|Joe Liles
+Keep The Whole World Singing|TTBB|Joe Liles
+Let The Lower Lights Be Burning|SSAA|Joe Liles
+Let The Lower Lights Be Burning|TTBB|Joe Liles
+Let There Be Music Let There Be Love|TTBB|Joe Liles
+Let There Be Music Let There Be Love|SSAA, SATB|Joe Liles
+The Lord's Prayer|TTBB|Joe Liles
+Lost In The Fifties Tonight (In The Still Of The Nite)|SSAA|Joe Liles
+Love The One You're With|SSAA|Joe Liles
+Love's Old Sweet Song|SSAA|Joe Liles
+Lovely Way To Spend An Evening|SATB|Joe Liles
+Mary Did You Know|TTBB, SSAA|Joe Liles
+Memories|TTBB|Joe Liles
+Memories Of You|TTBB|Joe Liles
+The Moment I Saw Your Eyes|TTBB, SATB|Joe Liles
+The Moment I Saw Your Eyes|SSAA|Joe Liles
+My Buddy|SSAA|Joe Liles
+My Buddy|TTBB|Joe Liles
+My Daddy's Still Singing His Song|TTBB|Joe Liles
+My Heart Is Aching For You|TTBB|Joe Liles
+My Mommy's Still Singing Her Song|SSAA|Joe Liles
+A New Quartet|TTBB|Joe Liles
+No Love Song|SSAA|Joe Liles
+O Canada!|TTBB, SSAA, SATB|Joe Liles
+O Christmas Tree|SSAA|Joe Liles
+O Christmas Tree|TTBB|Joe Liles
+The Old Man's Back In Town|SSAA|Joe Liles
+Old Rugged Cross|TTBB|Joe Liles
+On The Way To Home Sweet Home|TTBB|Joe Liles
+One Heart, One Voice|TTBB|Joe Liles
+One Song At A Time|TTBB, SSAA|Joe Liles
+Onward, Christian Soldiers|TTBB|Joe Liles
+Open My Eyes That I May See|TTBB|Joe Liles
+Peace I Leave With You|TTBB|Joe Liles
+Play A Simple Melody|TTBB|Joe Liles
+Puff The Magic Dragon|SSAA|Joe Liles
+Rocky Top|TTBB, SSAA|Joe Liles
+Room Full Of Roses|TTBB|Joe Liles
+Santa Claus Is Comin' To Town|TTBB|Joe Liles
+Sing Out, Sing Out|TTBB|Joe Liles
+Sing The Lovers|SSAA|Joe Liles
+Sing We Now of Christmas|TTBB, SSAA, SATB|Joe Liles
+Singa Tagga Daya Fraternity Song|TTBB|Joe Liles
+Sleep|TTBB|Joe Liles
+So Long Song|TTBB|Joe Liles
+Something About Ya|SSAA|Joe Liles
+Sound Of Music / Climb Ev'ry Mountain Medley|TTBB|Joe Liles
+Step To The Rear / See Me Now Medley|TTBB|Joe Liles
+Teach The Children To Sing|TTBB|Joe Liles
+Tell Me You'll Forgive Me|TTBB|Joe Liles
+That Silver Haired Daddy Of Mine|TTBB|Joe Liles
+That Tumble Down Shack In Athlone|SSAA|Joe Liles
+There's No One But You|TTBB|Joe Liles
+Through The Years|TTBB|Joe Liles
+Two Patriotic Classics|TTBB|Joe Liles
+What A Wonderful Wedding That Will Be|TTBB|Joe Liles
+What A Wonderful World|SSAA|Joe Liles
+What A Wonderful World|TTBB|Joe Liles
+When God Holds You Close In His Arms|TTBB|Joe Liles
+When I Look At You|SSAA|Joe Liles
+When I Look At You|TTBB|Joe Liles
+When Lindy Flew The Ocean|TTBB|Joe Liles
+When The Roll Is Called Up Yonder|TTBB|Joe Liles
+Where Have My Old Friends Gone?|TTBB, SSAA|Joe Liles
+Where Have My Old Friends Gone?|SSAA|Joe Liles
+You Raise Me Up|TTBB|Joe Liles
+You Were Only Fooling|TTBB|Joe Liles
+Corabelle|TTBB|G. Limburg
+Back In The Old Neighborhood|SSAA|Lauren Lindeman
+'39|TTBB, SATB|Anders Lindqvist
+After You've Gone|TTBB|Anders Lindqvist
+Afterglow|TTBB|Anders Lindqvist
+Ain't Nobody|SATB|Anders Lindqvist
+All About That Bass|SATB|Anders Lindqvist
+All The Things You Are|TTBB|Anders Lindqvist
+Angels|TTBB|Anders Lindqvist
+Art For Art's Sake|TTBB|Anders Lindqvist
+As|SATB|Anders Lindqvist
+Bara Bada Bastu|TTBB|Anders Lindqvist
+Birdland|SATB|Anders Lindqvist
+Blue Moon|SATB|Anders Lindqvist
+Blue Rondo A La Turk|SATB|Anders Lindqvist
+Border Song|TTBB|Anders Lindqvist
+Brain Damage|TTBB|Anders Lindqvist
+Breakfast In America|TTBB|Anders Lindqvist
+C'est La Vie|TTBB|Anders Lindqvist
+California Dreamin'|TTBB|Anders Lindqvist
+Can't Take My Eyes Off Of You|SATB|Anders Lindqvist
+Candle in the Wind|TTBB|Anders Lindqvist
+Christmas Sludge|SATB|Anders Lindqvist
+Colors Of The Wind|SATB|Anders Lindqvist
+Comfortably Numb|TTBB|Anders Lindqvist
+Coventry Carol|TTBB|Anders Lindqvist
+Cracked|TTBB|Anders Lindqvist
+A Day In The Life|SATB|Anders Lindqvist
+Don't Know Why|SATB|Anders Lindqvist
+Don't Let It Show|TTBB|Anders Lindqvist
+Don't Let The Sun Go Down On Me|TTBB|Anders Lindqvist
+Down By The Lazy River|TTBB, SATB|Anders Lindqvist
+Eclipse|TTBB|Anders Lindqvist
+Eine Kleine Nachtmusik|SATB|Anders Lindqvist
+Entangled|TTBB|Anders Lindqvist
+Eternity|TTBB, SATB|Anders Lindqvist
+Everything I Own|SATB|Anders Lindqvist
+Feelin' Stronger Every Day|TTBB|Anders Lindqvist
+Fire And Rain|TTBB|Anders Lindqvist
+Fool On The Hill|TTBB|Anders Lindqvist
+Fragile|TTBB, SATB|Anders Lindqvist
+From Now On|SATB|Anders Lindqvist
+Girl|SATB|Anders Lindqvist
+God Rest Ye Merry, Gentlemen|SATB|Anders Lindqvist
+Goodbye Yellow Brick Road|TTBB|Anders Lindqvist
+Gotta get you into my life|SATB|Anders Lindqvist
+Hello|TTBB|Anders Lindqvist
+Here Comes The Flood|SATB|Anders Lindqvist
+How Deep Is The Ocean|SATB|Anders Lindqvist
+How Far I'll Go|SSAA, SATB|Anders Lindqvist
+I Am The Walrus|SATB|Anders Lindqvist
+I Can't Make You Love Me|TTBB|Anders Lindqvist
+I Want It That Way|TTBB|Anders Lindqvist
+If You Leave Me Now|TTBB|Anders Lindqvist
+It's My Life|TTBB|Anders Lindqvist
+Killer Queen|TTBB|Anders Lindqvist
+King Of The Road|SATB|Anders Lindqvist
+Kiss From A Rose|TTBB|Anders Lindqvist
+Let Your Soul Be Your Pilot|TTBB|Anders Lindqvist
+Life On Mars|TTBB|Anders Lindqvist
+Like I'm Gonna Lose You|SATB|Anders Lindqvist
+Living For The City|SATB|Anders Lindqvist
+The Living Years|TTBB|Anders Lindqvist
+The Long and Winding Road|TTBB|Anders Lindqvist
+Look Who's Laughing Now|TTBB|Anders Lindqvist
+Love Of My Life|TTBB, SSAA, SATB|Anders Lindqvist
+Love's In Need Of Love Today|SATB|Anders Lindqvist
+Monster|SATB|Anders Lindqvist
+Moon Over Bourbon Street|TTBB, SATB|Anders Lindqvist
+A Nightingale Sang In Berkeley Square|TTBB, SATB|Anders Lindqvist
+One Heart|TTBB, SATB|Anders Lindqvist
+Open Your Heart|SATB|Anders Lindqvist
+The Parting Glass|TTBB|Anders Lindqvist
+Penny Lane|TTBB, SATB|Anders Lindqvist
+Perfect|TTBB|Anders Lindqvist
+Shallow|SATB|Anders Lindqvist
+Show Me The Way|TTBB|Anders Lindqvist
+Space Oddity|TTBB|Anders Lindqvist
+Spinning Wheel|TTBB|Anders Lindqvist
+Summer In The City|TTBB|Anders Lindqvist
+Tattoo|TTBB, SATB|Anders Lindqvist
+Things We Do For Love|TTBB, SSAA, SATB|Anders Lindqvist
+This Is Me|TTBB|Anders Lindqvist
+Thunderball|TTBB|Anders Lindqvist
+A View To A Kill|TTBB|Anders Lindqvist
+Viva La Vida|TTBB|Anders Lindqvist
+The Way We Were|TTBB|Anders Lindqvist
+We Can Work It Out|SATB|Anders Lindqvist
+Wild Mountain Thyme|TTBB|Anders Lindqvist
+Wonderful Tonight|TTBB|Anders Lindqvist
+A Whole New World|SSAA|Tedda Lippincott
+Ac-cent-tchu-ate The Positive|SSAA|Tedda Lippincott
+Achy Breaky Heart|SSAA|Tedda Lippincott
+Alice Blue Gown|SSAA|Tedda Lippincott
+All I Ask Of You|SSAA|Tedda Lippincott
+All I Have To Do Is Dream|SSAA|Tedda Lippincott
+All Of Me|SSAA|Tedda Lippincott
+Amazing Grace|SSAA|Tedda Lippincott
+America The Beautiful / God Bless America|SSAA|Tedda Lippincott
+America, The Dream Goes On|SSAA|Tedda Lippincott
+And So It Goes|SSAA|Tedda Lippincott
+Angels Among Us|SSAA|Tedda Lippincott
+Annie's Song|SSAA|Tedda Lippincott
+Another Somebody Done Somebody Wrong Song|SSAA|Tedda Lippincott
+Any Dream Will Do|SSAA|Tedda Lippincott
+Any Man Of Mine|SSAA|Tedda Lippincott
+Any Time|SSAA|Tedda Lippincott
+Armed Forces Medley|SSAA|Tedda Lippincott
+Auctioneer|SSAA|Tedda Lippincott
+Be Our Guest|SSAA|Tedda Lippincott
+Beach Boys Medley|SSAA|Tedda Lippincott
+Because He Lives|SSAA|Tedda Lippincott
+Because It's Christmas|SSAA|Tedda Lippincott
+Beep Beep|SSAA|Tedda Lippincott
+Best Of Times|SSAA|Tedda Lippincott
+Big Boned Gal|SSAA|Tedda Lippincott
+Big Girls Don't Cry|SSAA|Tedda Lippincott
+Big Rock Candy Mountain|SSAA|Tedda Lippincott
+Blue|SSAA|Tedda Lippincott
+Blue Christmas|SSAA|Tedda Lippincott
+Boot Scootin' Boogie|SSAA|Tedda Lippincott
+The Boy From New York City|SSAA|Tedda Lippincott
+Breaking Up Is Hard To Do|SSAA|Tedda Lippincott
+Calendar Girl|SSAA|Tedda Lippincott
+California Dreamin'|SSAA|Tedda Lippincott
+Can You Feel The Love Tonight?|SSAA|Tedda Lippincott
+Can't Help Falling In Love|SSAA|Tedda Lippincott
+Can-Can Parody|SSAA|Tedda Lippincott
+Chances Are|SSAA|Tedda Lippincott
+Change The World|SSAA|Tedda Lippincott
+Channel Surfin'|SSAA|Tedda Lippincott
+Chattanoogie Shoe Shine Boy|SSAA|Tedda Lippincott
+Children Go Where I Send Thee|SSAA|Tedda Lippincott
+Christmas Is A Feeling|SSAA|Tedda Lippincott
+Christmas Waltz / Silver Bells|SSAA|Tedda Lippincott
+Coffee In A Cardboard Cup|SSAA|Tedda Lippincott
+Count your blessings|SSAA|Tedda Lippincott
+Crazy|SSAA|Tedda Lippincott
+Daydreams From The Memories|SSAA|Tedda Lippincott
+Diamonds Are A Girls Best Friend|SSAA|Tedda Lippincott
+Do You Hear What I Hear|SSAA|Tedda Lippincott
+Dream Baby|SSAA|Tedda Lippincott
+Ev'rybody Wants To Be A Cat|SSAA|Tedda Lippincott
+Everybody Loves Somebody|SSAA|Tedda Lippincott
+Everything I Do, I Do It For You|SSAA|Tedda Lippincott
+Fa-La-La|SSAA|Tedda Lippincott
+Fever|SSAA|Tedda Lippincott
+For Every Smile You Gave Me You Caused A Thousand Tears|SSAA|Tedda Lippincott
+Forest Lawn|SSAA|Tedda Lippincott
+Forever Young|SSAA|Tedda Lippincott
+From A Distance|SSAA|Tedda Lippincott
+Getting To Know You|SSAA|Tedda Lippincott
+Give Us This Day|SSAA|Tedda Lippincott
+God Bless America|SSAA|Tedda Lippincott
+God Bless The U.S.A.|SSAA|Tedda Lippincott
+Gone|SSAA|Tedda Lippincott
+Good Old A Cappella|SSAA|Tedda Lippincott
+Grandpa (Tell Me `Bout The Good Old Days)|SSAA|Tedda Lippincott
+Hava Nagila|SSAA|Tedda Lippincott
+He's My Rock, My Sword, My Shield|SSAA|Tedda Lippincott
+Hello Mary Lou|SSAA|Tedda Lippincott
+The Holly And The Ivy|SSAA|Tedda Lippincott
+Holly Jolly Christmas|SSAA|Tedda Lippincott
+Honey, I'm Home|SSAA|Tedda Lippincott
+Hooked On A Feeling|SSAA|Tedda Lippincott
+House I Live In|SSAA|Tedda Lippincott
+How Can I Miss You If You Won't Go Away?|SSAA|Tedda Lippincott
+I Can't Stop Loving You|SSAA|Tedda Lippincott
+I Cross My Heart|SSAA|Tedda Lippincott
+I Finally Found Someone|SSAA|Tedda Lippincott
+I Hope You Dance|SSAA|Tedda Lippincott
+I May Never Pass This Way Again|SSAA|Tedda Lippincott
+I Used To Love You But It's All Over|SSAA|Tedda Lippincott
+I Want A Hippopotamus For Christmas|SSAA|Tedda Lippincott
+I Will Follow Him|SSAA|Tedda Lippincott
+I'll Be Home For Christmas|SSAA|Tedda Lippincott
+I'll Be Seeing You|SSAA|Tedda Lippincott
+I'll Be Your Friend Until Forever|SSAA|Tedda Lippincott
+I'll Build A Stairway To Paradise|SSAA|Tedda Lippincott
+I'll Get By (As Long As I Have You)|SSAA|Tedda Lippincott
+I'm Confessin' That I Love You|SSAA|Tedda Lippincott
+I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tedda Lippincott
+If I Had My Life To Live Over|SSAA|Tedda Lippincott
+If We Can't Be The Same Old Sweethearts|SSAA|Tedda Lippincott
+If You're Gonna Play In Texas, You Gotta Have A Fiddle In The Band|SSAA|Tedda Lippincott
+In My Daughter's Eyes|SSAA|Tedda Lippincott
+In The Chapel In the Moonlight|SSAA|Tedda Lippincott
+In The Garden|SSAA|Tedda Lippincott
+It All Depends On You|SSAA|Tedda Lippincott
+It Had To Be You|SSAA|Tedda Lippincott
+It Was Almost Like A Song|SSAA|Tedda Lippincott
+It's Getting Better|SSAA|Tedda Lippincott
+Just A Closer Walk With Thee|SSAA|Tedda Lippincott
+Last Night Was The End Of The World|SSAA|Tedda Lippincott
+Lean On Me|SSAA|Tedda Lippincott
+Let It Be Christmas|SSAA|Tedda Lippincott
+Let's Hang On|SSAA|Tedda Lippincott
+Life Upon The Wicked Stage-Ain't Nothing For A Girl|SSAA|Tedda Lippincott
+Light The Candles|SSAA|Tedda Lippincott
+Lion Sleeps Tonight|SSAA|Tedda Lippincott
+A Little Old Lady In Tennis Shoes|SSAA|Tedda Lippincott
+Little Toy Trains|SSAA|Tedda Lippincott
+Lollipop|SSAA|Tedda Lippincott
+Look At That Face|SSAA|Tedda Lippincott
+Look At Us|SSAA|Tedda Lippincott
+Love Can Build A Bridge|SSAA|Tedda Lippincott
+Love Me|SSAA|Tedda Lippincott
+Mairzy Doats|SSAA|Tedda Lippincott
+Moments To Remember|SSAA|Tedda Lippincott
+Monday, Monday|SSAA|Tedda Lippincott
+More Than Words|SSAA|Tedda Lippincott
+Moving Up To Gloryland|SSAA|Tedda Lippincott
+Music Moves Me|SSAA|Tedda Lippincott
+Music Of The Night|SSAA|Tedda Lippincott
+My Daddy Is Only A Picture|SSAA|Tedda Lippincott
+My Guy|SSAA|Tedda Lippincott
+My Heart Will Go On|SSAA|Tedda Lippincott
+My Prayer|SSAA|Tedda Lippincott
+Never Let Go Of Your Dream|SSAA|Tedda Lippincott
+A Nightingale Sang In Berkeley Square|SSAA|Tedda Lippincott
+Octopus's Garden|SSAA|Tedda Lippincott
+Old Bones|SSAA|Tedda Lippincott
+Old Piano Roll Blues|SSAA|Tedda Lippincott
+Old Rugged Cross|SSAA|Tedda Lippincott
+Older Women|SSAA|Tedda Lippincott
+On A Wonderful Day Like Today|SSAA|Tedda Lippincott
+One Fine Day|SSAA|Tedda Lippincott
+One Little Candle|SSAA|Tedda Lippincott
+Only You|SSAA|Tedda Lippincott
+Our Love Is Here To Stay|SSAA|Tedda Lippincott
+Phantom Of The Opera|SSAA|Tedda Lippincott
+Praise The Lord And Pass The Ammunition / Comin' In On A Wing And A Prayer|SSAA|Tedda Lippincott
+Precious Friends|SSAA|Tedda Lippincott
+Purple People Eater|SSAA|Tedda Lippincott
+Put On A Happy Face|SSAA|Tedda Lippincott
+A Quiet Place|SSAA|Tedda Lippincott
+Reach Out To Jesus|SSAA|Tedda Lippincott
+Rockin' Around The Christmas Tree|SSAA|Tedda Lippincott
+Rockin' Robin|SSAA, Young SSAA|Tedda Lippincott
+Sam, The Old Accordion Man|SSAA|Tedda Lippincott
+Sam, You Made The Pants Too Long|SSAA|Tedda Lippincott
+San Antonio Rose|SSAA|Tedda Lippincott
+Sh Boom|SSAA|Tedda Lippincott
+Sisters|SSAA|Tedda Lippincott
+Sleep Little Tiny King|SSAA|Tedda Lippincott
+Snow|SSAA|Tedda Lippincott
+Someone Else's Star|SSAA|Tedda Lippincott
+Someone To Watch Over Me|SSAA|Tedda Lippincott
+Something In Red|SSAA|Tedda Lippincott
+Somewhere|SSAA|Tedda Lippincott
+Somewhere In My Broken Heart|SSAA|Tedda Lippincott
+Somewhere Out There|SSAA|Tedda Lippincott
+The Sound Of Silence|SSAA|Tedda Lippincott
+Stayin' Alive|SSAA|Tedda Lippincott
+Steam Heat|SSAA|Tedda Lippincott
+Stormy Weather|SSAA|Tedda Lippincott
+Sweet Hour Of Prayer|SSAA|Tedda Lippincott
+Take Me To The Land Of Jazz|SSAA|Tedda Lippincott
+Tell Santy I Live In A Shanty|SSAA|Tedda Lippincott
+Thank God And Greyhound|SSAA|Tedda Lippincott
+Thank You for being a Friend|SSAA|Tedda Lippincott
+Thank You Soldiers|SSAA|Tedda Lippincott
+That Old Black Magic|SSAA|Tedda Lippincott
+That Old Fashioned Mother Of Mine|SSAA|Tedda Lippincott
+That's Amore|SSAA|Tedda Lippincott
+That's When Life Is Worth Living|SSAA|Tedda Lippincott
+The Song Remembers When|SSAA|Tedda Lippincott
+Then You Can Tell Me Goodbye|SSAA|Tedda Lippincott
+There Is Nothing Like A Dame|SSAA|Tedda Lippincott
+There's A Kind Of Hush (All Over The World)|SSAA|Tedda Lippincott
+They Always Pick On Me|SSAA|Tedda Lippincott
+This Is The Army, Mr. Jones|SSAA|Tedda Lippincott
+This Is The Moment|SSAA|Tedda Lippincott
+This World|SSAA|Tedda Lippincott
+Through The Years|SSAA|Tedda Lippincott
+Tie a Yellow Ribbon 'Round The Ole Oak Tree|SSAA|Tedda Lippincott
+A Time For Joy|SSAA|Tedda Lippincott
+Time Was|SSAA|Tedda Lippincott
+To Know Him Is To Love Him|SSAA|Tedda Lippincott
+Under The Sea|SSAA|Tedda Lippincott
+Walkin' After Midnight|SSAA|Tedda Lippincott
+We Live On Borrowed Time|SSAA|Tedda Lippincott
+We Need A Little Christmas|SSAA|Tedda Lippincott
+We Rise Again|SSAA|Tedda Lippincott
+We'll Meet Again|SSAA|Tedda Lippincott
+We're On Top|SSAA|Tedda Lippincott
+What A Wonderful World|SSAA|Tedda Lippincott
+What Color Is God's Skin|SSAA|Tedda Lippincott
+What Would I Do Without My Music|SSAA|Tedda Lippincott
+When A Child Is Born|SSAA|Tedda Lippincott
+When God Dips His Love In My Heart|SSAA|Tedda Lippincott
+When I Lost You|SSAA|Tedda Lippincott
+When I'm Sixty Four|SSAA|Tedda Lippincott
+When Will I Be Loved|SSAA|Tedda Lippincott
+When You're Over Sixty & Feel Like Sweet Sixteen|SSAA|Tedda Lippincott
+Where The Boys Are|SSAA|Tedda Lippincott
+Whispering|SSAA|Tedda Lippincott
+White Christmas|SSAA|Tedda Lippincott
+Why Haven't I Heard From You|SSAA|Tedda Lippincott
+With Bells On|SSAA|Tedda Lippincott
+With One Look|SSAA|Tedda Lippincott
+Words|SSAA|Tedda Lippincott
+Y.M.C.A.|SSAA|Tedda Lippincott
+You Don't Own Me|SSAA|Tedda Lippincott
+You Need Hands|SSAA|Tedda Lippincott
+You Raise Me Up|SSAA|Tedda Lippincott
+You'd Be Surprised|SSAA|Tedda Lippincott
+You'll Never Walk Alone|SSAA|Tedda Lippincott
+You're In Style When You're Wearing A Smile|SSAA|Tedda Lippincott
+You're Never Too Old For Love|SSAA|Tedda Lippincott
+You've Got A Friend|SSAA|Tedda Lippincott
+Young At Heart|SSAA|Tedda Lippincott
+Your First Day In Heaven|SSAA|Tedda Lippincott
+ABC|SSAA|Glenda Lloyd
+Absolutely Everybody|SSAA|Glenda Lloyd
+After You Get What You Want You Don't Want It|SSAA|Glenda Lloyd
+All Of Me|TTBB|Glenda Lloyd
+Am I Ever Gonna See Your Face Again|SSAA|Glenda Lloyd
+Break My Stride|SSAA|Glenda Lloyd
+California Dreamin'|SSAA|Glenda Lloyd
+Can't Help Falling In Love|SSAA|Glenda Lloyd
+Christmas Day (The North Wind)|SSAA|Glenda Lloyd
+Come What May|SSAA|Glenda Lloyd
+Company|SSAA|Glenda Lloyd
+Don't Dream It's Over|SSAA|Glenda Lloyd
+Feels Like Home|SSAA|Glenda Lloyd
+Help!|SSAA|Glenda Lloyd
+Here Comes The Sun|SSAA|Glenda Lloyd
+I Am Woman|SSAA|Glenda Lloyd
+I Feel The Earth Move|SSAA|Glenda Lloyd
+I Honestly Love You|SSAA|Glenda Lloyd
+I Still Call Australia Home|SSAA|Glenda Lloyd
+I'll Never Stop Loving You|SSAA|Glenda Lloyd
+I'm Yours|SSAA|Glenda Lloyd
+Joy To The World|SSAA|Glenda Lloyd
+Let It Go|SSAA|Glenda Lloyd
+The Little Things|SSAA|Glenda Lloyd
+Lo How a Rose Ere Blooming|SSAA|Glenda Lloyd
+Mary's Boy Child|SSAA|Glenda Lloyd
+Mean|SSAA|Glenda Lloyd
+Medley: Sos, Since U Been Gone|SSAA|Glenda Lloyd
+Message In A Bottle|SSAA|Glenda Lloyd
+Mission: Impossible Theme|SSAA|Glenda Lloyd
+Moonlight Savings Time|SSAA|Glenda Lloyd
+Mr. Blue Sky|SSAA|Glenda Lloyd
+Once in Royal David's City|SSAA|Glenda Lloyd
+Only You|SSAA|Glenda Lloyd
+Permission To Shine|SSAA|Glenda Lloyd
+The Place Where the Lost Things Go|SSAA|Glenda Lloyd
+Please Don't Ask Me|TTBB, SSAA, SATB|Glenda Lloyd
+Put 'em In A Box, Tie 'em With A Ribbon|SSAA|Glenda Lloyd
+Reach|SSAA|Glenda Lloyd
+Rescue Me|SSAA|Glenda Lloyd
+Rock Around The Clock|SSAA|Glenda Lloyd
+Rudolph The Red Nosed Reindeer|SSAA|Glenda Lloyd
+S.O.S.|SSAA|Glenda Lloyd
+Scarborough Fair|SSAA|Glenda Lloyd
+Shelter|SSAA|Glenda Lloyd
+Skylark|SSAA|Glenda Lloyd
+So Far Away|SSAA|Glenda Lloyd
+Somebody to Love|SSAA|Glenda Lloyd
+Someone Like You|SSAA|Glenda Lloyd
+Sweet Caroline|SSAA|Glenda Lloyd
+The Three Drovers|SSAA|Glenda Lloyd
+Together We Are One|SSAA|Glenda Lloyd
+The Twelve Days Of Christmas|SSAA|Glenda Lloyd
+Viva Las Vegas|SSAA|Glenda Lloyd
+We Gotta Get Out Of This Place|SSAA|Glenda Lloyd
+We Wish You A Merry Christmas|SSAA|Glenda Lloyd
+Weird Science|SSAA|Glenda Lloyd
+You Brought A New Kind Of Love To Me|SSAA|Glenda Lloyd
+For Once In My Life|SSAA|Suzy Lobaugh
+Home For The Holidays|SSAA|Suzy Lobaugh
+It Had To Be You|SSAA|Suzy Lobaugh
+Little Locket of Long Ago|SSAA|Suzy Lobaugh
+Nobody Does It Like Me!|SSAA|Suzy Lobaugh
+Soon|SSAA|Suzy Lobaugh
+Thank You Very Much|SSAA|Suzy Lobaugh
+There's Nobody Else But You|SSAA|Suzy Lobaugh
+Too Marvelous For Words|SSAA|Suzy Lobaugh
+Unchained Melody|SSAA|Suzy Lobaugh
+Whispering|SSAA|Suzy Lobaugh
+With A Little Help From My Friends|SSAA|Suzy Lobaugh
+All Of My Life|SSAA|Mary Grace Lodico
+Amazing Grace|SSAA|Mary Grace Lodico
+I've Heard That Song Before|SSAA|Mary Grace Lodico
+Moonlight Becomes You|SSAA|Mary Grace Lodico
+My Wonderful One|SSAA|Bob Long
+What A Wonderful World|TTBB, SSAA|Bob Long
+It Only Happens When I Dance With You|TTBB|David Longroy
+She's Gonna Love That Barbershop Song|TTBB|David Longroy
+Cuando Calienta El Sol|SSAA|Carol Lord
+If My Nose Was Running Money|TTBB|David Lorenz
+The Goodbye Song|TTBB|Allyson Lotz
+Happier Than Ever|TTBB|Allyson Lotz
+All These Things That I've Done|SATB|Simon Lubkowski
+Away In A Manger|SATB|Simon Lubkowski
+Can't Help Falling In Love|SATB|Simon Lubkowski
+The Christmas Song|SATB|Simon Lubkowski
+Every Little Thing She Does Is Magic|SATB|Simon Lubkowski
+Greatest Day|TTBB|Simon Lubkowski
+In The Bleak Midwinter|SATB|Simon Lubkowski
+It's The Most Wonderful Time Of The Year|TTBB|Simon Lubkowski
+The Long and Winding Road|SATB|Simon Lubkowski
+O Come O Come Emmanuel|SATB|Simon Lubkowski
+Rewrite The Stars|SATB|Simon Lubkowski
+Sweet Caroline|TTBB|Simon Lubkowski
+Wagons West|TTBB|Bob Lucht
+Looking At The World Through Rose Colored Glasses|TTBB|Gordon Lug
+'Til Tomorrow|SSAA|Jo Lund
+A Barbershop Hello!|SSAA|Jo Lund
+Ain't Misbehavin' Medley|SSAA|Jo Lund
+Alice Blue Gown|SSAA|Jo Lund
+Almost Like Being In Love|SSAA|Jo Lund
+Am I Wasting My Time On You|SSAA|Jo Lund
+Amazing Grace|SSAA|Jo Lund
+America|SSAA|Jo Lund
+And The Angels Sing|SSAA|Jo Lund
+Any Time|SSAA|Jo Lund
+Apple Blossom Time/Don't Sit Under the Apple Tree Medley|SSAA|Jo Lund
+Armed Forces Medley|SSAA|Jo Lund
+As Long As Were Singing Our Song|SSAA|Jo Lund
+Auld Lang Syne|SSAA|Jo Lund
+Baby Face / You Must Have Been A Beautiful Baby Medley|SSAA|Jo Lund
+Baby Face Medley|SSAA|Jo Lund
+Baby, Won't You Please Come Home|SSAA|Jo Lund
+Ballad Medley|TTBB, SSAA|Jo Lund
+Because You Loved Me|SSAA|Jo Lund
+Best Of Times|SSAA|Jo Lund
+Bewitched, Bothered, and Bewildered|SSAA|Jo Lund
+Big Spender|SSAA|Jo Lund
+Blow Gabriel Blow|SSAA|Jo Lund
+Blue|SSAA|Jo Lund
+The Boy Next Door|SSAA|Jo Lund
+Bring On The Pepper|SSAA|Jo Lund
+Broadway Medley|SSAA|Jo Lund
+Broken Hearted (Here Am I)|SSAA|Jo Lund
+Brother Can You Spare A Dime|SSAA|Jo Lund
+Cabaret|SSAA|Jo Lund
+Call Me Back Pal O' Mine|SSAA|Jo Lund
+Can't Have any Fun without You|SSAA|Jo Lund
+Can't You Understand?|SSAA|Jo Lund
+Chicago, (that toddlin' town), Charleston Medley|SSAA|Jo Lund
+Chicago, (that toddlin' town), Dancing Medley|SSAA|Jo Lund
+Christmas Holidays Medley|SSAA|Jo Lund
+Christmas In New Orleans|SSAA|Jo Lund
+Christmas Needs Love to Be Christmas|SSAA|Jo Lund
+The Christmas Song|SSAA|Jo Lund
+Christmas Waltz|SSAA|Jo Lund
+City Lights|SSAA|Jo Lund
+The Colors of My Life|SSAA|Jo Lund
+The Colour of My Love|SSAA|Jo Lund
+Come In From The Rain|SSAA|Jo Lund
+Come Rain Or Come Shine|SSAA|Jo Lund
+Congratulate Me|SSAA|Jo Lund
+Cry Me A River|SSAA|Jo Lund
+Dancing In The Street|SSAA|Jo Lund
+Dearie|SSAA|Jo Lund
+Don't Blame Me|SSAA|Jo Lund
+Don't Bring Lulu|SSAA|Jo Lund
+Dream Angus|SSAA|Jo Lund
+Eagle When She Flies|SSAA|Jo Lund
+Easy Street|SSAA|Jo Lund
+The End of the World|SSAA|Jo Lund
+Endless Love|SATB|Jo Lund
+Every Street's A Boulevard|SSAA|Jo Lund
+Everything's Comin' Up Roses|SSAA|Jo Lund
+Exactly Like Me!|SSAA|Jo Lund
+Faded Old Love Letters|SSAA|Jo Lund
+Feelings|SSAA|Jo Lund
+Fifties Medley|SSAA|Jo Lund
+Friends|SSAA|Jo Lund
+Friendship|SSAA|Jo Lund
+God Bless My Family|SSAA|Jo Lund
+God Help The Outcasts|SSAA|Jo Lund
+Good Vibrations|SSAA|Jo Lund
+Greased Lightning|SSAA|Jo Lund
+The Greatest Love Of All|SSAA|Jo Lund
+Guys and Dolls Medley|SSAA|Jo Lund
+Hard Hearted Hannah|SSAA|Jo Lund
+Harlem Sandman / Mr. Sandman Medley|SSAA|Jo Lund
+Have You Met Miss Jones|SSAA|Jo Lund
+Have Yourself A Merry Little Christmas|SSAA|Jo Lund
+He Believes In Me|SSAA|Jo Lund
+Hooray For Hollywood|SSAA|Jo Lund
+House of Blue Lights|SSAA|Jo Lund
+How About Me?|SSAA|Jo Lund
+How Long Has This Been Going On?|SSAA|Jo Lund
+I Believe In Music|SSAA|Jo Lund
+I Can Dream, Can't I?|SSAA|Jo Lund
+I Cried For You|SSAA|Jo Lund
+I Got Lost In His Arms|SSAA|Jo Lund
+I Love a Banjo|SSAA|Jo Lund
+I Love My Baby|SSAA|Jo Lund
+I Love To Hear That Old Barbershop Style|SSAA|Jo Lund
+I Still Believe In Me|SSAA|Jo Lund
+I Want To Be A Showstopper!|SSAA|Jo Lund
+I Want To Do the Old Soft Shoe|SSAA|Jo Lund
+I Was A Fool To Let You Go|SSAA|Jo Lund
+I Wish I Could Shimmy Like My Sister Kate|SSAA|Jo Lund
+I Wish I Had My Old Pal Back Again|SSAA|Jo Lund
+I'll See You In My Dreams|SSAA|Jo Lund
+I'm Alone Because I Love You|SSAA|Jo Lund
+I'm Always Chasing Rainbows|SSAA|Jo Lund
+I'm Confessin' That I Love You|SSAA|Jo Lund
+I'm Drifting Tonight Through Old Memory Lane|SSAA|Jo Lund
+I'm Old Fashioned|SSAA|Jo Lund
+I'm the Last One Left On the Corner|SSAA|Jo Lund
+I've Got A Crush On You|SSAA|Jo Lund
+If He Walked Into My Life|SSAA|Jo Lund
+If I Had My Way|SSAA|Jo Lund
+If I Had You/Cuddle Up a Little Closer Medley|SSAA|Jo Lund
+"If I Knock The ""L"" Out Of Kelly"|SSAA|Jo Lund
+If I Only Had A Brain|SSAA|Jo Lund
+In Louisiana|SSAA|Jo Lund
+In The Garden|SSAA|Jo Lund
+It Had To Be You|SSAA|Jo Lund
+It Might As Well Be Spring|SSAA|Jo Lund
+It's Over|SSAA|Jo Lund
+It's Raining on Prom Night|SSAA|Jo Lund
+Jazz Me Blues/Jazzin' in New Orleans Medley|SSAA|Jo Lund
+Jazzin In New Orleans|SSAA|Jo Lund
+Jazzman's Serenade|SSAA|Jo Lund
+Jukebox Saturday Night Medley|SSAA|Jo Lund
+Kokomo|SSAA|Jo Lund
+La Bamba|SSAA|Jo Lund
+La Lasagne|SSAA|Jo Lund
+Last Night Was The End Of The World|SSAA|Jo Lund
+Laughing On The Outside|SSAA|Jo Lund
+"Let Me ""Us"" Entertain You"|SSAA|Jo Lund
+Let Me Call You Sweetheart|SSAA|Jo Lund
+Let Me Entertain You|SSAA|Jo Lund
+Let The Rest Of The World Go By|SSAA|Jo Lund
+Let There Be Peace On Earth|SSAA|Jo Lund
+Lock My Heart / Goody Goody Medley|SSAA|Jo Lund
+Lonesome|SSAA|Jo Lund
+Long Ago Lady|SSAA|Jo Lund
+Love Is In The Air|SSAA|Jo Lund
+Mamma's Gone/I Used to Love You Medley|SSAA|Jo Lund
+Man I Love|SSAA|Jo Lund
+Marion's Girls|SSAA|Jo Lund
+Maybe This Time|SSAA|Jo Lund
+Me And My Baby|SSAA|Jo Lund
+Mean To Me|SSAA|Jo Lund
+Mean to You|SSAA|Jo Lund
+Metro Rhythm Opener|SSAA|Jo Lund
+Miss Celie's Blues|SSAA|Jo Lund
+My Baby Just Cares For Me|SSAA|Jo Lund
+My Buddy|SSAA|Jo Lund
+My Buddy, Miss You Medley|SSAA|Jo Lund
+My Cutey's Due At Two-To-Two To-day|SSAA|Jo Lund
+My Guy|SSAA|Jo Lund
+My Melancholy Baby|SSAA|Jo Lund
+Naturally|SSAA|Jo Lund
+New York State of Mind|SSAA|Jo Lund
+New York, New York|SSAA|Jo Lund
+New York, New York|SATB|Jo Lund
+Nine To Five|SSAA|Jo Lund
+No One Is Alone|SSAA|Jo Lund
+Nobody Does It Like Me!|SSAA|Jo Lund
+Nonsense Medley|SSAA|Jo Lund
+Old Fashioned Medley|SSAA|Jo Lund
+The Old Horse And Buggy Had A Certain Swing|SSAA|Jo Lund
+The Old Songs|SSAA|Jo Lund
+On A Slow Boat To China|SSAA|Jo Lund
+On My Own|SSAA|Jo Lund
+Once In A While|SSAA|Jo Lund
+Once Upon A Time|SSAA|Jo Lund
+Opus One|SSAA|Jo Lund
+Orange Colored Sky|SSAA|Jo Lund
+P.S. I Love You|SSAA|Jo Lund
+Pan Am Commercial|SSAA|Jo Lund
+Perfect Day|SSAA|Jo Lund
+Puttin' On The Ritz|SSAA|Jo Lund
+Quartet Opener|SSAA|Jo Lund
+Rainbow Connection|SSAA|Jo Lund
+Razzle Dazzle|SSAA|Jo Lund
+Red Hot Mamma|SSAA|Jo Lund
+Region 15 Directors Song|SSAA|Jo Lund
+Reunite Commercial|SSAA|Jo Lund
+Rhode Island Is Famous For You|SSAA|Jo Lund
+The River Of Dreams|SSAA|Jo Lund
+Rock and Rock Medley|SSAA|Jo Lund
+Rodgers & Hammerstein Medley|SSAA|Jo Lund
+Rolling Along on Long Island|SSAA|Jo Lund
+Ronstadt, Linda Medley|SSAA|Jo Lund
+The Rose|SSAA|Jo Lund
+Sam, You Made The Pants Too Long|SSAA|Jo Lund
+Sandbox of Dreams|SSAA|Jo Lund
+Sara Lee|SSAA|Jo Lund
+Scarborough Fair|SSAA|Jo Lund
+Scotch And Soda|SSAA|Jo Lund
+Second Hand Rose|SSAA|Jo Lund
+Seventies Medley|SSAA|Jo Lund
+Shaddap You Face|SSAA|Jo Lund
+Shine On, Harvest Moon|SSAA|Jo Lund
+Shoop-Shoop Song, The (It's In His Kiss)|SSAA|Jo Lund
+Show Opener|SSAA|Jo Lund
+Silver Sorority Song|SSAA|Jo Lund
+Singin' In The Rain|SSAA|Jo Lund
+Smokey Joe's Cafe|SSAA|Jo Lund
+Someday|SSAA|Jo Lund
+Somewhere Out There|SSAA|Jo Lund
+Sophisticated Ladies Medley|SSAA|Jo Lund
+Speakeasy!|SSAA|Jo Lund
+Statue of Liberty|SSAA|Jo Lund
+Step To The Rear|SSAA|Jo Lund
+Steppin' Out Medley|SSAA|Jo Lund
+Summer Me, Winter Me|SSAA|Jo Lund
+Sweet Georgia Brown|SSAA|Jo Lund
+Take Me Out To The Ball Game|SSAA|Jo Lund
+Thank God I'm Old|SSAA|Jo Lund
+Thank Heaven For Little Girls|SSAA|Jo Lund
+Thanks For The Memory|SSAA|Jo Lund
+That Summer When We Were Young|SSAA|Jo Lund
+That's How You Jazz|SSAA|Jo Lund
+That's How You Jazz/The Jam Medley|SSAA|Jo Lund
+That's Our Renee|SSAA|Jo Lund
+That's What Friends Are For|SSAA|Jo Lund
+There I've Said It Again|SSAA|Jo Lund
+There'll Be Some Changes/Running Wild Medley|SSAA|Jo Lund
+They Go Wild, Simply Wild Over Me/Running Wild medley|SSAA|Jo Lund
+This Could be the Start of Something Big|SSAA|Jo Lund
+This Is The Life|SSAA|Jo Lund
+This Land Is Your Land|SSAA|Jo Lund
+To Keep My Love Alive|SSAA|Jo Lund
+Together Wherever We Go|SSAA|Jo Lund
+Twilight Tone|SSAA|Jo Lund
+Two (Four) Of A Kind|SSAA|Jo Lund
+Volare|SSAA|Jo Lund
+Warm-Ups|SSAA|Jo Lund
+Way Down Yonder In New Orleans|SSAA, Young SSAA|Jo Lund
+We Go Together|SSAA|Jo Lund
+We Need A Little Christmas|SSAA|Jo Lund
+We Wish You A Merry Christmas|SSAA|Jo Lund
+We've Only Just Begun|SSAA|Jo Lund
+Wedding Bells Are Breaking Up That Old Gang Of Mine|SSAA|Jo Lund
+West Side Story Medley|SSAA|Jo Lund
+What I Did For Love|SSAA|Jo Lund
+When I Fall In Love|SSAA|Jo Lund
+When It's Night time in Italy, It's Wednesday Over Here|SSAA|Jo Lund
+When You Wish Upon A Star|SSAA|Jo Lund
+Where Did Robinson Crusoe Go With Friday On Saturday Night|SSAA|Jo Lund
+Wildfire|SSAA|Jo Lund
+Winchester Cathedral|SSAA|Jo Lund
+With Plenty Of Money And You/Were In The Money Medley|SSAA|Jo Lund
+Wizard Of Oz Medley|SSAA|Jo Lund
+Won't You Charleston With Me/Charleston Medley|SSAA|Jo Lund
+Wrap Your Troubles In Dreams|SSAA|Jo Lund
+Yes, We Have No Bananas|SSAA|Jo Lund
+You Always Hurt the One You Love|SSAA|Jo Lund
+You Don't Own Me|SSAA|Jo Lund
+You Light Up My Life|SSAA|Jo Lund
+You Make Me Feel So Young|TTBB, SSAA|Jo Lund
+You Were Meant For Me/You Are My Lucky Star Medley|SSAA|Jo Lund
+You'll Never Walk Alone|SSAA|Jo Lund
+The Christmas Song|TTBB|Gregory Lyne
+Deep River|TTBB|Gregory Lyne
+Down On The Corner|TTBB|Gregory Lyne
+Feast Of Lights Medley|TTBB|Gregory Lyne
+Feast Of Lights Medley|SSAA|Gregory Lyne
+Forty-Five Minutes from Broadway|TTBB|Gregory Lyne
+God Bless America|TTBB|Gregory Lyne
+God Bless America|SSAA, SATB|Gregory Lyne
+I Left My Heart On A Tree With Mary|TTBB|Gregory Lyne
+If You Can't Get A Girl In The Summertime|TTBB|Gregory Lyne
+Jesus, Jesus, Rest Your Head|TTBB, SATB|Gregory Lyne
+Let Me Call You Sweetheart|TTBB|Gregory Lyne
+Looking At The World Through Rose Colored Glasses|TTBB|Gregory Lyne
+May You Always|TTBB|Gregory Lyne
+On The Farm In Old Missouri|TTBB|Gregory Lyne
+Rain|TTBB|Gregory Lyne
+Take A Little Time|TTBB|Gregory Lyne
+Those Good Old Fluffy Ruffle Days|TTBB|Gregory Lyne
+Vo-De-O-Do|TTBB|Gregory Lyne
+When You Look In The Heart Of A Rose|SSAA|Gregory Lyne
+When You Look In The Heart Of A Rose|TTBB|Gregory Lyne
+Who'll Take My Place When I'm Gone|TTBB|Gregory Lyne
+May You Always|SSAA|Judy M. MacDonald
+Bundle Of Old Love Letters|TTBB|D. C. Macintyre
+Have Yourself A Merry Little Christmas|TTBB|Blaine Mack
+New York, New York|TTBB|Blaine Mack
+When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Blaine Mack
+The Christmas Song|TTBB|Andy Maddox
+I Ain't Down Yet|TTBB|Andy Maddox
+I Love A Rainy Night|TTBB|Will Makra
+Oh Sherrie!|TTBB|Will Makra
+Old Toy Trains|TTBB|Will Makra
+Backwards|TTBB|Greg Mallett
+Be My Friend The Facebook Song|TTBB|Greg Mallett
+Be Present At Our Table, Lord|TTBB|Greg Mallett
+Betty|TTBB, SSAA, SATB|Greg Mallett
+Cabaret|TTBB|Greg Mallett
+Canadian Girls|TTBB|Greg Mallett
+Dancing Through Life|TTBB|Greg Mallett
+Flight|TTBB, SSAA|Greg Mallett
+Found/Tonight|TTBB, SATB|Greg Mallett
+Gimme Gimme|TTBB, SSAA|Greg Mallett
+God, I Hate Shakespeare|TTBB|Greg Mallett
+Hallelujah|TTBB|Greg Mallett
+Hava Nagila|TTBB|Greg Mallett
+Have Yourself A Merry Little Christmas|TTBB, SATB|Greg Mallett
+Heave Away|TTBB|Greg Mallett
+History|TTBB|Greg Mallett
+How Bout A Dance?|TTBB, SSAA, SATB|Greg Mallett
+I Believe|TTBB|Greg Mallett
+I Don't Understand The Poor|TTBB|Greg Mallett
+I Love You|TTBB, SATB|Greg Mallett
+If The World Was Ending|TTBB|Greg Mallett
+In The Market For A Miracle|TTBB|Greg Mallett
+It's A Beautiful Day|TTBB|Greg Mallett
+Let Me Be Your Star|TTBB|Greg Mallett
+Losing My Mind|TTBB|Greg Mallett
+The Man That Got Away|TTBB|Greg Mallett
+Meadowlark|TTBB|Greg Mallett
+Merry Christmas|TTBB, SSAA, SATB|Greg Mallett
+Merry Christmas Darling|TTBB|Greg Mallett
+Moving Too Fast|TTBB|Greg Mallett
+My House|TTBB|Greg Mallett
+Not My Father's Son|TTBB|Greg Mallett
+Oh, It's A Lovely War! Medley|TTBB|Greg Mallett
+Olivia|TTBB|Greg Mallett
+Omar Sharif|TTBB|Greg Mallett
+Only Ifs|SATB|Greg Mallett
+Pachelbel Canon|TTBB, SSAA|Greg Mallett
+Prepared|TTBB|Greg Mallett
+Rock 'n' Roll Song|TTBB|Greg Mallett
+Rockin' Around The Pole|TTBB|Greg Mallett
+Run To You|TTBB|Greg Mallett
+Sal Tlay Ka Siti|TTBB|Greg Mallett
+Sarah|TTBB|Greg Mallett
+School Song|TTBB|Greg Mallett
+Seasons of Love|TTBB|Greg Mallett
+Sham-a-ling-dong-ding|TTBB|Greg Mallett
+Some Things Are Meant To Be|TTBB|Greg Mallett
+Supermarket Flowers|TTBB|Greg Mallett
+There's A Place For Us|TTBB|Greg Mallett
+Valerie|TTBB|Greg Mallett
+What Do I Know?|TTBB|Greg Mallett
+Wish You Were Gay|TTBB|Greg Mallett
+Without Love|TTBB|Greg Mallett
+Words Fail|TTBB|Greg Mallett
+You Will Be Found|TTBB|Greg Mallett
+It Had To Be You|SSAA|Dennis Malone
+Love Is Here To Stay|TTBB|Dennis Malone
+Singing The Blues|TTBB|Dennis Malone
+The Truth About Men|TTBB|Dennis Malone
+In A Shanty In Old Shanty Town|TTBB|Shirley Maney
+A cappella in Acapulco|SATB, SSATB|Joe Mannherz
+A Certain Smile|TTBB|Joe Mannherz
+A Child is Born|SATB|Joe Mannherz
+A childs prayer|TTBB|Joe Mannherz
+A Dream Is A Wish Your Heart Makes|TTBB, SSAA|Joe Mannherz
+A Moment Like This|SATB|Joe Mannherz
+Africa|SATB|Joe Mannherz
+After You Get What You Want You Don't Want It|TTBB, SSAA|Joe Mannherz
+Ain't She Sweet / Yes Sir, That's My Baby Medley|TTBB, SSAA|Joe Mannherz
+Alabama|TTBB|Joe Mannherz
+Alabamy Bound|TTBB|Joe Mannherz
+All By Myself|TTBB|Joe Mannherz
+All Dressed Up With A Broken Heart|TTBB, SSAA|Joe Mannherz
+All I Ask Of You|SATB, SSATB|Joe Mannherz
+All Of Me|TTBB, SSAA|Joe Mannherz
+All You Need Is Love|SATB, SSATB|Joe Mannherz
+Along Comes Mary|SATB, SSATB|Joe Mannherz
+Always|TTBB, SSAA|Joe Mannherz
+Amazing Grace|SATB, SSATB|Joe Mannherz
+America|SATB, SSATB|Joe Mannherz
+American Pie|TTBB, SSAA|Joe Mannherz
+And So It Goes|SATB, SSATB|Joe Mannherz
+And So To Sleep Again|SATB|Joe Mannherz
+And the Beat goes on|SATB, SSATB|Joe Mannherz
+Another Christmas|SATB, SSATB|Joe Mannherz
+Another Day|SATB, SSATB|Joe Mannherz
+Anything Goes|TTBB, SSAA|Joe Mannherz
+Aquarius|TTBB|Joe Mannherz
+As If We Never Said Goodbye|SSAA|Joe Mannherz
+At Last|TTBB, SSAA|Joe Mannherz
+Attention|TTBB, SATB, SSATB|Joe Mannherz
+Ave Maria|TTBB|Joe Mannherz
+Baby plays around|TTBB, SATB, SSATB|Joe Mannherz
+Baby, It's Cold Outside|SATB, SSATB|Joe Mannherz
+Band Parade Medley|TTBB|Joe Mannherz
+Basin Street!|TTBB, SSAA|Joe Mannherz
+Be A Clown|TTBB|Joe Mannherz
+Be my wife|TTBB|Joe Mannherz
+Beat Goes On|SATB, SSATB|Joe Mannherz
+Because|SATB, SSATB|Joe Mannherz
+Begin The Beguine|TTBB, SSAA, SATB|Joe Mannherz
+Best things happen while you dance/ Dance Medley|SSAA|Joe Mannherz
+Bewitched, Bothered, and Bewildered|TTBB, SSAA|Joe Mannherz
+Birdland|SATB, SSATB|Joe Mannherz
+Birth Of The Blues|TTBB|Joe Mannherz
+Blessed is the Rain|TTBB, SSAA, SATB|Joe Mannherz
+Blue Skies|SATB, SSATB|Joe Mannherz
+Body & Soul|SATB, SSATB|Joe Mannherz
+Bohemian Rhapsody|SATB|Joe Mannherz
+Both Sides Now|TTBB|Joe Mannherz
+Bowery Medley|TTBB|Joe Mannherz
+Brahms Lullaby|SATB, SSATB|Joe Mannherz
+Brazil|SATB, SSATB|Joe Mannherz
+Brians song|TTBB, SSAA|Joe Mannherz
+Broken Hearted|TTBB|Joe Mannherz
+Brother Can You Spare A Dime|TTBB|Joe Mannherz
+But Not For Me|TTBB|Joe Mannherz
+Cabaret|TTBB, SSAA|Joe Mannherz
+California Dreamin'|SATB, SSATB|Joe Mannherz
+California Here I Come|TTBB, SSAA|Joe Mannherz
+Candlelight Carol|SATB, SSATB|Joe Mannherz
+Carol Of The Bells|SATB, SSATB|Joe Mannherz
+Caroling, Caroling|SATB, SSATB|Joe Mannherz
+Chapel Of Love|SATB, SSATB|Joe Mannherz
+Charleston|TTBB|Joe Mannherz
+Chattanooga Choo Choo|TTBB, SATB, SSATB|Joe Mannherz
+Chili Con Carne|SATB, SSATB|Joe Mannherz
+A Christmas Love Song|SATB|Joe Mannherz
+Christmas Lullaby|SATB, SSATB|Joe Mannherz
+The Christmas Song|TTBB, SATB, SSATB|Joe Mannherz
+Christmastime is here|SATB, SSATB|Joe Mannherz
+Climb Ev'ry Mountain|TTBB|Joe Mannherz
+Cloudburst|SATB|Joe Mannherz
+Coffee calls for a Cigarette|SATB, SSATB|Joe Mannherz
+The Colour of My Love|TTBB, SSAA|Joe Mannherz
+Come Blow Your Horn|TTBB, SSAA|Joe Mannherz
+Come Dance With Me|TTBB, SSAA|Joe Mannherz
+Consider Yourself|TTBB|Joe Mannherz
+Count your blessings|TTBB|Joe Mannherz
+Cousin Dupree|TTBB, SATB|Joe Mannherz
+Daddy's Little Girl|TTBB|Joe Mannherz
+Dance Medley|TTBB, SSAA|Joe Mannherz
+Darktown Strutters' Ball|TTBB|Joe Mannherz
+Dear Little Boy Of Mine|TTBB|Joe Mannherz
+Dear Old Pal Of Mine|TTBB|Joe Mannherz
+Deep Purple|TTBB, SATB, SSATB|Joe Mannherz
+Desperado|TTBB|Joe Mannherz
+Did I Remember?|TTBB, SSAA|Joe Mannherz
+Do - Re - Mi|TTBB|Joe Mannherz
+Do You Know What It Means To Miss New Orleans|TTBB|Joe Mannherz
+Do you really love me|SSAA|Joe Mannherz
+Do You Remember|TTBB, SSAA|Joe Mannherz
+Don't Ask Me Why|SSAA, SATB, SSATB|Joe Mannherz
+Don't Blame Me|TTBB|Joe Mannherz
+Don't You Worry Bout A Thing|SATB, SSATB|Joe Mannherz
+Drag Me Down|SATB, SSATB|Joe Mannherz
+Dream A Little Dream Of Me|SATB|Joe Mannherz
+Dream Medley|SSAA|Joe Mannherz
+Easy Living|TTBB, SSAA, SATB|Joe Mannherz
+Easy Street|TTBB, SSAA, SATB|Joe Mannherz
+Edelweiss|TTBB|Joe Mannherz
+Eleanor Rigby|SATB, SSATB|Joe Mannherz
+Embraceable You|SATB, SSATB|Joe Mannherz
+The Entertainer|SATB|Joe Mannherz
+Ev'ry Time We Say Goodbye|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+Everything Old Is New Again|TTBB, SSAA|Joe Mannherz
+Exactly Like You|SSAA|Joe Mannherz
+The Exodus Song|TTBB|Joe Mannherz
+Face to face|TTBB|Joe Mannherz
+Feeling Good|SATB, SSATB|Joe Mannherz
+Figure It Out|SATB, SSATB|Joe Mannherz
+The First Time Ever I Saw Your Face|SATB, SSATB|Joe Mannherz
+Flip top|SATB, SSATB|Joe Mannherz
+Fly Me To The Moon|TTBB, SSAA|Joe Mannherz
+Fly me to the Moon/Come fly with me Medley|TTBB, SSAA, SATB|Joe Mannherz
+Folks Who Live On The Hill|TTBB, SSAA, SATB|Joe Mannherz
+Fool On The Hill|SATB, SSATB|Joe Mannherz
+For All We Know|TTBB|Joe Mannherz
+For Once In My Life|TTBB|Joe Mannherz
+For the Want of a Kiss|TTBB, SSAA, SATB|Joe Mannherz
+Forever Friends|SSAA|Joe Mannherz
+Forgotten Dreams/Long Ago Medley|SSAA, SATB, SSATB|Joe Mannherz
+The Frim Fram Sauce|TTBB, SSAA|Joe Mannherz
+From This Moment On|TTBB, SSAA, SATB|Joe Mannherz
+Funny face|SATB, SSATB|Joe Mannherz
+The Girl From Ipanema|SATB, SSATB|Joe Mannherz
+The Girl In Noman's Land|SSAA|Joe Mannherz
+Go Tell It On The Mountain|SATB, SSATB|Joe Mannherz
+God Bless The Child|TTBB, SSAA, SATB|Joe Mannherz
+God Only Knows|SATB, SSATB|Joe Mannherz
+GOD so loved the World|SATB|Joe Mannherz
+Going Bananas|SSAA, SATB, SSATB|Joe Mannherz
+Good Morning|TTBB, SSAA|Joe Mannherz
+Good Morning Heartache|TTBB, SSAA, SATB|Joe Mannherz
+Gotta Be This Or That|TTBB, SSAA|Joe Mannherz
+Gotta get you into my life|SATB, SSATB|Joe Mannherz
+Grandma Got Run Over By A Reindeer|TTBB, SSAA, SATB|Joe Mannherz
+Great Day|SSAA|Joe Mannherz
+Grown-Up Christmas List|SSAA, SATB, SSATB|Joe Mannherz
+Guinnevere|SATB, SSATB|Joe Mannherz
+The Hands of Time|TTBB, SSAA|Joe Mannherz
+Happy|SATB, SSATB|Joe Mannherz
+Happy Birthday To You|SATB|Joe Mannherz
+Happy Holiday Medley|SATB, SSATB|Joe Mannherz
+Happy Trails|TTBB|Joe Mannherz
+Have Yourself A Merry Little Christmas|SATB, SSATB|Joe Mannherz
+Hazy Shade of Winter|SATB|Joe Mannherz
+He's a Runner|SATB, SSATB|Joe Mannherz
+Heart Of A Clown|TTBB|Joe Mannherz
+Helplessly Hoping|SATB, SSATB|Joe Mannherz
+Here's That Rainy Day|SSAA|Joe Mannherz
+Hey Santa|SATB, SSATB|Joe Mannherz
+Hey There|TTBB, SSAA|Joe Mannherz
+Hi Neighbor|TTBB|Joe Mannherz
+Hi-De-Ho (That Old Sweet Roll)|TTBB|Joe Mannherz
+History|SATB, SSATB|Joe Mannherz
+Hit That Jive Jack|SATB, SSATB|Joe Mannherz
+Hit The Road Jack|SATB, SSATB|Joe Mannherz
+Holly Jolly Christmas|SATB, SSATB|Joe Mannherz
+Hotel California|SATB, SSATB|Joe Mannherz
+A House Is Not A Home|SATB|Joe Mannherz
+A House With Love In It|SATB|Joe Mannherz
+How Are Things In Glocca Morra|TTBB|Joe Mannherz
+How High The Moon|SATB, SSATB|Joe Mannherz
+How Little We Know|TTBB, SSAA|Joe Mannherz
+How Many Times|TTBB, SSAA|Joe Mannherz
+I Can't Believe That You're In Love With Me|TTBB, SSAA|Joe Mannherz
+I Can't Get Started with You|TTBB|Joe Mannherz
+I Can't Give You Anything But Love|TTBB, SSAA|Joe Mannherz
+I Could Write a Book|TTBB, SSAA|Joe Mannherz
+I Don't Know Enough About You|TTBB|Joe Mannherz
+I Don't Know How To Say Goodbye|TTBB, SSAA, SATB|Joe Mannherz
+I don't wanna be the one|TTBB, SSAA|Joe Mannherz
+I Get Along Without You Very Well|TTBB, SSAA|Joe Mannherz
+I Got Rhythm|SATB|Joe Mannherz
+I Heard The Bells On Christmas Day|SATB, SSATB|Joe Mannherz
+I Just Wanna Be A Kid|TTBB, SSAA|Joe Mannherz
+I Know Why And So Do You|TTBB, SSAA|Joe Mannherz
+I Like to Lead When I Dance|TTBB, SSAA, SATB|Joe Mannherz
+I Love Being Here With You|TTBB, SSAA|Joe Mannherz
+I May Never Pass This Way Again|TTBB, SSAA|Joe Mannherz
+I Need to be in Love|TTBB, SSAA|Joe Mannherz
+I Never Knew|TTBB, SSAA|Joe Mannherz
+I Only Have Eyes For You|TTBB, SSAA|Joe Mannherz
+I Remember LA|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+I Remember You|TTBB, SATB, SSATB|Joe Mannherz
+I Sing|SATB, SSATB|Joe Mannherz
+I Talk To The Trees|TTBB, SSAA|Joe Mannherz
+I Won't Cry Anymore|TTBB, SSAA|Joe Mannherz
+I Won't Send Roses|TTBB|Joe Mannherz
+I Wonder What You're Doing for Christmas|SATB, SSATB|Joe Mannherz
+I'd Be Fine With Christmas Time|TTBB, SSAA|Joe Mannherz
+I'll Be Home For Christmas|SATB, SSATB|Joe Mannherz
+I'll Be Seeing You|TTBB, SATB, SSATB|Joe Mannherz
+I'll Get By|TTBB|Joe Mannherz
+I'll hear your voice|SATB, SSATB|Joe Mannherz
+I'm Afraid This Must Be Love|SSAA|Joe Mannherz
+I'm Alright|SATB, SSATB|Joe Mannherz
+I'm Beginning To See The Light|TTBB|Joe Mannherz
+I'm going Bananas|SSAA, SATB, SSATB|Joe Mannherz
+I'm No Account Anymore|TTBB, SSAA|Joe Mannherz
+I'm Sorry I Made You Cry|TTBB, SSAA|Joe Mannherz
+I'm with you|SATB, SSATB|Joe Mannherz
+I've Found A New Baby (I Found A New Baby)|TTBB, SATB, SSATB|Joe Mannherz
+I've Got A Crush On You|TTBB, SSAA|Joe Mannherz
+I've Got My Love To Keep Me Warm|SATB|Joe Mannherz
+I've Got The World On A String|SSAA, SATB, SSATB|Joe Mannherz
+I've Grown Accustomed To Her Face|TTBB, SATB, SSATB|Joe Mannherz
+I've Seen All Good People|SATB, SSATB|Joe Mannherz
+If I Love Again|TTBB, SSAA|Joe Mannherz
+If I Ruled The World|TTBB|Joe Mannherz
+Island Life|SATB, SSATB|Joe Mannherz
+Isn't It A Pity|TTBB|Joe Mannherz
+It Had To Be You|TTBB|Joe Mannherz
+It Only Takes A Moment|TTBB, SSAA, SATB|Joe Mannherz
+It's A Most Unusual Day|SATB|Joe Mannherz
+It's A Pity To Say Goodnight|TTBB, SSAA|Joe Mannherz
+It's beginning to look a lot like christmas|TTBB|Joe Mannherz
+It's Only A Paper Moon|TTBB|Joe Mannherz
+It's Sand, Man|SSAA, SATB, SSATB|Joe Mannherz
+It's The Same Old Dream|TTBB, SSAA|Joe Mannherz
+Java Jive|TTBB, SSAA|Joe Mannherz
+Jazz Medley|TTBB, SSAA|Joe Mannherz
+Jazzy Samba (the)|SATB, SSATB|Joe Mannherz
+Jingle-Bell Rock|SATB, SSATB|Joe Mannherz
+Johnny Fedora and Alice Blue Bonnet|TTBB, SSAA|Joe Mannherz
+Jolly Holiday|TTBB|Joe Mannherz
+Josie|SATB, SSATB|Joe Mannherz
+The Joy of Life|TTBB, SSAA|Joe Mannherz
+Joy To The World|SSATB|Joe Mannherz
+Just The Way You Are|SATB, SSATB|Joe Mannherz
+Keepin' Out Of Mischief Now|SATB, SSATB|Joe Mannherz
+King Of The Road|SATB, SSATB|Joe Mannherz
+The Kingdom of Shy|SATB, SSATB|Joe Mannherz
+Kiss the Boys Goodbye|SSAA|Joe Mannherz
+L.O.V.E. Medley|TTBB, SSAA|Joe Mannherz
+Last night|SATB, SSATB|Joe Mannherz
+Lazy Afternoon|SATB, SSATB|Joe Mannherz
+Le Jazz Hot!|TTBB, SSAA|Joe Mannherz
+Let Me Be Your Star|SSAA|Joe Mannherz
+Let's Call The Whole Thing Off|TTBB, SSAA|Joe Mannherz
+Let's Get Away From It All|SATB, SSATB|Joe Mannherz
+Let's Misbehave|SATB, SSATB|Joe Mannherz
+Let's Start Tomorrow Tonight|SSAA|Joe Mannherz
+Like It's Christmas|TTBB, SSAA, SATB|Joe Mannherz
+Listen to the Dawn|SATB, SSATB|Joe Mannherz
+Little bitty pretty one|SATB, SSATB|Joe Mannherz
+Little Boy Lost|SSAA|Joe Mannherz
+Little Darlin'|SATB, SSATB|Joe Mannherz
+Little Man You've Had A Busy Day|SATB, SSATB|Joe Mannherz
+Lonesome Looser|SATB, SSATB|Joe Mannherz
+Lonesome Suzie|TTBB|Joe Mannherz
+Long Distance Runaround|SATB, SSATB|Joe Mannherz
+The Lord's Prayer|TTBB|Joe Mannherz
+Losing My Mind|SSAA|Joe Mannherz
+Love Letters In The Sand|TTBB|Joe Mannherz
+Love Letters Straight From Your Heart|TTBB, SSAA|Joe Mannherz
+Love looks so well on you|TTBB|Joe Mannherz
+Love Me or Leave Me|SATB, SSATB|Joe Mannherz
+Love Walked In|TTBB, SSAA|Joe Mannherz
+Lovely Way To Spend An Evening|TTBB, SSAA|Joe Mannherz
+Lower Case Love|TTBB, SSAA|Joe Mannherz
+Luck Be A Lady|TTBB, SSAA|Joe Mannherz
+Lullaby In Ragtime|TTBB, SSAA|Joe Mannherz
+Lullaby of Birdland|TTBB, SATB, SSATB|Joe Mannherz
+Lullabye|SATB, SSATB|Joe Mannherz
+Lullay My Liking|SATB, SSATB|Joe Mannherz
+Mack The Knife|SATB, SSATB|Joe Mannherz
+The Magic Window|TTBB, SSAA|Joe Mannherz
+Make 'Em Laugh|TTBB|Joe Mannherz
+Mam'selle|TTBB|Joe Mannherz
+Man With The Bag|SATB, SSATB|Joe Mannherz
+Mary Did You Know|SATB, SSATB|Joe Mannherz
+Mary Poppins Medley|TTBB|Joe Mannherz
+Mas Que Nada|SATB, SSATB|Joe Mannherz
+The Masquerade Is Over|TTBB|Joe Mannherz
+May you always walk in Sunshine|TTBB|Joe Mannherz
+Mele Kalikimaka|TTBB, SSAA, SATB|Joe Mannherz
+Merry Christmas Darling|SATB, SSATB|Joe Mannherz
+Miss Celie's Blues|SSAA|Joe Mannherz
+Miss You Most at Christmas|TTBB, SSAA, SATB|Joe Mannherz
+Mistakes|TTBB|Joe Mannherz
+Monks new tune|SATB, SSATB|Joe Mannherz
+Monster Mash|TTBB, SATB, SSATB|Joe Mannherz
+Monsters Medley|SATB, SSATB|Joe Mannherz
+Mood Indigo|TTBB, SSAA|Joe Mannherz
+Moondance/Fever Medley|TTBB|Joe Mannherz
+Moonglow|SATB, SSATB|Joe Mannherz
+Moonlight Becomes You|TTBB|Joe Mannherz
+More Than You Know|TTBB, SSAA|Joe Mannherz
+Most Wonderful Time Of The Year|SATB, SSATB|Joe Mannherz
+Mr. Piano Man|TTBB|Joe Mannherz
+Muskrat Ramble|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+My Buddy|TTBB|Joe Mannherz
+My Diane|TTBB, SATB, SSATB|Joe Mannherz
+My Dreams Are Getting Better All The Time|SATB, SSATB|Joe Mannherz
+My Foolish Heart|SATB, SSATB|Joe Mannherz
+My Funny Valentine|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+My Girl|TTBB, SSAA|Joe Mannherz
+My Little Pal|TTBB, SATB, SSATB|Joe Mannherz
+My Romance|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+Naturally|TTBB|Joe Mannherz
+Nature Boy|TTBB, SSAA|Joe Mannherz
+Nellie Kelly, I Love You|TTBB|Joe Mannherz
+Never Neverland|TTBB, SSAA|Joe Mannherz
+New Orleans Medley|TTBB|Joe Mannherz
+New York, New York|TTBB|Joe Mannherz
+Nice Work If You Can Get It|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+A Nightingale Sang In Berkeley Square|TTBB, SATB, SSATB|Joe Mannherz
+Nitey Nite|SSAA|Joe Mannherz
+Not While I'm Around|TTBB, SSAA|Joe Mannherz
+Now and Forever|SATB, SSATB|Joe Mannherz
+Now I'm Following You|SSAA|Joe Mannherz
+O Christmas Tree|SATB, SSATB|Joe Mannherz
+O Holy Night|TTBB, SATB, SSATB|Joe Mannherz
+Oh, How I Miss You Tonight|TTBB|Joe Mannherz
+Old Glory|SATB, SSATB|Joe Mannherz
+On eagles wings|SSAA|Joe Mannherz
+Once In A Lifetime|SATB, SSATB|Joe Mannherz
+Once In A While|TTBB|Joe Mannherz
+Once Upon A December|SATB, SSATB|Joe Mannherz
+One Fine Day|TTBB|Joe Mannherz
+One for the road|SATB, SSATB|Joe Mannherz
+One Love|TTBB|Joe Mannherz
+One Note Samba|SATB, SSATB|Joe Mannherz
+Opus One|SATB, SSATB|Joe Mannherz
+Orange Colored Sky|TTBB|Joe Mannherz
+Over The Rainbow|TTBB, SSAA|Joe Mannherz
+Oye Como Va|SATB, SSATB|Joe Mannherz
+Pachelbel Canon|SATB, SSATB|Joe Mannherz
+Paddlin' Madelin' Home|TTBB|Joe Mannherz
+Payphone|SATB, SSATB|Joe Mannherz
+People|SATB, SSATB|Joe Mannherz
+Philadelphia Freedom|SSAA|Joe Mannherz
+Picture of Mother|TTBB|Joe Mannherz
+Please Don't Make Me Love You|SSAA|Joe Mannherz
+Pure Imagination|TTBB|Joe Mannherz
+Question 67 & 68|SATB, SSATB|Joe Mannherz
+Quiet Nights of Quiet Stars|SATB, SSATB|Joe Mannherz
+Rain In Spain|SSAA|Joe Mannherz
+Rainbow Connection|TTBB, SSAA, SATB|Joe Mannherz
+Red Rubber Ball|SATB, SSATB|Joe Mannherz
+Reindeer|TTBB, SSAA|Joe Mannherz
+Remember|SATB, SSATB|Joe Mannherz
+The Restroom song|SATB, SSATB|Joe Mannherz
+Ride Like the Wind|SATB, SSATB|Joe Mannherz
+Route 66|SATB, SSATB|Joe Mannherz
+Sam, The Old Accordion Man|TTBB|Joe Mannherz
+Samba Do Aviao|SATB, SSATB|Joe Mannherz
+Satin Doll|SATB, SSATB|Joe Mannherz
+Scarborough Fair|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+Scotch And Soda|SATB, SSATB|Joe Mannherz
+Scrooge Medley|SATB, SSATB|Joe Mannherz
+The Secret Of Christmas|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+Send In The Clowns|TTBB|Joe Mannherz
+She|TTBB|Joe Mannherz
+Silent Night|TTBB, SATB, SSATB|Joe Mannherz
+Silver Bells|SATB, SSATB|Joe Mannherz
+Sing A Song|SATB, SSATB|Joe Mannherz
+Sixty's Medley|SATB, SSATB|Joe Mannherz
+Sleigh Ride|TTBB|Joe Mannherz
+Softly|TTBB|Joe Mannherz
+Some Enchanted Evening|SSAA|Joe Mannherz
+Somebody to Love|SSAA, SATB, SSATB|Joe Mannherz
+Someone Like You|SSAA|Joe Mannherz
+Someone To Watch Over Me|TTBB, SSAA|Joe Mannherz
+Something|SATB, SSATB|Joe Mannherz
+Sometimes in Winter|TTBB, SSAA, SATB|Joe Mannherz
+Somewhere Out There|TTBB|Joe Mannherz
+Soon It's Gonna Rain|SATB, SSATB|Joe Mannherz
+Sooner or Later|SSAA, SATB, SSATB|Joe Mannherz
+Sophisticated Lady|SATB, SSATB|Joe Mannherz
+Sound of Music Medley|TTBB|Joe Mannherz
+Splanky|SATB, SSATB|Joe Mannherz
+A Spoonful Of Sugar|TTBB, SSAA|Joe Mannherz
+Stand By Me|SATB|Joe Mannherz
+Star Spangled Banner|SATB, SSATB|Joe Mannherz
+Stardust|SATB, SSATB|Joe Mannherz
+Still Dream|SATB, SSATB|Joe Mannherz
+Still, Still, Still|SATB, SSATB|Joe Mannherz
+Straighten Up And Fly Right|SATB, SSATB|Joe Mannherz
+Stranger on the Shore|SSAA|Joe Mannherz
+Strawberry Fields|SATB, SSATB|Joe Mannherz
+Sucker|TTBB, SSAA, SATB|Joe Mannherz
+Sugar on the Side|SSAA|Joe Mannherz
+Summer Me, Winter Me|TTBB, SSAA|Joe Mannherz
+Summer Samba|SATB, SSATB|Joe Mannherz
+Sunny|SATB, SSATB|Joe Mannherz
+Sunrise, Sunset|TTBB|Joe Mannherz
+Sunshine, I Can Fly|SATB|Joe Mannherz
+Sweet Reunion|SATB, SSATB|Joe Mannherz
+Sweetheart Tree|TTBB|Joe Mannherz
+Swingin' On A Star|SATB, SSATB|Joe Mannherz
+Take Me to the World|SSAA|Joe Mannherz
+"Take The ""A"" Train"|SATB, SSATB|Joe Mannherz
+Tears (For Souvenirs)|TTBB|Joe Mannherz
+Tenderly|SATB, SSATB|Joe Mannherz
+Thank You for being a Friend|SATB, SSATB|Joe Mannherz
+Thank You Very Much|TTBB|Joe Mannherz
+That Little Boy Of Mine|TTBB|Joe Mannherz
+That's Entertainment|TTBB|Joe Mannherz
+That's Life|TTBB, SSAA|Joe Mannherz
+The More I See You|TTBB, SSAA|Joe Mannherz
+The One I Love Belongs To Somebody Else|SSAA, SATB|Joe Mannherz
+Their Hearts Were Full Of Spring|TTBB, SATB|Joe Mannherz
+There Goes My Heart|TTBB, SSAA|Joe Mannherz
+There Will Never Be Another You|TTBB, SSAA|Joe Mannherz
+There's Something About A Soldier|TTBB, SSAA|Joe Mannherz
+They All Laughed|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+They Can't Take That Away From Me|TTBB, SSAA|Joe Mannherz
+This Boy or This Girl|TTBB, SSAA|Joe Mannherz
+Till There Was You|TTBB|Joe Mannherz
+Time Heals Everything|SATB|Joe Mannherz
+Time In A Bottle|SSAA|Joe Mannherz
+TOGOM|TTBB|Joe Mannherz
+Too Human|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+Toot, Toot, Tootsie|TTBB|Joe Mannherz
+Toyland|TTBB|Joe Mannherz
+Tuxedo Junction|TTBB, SATB, SSATB|Joe Mannherz
+The Twelve Days Of Christmas|TTBB|Joe Mannherz
+Two O'clock Jump|SATB|Joe Mannherz
+Underneath the Tree|SSAA, SATB|Joe Mannherz
+Until It's Time For You To Go|TTBB|Joe Mannherz
+Until The Real Thing Comes Along|TTBB, SSAA|Joe Mannherz
+Up On The Roof|SATB, SSATB|Joe Mannherz
+Up, Up And Away (My Beautiful Balloon)|SATB, SSATB|Joe Mannherz
+Uptown Girl|SSATB|Joe Mannherz
+Velvet|TTBB, SATB, SSATB|Joe Mannherz
+Veni Creator Spiritu|SATB|Joe Mannherz
+Wait and See|SATB, SSATB|Joe Mannherz
+Waitin' For The Train To Come In|TTBB|Joe Mannherz
+Wake Up Little Girl|TTBB|Joe Mannherz
+Walk Between the Raindrops|SATB, SSATB|Joe Mannherz
+Walkin on Broken Glass|SATB, SSATB|Joe Mannherz
+Walkin'|SSATB|Joe Mannherz
+Warm|TTBB, SSAA, SATB|Joe Mannherz
+Waters of March/Rhapsody in Blue|SATB, SSATB|Joe Mannherz
+Wave|SATB, SSATB|Joe Mannherz
+The Way We Were|TTBB, SSAA|Joe Mannherz
+Way You Look Tonight|TTBB|Joe Mannherz
+We Wish You A Merry Christmas|SATB, SSATB|Joe Mannherz
+What Are You Doing New Year's Eve?|TTBB|Joe Mannherz
+What Are You Doing The Rest Of Your Life|SSAA, SATB, SSATB|Joe Mannherz
+What can you Lose|SATB, SSATB|Joe Mannherz
+What I Did For Love|TTBB, SSAA|Joe Mannherz
+What Kind Of Fool Am I|TTBB, SATB, SSATB|Joe Mannherz
+Whatever Happened To Melody|SSAA|Joe Mannherz
+When A Child Is Born|SATB, SSATB|Joe Mannherz
+When Autumn Comes|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+When I Look In Your Eyes|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+When I'm Sixty Four|SATB, SSATB|Joe Mannherz
+When My Heart Finds Christmas|SATB, SSATB|Joe Mannherz
+When October Goes|TTBB, SSAA|Joe Mannherz
+When She Loved Me|TTBB, SSAA|Joe Mannherz
+When Sunny Gets Blue|SATB, SSATB|Joe Mannherz
+When The Parson Hands The Wedding Band From Me To Mandy Lee|TTBB|Joe Mannherz
+Where Are You Christmas?|SATB, SSATB|Joe Mannherz
+Where Do I Go From You?|TTBB, SSAA|Joe Mannherz
+Where Do You Start?|TTBB|Joe Mannherz
+Whiffenpoof Song|TTBB|Joe Mannherz
+Whistling|SATB, SSATB|Joe Mannherz
+White Christmas|SATB, SSATB|Joe Mannherz
+Why Do People Fall In Love|SSAA|Joe Mannherz
+Wide World of Sports|SATB, SSATB|Joe Mannherz
+The Windmills of your Mind|SATB, SSATB|Joe Mannherz
+Would It Still Be Christmas|SATB, SSATB|Joe Mannherz
+Yes Sir, That's My Baby/Ain't She Sweet|TTBB, SSAA|Joe Mannherz
+You|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+You and the Night and the Music|TTBB, SSAA|Joe Mannherz
+You don't know what love is|TTBB, SSAA, SATB|Joe Mannherz
+You Made Me Love You|SSAA|Joe Mannherz
+You Make Me Feel So Young|TTBB, SSAA|Joe Mannherz
+You Needed Me|TTBB, SSAA|Joe Mannherz
+You Took Advantage Of Me|TTBB, SSAA, SATB, SSATB|Joe Mannherz
+You'd Be So Nice To Come Home To|TTBB|Joe Mannherz
+You're A Mean One, Mr. Grinch|SSAA|Joe Mannherz
+Young And Foolish|TTBB, SSAA|Joe Mannherz
+Zip A Dee Doo Dah|SSAA|Joe Mannherz
+Here's To My Lady|TTBB|Dick Marble
+Back In The Old Routine|TTBB|R. J. Margison
+Bless 'Em All|TTBB|R. J. Margison
+Good Night Little Soldier|TTBB|R. J. Margison
+Goodbye Betty Brown|TTBB|R. J. Margison
+"If I Knock The ""L"" Out Of Kelly"|TTBB|R. J. Margison
+It Is No Secret|TTBB|R. J. Margison
+Just A Dream Of You Dear|TTBB|R. J. Margison
+So Long, It's Been Good To Know Yuh|TTBB|R. J. Margison
+Til We Meet Again|TTBB|R. J. Margison
+To Have And To Hold|TTBB|R. J. Margison
+Wind Beneath My Wings|SSAA|R. J. Margison
+Bless You Darlin' Mother|TTBB|Dave Marquis
+High Hopes|TTBB|Dave Marquis
+If|TTBB|Dave Marquis
+White Wings|TTBB|Deac Martin
+A Spoonful Of Sugar|SSAA|Loretta Martin
+Love Potion No. 9|SSAA|Melissa A. Martin
+All I Need Is The Girl|TTBB|Robert Martin
+If I Had You|TTBB|Robert Martin
+Pennies from Heaven|TTBB|Robert Martin
+Sunday|TTBB|Robert Martin
+Anything Goes|SSAA|Frank Marzocco
+Begin The Beguine|SSAA|Frank Marzocco
+Begin The Beguine|TTBB|Frank Marzocco
+Don't Fence Me In|SSAA|Frank Marzocco
+From This Moment On|SSAA|Frank Marzocco
+I Never Knew / Somebody Loves Me|SSAA|Frank Marzocco
+I Never Knew / Somebody Loves Me|TTBB|Frank Marzocco
+I'm Dancing This Dance in the Wrong Romance|SSAA|Frank Marzocco
+If I Had You|TTBB|Frank Marzocco
+Once Upon A Time|SSAA|Frank Marzocco
+One By One|SSAA|Frank Marzocco
+When I Fall In Love|TTBB|Frank Marzocco
+The Lord Is Good To Me|SSAA|Ron Mason
+Against The Grain|SSAA|Jim Massey
+The Circle Of Life|SSAA|Jim Massey
+Glow Worm|SSAA|Jim Massey
+Heart|SSAA|Jim Massey
+Help, I'm Turning Into My Parents|SSAA|Jim Massey
+I Hope You Dance|SSAA|Jim Massey
+I Love To Laugh|SSAA|Jim Massey
+I Want A Hippopotamus For Christmas|SSAA|Jim Massey
+I Want To Be A Cowboys Sweetheart|SSAA|Jim Massey
+I'm So Excited|SSAA|Jim Massey
+Lazy River|SSAA|Jim Massey
+Older Women|SSAA|Jim Massey
+The Rhythm Of Life|SSAA|Jim Massey
+Ring Them Bells|SSAA|Jim Massey
+Shout!|SSAA|Jim Massey
+We Need A Little Christmas|SSAA|Jim Massey
+Thanks For The Memory|TTBB|K. Mast
+As I Love You|TTBB|Brian Mastrull
+Crazy She Calls Me|TTBB|Brian Mastrull
+Daydream Believer|TTBB, SSAA|Brian Mastrull
+The Dummy Song|TTBB|Brian Mastrull
+Hard To Say I'm Sorry|TTBB, SSAA|Brian Mastrull
+Here We Come A-Caroling|TTBB|Brian Mastrull
+Holiday Road|TTBB|Brian Mastrull
+Humble and Kind|TTBB|Brian Mastrull
+I Won't Cry Anymore|TTBB|Brian Mastrull
+I'll Be Satisfied|TTBB|Brian Mastrull
+It's Not For Me To Say|TTBB|Brian Mastrull
+Jingle Bells|TTBB|Brian Mastrull
+Kokomo|TTBB|Brian Mastrull
+The Man In the Looking Glass|TTBB|Brian Mastrull
+Man With The Bag|TTBB|Brian Mastrull
+Medley: Dance with Me, Shut Up And Dance|TTBB|Brian Mastrull
+Midnight Train to Georgia|TTBB|Brian Mastrull
+My Kind Of Girl|TTBB|Brian Mastrull
+Next Door To An Angel|TTBB|Brian Mastrull
+One Lie Leads To Another|TTBB|Brian Mastrull
+Paralyzed|TTBB, SSAA, SATB|Brian Mastrull
+The River Of Dreams|TTBB|Brian Mastrull
+Round and Round|TTBB|Brian Mastrull
+Teach Your Children|TTBB|Brian Mastrull
+Thankful Heart|TTBB|Brian Mastrull
+Walk Like a Man|TTBB|Brian Mastrull
+When I Am With You|TTBB|Brian Mastrull
+White Winter Hymnal|TTBB|Brian Mastrull
+You've Got A Friend|TTBB|Brian Mastrull
+Happy Days|TTBB|Joshua Matisoff
+Ev'ry Day Of My Life|TTBB|Robert Mattes
+Greenfields|TTBB|Robert Matteucci
+One Is The Loneliest Number|TTBB|Robert Matteucci
+Beach Boys Medley|SSAA|Paula Mauritzen
+Bless This House|TTBB|Harry Mays
+One Rose|TTBB|Harry Mays
+The Pal That I Loved Stole The Gal That I Loved|TTBB|Harry Mays
+Sound Of Music|TTBB|Harry Mays
+When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Harry Mays
+Whiffenpoof Song|TTBB|Harry Mays
+Ain't No Mountain High Enough|SSAA|Patrick McAlexander
+All Over The World|SATB|Patrick McAlexander
+All Star|TTBB|Patrick McAlexander
+Always Take Mother's Advice|TTBB|Patrick McAlexander
+Around the World|TTBB|Patrick McAlexander
+Arthur (Arthur In The Afternoon)|SSAA|Patrick McAlexander
+Audition (the Fools Who Dream)|TTBB|Patrick McAlexander
+Baby One More Time|TTBB|Patrick McAlexander
+Bare Necessities|TTBB|Patrick McAlexander
+Bewitched|TTBB|Patrick McAlexander
+Brazil|TTBB|Patrick McAlexander
+A Bushel And A Peck|SSAA|Patrick McAlexander
+C'est Si Bon|TTBB|Patrick McAlexander
+Can't Help Lovin' Dat Man|SSAA|Patrick McAlexander
+Can't Stop Singing|TTBB|Patrick McAlexander
+The Circle Of Life|TTBB, SATB|Patrick McAlexander
+Corner Of The Sky|TTBB, SSAA|Patrick McAlexander
+The Dance|TTBB|Patrick McAlexander
+Dancing In The Street|SATB|Patrick McAlexander
+Deep In The Heart Of Texas|TTBB|Patrick McAlexander
+Dream On|TTBB|Patrick McAlexander
+Ease On Down The Road|TTBB|Patrick McAlexander
+Feeling Good|TTBB|Patrick McAlexander
+Five Minutes More|TTBB|Patrick McAlexander
+Flaggin' The Train To Tuscaloosa|TTBB|Patrick McAlexander
+A Foggy Day|TTBB|Patrick McAlexander
+From Me To You|TTBB|Patrick McAlexander
+God Bless Us Everyone|TTBB|Patrick McAlexander
+Good Vibrations|SSAA|Patrick McAlexander
+Grown-Up Christmas List|TTBB|Patrick McAlexander
+Hit Me With A Hot Note|SSAA|Patrick McAlexander
+How Lucky You Are|TTBB, SSAA, SATB|Patrick McAlexander
+I Wanna Dance With Somebody|SATB|Patrick McAlexander
+I Won't Say I'm In Love|SSAA|Patrick McAlexander
+I'm Off To See My Sweetness|TTBB|Patrick McAlexander
+I'm Shooting High|SSAA|Patrick McAlexander
+If I May|TTBB, SSAA|Patrick McAlexander
+It Ain't What You Do|TTBB|Patrick McAlexander
+Le Jazz Hot!|TTBB|Patrick McAlexander
+Lollipops & Roses|TTBB|Patrick McAlexander
+Love Me or Leave Me|TTBB|Patrick McAlexander
+Love You Madly|TTBB|Patrick McAlexander
+A Lovely Night|SSAA|Patrick McAlexander
+M-O-T-H-E-R|TTBB|Patrick McAlexander
+Make 'Em Laugh|TTBB|Patrick McAlexander
+Man With The Bag|SSAA|Patrick McAlexander
+Medley: I Thought About You, The Very Thought Of You|TTBB|Patrick McAlexander
+Medley: Jumpin' East Of Java, Java Jive|TTBB|Patrick McAlexander
+Medley: What Are You Doing New Years's Eve, New Year's Day|SATB|Patrick McAlexander
+My Mother's Eyes|TTBB|Patrick McAlexander
+A New Fangled Tango|TTBB, SATB|Patrick McAlexander
+New York, New York|TTBB, SSAA|Patrick McAlexander
+Nobody Does It Like Me!|TTBB|Patrick McAlexander
+Now and Forever|TTBB|Patrick McAlexander
+Only Hope|TTBB|Patrick McAlexander
+Orange Colored Sky|TTBB|Patrick McAlexander
+Out Of The Blue|SSAA|Patrick McAlexander
+Piano Man|TTBB|Patrick McAlexander
+Pity Party|SSAA|Patrick McAlexander
+Please Don't Talk About Me When I'm Gone|SATB|Patrick McAlexander
+Rhythm Is Our Business|TTBB|Patrick McAlexander
+Save Your Sorrow|TTBB|Patrick McAlexander
+Sing for Your Supper|SSAA|Patrick McAlexander
+Sisters Are Doing It For Themselves|SSAA|Patrick McAlexander
+Skidamarink|TTBB|Patrick McAlexander
+Somebody to Love|TTBB|Patrick McAlexander
+Someone To Watch Over Me|SSAA|Patrick McAlexander
+Something's Gotta Give|SSAA|Patrick McAlexander
+Still Crazy After All These Years|TTBB|Patrick McAlexander
+Summer Wind|TTBB|Patrick McAlexander
+Sunday Kind Of Love|TTBB|Patrick McAlexander
+Sunny In Seattle|TTBB|Patrick McAlexander
+The Sweetest Sounds|SSAA|Patrick McAlexander
+Takin' It To The Streets|TTBB|Patrick McAlexander
+Ten Minutes Ago|TTBB|Patrick McAlexander
+Thank You for being a Friend|TTBB, SSAA|Patrick McAlexander
+That Old Black Magic|TTBB|Patrick McAlexander
+The Way I Am|SSAA|Patrick McAlexander
+There Are Worse Things I Could Do|SSAA|Patrick McAlexander
+The Trolley Song|TTBB|Patrick McAlexander
+The Trouble With Me Is You|TTBB|Patrick McAlexander
+What Are You Doing New Year's Eve?|SATB|Patrick McAlexander
+Whatcha Gonna Do When There Ain't No Jazz|TTBB|Patrick McAlexander
+When Christmas Comes To Town|TTBB|Patrick McAlexander
+When I Grow Up|TTBB|Patrick McAlexander
+When You're Smiling|TTBB|Patrick McAlexander
+You Didn't Want Me When You Had Me|TTBB|Patrick McAlexander
+You Don't Need To Love Me|TTBB|Patrick McAlexander
+You Will Be Okay Stolas Lullaby|TTBB|Patrick McAlexander
+You're My Best Friend|TTBB|Patrick McAlexander
+Breezin' Along With The Breeze|TTBB|Jack McCabe
+For Me And My Gal|TTBB|Jack McCabe
+On A Slow Boat To China|TTBB|Jack McCabe
+I Will Follow Him|SSAA|Karen McCarville
+In My Room|SSAA|Karen McCarville
+In The Still Of The Night|SSAA|Karen McCarville
+Ob-La-Di, Ob-La-Da|SSAA|Karen McCarville
+Old Time Religion Medley|SSAA|Karen McCarville
+Swing Down Chariot|SSAA|Karen McCarville
+This Little Light Of Mine|SSAA|Karen McCarville
+Yes Indeed|SSAA|Karen McCarville
+Girl Of My Dreams|TTBB|Lloyd McClure
+My Buddy|TTBB|Lloyd McClure
+Whiffenpoof Song|TTBB|Lloyd McClure
+At The Crazy Bones Skeleton Ball|TTBB|Michael McCord
+At The Crazy Bones Skeleton Ball|SSAA|Michael McCord
+Funniest Clown In The Big Top|TTBB|Michael McCord
+I'm Trying to Find Where the Angels Live|SSAA|Michael McCord
+I'm Trying to Find Where the Angels Live|TTBB|Michael McCord
+I Get The Blues When It Rains|TTBB|D. D. McCormick
+Powder Your Face With Sunshine|TTBB|C. F. McCreary
+Poisoning Pigeons In The Park|TTBB|Benjamin McDaniel
+Sunflower|TTBB|Benjamin McDaniel
+All Alone|SSAA|Jean McFadyen
+Because You Loved Me|SSAA|Jean McFadyen
+Copacabana|SSAA|Jean McFadyen
+Dream|SSAA|Jean McFadyen
+Glory Of Love|SSAA|Jean McFadyen
+Here Come The Clowns|SSAA|Jean McFadyen
+I Can't Wait To Get Home|SSAA|Jean McFadyen
+I Hope You Dance|SSAA|Jean McFadyen
+Irish Blessing|SSAA|Jean McFadyen
+Is You Is Or Is You Ain't (Ma Baby)|SSAA|Jean McFadyen
+It's A Blue World|SSAA|Jean McFadyen
+Just The Way You Are|SSAA|Jean McFadyen
+Make Love To Me|SSAA|Jean McFadyen
+Mambo Italiano|SSAA|Jean McFadyen
+My Heart Will Go On|SSAA|Jean McFadyen
+Only One|SSAA|Jean McFadyen
+Rainbows In The Snow|SSAA|Jean McFadyen
+Rock This Town|SSAA|Jean McFadyen
+Skylark|SSAA|Jean McFadyen
+Someone That I Used To Love|SSAA|Jean McFadyen
+Stray Cat Strut|SSAA|Jean McFadyen
+This Ole House|SSAA|Jean McFadyen
+Valentine|SSAA|Jean McFadyen
+You And Me Against The World|SSAA|Jean McFadyen
+Good Night My Someone|SSAA|Joy McGregor
+Great Is Thy Faithfulness|SSAA|Joy McGregor
+Hopelessly Devoted To You|SSAA|Joy McGregor
+I Heard The Bells On Christmas Day|SSAA|Joy McGregor
+If My Friends Could See Me Now|SSAA|Joy McGregor
+It's Been A Long, Long Time|SSAA|Joy McGregor
+Just Loving You|SSAA|Joy McGregor
+Moonlight Becomes You|SSAA|Joy McGregor
+Says My Heart|SSAA|Joy McGregor
+A Shine On Your Shoes|SSAA|Joy McGregor
+About A Quarter To Nine|TTBB|Eugene McHugh
+Baby Won't You Please Come Home|TTBB|Eugene McHugh
+Peggy O'Neil|TTBB|Eugene McHugh
+Screaming Eagles|TTBB|Eugene McHugh
+Silent Night|SSAA|Eugene McHugh
+Silent Night|TTBB|Eugene McHugh
+Alexander's Got A Jazz Band Now|TTBB|Jim Jim McKee
+Beyond The Blue Horizon|TTBB|Jeff McKeen
+Don't Stop Me Now|SSAA|Kathleen McMillan
+And So It Goes|SSAA|Barbara McNeill
+Bald Headed Men|SSAA|Barbara McNeill
+Bop Till You Drop|SSAA|Barbara McNeill
+The Boy From New York City|SSAA|Barbara McNeill
+Down At The Twist And Shout|SSAA|Barbara McNeill
+God Bless The Child|SSAA|Barbara McNeill
+I'll Miss You When You're Gone|SSAA|Barbara McNeill
+Jesus, Jesus, Rest Your Head|SSAA|Barbara McNeill
+Lazy River|SSAA|Barbara McNeill
+Little Saint Nick|SSAA|Barbara McNeill
+Low Down Rhythm|SSAA|Barbara McNeill
+Make Love To Me|SSAA|Barbara McNeill
+Ode To Joy (Joyful, Joyful)|SSAA|Barbara McNeill
+The Old Maids Ball|SSAA|Barbara McNeill
+On My Own|SSAA|Barbara McNeill
+Opus One|SSAA|Barbara McNeill
+Thriller|SSAA|Barbara McNeill
+Waitin' For The Train To Come In|SSAA|Barbara McNeill
+Hi Neighbor|TTBB|Gene McNish
+Old Upright Piano|TTBB|Ken McPhaden
+Blue Velvet|TTBB|Jim McQuiston
+My Story Book Girl|TTBB|J. Z. Means
+Alleluia|SSAA|Joan Melling
+Mary Did You Know|SSAA|Joan Melling
+The Night Before Christmas|SSAA|Joan Melling
+Refrigerator Rhapsody|SSAA|Joan Melling
+Still Gonna Die|SSAA|Joan Melling
+The Twelve Days After Christmas|SSAA|Joan Melling
+As Long As I'm Singing|TTBB, SSAA|Mike Menefee
+Auld Lang Syne|SATB|Mike Menefee
+Beautiful Girl|SSAA|Mike Menefee
+Bring Us In Good Ale|SATB|Mike Menefee
+Can't Take My Eyes Off Of You|TTBB|Mike Menefee
+City Of New Orleans|TTBB|Mike Menefee
+The Frim Fram Sauce|SSAA|Mike Menefee
+Glory Of Love|SSAA|Mike Menefee
+Going Home|TTBB|Mike Menefee
+Goodnight My Angel|TTBB, SSAA|Mike Menefee
+Homegrown Tomatoes|TTBB, SSAA|Mike Menefee
+How Can I Keep From Singing|SATB|Mike Menefee
+I Got You (I Feel Good)|SSAA|Mike Menefee
+If I Had You|TTBB|Mike Menefee
+Isn't She Lovely|TTBB|Mike Menefee
+It's The Most Wonderful Time Of The Year|SATB|Mike Menefee
+King Of The Road|TTBB|Mike Menefee
+Laundry|SSAA|Mike Menefee
+Let The Rest Of The World Go By|TTBB|Mike Menefee
+Mansions Of The Lord|TTBB|Mike Menefee
+Miss You|TTBB, SSAA|Mike Menefee
+Modersmalets Sang|TTBB|Mike Menefee
+Money, Money, Money|SSAA|Mike Menefee
+Moonglow|TTBB|Mike Menefee
+My Lovely One (Liebestraum)|TTBB|Mike Menefee
+Riders In The Sky|TTBB|Mike Menefee
+Rockin' Robin|TTBB|Mike Menefee
+Rudolph The Red Nosed Reindeer|TTBB|Mike Menefee
+Song Of Change|SATB|Mike Menefee
+Sweet Caroline|TTBB|Mike Menefee
+The Bell That Couldn't Jingle|TTBB|Mike Menefee
+There You'll Be|SATB|Mike Menefee
+Yahoo!|SSAA|Mike Menefee
+Have Yourself A Merry Little Christmas|TTBB|Larry Merriman
+Comin' In On A Wing And A Prayer|TTBB|Howard Mesecher
+Do - Re - Mi|TTBB|Howard Mesecher
+Mardi Gras March|TTBB|Howard Mesecher
+Way Down Yonder In New Orleans|TTBB|Howard Mesecher
+I Don't Know Enough About You|TTBB|Charles Metzger
+Mr. Bojangles|TTBB|Charles Metzger
+What Do You Want To Make Those Eyes At Me For|TTBB|Charles Metzger
+Amazing Grace|SSAA|Jan Meyer
+Anyway|SSAA|Jan Meyer
+Auld Lang Syne|SSAA|Jan Meyer
+Bling It On!|SSAA|Jan Meyer
+Charley, My Boy|SSAA|Jan Meyer
+Chocolate|SSAA|Jan Meyer
+Down By The Old Mill Stream|SSAA|Jan Meyer
+Forever Young|SSAA|Jan Meyer
+Forgetting|SSAA|Jan Meyer
+Holly Jolly Christmas|SSAA|Jan Meyer
+I Never Knew the Love I Was Missin'|SSAA|Jan Meyer
+I Wanna Sing Barbershop|SSAA|Jan Meyer
+I'm Beginning To See The Light|SSAA|Jan Meyer
+If I Had My Way|SSAA|Jan Meyer
+It's A Pity To Say Goodnight|SSAA|Jan Meyer
+Let Me Call You Sweetheart|SSAA|Jan Meyer
+Look For The Light|SSAA|Jan Meyer
+Mary Did You Know|SSAA|Jan Meyer
+Medley: My Guy, Da Doo Ron Ron, One Fine Day, Johnny Angel|SSAA|Jan Meyer
+Medley: Where The Boat Leaves From / One Love|SSAA|Jan Meyer
+Nuttin' For Christmas|SSAA|Jan Meyer
+The Polar Express|SSAA|Jan Meyer
+Queen of This Foursome|SSAA|Jan Meyer
+Reach|SSAA|Jan Meyer
+Runnin' Wild|SSAA|Jan Meyer
+Seasons of Love|SSAA|Jan Meyer
+Side by Side|SSAA|Jan Meyer
+Silver Bells|SSAA|Jan Meyer
+So Far Away|SSAA|Jan Meyer
+Somebody Stole the Church Bell|SSAA|Jan Meyer
+Take A Number From One To Ten|SSAA|Jan Meyer
+Up In Heaven|SSAA|Jan Meyer
+Wait Till The Sun Shines, Nellie|SSAA|Jan Meyer
+When Lights Are Low|SSAA|Jan Meyer
+When You Wore A Tulip|SSAA|Jan Meyer
+A Wink And A Smile|SSAA|Jan Meyer
+'Til Tomorrow|TTBB|Robert Meyer
+Ain't We Got Fun|TTBB|Robert Meyer
+All Alone|TTBB|Robert Meyer
+Marching Along Together|TTBB|Robert Meyer
+A Pretty Girl Is Like A Melody|TTBB|Robert Meyer
+On The Street Where You Live|TTBB|Ron Middlestaedt
+Vict'ry Polka|TTBB|Ron Middlestaedt
+Whiffenpoof Song|TTBB|Ron Middlestaedt
+America|SSAA|Peg Millard
+Call Me A Taxi|SSAA|Peg Millard
+Don't Blame Me|SSAA|Peg Millard
+A House Is Not A Home|SSAA|Peg Millard
+Let Us Sing (A Show Opener)|SSAA|Peg Millard
+The Lord's Prayer|SSAA|Peg Millard
+What A Wonderful World|SSAA|Peg Millard
+Paddlin' Madelin' Home|TTBB|Benjamin Miller
+Harmony|SATB|Douglas Miller
+Harmony|TTBB|Douglas Miller
+On Moonlight Bay|TTBB|Douglas Miller
+Begin The Beguine|TTBB|Justin Miller
+Grow As We Go|SATB|Justin Miller
+Happy As The Sun|TTBB|Justin Miller
+I Need Thee Ev'ry Hour|SATB|Justin Miller
+I'll Be Here|TTBB|Justin Miller
+It's Been A Long, Long Time|TTBB|Justin Miller
+La Vie en Rose|TTBB|Justin Miller
+Look For The Light|TTBB, SSAA, SATB|Justin Miller
+Lullaby|TTBB|Justin Miller
+Medley: Hard To Say I'm Sorry, You're The Inspiration|TTBB|Justin Miller
+Medley: Rainbow Connection, Pure Imagination|TTBB|Justin Miller
+Medley: Wait Till You See Her, Crazy She Calls Me|TTBB|Justin Miller
+Old Devil Moon|TTBB|Justin Miller
+Snow|SATB|Justin Miller
+Still Fighting It|TTBB|Justin Miller
+Then I'll Be Tired Of You|TTBB|Justin Miller
+What A Wonderful World|TTBB|Justin Miller
+Charleston, Flappers And Razz-A-Ma-Tazz|TTBB|Merrill Miller
+Cocktails For Two|TTBB|Merrill Miller
+If I Had My Life To Live Over|TTBB|Merrill Miller
+Old Grey Bonnet Medley|TTBB|Merrill Miller
+Try A Little Tenderness|TTBB|Merrill Miller
+Cavatina|SSAA|Jenny Mills
+Messin' with Fire|SSAA|Jenny Mills
+What Are You Doing The Rest Of Your Life|SSAA|Jenny Mills
+All That I Ask Is Love|SSAA|Ann Minihane
+Atlanta, Georgia|SSAA|Ann Minihane
+Everything Old Is New Again|SSAA|Ann Minihane
+Get Happy|SSAA|Ann Minihane
+High Hopes|SSAA|Ann Minihane
+I'm Confessin|SSAA|Ann Minihane
+Jazz Me Blues|SSAA|Ann Minihane
+May You Always|SSAA|Ann Minihane
+A Nightingale Sang In Berkeley Square|SSAA|Ann Minihane
+On The Sunny Side Of The Street|SSAA, Young SSAA|Ann Minihane
+The Stars Will Remember|SSAA|Ann Minihane
+That Old Gang Of Mine|SSAA|Ann Minihane
+That Wonderful Mother Of Mine|SSAA|Ann Minihane
+When I Fall In Love|SSAA|Ann Minihane
+You're Never Fully Dressed Without A Smile|SSAA|Ann Minihane
+Goodnight, Sweetheart, Goodnight|TTBB|Craig Minor
+Just The Way You Are|SATB|Craig Minor
+New Words|TTBB|Craig Minor
+Ol' 55|TTBB|Craig Minor
+On and On|TTBB|Craig Minor
+She|TTBB|Craig Minor
+Steam Heat|TTBB|Craig Minor
+Wherever The Trail May Lead|TTBB|Craig Minor
+'Til Tomorrow|SSAA|Joey Minshall
+A Dream Is A Wish Your Heart Makes|SSAA|Joey Minshall
+After The Gold Rush|SATB|Joey Minshall
+After The Roses Have Faded Away|SSAA|Joey Minshall
+Ain't No Mountain High Enough|SSAA|Joey Minshall
+All By Myself|SSAA|Joey Minshall
+All The Things You Are|SSAA|Joey Minshall
+Anyway|SSAA|Joey Minshall
+As If We Never Said Goodbye|SSAA|Joey Minshall
+As Long As I'm Singing|SSAA|Joey Minshall
+Away In A Manger|SSAA|Joey Minshall
+Be A Santa|SSAA|Joey Minshall
+Because|SSAA|Joey Minshall
+Believe|SSAA, Young SSAA|Joey Minshall
+The Best of Days|SSAA|Joey Minshall
+Bewitched|SSAA|Joey Minshall
+Blue, Red and Grey|SSAA|Joey Minshall
+Born To Be Wild|SSAA|Joey Minshall
+Boys in the Bright White Sports Car (Trooper)|SSAA|Joey Minshall
+Bucket of Love|SSAA|Joey Minshall
+Canada, My Home|SSAA|Joey Minshall
+Canadian Medley|SSAA|Joey Minshall
+Canadian Medley|TTBB|Joey Minshall
+Car Wash|SSAA|Joey Minshall
+Come On, Ring Those Bells|SSAA|Joey Minshall
+Count On Me|SSAA, Young SSAA|Joey Minshall
+Crazy Dreams|SSAA|Joey Minshall
+Defying Gravity|SSAA|Joey Minshall
+Do I Love You?|SSAA|Joey Minshall
+Ease On Down The Road|SSAA|Joey Minshall
+Easy Street|SSAA|Joey Minshall
+Edge of Glory|SSAA|Joey Minshall
+Entrance Of The Gladiators|SSAA|Joey Minshall
+Evergreen|SSAA|Joey Minshall
+Every Woman's Song|SSAA|Joey Minshall
+Everybody Loves A Lover|SSAA|Joey Minshall
+Everybody Loves Somebody|SSAA|Joey Minshall
+Fame|SSAA|Joey Minshall
+Fare Thee Well|SSAA|Joey Minshall
+For Once In My Life|SSAA|Joey Minshall
+Gee But It's Good To Be Here|SSAA|Joey Minshall
+Ghost|SSAA|Joey Minshall
+Girl Child Born|SSAA|Joey Minshall
+Girl on Fire|SSAA|Joey Minshall
+Give Me The Circus Life|SSAA|Joey Minshall
+Glitter In The Air|SSAA|Joey Minshall
+Go The Distance|SSAA|Joey Minshall
+The Greatest Love Of All|SSAA|Joey Minshall
+Guess Who I Saw Today|SSAA|Joey Minshall
+Happy Birthday To You|TTBB, SSAA|Joey Minshall
+Happy Rhythm|SSAA|Joey Minshall
+Happy Shoes|SSAA|Joey Minshall
+Happy Together|SSAA, SATB|Joey Minshall
+Have Yourself A Merry Little Christmas|SSAA|Joey Minshall
+Heat Wave|SSAA|Joey Minshall
+Here And Now|SSAA|Joey Minshall
+Hero|SSAA|Joey Minshall
+Hey Mister! Stay!|SSAA|Joey Minshall
+Holding Out For A Hero|SSAA|Joey Minshall
+Home|SSAA|Joey Minshall
+Home To Stay|SSAA|Joey Minshall
+How D'Ya Like Your Eggs in the Morning|SSAA|Joey Minshall
+I Am the Very Model of a Mommy of a Toddler|SSAA|Joey Minshall
+I Believe|SSAA|Joey Minshall
+I Can Cook Too|SSAA|Joey Minshall
+I Couldn't Sleep a Wink Last Night|SSAA|Joey Minshall
+I Get Along Without You Very Well|SSAA|Joey Minshall
+I May Wander|SSAA|Joey Minshall
+I Need to be in Love|SSAA|Joey Minshall
+I Won't Last A Day Without You|TTBB, SSAA|Joey Minshall
+I Wonder As I Wander|SSAA|Joey Minshall
+I'd Like To Teach The World To Sing|SSAA|Joey Minshall
+I'll Be Easy To Find|SSAA|Joey Minshall
+I'll Tell My Ma When I Go Home|SSAA|Joey Minshall
+If|SSAA, SATB|Joey Minshall
+If I Were A Bell|SSAA|Joey Minshall
+Imagine|SSAA|Joey Minshall
+It's A Million To One You're In Love|SSAA|Joey Minshall
+It's My Life|TTBB|Joey Minshall
+It's Your Song|SSAA|Joey Minshall
+Jazz Band|SATB|Joey Minshall
+Keep The Home Fires Burning|SSAA|Joey Minshall
+La Vie en Rose|SSAA|Joey Minshall
+Le Canon|TTBB, SSAA|Joey Minshall
+Lean On Me|TTBB, SSAA|Joey Minshall
+Let Him Go, Let Him Tarry|SSAA|Joey Minshall
+Life Is A Highway|SSAA|Joey Minshall
+The Lighthouse Keeper|SSAA|Joey Minshall
+Lion Sleeps Tonight|SSAA|Joey Minshall
+Little Drummer Boy|SSAA|Joey Minshall
+The Loco-motion|SSAA, Young SSAA|Joey Minshall
+The Longest Time|SSAA|Joey Minshall
+A Lot of Livin' To Do|SSAA|Joey Minshall
+Love Potion No. 9|SSAA|Joey Minshall
+Macavity: the Mystery Cat|SSAA|Joey Minshall
+Magic Tonight!|SSAA|Joey Minshall
+Make Someone Happy|SSAA|Joey Minshall
+May The Good Lord Bless And Keep You|SSAA|Joey Minshall
+May You Always|SSAA|Joey Minshall
+Medley: Aquarius, Let The Sunshine In|SATB|Joey Minshall
+Medley: Boys In The Bright White Sports Car, We're Here For A Good Time|SSAA|Joey Minshall
+Medley: I Don't Care If The Sun Don't Shine, Steppin' Out With My Baby|SSAA|Joey Minshall
+Medley: Just The Way You Are, I Gotta Feeling, Firework|SSAA|Joey Minshall
+Medley: Space Oddity, Calling Occupants, Rocket Man|SSAA|Joey Minshall
+Medley: The Little Drummer Boy, Peace on Eartn|SSAA|Joey Minshall
+Men In Black|SSAA|Joey Minshall
+Moves Like Jagger|SSAA|Joey Minshall
+My Romance|SSAA|Joey Minshall
+My Way|SSAA|Joey Minshall
+Naturally|SSAA|Joey Minshall
+O Canada!|SSAA|Joey Minshall
+On A Wonderful Day Like Today|SSAA|Joey Minshall
+On My Own|SSAA|Joey Minshall
+One Day I'll Fly Away|SSAA|Joey Minshall
+One Voice|SSAA|Joey Minshall
+Optimistic Voices|SSAA|Joey Minshall
+Our House|SATB|Joey Minshall
+Party Pie|SSAA|Joey Minshall
+Peace Prayer Mandala|SSAA|Joey Minshall
+Perhaps Love|SSAA|Joey Minshall
+Picnic|SSAA|Joey Minshall
+The Place Where the Lost Things Go|SSAA|Joey Minshall
+Quiet Please There's a Lady Onstage|SSAA|Joey Minshall
+Rainbow Connection|SSAA|Joey Minshall
+Reach|SSAA|Joey Minshall
+Return to Pooh Corner|SSAA|Joey Minshall
+The River|SSAA|Joey Minshall
+Sabre Dance|SSAA|Joey Minshall
+Sara Lee|SSAA|Joey Minshall
+Seasons of Love|SSAA|Joey Minshall
+Send In The Clowns|SSAA|Joey Minshall
+Shine|SSAA|Joey Minshall
+Since You've Been Gone|SSAA|Joey Minshall
+Sing Sing|SSAA|Joey Minshall
+So Far|SSAA|Joey Minshall
+Some Enchanted Evening|SSAA, SATB|Joey Minshall
+Somewhere Out There|SSAA|Joey Minshall
+Song for Irene|SSAA|Joey Minshall
+Song For the Mira|SSAA|Joey Minshall
+Standing Outside The Fire|SSAA|Joey Minshall
+Star Trek: The Next Generation - Main Title|SATB|Joey Minshall
+Stars Fell On Alabama|SSAA|Joey Minshall
+Streets Of London|TTBB|Joey Minshall
+The Summer Knows|SSAA|Joey Minshall
+Summer Nights|SATB|Joey Minshall
+Summer Of 42|SSAA|Joey Minshall
+Sweet Adeline|SSAA|Joey Minshall
+The Swingin' Shepherd Blues|SSAA|Joey Minshall
+Take A Chance On Me|SSAA, SATB|Joey Minshall
+Tangerine|SSAA|Joey Minshall
+Tell Me Why|SSAA|Joey Minshall
+The Way You Look Tonight|SSAA|Joey Minshall
+This Time Around|SSAA|Joey Minshall
+Til Tomorrow|SSAA|Joey Minshall
+Time In A Bottle|SSAA, SATB|Joey Minshall
+The Time Warp|SSAA|Joey Minshall
+To Make You Feel My Love|SSAA|Joey Minshall
+Together in Harmony|SSAA|Joey Minshall
+Top Of The World|SSAA|Joey Minshall
+Under The Sea|SSAA|Joey Minshall
+Up, Up And Away (My Beautiful Balloon)|SATB|Joey Minshall
+Way You Look Tonight|SSAA|Joey Minshall
+We're Here For a Good Time (Not a Long Time)|TTBB, SSAA|Joey Minshall
+What A Wonderful World|SSAA, Young SSAA|Joey Minshall
+What A Wonderful World|SSAA|Joey Minshall
+What Are You Doing New Year's Eve?|SSAA|Joey Minshall
+When You Believe|SSAA|Joey Minshall
+A Whole New World|SSAA|Joey Minshall
+The Winner's Circle|SSAA|Joey Minshall
+With A Little Help From My Friends|SSAA|Joey Minshall
+Wonderful Day like Today|SSAA|Joey Minshall
+Y.M.C.A.|SSAA|Joey Minshall
+Yesterday Once More|SSAA|Joey Minshall
+Yesterday Once More|TTBB|Joey Minshall
+You And I|TTBB|Joey Minshall
+You Can't Hurry Love|SSAA|Joey Minshall
+You Don't Own Me|SSAA|Joey Minshall
+You Raise Me Up|SSAA|Joey Minshall
+You're The Flower Of My Heart, Sweet Adeline|SSAA|Joey Minshall
+You're the Music in My Heart, Sweet Adeline|SSAA|Joey Minshall
+The Daughter of Sweet Adeline|TTBB|John Minsker
+On The Beaches Of Normandy|SATB|Peter Mitchell
+Hushabye Mountain|TTBB|William Mitchell
+I Found A Million Dollar Baby|SSAA|William Mitchell
+Lullaby In Ragtime|TTBB|William Mitchell
+Chiquita Banana|TTBB|Dave Mohr
+Delta Dawn|TTBB|Dave Mohr
+After The Roses Have Faded Away|TTBB|Earl Moon
+All That I Ask Of You Is Love|TTBB|Earl Moon
+All the World Will Be Jealous|TTBB|Earl Moon
+America (My Country, 'Tis Of Thee)|TTBB|Earl Moon
+Any Time|TTBB|Earl Moon
+Baby Won't You Please Come Home|SSAA|Earl Moon
+Baby, Won't You Please Come Home|TTBB|Earl Moon
+Back In 1910|TTBB|Earl Moon
+The Barbershop Strut|TTBB|Earl Moon
+Barefoot Days|TTBB|Earl Moon
+A Blossom Fell|TTBB|Earl Moon
+Christmas Chopsticks|SSAA|Earl Moon
+Christmas Chopsticks|TTBB|Earl Moon
+Don't Cry, Little Girl, Don't Cry|TTBB|Earl Moon
+Don't Go In The Lion's Cage Tonight|TTBB|Earl Moon
+Forgive Me|SSAA|Earl Moon
+Forgive Me|TTBB|Earl Moon
+Fortune In Dreams|SSAA|Earl Moon
+Fortune In Dreams|TTBB|Earl Moon
+A Garden In The Rain|TTBB|Earl Moon
+Happy Days And Lonely Nights|TTBB|Earl Moon
+I Believe|TTBB|Earl Moon
+I Wonder Who's Kissing Her Now|SSAA|Earl Moon
+I'm Always Chasing Rainbows|TTBB|Earl Moon
+I've Been Everywhere|TTBB|Earl Moon
+If I Had My Way|TTBB|Earl Moon
+In The Arms Of Love|TTBB|Earl Moon
+It Came Upon A Midnight Clear / Silent Night Medley|TTBB|Earl Moon
+Jeannine I Dream Of Lilac Time|TTBB|Earl Moon
+Just Because / Shine Medley|TTBB|Earl Moon
+Let There Be Peace On Earth|TTBB|Earl Moon
+London By Night|TTBB|Earl Moon
+The Movies|TTBB|Earl Moon
+My Father, My Friend, My Dad|TTBB|Earl Moon
+Oh, Come All Ye Faithful / Joy To The World Medley|TTBB|Earl Moon
+The Old Spinning Wheel|TTBB|Earl Moon
+Richest Man In The World|TTBB|Earl Moon
+Roses Of Picardy|TTBB|Earl Moon
+Sam, The Old Accordion Man|TTBB|Earl Moon
+Sleepy Time Gal|TTBB|Earl Moon
+Those Roarin' Soarin' 20's|TTBB|Earl Moon
+Wahoo|TTBB|Earl Moon
+Waltz Me Around Again, Willie|TTBB|Earl Moon
+We'll Meet Again|TTBB|Earl Moon
+Who's Sorry Now|TTBB|Earl Moon
+Who's Sorry Now|SSAA|Earl Moon
+Yes Indeed|TTBB|Earl Moon
+Yes Indeed|SSAA, SATB|Earl Moon
+You're In Love With Everyone|TTBB|Earl Moon
+Young And Foolish|TTBB|Earl Moon
+Let It Be Me|SSAA|Connie Moore
+What If|SSAA|Connie Moore
+In A Shanty In Old Shanty Town|TTBB|James Moore
+Looking At The World Through Rose Colored Glasses|TTBB|James Moore
+Lost In The Heart Of My Own Home Town|TTBB|James Moore
+Seven Bridges Road|TTBB|Sean Mootrey
+Comin' In On A Wing And A Prayer|TTBB|Ellsworth Morey
+Cruisin' Down The River|TTBB|Ellsworth Morey
+Hey Look Me Over|TTBB|Ellsworth Morey
+Moon Love|TTBB|Ellsworth Morey
+Powder Your Face With Sunshine|TTBB|Ellsworth Morey
+Sheik Of Araby|TTBB|Ellsworth Morey
+The Sweetheart Of Sigma Chi|TTBB|Ellsworth Morey
+Till There Was You|TTBB|Ellsworth Morey
+The World is Waiting For The Sunrise|TTBB|Ellsworth Morey
+The Air That I Breathe|SSAA|Emily Moriarty
+Alive|SSAA|Emily Moriarty
+All About That Bass|SSAA|Emily Moriarty
+All By Myself|SSAA|Emily Moriarty
+All I Do Is Dream Of You|SSAA|Emily Moriarty
+All I Have To Do Is Dream|SSAA|Emily Moriarty
+Am I Ever Gonna See Your Face Again|SSAA|Emily Moriarty
+Amazing Grace|SSAA|Emily Moriarty
+Because|SSAA|Emily Moriarty
+Beggin'|TTBB|Emily Moriarty
+Bewitched|SSAA|Emily Moriarty
+Brand New Key|SSAA|Emily Moriarty
+Can't Help Falling In Love|TTBB, SSAA|Emily Moriarty
+Chandelier|SSAA|Emily Moriarty
+Cheap Thrills|SSAA|Emily Moriarty
+Danger Zone|SSAA|Emily Moriarty
+Do A Little Good|SSAA|Emily Moriarty
+Don't You Remember|SSAA|Emily Moriarty
+Edelweiss|SSAA|Emily Moriarty
+Five Foot Two|SSAA|Emily Moriarty
+From Me To You|SSAA|Emily Moriarty
+Good Day Sunshine|SSAA|Emily Moriarty
+Hair|SSAA|Emily Moriarty
+Happy Birthday To You|SSAA|Emily Moriarty
+Help!|SATB|Emily Moriarty
+Here You Come Again|SSAA|Emily Moriarty
+High Hopes|SSAA|Emily Moriarty
+Hold The Line|SATB|Emily Moriarty
+Home Among The Gumtrees|SSAA|Emily Moriarty
+How D'Ya Like Your Eggs in the Morning|SSAA|Emily Moriarty
+I Need to be in Love|SSAA|Emily Moriarty
+I Want To Be Evil|SSAA|Emily Moriarty
+I Want To Break Free|SSAA|Emily Moriarty
+I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Emily Moriarty
+If|SSAA, SATB|Emily Moriarty
+Jing-a-ling, Jing-a-ling|SSAA|Emily Moriarty
+Jolene|TTBB|Emily Moriarty
+The Lemonade Song|SSAA|Emily Moriarty
+Let The Sunshine In|SSAA|Emily Moriarty
+Let's Have Another Cup of Coffee|SSAA|Emily Moriarty
+Lose My Breath|SSAA|Emily Moriarty
+Love Is Christmas|SSAA|Emily Moriarty
+Love's Old Sweet Song|SSAA|Emily Moriarty
+Lovefool|SSAA|Emily Moriarty
+Maybe This Christmas|SSAA|Emily Moriarty
+Moon Love|SSAA|Emily Moriarty
+New|SSAA|Emily Moriarty
+Rehab|SSAA|Emily Moriarty
+The River|SSAA|Emily Moriarty
+Roam|SSAA|Emily Moriarty
+Sara|SSAA|Emily Moriarty
+Say My Name|SSAA|Emily Moriarty
+Some Enchanted Evening|SSAA, SATB|Emily Moriarty
+Stayin' Alive|SSAA|Emily Moriarty
+The Summer Knows|SSAA|Emily Moriarty
+Summer Of 42|SSAA|Emily Moriarty
+Teardrop|SSAA|Emily Moriarty
+Tell Me Why|SSAA|Emily Moriarty
+The Luckiest|SSAA|Emily Moriarty
+There's A Place|SSAA|Emily Moriarty
+These Boots Are Made For Walkin'|TTBB, SSAA|Emily Moriarty
+The Trolley Song|SSAA|Emily Moriarty
+Two Weeks|TTBB|Emily Moriarty
+Unstoppable|SSAA|Emily Moriarty
+Viva La Vida|SSAA|Emily Moriarty
+W.I.t.c.h|SSAA|Emily Moriarty
+Walking In The Air|TTBB, SSAA|Emily Moriarty
+We Gotta Get Out Of This Place|SSAA|Emily Moriarty
+When You Wore A Tulip|SSAA|Emily Moriarty
+Where Is My Mind?|SSAA|Emily Moriarty
+White Wine In The Sun|SSAA|Emily Moriarty
+You Are The Sunshine Of My Life|SSAA|Emily Moriarty
+You Don't Own Me|SSAA|Emily Moriarty
+You're The Voice|SSAA|Emily Moriarty
+Zombie|SSAA, SATB|Emily Moriarty
+A Hard Days Night|TTBB|Alex Morris
+Absolutely Everybody|SSAA, SATB|Alex Morris
+Africa|TTBB, SSAA, SATB|Alex Morris
+American|TTBB|Alex Morris
+And So It Goes|TTBB|Alex Morris
+Better Be Home Soon|TTBB, SSAA, SATB|Alex Morris
+Big Bulbs|TTBB, SSAA, SATB|Alex Morris
+Both Sides Now|SATB|Alex Morris
+Breakfast at Tiffany's|TTBB|Alex Morris
+Can't Take My Eyes Off Of You|TTBB, SSAA, SATB|Alex Morris
+Celebrate|SATB|Alex Morris
+Don't Dream It's Over|TTBB|Alex Morris
+Don't Know Why|TTBB|Alex Morris
+Don't Stop Me Now|SSAA|Alex Morris
+Every Breath You Take|TTBB|Alex Morris
+From This Moment On|SSAA|Alex Morris
+I Love It|SATB|Alex Morris
+Just The Way You Are|SSAA|Alex Morris
+Let Me Entertain You|TTBB|Alex Morris
+Oops! I Did It Again|TTBB|Alex Morris
+Pieces Of Dreams|TTBB|Alex Morris
+Poison|SATB|Alex Morris
+Primetime|SATB|Alex Morris
+Rawhide|TTBB|Alex Morris
+Rolling In The Deep|SATB|Alex Morris
+Say Something|SSAA|Alex Morris
+Somewhere Only We Know|SSAA|Alex Morris
+Superstition|SATB|Alex Morris
+Taylor The Latte Boy|SATB|Alex Morris
+Throw Your Arms Around Me|TTBB, SSAA|Alex Morris
+Time After Time|TTBB|Alex Morris
+Toxic|TTBB|Alex Morris
+Truly, Madly, Deeply|SATB|Alex Morris
+Unwritten|SSAA, SATB|Alex Morris
+Walk Like an Egyptian|SATB|Alex Morris
+Waltzing Matilda|TTBB, SSAA|Alex Morris
+When I was your Man|TTBB|Alex Morris
+When The Party's Over|SATB|Alex Morris
+When The War Is Over|SSAA|Alex Morris
+Wide Open Spaces|SATB|Alex Morris
+Without You|SATB|Alex Morris
+This Is It!|SSAA|Heather Morriss
+Fido Is A Hot Dog Now|TTBB|Dennis Morrissey
+Goodbye Wild Women Goodbye|TTBB|Dennis Morrissey
+I Feel A Song Comin' On|SSAA|Dennis Morrissey
+I Feel A Song Comin' On|TTBB|Dennis Morrissey
+My Buddy|TTBB|Dennis Morrissey
+New York, New York|TTBB|Dennis Morrissey
+No! No! A Thousand Times No!!|TTBB|Dennis Morrissey
+Old Rugged Cross|TTBB|Dennis Morrissey
+On With The Show|TTBB|Dennis Morrissey
+Til We Meet Again|TTBB|Dennis Morrissey
+Charmed Life|SSAA|Chris Moyer
+The Gift To Be Simple|SSAA|Chris Moyer
+Good Old A Cappella|SSAA|Chris Moyer
+Groovy Kind Of Love|SSAA|Chris Moyer
+Baby Face / You Must Have Been A Beautiful Baby Medley|TTBB|John Muir
+Broken Hearted|TTBB|John Muir
+Consider Yourself|TTBB|John Muir
+Gang That Sang Heart Of My Heart Parody|TTBB|John Muir
+Good Night My Someone|TTBB|John Muir
+I Don't Want A Doctor, All I Want Is A Beautiful Girl|TTBB|John Muir
+I Used To Call Her Baby|TTBB|John Muir
+On The Sunny Side Of The Street|TTBB|John Muir
+Shine On, Harvest Moon|TTBB|John Muir
+Singin' In The Bathtub|TTBB|John Muir
+When Banana Skins Are Falling|TTBB|John Muir
+Down On The Farm|TTBB|John Mulkin
+In A Little Red Barn|TTBB|John Mulkin
+Beyond the Sea|TTBB|Dan Mulligan
+Downtown|TTBB|Dan Mulligan
+Ferry Cross the Mersey|TTBB|Dan Mulligan
+The Goodbye Song|SATB|Dan Mulligan
+Here Comes Santa Claus|TTBB|Dan Mulligan
+I MIss You So|TTBB|Dan Mulligan
+I'd Really Love To See You Tonight|TTBB|Dan Mulligan
+It Don't Mean A Thing (If It Ain't Got That Swing)|TTBB|Dan Mulligan
+It's Been A Long, Long Time|TTBB|Dan Mulligan
+It's Not Unusual|TTBB|Dan Mulligan
+L-O-V-E|TTBB|Dan Mulligan
+Medley: I Can't Be Bothered Now, As Long As I'm Singing|TTBB|Dan Mulligan
+Ripped Pants|TTBB|Dan Mulligan
+Somebody to Love|TTBB|Dan Mulligan
+Timeless To Me|SATB|Dan Mulligan
+Wonderful Day like Today|TTBB|Dan Mulligan
+You Turned The Tables On Me|TTBB|Dan Mulligan
+San Francisco Bay Blues|TTBB|Denis Murphy
+Carolina In My Mind|TTBB|David Naddor
+I Miss the Good Ol' Days|TTBB|David Naddor
+This Land Is Your Land|TTBB|David Naddor
+Till There Was You|TTBB|David Naddor
+When I Grow Too Old To Dream|TTBB|Frank Nanney
+Anything Goes|SSAA|Tony Nasto
+Brotherhood of Man|TTBB|Tony Nasto
+Dig A Little Deeper|SATB|Tony Nasto
+Dream Is A Wish Your Heart Makes|SSAA|Tony Nasto
+Forever Now|SSAA|Tony Nasto
+Glory Of Love|SSAA|Tony Nasto
+I Am Woman|SSAA|Tony Nasto
+I'd Order Love|SSAA|Tony Nasto
+If I Were A Bell|SSAA|Tony Nasto
+Kiss|TTBB|Tony Nasto
+L-O-V-E|SSAA|Tony Nasto
+Leader Of The Band|TTBB|Tony Nasto
+Me And Julio Down By The Schoolyard|TTBB|Tony Nasto
+Moonshine Lullaby|SSAA|Tony Nasto
+My Once Upon A Time|SSAA|Tony Nasto
+Over The Rainbow|TTBB|Tony Nasto
+True Colors|SATB|Tony Nasto
+You And Me Against The World|SSAA|Tony Nasto
+ABBA Medley|TTBB, SSAA|Dan Naumann
+Beatles Medley|TTBB, SSAA|Dan Naumann
+The Best Thing in the World Today Cafe|SATB|Dan Naumann
+Five O'Clock World|TTBB|Dan Naumann
+The Fourth of July Parade|TTBB|Dan Naumann
+Goodnight My Angel|TTBB, SSAA, SATB|Dan Naumann
+I'll Close My Eyes|TTBB, SSAA|Dan Naumann
+If I Had A Million Dollars|TTBB|Dan Naumann
+In My Daughter's Eyes|SSAA|Dan Naumann
+It Was Almost Like A Song|TTBB|Dan Naumann
+Joint Is Jumping|TTBB|Dan Naumann
+Loves Me Like A Rock|TTBB|Dan Naumann
+Luck Be A Lady|TTBB, SSAA|Dan Naumann
+Mambo Italiano|TTBB, SSAA|Dan Naumann
+Seaside Rendezvous|SATB|Dan Naumann
+Sh Boom|TTBB|Dan Naumann
+Sooner or Later|TTBB, SSAA|Dan Naumann
+That Lonesome Road|TTBB|Dan Naumann
+Thriller|TTBB, SSAA|Dan Naumann
+Touch Me In The Morning|SSAA|Dan Naumann
+What A Wonderful World|TTBB|Dan Naumann
+What Are You Doing New Year's Eve?|TTBB, SSAA, SATB|Dan Naumann
+Where Are You Christmas?|TTBB, SSAA, SATB|Dan Naumann
+Yes Sir, That's My Baby|TTBB|Dan Naumann
+Yesterday Once More|SSAA|Dan Naumann
+You Are Everything|SSAA|Dan Naumann
+You Stepped Out Of A Dream|TTBB, SSAA|Dan Naumann
+You're Breaking In A New Heart|SSAA|Dan Naumann
+Zombie Jamboree|TTBB, SSAA, Young SSAA|Dan Naumann
+After The Gold Rush|SSAA|Sheryl Neal
+As Easy As Rolling Off A Log|SSAA|Sheryl Neal
+Baby One More Time|SSAA|Sheryl Neal
+Baby, Baby|SSAA|Sheryl Neal
+Christmas Tree Farm|SSAA|Sheryl Neal
+Come and Get Your Love|SATB|Sheryl Neal
+Didn't Leave Nobody But the Baby|SSAA|Sheryl Neal
+Do I Love You?|SSAA|Sheryl Neal
+From Now On|TTBB|Sheryl Neal
+Game Of Love|SSAA|Sheryl Neal
+Georgia On My Mind|SSAA|Sheryl Neal
+Glimpse Of Us|SSAA|Sheryl Neal
+The Grass Is Blue|TTBB, SSAA|Sheryl Neal
+Happy|SSAA|Sheryl Neal
+Happy Days Are Here Again|SSAA|Sheryl Neal
+I Want It That Way|SSAA|Sheryl Neal
+I'd Die without You|TTBB|Sheryl Neal
+In the First Light|TTBB, SSAA|Sheryl Neal
+Jesse|SSAA|Sheryl Neal
+Jingle Bells|SSAA|Sheryl Neal
+Let's Hear It For The Boy|SSAA|Sheryl Neal
+Let's Misbehave|SSAA|Sheryl Neal
+Little Blue|SSAA|Sheryl Neal
+Memories|TTBB, SSAA, SATB|Sheryl Neal
+Mockin' Bird Hill|SSAA|Sheryl Neal
+The Older I Get|SSAA|Sheryl Neal
+Once Upon A Dream|SSAA|Sheryl Neal
+Orinocco Flow|SSAA|Sheryl Neal
+Pick Yourself Up|SSAA|Sheryl Neal
+Remedy|SSAA|Sheryl Neal
+Rock You Like A Hurricane|SSAA|Sheryl Neal
+Seven Bridges Road|TTBB, SSAA|Sheryl Neal
+Sing A Song|SATB|Sheryl Neal
+Somebody Knows|SSAA|Sheryl Neal
+Somebody Loves Me|SSAA|Sheryl Neal
+Somebody Loves Me/Let's Talk About My Sweetie|SSAA|Sheryl Neal
+Survivor|SSAA|Sheryl Neal
+Sweet Sweet Smile|SSAA|Sheryl Neal
+Take A Number From One To Ten|SSAA|Sheryl Neal
+They All Laughed|SSAA|Sheryl Neal
+Things Are Looking Up|SSAA|Sheryl Neal
+Those Were The Days|SSAA|Sheryl Neal
+Tightrope|SSAA|Sheryl Neal
+Voices|SSAA|Sheryl Neal
+Waitin' On The Far Side Banks of Jordan|SSAA|Sheryl Neal
+What Can I Say After I Say I'm Sorry|SSAA|Sheryl Neal
+White Christmas|SSAA|Sheryl Neal
+Wonderful Christmastime|SSAA|Sheryl Neal
+Nellie Kelly, I Love You|TTBB|Sheldon Nelson
+After My Laughter Came Tears|TTBB|Larry Newth
+Little Town In Ould County Down|TTBB|Larry Newth
+Softly As I Leave You|TTBB|Larry Newth
+A Foggy Day In London Town|SSAA|Dede Nibler
+Duetto Buffo Di Due Gatti|SSAA|Dede Nibler
+Friend Like Me|SSAA|Dede Nibler
+Good Night|SSAA|Dede Nibler
+I Can Dream, Can't I?|SSAA|Dede Nibler
+I Heard It Through The Grapevine|SSAA|Dede Nibler
+I've Got The Music In Me|SSAA|Dede Nibler
+I've Got The World On A String|SSAA|Dede Nibler
+It Could Happen To You|SSAA|Dede Nibler
+It's The Talk Of The Town|SSAA|Dede Nibler
+Leader Of The Pack|SSAA|Dede Nibler
+Long Ago (And Far Away)|SSAA|Dede Nibler
+Someone To Watch Over Me|SSAA|Dede Nibler
+Songbird|SSAA|Dede Nibler
+Stormy Weather|SSAA|Dede Nibler
+The Super Supper March|SSAA|Dede Nibler
+That Old Black Magic|SSAA|Dede Nibler
+There Is Room In The World|SSAA|Dede Nibler
+Tuxedo Junction|SSAA|Dede Nibler
+Why Did I Choose You?|SSAA|Dede Nibler
+Follow The Flag|TTBB|Doug Nichol
+(Ghost) Riders In The Sky|TTBB|Jon Nicholas
+A Hard Days Night|TTBB|Jon Nicholas
+All I Have To Do Is Dream|TTBB|Jon Nicholas
+All Time Low|TTBB|Jon Nicholas
+Am I Ready|TTBB|Jon Nicholas
+Amazing Grace|TTBB|Jon Nicholas
+America The Beautiful|TTBB|Jon Nicholas
+Angels We Have Heard On High|TTBB|Jon Nicholas
+As The Deer|TTBB|Jon Nicholas
+Away In A Manger|TTBB|Jon Nicholas
+Baby's Request|TTBB|Jon Nicholas
+Baby's Request|TTBB, SSAA|Jon Nicholas
+Baby, It's Cold Outside|TTBB|Jon Nicholas
+Back In The Saddle Again|TTBB|Jon Nicholas
+Bandstand Boogie|TTBB|Jon Nicholas
+Barbara Ann|TTBB, SATB|Jon Nicholas
+Battle Hymn Of The Republic|TTBB|Jon Nicholas
+Believe|TTBB|Jon Nicholas
+Between The Devil And The Deep Blue Sea|TTBB, SSAA|Jon Nicholas
+Black Water|TTBB|Jon Nicholas
+Blue Christmas|TTBB|Jon Nicholas
+Blue Shadows|TTBB|Jon Nicholas
+Blue Skies|TTBB|Jon Nicholas
+Blue Velvet|TTBB|Jon Nicholas
+Bury Me Not On The Lone Prairie|TTBB|Jon Nicholas
+Bye Bye Blackbird|TTBB|Jon Nicholas
+Calendar Girl|TTBB|Jon Nicholas
+California Girls|TTBB|Jon Nicholas
+Can't Buy Me Love|TTBB|Jon Nicholas
+Can't Help Falling In Love|TTBB, SSAA|Jon Nicholas
+Carol From An Irish Cabin|SATB|Jon Nicholas
+Chasing Cars|TTBB|Jon Nicholas
+Chattanooga Choo Choo|TTBB, SSAA|Jon Nicholas
+Chattanooga Choo Choo/Pennsylvania, Goodbye Medley|TTBB, SSAA|Jon Nicholas
+Children Go Where I Send Thee|TTBB, SSAA|Jon Nicholas
+Christmas Cookie|TTBB|Jon Nicholas
+Christmas in Kentucky|TTBB, SSAA, SATB|Jon Nicholas
+Christmas Island|TTBB|Jon Nicholas
+Christmas Time Is Here|TTBB|Jon Nicholas
+Come, Christians, Join to Sing|TTBB|Jon Nicholas
+Come, Thou Almighty King|TTBB|Jon Nicholas
+Come, Ye Thankful People, Come|TTBB|Jon Nicholas
+Cool Water|TTBB|Jon Nicholas
+Crown Him With Many Crowns|TTBB|Jon Nicholas
+Daisy Bell|TTBB|Jon Nicholas
+Danny Boy|TTBB|Jon Nicholas
+Day By Day|TTBB|Jon Nicholas
+Days of Wine and Roses|SSAA|Jon Nicholas
+Days of Wine and Roses|TTBB, SSAA|Jon Nicholas
+Dear Lord And Father Of Mankind|TTBB|Jon Nicholas
+Deck The Halls|TTBB|Jon Nicholas
+Dedicated To You|TTBB|Jon Nicholas
+Deep Henderson|TTBB|Jon Nicholas
+Do You Hear What I Hear|TTBB|Jon Nicholas
+Dock Of The Bay, The (Sittin On)|TTBB|Jon Nicholas
+Don't Cry for me Argentina|TTBB|Jon Nicholas
+Don't Fence Me In|TTBB|Jon Nicholas
+Don't Let The Sun Go Down On Me|TTBB|Jon Nicholas
+Draggin' The Line|TTBB|Jon Nicholas
+Dream A Little Dream Of Me|TTBB, SSAA|Jon Nicholas
+Drive|TTBB|Jon Nicholas
+Drivin' My Life Away|TTBB|Jon Nicholas
+Dumas Walker|TTBB|Jon Nicholas
+East Bound And Down|TTBB|Jon Nicholas
+Eight Days a Week|TTBB|Jon Nicholas
+Eleanor Rigby|TTBB|Jon Nicholas
+Emily|TTBB|Jon Nicholas
+Everybody Loves Somebody|TTBB|Jon Nicholas
+Firefly|SSAA|Jon Nicholas
+Firefly|TTBB|Jon Nicholas
+The First Noel|TTBB|Jon Nicholas
+Five Foot Two|TTBB|Jon Nicholas
+Five Minutes More|TTBB|Jon Nicholas
+Fixing A Hole|TTBB|Jon Nicholas
+Fly Me To The Moon|TTBB|Jon Nicholas
+Fool On The Hill|TTBB|Jon Nicholas
+For The Beauty of the Earth|TTBB|Jon Nicholas
+Funny How Time Slips Away|TTBB|Jon Nicholas
+Get A Job|TTBB|Jon Nicholas
+Go Rest High on that Mountain|TTBB, SSAA, SATB|Jon Nicholas
+Go Rest High on that Mountain|TTBB|Jon Nicholas
+Go Tell It On The Mountain|TTBB|Jon Nicholas
+God Bless America|TTBB|Jon Nicholas
+Good Christian Men, Rejoice|TTBB|Jon Nicholas
+Grandma Got Run Over By A Reindeer|TTBB|Jon Nicholas
+The Great Pretender|TTBB|Jon Nicholas
+GTO|TTBB|Jon Nicholas
+Happy Birthday To You|TTBB|Jon Nicholas
+Happy Days Are Here Again|TTBB|Jon Nicholas
+Happy Trails|TTBB|Jon Nicholas
+He's Got The Whole World|TTBB|Jon Nicholas
+Hear Them Bells|TTBB|Jon Nicholas
+Help Me Rhonda|TTBB|Jon Nicholas
+Help!|TTBB, SSAA|Jon Nicholas
+Here Comes Santa Claus|TTBB|Jon Nicholas
+Here Comes The Sun|TTBB|Jon Nicholas
+Hey Good Lookin'|TTBB|Jon Nicholas
+Hey! Baby!|TTBB|Jon Nicholas
+Hey, Soul Sister|TTBB|Jon Nicholas
+Home For The Holidays|TTBB|Jon Nicholas
+Home On The Range|TTBB|Jon Nicholas
+Homeward Bound|TTBB|Jon Nicholas
+Hooked On A Feeling|TTBB, SSAA, SATB|Jon Nicholas
+How Can I Keep From Singing|TTBB|Jon Nicholas
+I Believe In You|TTBB|Jon Nicholas
+I Don't Know If I Should Call Her|TTBB|Jon Nicholas
+I Got Rhythm|SSAA|Jon Nicholas
+I Heard The Bells On Christmas Day|TTBB, SSAA|Jon Nicholas
+I Never Walk Alone|SSAA, SATB|Jon Nicholas
+I Really Don't Want To Know|TTBB|Jon Nicholas
+I Saw Her Standing There|TTBB|Jon Nicholas
+I Saw Mommy Kissing Santa Claus|TTBB|Jon Nicholas
+I Tried Your Love|TTBB|Jon Nicholas
+I Want A Hippopotamus For Christmas|TTBB|Jon Nicholas
+I Wonder As I Wander|TTBB|Jon Nicholas
+I'll Be Home For Christmas|TTBB|Jon Nicholas
+I'll Be There For You|TTBB, SSAA|Jon Nicholas
+I'm A Believer|TTBB|Jon Nicholas
+I'm On My Way|TTBB|Jon Nicholas
+I'm Still Holding You|TTBB, SSAA|Jon Nicholas
+I've Got A Pocketful of Dreams|SSAA|Jon Nicholas
+I've Got My Love To Keep Me Warm|SSAA|Jon Nicholas
+If I Loved You|TTBB|Jon Nicholas
+If You Ain't Lovin'|TTBB|Jon Nicholas
+In The Bleak Midwinter|TTBB|Jon Nicholas
+Inch Worm|TTBB|Jon Nicholas
+Indiana|TTBB|Jon Nicholas
+It Was Love At First Sight|TTBB, SSAA|Jon Nicholas
+It Was Magic|TTBB|Jon Nicholas
+Java Jive|SSAA|Jon Nicholas
+Jazzin' The Blues Away|TTBB|Jon Nicholas
+Jeanie With The Light Brown Hair|TTBB|Jon Nicholas
+Jingle Bells|TTBB|Jon Nicholas
+Jingle Bells Parody|TTBB|Jon Nicholas
+Joy To The World|TTBB|Jon Nicholas
+Just In Case You Change Your Mind|TTBB|Jon Nicholas
+Katrina|TTBB|Jon Nicholas
+Lazy River|TTBB|Jon Nicholas
+Let It Snow Let It Snow Let It Snow|TTBB|Jon Nicholas
+The Letter|SSAA|Jon Nicholas
+The Letter|TTBB|Jon Nicholas
+Life In Technicolor II|TTBB|Jon Nicholas
+Lift Every Voice And Sing|SATB|Jon Nicholas
+Little Drummer Boy|TTBB|Jon Nicholas
+Little Saint Nick|TTBB, SSAA|Jon Nicholas
+Livin' On A Prayer|TTBB|Jon Nicholas
+Long Are The Days|TTBB|Jon Nicholas
+A Long, Slow Train|TTBB|Jon Nicholas
+Love Is On The Air Tonight|TTBB|Jon Nicholas
+Love Me Tender|TTBB|Jon Nicholas
+A Lover's Question|TTBB|Jon Nicholas
+Lucky Day|TTBB|Jon Nicholas
+Magic Is The Moonlight|TTBB|Jon Nicholas
+Magic To Do|TTBB|Jon Nicholas
+The Magic Touch|TTBB|Jon Nicholas
+Man With The Bag|TTBB|Jon Nicholas
+Mansions Of The Lord|TTBB|Jon Nicholas
+Mary Did You Know|TTBB, SSAA|Jon Nicholas
+Material Girl|SSAA|Jon Nicholas
+Maxwell's Silver Hammer|TTBB|Jon Nicholas
+May The Good Lord Bless And Keep You|TTBB|Jon Nicholas
+Mele Kalikimaka|TTBB, SSAA|Jon Nicholas
+Milk and Bread!|TTBB|Jon Nicholas
+A Million to One|TTBB|Jon Nicholas
+Mobile|TTBB|Jon Nicholas
+Mom|TTBB|Jon Nicholas
+The Most Beautiful Girl|TTBB|Jon Nicholas
+Mountain Music|TTBB|Jon Nicholas
+Much To My Surprise|TTBB|Jon Nicholas
+Must Be Santa|TTBB|Jon Nicholas
+My Faith Looks Up To Thee|TTBB|Jon Nicholas
+My Favorite Things|TTBB|Jon Nicholas
+My Girl|TTBB|Jon Nicholas
+My Old Kentucky Home|TTBB|Jon Nicholas
+National Anthem of South Africa|TTBB|Jon Nicholas
+Never My Love|TTBB, SSAA|Jon Nicholas
+Neverland|TTBB|Jon Nicholas
+New York, New York|TTBB|Jon Nicholas
+Night Life|TTBB|Jon Nicholas
+Nine To Five|SSAA|Jon Nicholas
+Nuttin' For Christmas|TTBB|Jon Nicholas
+O|SATB|Jon Nicholas
+O Come O Come Emmanuel|TTBB|Jon Nicholas
+O God, Our Help In Ages Past|TTBB|Jon Nicholas
+O Holy Night|TTBB|Jon Nicholas
+Oh, Lonesome Me|TTBB|Jon Nicholas
+On A Slow Boat To China|TTBB|Jon Nicholas
+On The Road Again|TTBB|Jon Nicholas
+One Pair Of Hands|TTBB|Jon Nicholas
+Out Of Breath|TTBB|Jon Nicholas
+Over The Rainbow|TTBB|Jon Nicholas
+Paradise|TTBB, SATB|Jon Nicholas
+Pennsylvania 6-5000|TTBB|Jon Nicholas
+Pirates of the Sea|TTBB|Jon Nicholas
+Please Come Home For Christmas|TTBB|Jon Nicholas
+Praise Ye The Lord, The Almighty|TTBB|Jon Nicholas
+Precious Lord Take My Hand|TTBB|Jon Nicholas
+Prepare The Way|TTBB|Jon Nicholas
+Price Tag|SSAA|Jon Nicholas
+Proud Mary|TTBB|Jon Nicholas
+Quicksilver|TTBB|Jon Nicholas
+Rawhide|TTBB|Jon Nicholas
+Red Rubber Ball|TTBB|Jon Nicholas
+Rhythm Is Gonna Get You|SSAA|Jon Nicholas
+Rhythm Of The Rain|TTBB|Jon Nicholas
+Ride The Chariot|TTBB|Jon Nicholas
+The Riff Song|TTBB|Jon Nicholas
+Rise Up Shepherd And Follow|TTBB|Jon Nicholas
+Rock and Roll Christmas|TTBB|Jon Nicholas
+Rock and Roll Christmas|SSAA|Jon Nicholas
+Rock Around The Clock|TTBB, SSAA, SATB|Jon Nicholas
+Rockin' Around The Christmas Tree|TTBB|Jon Nicholas
+Rosetta|TTBB|Jon Nicholas
+Row Your Boat|TTBB, SSAA|Jon Nicholas
+Row, Row, Row|TTBB|Jon Nicholas
+Run Rudolph Run|TTBB|Jon Nicholas
+San Francisco Bay Blues|TTBB|Jon Nicholas
+Santa Baby|TTBB|Jon Nicholas
+Santa Bring My Baby Back|TTBB|Jon Nicholas
+Santa Claus Is Comin' To Town|TTBB|Jon Nicholas
+School's Out|TTBB|Jon Nicholas
+September Song|TTBB|Jon Nicholas
+Seven Bridges Road|TTBB|Jon Nicholas
+Shiver My Timbers|TTBB|Jon Nicholas
+Silent Night|TTBB|Jon Nicholas
+Silver Bells|TTBB|Jon Nicholas
+Singing For You In That Barbershop Style|TTBB|Jon Nicholas
+Singing My Troubles Away|TTBB|Jon Nicholas
+A Sky Full of Stars|SATB|Jon Nicholas
+Skylark|TTBB|Jon Nicholas
+Slow Rockin' Christmas|TTBB|Jon Nicholas
+Slow Rockin' Christmas|SSAA|Jon Nicholas
+Snowbird|TTBB, SATB|Jon Nicholas
+Someobdy's Talkin' 'Bout Jesus|TTBB|Jon Nicholas
+Someone's Always After My Baby|TTBB|Jon Nicholas
+Something|TTBB|Jon Nicholas
+Something to Talk About|SSAA|Jon Nicholas
+Sometime|TTBB|Jon Nicholas
+Songbird|SSAA|Jon Nicholas
+The Sound Of Silence|TTBB|Jon Nicholas
+Sparks|TTBB|Jon Nicholas
+Stars Fell On Alabama|TTBB|Jon Nicholas
+Story Of The Rose|TTBB, SSAA|Jon Nicholas
+Stupid Deep|SATB|Jon Nicholas
+Summer Wind|TTBB|Jon Nicholas
+Surfin' Safari|TTBB|Jon Nicholas
+Surfin' U.S.A.|TTBB|Jon Nicholas
+Sweet Beulah Land|TTBB|Jon Nicholas
+Teddy Bear|SSAA|Jon Nicholas
+Ten Pins In The Sky|TTBB|Jon Nicholas
+Tenderly|TTBB, SATB|Jon Nicholas
+That Girl Could Kiss!|TTBB|Jon Nicholas
+That's Christmas To Me|TTBB|Jon Nicholas
+That's How The Yodel Was Born|TTBB|Jon Nicholas
+That's Someone You Never Forget|TTBB|Jon Nicholas
+The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Jon Nicholas
+The Desert Song|TTBB|Jon Nicholas
+They Call The Wind Maria|TTBB|Jon Nicholas
+The Time I Like Best|TTBB|Jon Nicholas
+Time In A Bottle|TTBB|Jon Nicholas
+The Tracks Of My Tears|TTBB|Jon Nicholas
+Trains and Boats and Planes|TTBB|Jon Nicholas
+Travelin' Man|TTBB|Jon Nicholas
+Travelin' Prayer|TTBB|Jon Nicholas
+Tumbling Tumbleweeds|TTBB|Jon Nicholas
+Twilight Time|TTBB|Jon Nicholas
+The Twist|TTBB|Jon Nicholas
+U. S. Armed Forces Medley|TTBB|Jon Nicholas
+Valse|TTBB|Jon Nicholas
+Very Last Day|TTBB|Jon Nicholas
+Vincent (Starry Starry Night)|TTBB|Jon Nicholas
+The Virgin Mary Had A Baby Boy|TTBB|Jon Nicholas
+Wanted Dead Or Alive|SATB|Jon Nicholas
+The Water Is Wide|TTBB|Jon Nicholas
+Way Down On Tampa Bay|TTBB|Jon Nicholas
+We Gather Together|TTBB|Jon Nicholas
+We Need A Little Christmas|TTBB|Jon Nicholas
+We Three Kings|TTBB|Jon Nicholas
+When Did You Leave Heaven?|TTBB|Jon Nicholas
+When I Look In Your Eyes|TTBB|Jon Nicholas
+When I'm Sixty Four|TTBB, SSAA|Jon Nicholas
+When the Ship Hit the Sand|TTBB|Jon Nicholas
+Whether The Weather Is Wet|TTBB|Jon Nicholas
+Whispering Grass|TTBB|Jon Nicholas
+White Christmas|TTBB|Jon Nicholas
+Whiter Than Snow|TTBB|Jon Nicholas
+Will The Circle Be Unbroken?|TTBB|Jon Nicholas
+Windy|TTBB|Jon Nicholas
+Winter Wonderland|TTBB|Jon Nicholas
+Wonderful Time Up There|TTBB|Jon Nicholas
+Working in a Coal Mine|TTBB|Jon Nicholas
+Y'all Come Back Saloon|TTBB|Jon Nicholas
+Y.M.C.A.|TTBB|Jon Nicholas
+Yellow Bird|TTBB|Jon Nicholas
+You Are My Sunshine|TTBB|Jon Nicholas
+You Give Love a Bad Name|SATB|Jon Nicholas
+You Raise Me Up|TTBB|Jon Nicholas
+You'll Never Walk Alone|TTBB, SSAA, SATB|Jon Nicholas
+You're A Mean One, Mr. Grinch|TTBB|Jon Nicholas
+You're Nobody 'Til Somebody Loves You|TTBB|Jon Nicholas
+Who's Sorry Now / Goody Goody Medley|TTBB|Tom Nichols
+Candle On The Water|SSAA|Connie Nickel
+Charleston|SSAA|Connie Nickel
+He's A Cousin Of Mine|SSAA|Connie Nickel
+Love Potion No. 9|SSAA|Connie Nickel
+Oh, What A Merry Christmas Day|SSAA|Connie Nickel
+Sound Of Music|SSAA|Connie Nickel
+Sunrise, Sunset|SSAA|Connie Nickel
+The Marvelous Toy|SSAA|Connie Nickel
+Unchained Melody|SSAA|Connie Nickel
+We Need A Little Christmas|SSAA|Connie Nickel
+Gonna Build A Mountain|SSAA|Aileen Nightingale Music
+Have You Ever Been Lonely?|SSAA|Aileen Nightingale Music
+Softly As I Leave You|TTBB|Aileen Nightingale Music
+There's A Song In The Air|SSAA|Aileen Nightingale Music
+When The Saints Go Marching In|SSAA, Young SSAA|Aileen Nightingale Music
+Ugly Duckling|TTBB|Herdes Nina
+Roll On, Mississippi, Roll On|TTBB|Chuck Northrup
+Last Night On The Back Porch|TTBB|Gay Notes
+Don't You Worry Bout A Thing|SSAA|Anna-Maria Nystrom
+Fields Of Gold|SSAA|Anna-Maria Nystrom
+Something to Talk About|SSAA|Anna-Maria Nystrom
+We Are Family|SSAA|Anna-Maria Nystrom
+Sentimental Journey|SSAA|Audrey Oakley
+Strangers|SSAA|Audrey Oakley
+So In Love|TTBB|Frank Oglesby
+Every Time I Join My Sister In A Song|SSAA|Paul C. Olguin
+The Gift Of Harmony|TTBB|Paul C. Olguin
+Let There Be Peace On Earth|TTBB|Paul C. Olguin
+You Are The One I Love|TTBB|Paul C. Olguin
+Hard Hearted Hannah|SSAA|Betty Oliver
+Hello My Baby|SSAA|Betty Oliver
+I'm Back In Love/I'm In Love Again Medley|SSAA|Betty Oliver
+Longer|SSAA|Betty Oliver
+Old Time Religion Medley|SSAA|Betty Oliver
+Seventy-Six Trombones|SSAA|Betty Oliver
+Together Wherever We Go|SSAA|Betty Oliver
+Whatever Happened To The Old Songs|TTBB|Betty Oliver
+Give Me A Basketball|TTBB|Paul Olquin
+When Uncle Joe Plays A Rag On His Banjo|TTBB|Chuck Olsen
+The Glendy Burke|TTBB|Bryan Olson
+Georgia Land|TTBB|Chuck Olson
+Christmas Time Is Here|SSAA|Jan Olson
+The Very Best Time Of Year|SSAA|Jan Olson
+Old Cape Cod|TTBB|Phil Ordaz
+World War I Medley|TTBB|Dick Ott
+10,000 Hours|TTBB|Cay Outerbridge
+The Age of Not Believing|TTBB|Cay Outerbridge
+All I Ask|SATB|Cay Outerbridge
+As We Stumble Along|TTBB, SSAA, SATB|Cay Outerbridge
+Bein' Green|TTBB|Cay Outerbridge
+Believe|SATB|Cay Outerbridge
+Bestest Friend|TTBB|Cay Outerbridge
+Both Sides Now|SSAA, SATB|Cay Outerbridge
+Bridge Over Troubled Water|TTBB, SSAA|Cay Outerbridge
+But The World Goes Around|TTBB|Cay Outerbridge
+The Climb|TTBB|Cay Outerbridge
+Dance With My Father|TTBB|Cay Outerbridge
+Dancing On My Own|TTBB|Cay Outerbridge
+Don't Let Me Go|TTBB|Cay Outerbridge
+Don't Stop Me Now|TTBB|Cay Outerbridge
+The First Time Ever I Saw Your Face|TTBB|Cay Outerbridge
+The Goodbye Song|TTBB|Cay Outerbridge
+Happiness Hotel|SSAA|Cay Outerbridge
+Here Comes The Sun|TTBB|Cay Outerbridge
+I Can See Clearly Now|TTBB|Cay Outerbridge
+I Have Confidence|TTBB, SSAA|Cay Outerbridge
+I Love Trash|TTBB|Cay Outerbridge
+I'll Never Love Again|SATB|Cay Outerbridge
+I'm Not A Loser|TTBB|Cay Outerbridge
+If I Didn't Have You|TTBB, SATB|Cay Outerbridge
+If Moon Was Cookie|TTBB|Cay Outerbridge
+It Shouldn't Happen To A Dream|TTBB|Cay Outerbridge
+It's Been A Long, Long Time|TTBB|Cay Outerbridge
+It's You I Like|SSAA|Cay Outerbridge
+Keep Marching|SSAA|Cay Outerbridge
+Keep The Customer Satisfied|TTBB|Cay Outerbridge
+Lean On Me|SATB|Cay Outerbridge
+Light Of A Clear Blue Morning|SSAA|Cay Outerbridge
+Look For The Light|SSAA|Cay Outerbridge
+Lost Mind|TTBB|Cay Outerbridge
+Make Your Own Kind of Music|TTBB|Cay Outerbridge
+Making Our Dreams Come True|TTBB, SSAA, SATB|Cay Outerbridge
+Medley: It Feels Good When You Sing A Song with Sing|SSAA|Cay Outerbridge
+Medley: What Do You Do With A B.A. In English / For Now|TTBB|Cay Outerbridge
+Merry Christmas, Happy Holidays|SSAA|Cay Outerbridge
+Movin' Right Along|SSAA|Cay Outerbridge
+The Muppet Show Theme|TTBB|Cay Outerbridge
+No One Else Is Singing My Song|TTBB|Cay Outerbridge
+On My Way|SATB|Cay Outerbridge
+Plain Plate of Noodles|TTBB|Cay Outerbridge
+Proud of Your Boy|TTBB|Cay Outerbridge
+Rainbow Connection|SATB|Cay Outerbridge
+Santa Mouse|TTBB|Cay Outerbridge
+Sing|SATB|Cay Outerbridge
+Splish Splash|TTBB|Cay Outerbridge
+There's a Fine Fine Line|SATB|Cay Outerbridge
+Things Are Looking Up|TTBB|Cay Outerbridge
+This Frog|TTBB|Cay Outerbridge
+Tomorrow|SATB|Cay Outerbridge
+Vincent (Starry Starry Night)|SATB|Cay Outerbridge
+What Would I Do Without You|SATB|Cay Outerbridge
+Why Try to Change Me Now?|TTBB, SATB|Cay Outerbridge
+You Won't Succeed On Broadway|TTBB|Cay Outerbridge
+You've Got A Friend|TTBB|Cay Outerbridge
+Surfer Girl|TTBB|Ethan Owens
+Great Is Thy Faithfulness|SATB|Dylan Oxford
+Put Your Dreams Away (For Another Day)|TTBB|Dylan Oxford
+Sweet Caroline|TTBB, SSAA, SATB|Dylan Oxford
+Hi Neighbor|TTBB|Rob Ozman
+Rainbow Connection|TTBB|Rob Ozman
+That's Entertainment|TTBB|Rob Ozman
+Noah's Wife Lived A Wonderful Life|TTBB|Bill Packard
+Stars Fell On Alabama|TTBB|Bill Packard
+Because|SATB|Manoj Padki
+Blue Hawaii|TTBB|Manoj Padki
+Burning Bridges|TTBB|Manoj Padki
+Down By The Riverside|SATB|Manoj Padki
+Flowers|SATB|Manoj Padki
+Get A Job|SATB|Manoj Padki
+Goodnight, Sweetheart, Goodnight|SATB|Manoj Padki
+Help!|SATB|Manoj Padki
+Here Comes The Sun|SATB|Manoj Padki
+Historia De Un Amor|SSAA, SATB|Manoj Padki
+How Blue The Night|TTBB|Manoj Padki
+I Fall In Love Too Easily|TTBB|Manoj Padki
+I Want A Hippopotamus For Christmas|SATB|Manoj Padki
+I Want A Hippopotamus For Christmas|TTBB|Manoj Padki
+I Will|SATB|Manoj Padki
+The Impossible Dream|SATB|Manoj Padki
+Indian Love Call|TTBB|Manoj Padki
+Lucy In The Sky with Diamonds|SATB|Manoj Padki
+Monster Mash|SATB|Manoj Padki
+Never Too Late|TTBB|Manoj Padki
+Nowhere Man|SATB|Manoj Padki
+Octopus's Garden|SATB|Manoj Padki
+Oh! Darling|SATB|Manoj Padki
+The Parting Glass|TTBB|Manoj Padki
+Penny Lane|SATB|Manoj Padki
+Perhaps Love|SATB|Manoj Padki
+Return to Pooh Corner|TTBB|Manoj Padki
+Sabbath Prayer|TTBB|Manoj Padki
+She's Leaving Home|SATB|Manoj Padki
+Silent Night|TTBB|Manoj Padki
+Star Spangled Banner|SATB|Manoj Padki
+Stayin' Alive|SATB|Manoj Padki
+These Dreams|SATB|Manoj Padki
+This Land Is Your Land|SATB|Manoj Padki
+Three Little Birds|SATB|Manoj Padki
+Thunderball|TTBB|Manoj Padki
+Walkin' After Midnight|TTBB|Manoj Padki
+Where Do I Begin|TTBB|Manoj Padki
+Where Everybody Knows Your Name|SATB|Manoj Padki
+The Wonder of You|SATB|Manoj Padki
+Yellow Submarine|SATB|Manoj Padki
+The Addams Family|SSAA|Erin Palmer
+My Girl|TTBB|John Palmer
+Ray-Ray-Raining|TTBB|Nick Papageorge
+Give Me A Million Beautiful Girls|TTBB|Alden Parker
+Hunting Song|TTBB|Alden Parker
+It's A Good Day|SATB|Alden Parker
+Jeannine I Dream Of Lilac Time|TTBB|Alden Parker
+Little Man You've Had A Busy Day|TTBB|Alden Parker
+New York Medley|TTBB|Alden Parker
+Poisoning Pigeons In The Park|TTBB|Alden Parker
+Red Sails In The Sunset|TTBB|Alden Parker
+Seventy-Six Trombones|TTBB|Alden Parker
+She Was An Acrobat's Daughter|TTBB|Alden Parker
+Talk To The Animals|TTBB|Alden Parker
+When It's Springtime In The Rockies|TTBB|Alden Parker
+After You've Gone|SSAA|Anna Maria Parker
+Breaking Up Is Hard To Do|SSAA|Anna Maria Parker
+Bye Bye Love|SSAA|Anna Maria Parker
+Can't Help Lovin' Dat Man|SSAA|Anna Maria Parker
+Candle On The Water|SSAA|Anna Maria Parker
+Chapel Of Love|SSAA|Anna Maria Parker
+Danny Boy|SSAA|Anna Maria Parker
+Deep River|SSAA|Anna Maria Parker
+Doo Wop Medley|SSAA|Anna Maria Parker
+The Entertainer|SSAA|Anna Maria Parker
+Everybody Loves A Lover|SSAA|Anna Maria Parker
+Have Yourself A Merry Little Christmas|SSAA|Anna Maria Parker
+Hello Young Lovers|SSAA|Anna Maria Parker
+Honky Tonk Moon|SSAA|Anna Maria Parker
+I Get The Blues When It Rains|SSAA|Anna Maria Parker
+I'm Always Chasing Rainbows|SSAA|Anna Maria Parker
+I'm Thru with Love|SSAA|Anna Maria Parker
+If|SSAA|Anna Maria Parker
+If I Could Be With You|SSAA|Anna Maria Parker
+If I Could Tell You|SSAA|Anna Maria Parker
+It's A Million To One You're In Love|SSAA|Anna Maria Parker
+Let There Be Peace On Earth|SSAA|Anna Maria Parker
+Lollipop|SSAA|Anna Maria Parker
+The Lord's Prayer|SSAA|Anna Maria Parker
+Love's Old Sweet Song|SSAA|Anna Maria Parker
+Me and the Man in the Moon|SSAA|Anna Maria Parker
+My Heart Stood Still|SSAA|Anna Maria Parker
+My Honey's Lovin' Arms|SSAA|Anna Maria Parker
+Oh, What A Beautiful Mornin'|SSAA|Anna Maria Parker
+One God|SSAA|Anna Maria Parker
+Over The Rainbow|SSAA|Anna Maria Parker
+Razzle Dazzle|SSAA|Anna Maria Parker
+Santa Claus Is Comin' To Town|SSAA|Anna Maria Parker
+The Song Is Ended|SSAA|Anna Maria Parker
+Songs for Hanukkah|SSAA|Anna Maria Parker
+Sugar Blues|SSAA|Anna Maria Parker
+Take Me Out To The Ball Game|SSAA, Young SSAA|Anna Maria Parker
+You Make Me Feel Like Dancing|SSAA|Anna Maria Parker
+You're Driving Me Crazy|SSAA|Anna Maria Parker
+Have A Little Talk With Myself|TTBB|Gary Parker
+Street Lamp On The Corner|TTBB|Gary Parker
+Christmas Time Is Here|SSAA|Patsee Parker
+Girl Talk|SSAA|Patsee Parker
+Inch Worm|SSAA|Patsee Parker
+Lazy Day|SSAA|Patsee Parker
+Mr. Mistoffelees|SSAA|Patsee Parker
+Someone's Been Sending Me Flowers|SSAA|Patsee Parker
+The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Patsee Parker
+Twas The Night Before Christmas|SSAA|Patsee Parker
+You Came A Long Way From St. Louis|SSAA|Patsee Parker
+Ain't Nobody Here But Us Chickens|TTBB|Tom Parker
+Bells Of Killarney|TTBB|Tom Parker
+Happy Trails|TTBB|Tom Parker
+Holy Ground Medley|TTBB|Tom Parker
+Little Old Mill|TTBB|Tom Parker
+She's A Typical Tip from Tipperary|TTBB|Tom Parker
+Blackbird|SATB|Matt Parks
+Don't Like Goodbyes|TTBB|Matt Parks
+I Won't Say I'm In Love|SSAA|Matt Parks
+Make Them Hear You|TTBB|Matt Parks
+Mr. Rogers Medley|TTBB|Matt Parks
+Shamey Shamey Shame|SSAA|Matt Parks
+Somethin' About December|SSAA|Matt Parks
+The Luckiest|TTBB|Matt Parks
+Touch the Sky|SSAA|Matt Parks
+Winter Wonderland|SSAA|Matt Parks
+Cab Driver|TTBB|Steve Pastrick
+Can't Take My Eyes Off Of You|SSAA|Staffan Paulson
+Candy Man|SSAA|Staffan Paulson
+Don't Know Why|SSAA|Staffan Paulson
+Drive My Car|TTBB, SSAA|Staffan Paulson
+The End of the World|SSAA|Staffan Paulson
+For Once In My Life|SSAA|Staffan Paulson
+Good Vibrations|TTBB, SATB|Staffan Paulson
+I Get Around|SSATB|Staffan Paulson
+I'm Outta Love|SSAA|Staffan Paulson
+Lady Marmalade|SSAA|Staffan Paulson
+Laughter In The Rain|TTBB, SSAA|Staffan Paulson
+Nat King Cole Medley|SSAA|Staffan Paulson
+Signed, Sealed, Delivered|TTBB, SSAA|Staffan Paulson
+Think|SSAA|Staffan Paulson
+True Colors|TTBB, SSAA|Staffan Paulson
+Walk a Mile In My Shoes|SSAA|Staffan Paulson
+Broken Hearted|TTBB|Dan Paymar
+Rockies Medley|TTBB|Dan Paymar
+Wahoo|TTBB|Jack Payne
+When It's Springtime In The Rockies|TTBB|Jack Payne
+A Town In Old New Hampshire|TTBB|Roger Payne
+Birth Of The Blues|TTBB|Roger Payne
+Blue-Collar Gal|TTBB|Roger Payne
+Chipmunks Christmas Song|TTBB|Roger Payne
+Encore|TTBB|Roger Payne
+Flying Sinatra Medley|TTBB|Roger Payne
+Frosty The Snowman/Santa Clause Is Coming To Town|TTBB|Roger Payne
+Go Tell It On The Mountain|TTBB|Roger Payne
+Heart|TTBB|Roger Payne
+I Love You Truly|TTBB|Roger Payne
+I've Been Workin' On The Railroad|TTBB, SSAA, SATB|Roger Payne
+Just A Gigolo / I Ain't Got Nobody|TTBB|Roger Payne
+Love Me And The World Is Mine|TTBB|Roger Payne
+Make A Fool Of Myself Tonight|TTBB|Roger Payne
+Monster Mash|TTBB, SSAA, SATB|Roger Payne
+My Bonnie Lies Over The Ocean|TTBB|Roger Payne
+One For My Baby (And One More For The Road)|TTBB|Roger Payne
+Singin' In The Bathtub|TTBB|Roger Payne
+Till There Was You|TTBB, SSAA|Roger Payne
+If We Can't Be The Same Old Sweethearts|TTBB|Tom Pearson
+Rain|TTBB|Bob Peculski
+Too Many Parties And Too Many Pals|TTBB|Bob Peculski
+Back In Those Wonderful Days|TTBB|Einar Pedersen
+Barbershop Girl Of My Dreams|TTBB|Einar Pedersen
+Birth Of The Blues|TTBB|Einar Pedersen
+Broadway Medley|TTBB|Einar Pedersen
+Cabaret|TTBB|Einar Pedersen
+Give Me That Barbershop Style|TTBB|Einar Pedersen
+Hawaii, I'll Love You Forever|TTBB|Einar Pedersen
+Hear Us Now, Oh God, Our Father|TTBB|Einar Pedersen
+Heart|TTBB|Einar Pedersen
+I Love Paris|TTBB|Einar Pedersen
+I'd Give The World To Be In My Home Town|TTBB|Einar Pedersen
+I'm Left On The Corner Alone|TTBB|Einar Pedersen
+Just A Little Fond Affection|TTBB|Einar Pedersen
+My Little Grass Shack In Kealakekua, Hawaii|TTBB|Einar Pedersen
+New Orleans Medley|TTBB|Einar Pedersen
+Old Songs Are Just Like Old Friends|SSAA|Einar Pedersen
+Old Songs Are Just Like Old Friends|TTBB|Einar Pedersen
+Playing The Clown|TTBB|Einar Pedersen
+Riders In The Sky|TTBB|Einar Pedersen
+Run, Run, Run Little Dogie|TTBB|Einar Pedersen
+Those Riverboat Songs|TTBB|Einar Pedersen
+United We Sing|TTBB|Einar Pedersen
+When The Saints Go Marching In|TTBB|Einar Pedersen
+You'll Never Know|TTBB|Einar Pedersen
+All The Things You Are|TTBB|Bill Pellant
+Embraceable You|TTBB|Bill Pellant
+I'm Lonesome For You Dear Old Pal|TTBB|Bill Pellant
+Little White Lies|TTBB|Bill Pellant
+The Nearness Of You|TTBB|Bill Pellant
+Night And Day|TTBB|Bill Pellant
+Oh, Susanna Dust Off That Old Pianna|TTBB|G. W. Pellant
+Old Songs / Roll Dem Bones Medley|TTBB|G. W. Pellant
+Rollin' Home|TTBB|G. W. Pellant
+An Hour Never Passes|SSAA|Karen Penketh
+Beautiful|SATB|Karen Penketh
+Chasing Cars|SATB|Karen Penketh
+Congratulations|SATB|Karen Penketh
+Count On Me|TTBB|Karen Penketh
+I'll Close My Eyes (and make believe it's you)|SATB|Karen Penketh
+I'm Just A Dancing Sweetheart|SATB|Karen Penketh
+Mistletoe and Wine|SATB|Karen Penketh
+Oh! Darling|SATB|Karen Penketh
+Thank You For The Music|SATB|Karen Penketh
+Walking In The Air|SATB|Karen Penketh
+When Christmas Comes To Town|TTBB|Karen Penketh
+Ac-cent-tchu-ate The Positive|TTBB|Marilyn Penketh
+Bridge Over Troubled Water|TTBB|Marilyn Penketh
+Dream A Little Dream Of Me|TTBB|Marilyn Penketh
+Edelweiss|TTBB|Marilyn Penketh
+Fields Of Gold|TTBB|Marilyn Penketh
+From The Time You Say Goodbye|TTBB|Marilyn Penketh
+Hawaiian Wedding Song|TTBB|Marilyn Penketh
+I Have A Dream|TTBB|Marilyn Penketh
+If I Give My Heart To You|TTBB|Marilyn Penketh
+If You Had All The World And Its Gold|TTBB|Marilyn Penketh
+In The Bleak Midwinter|TTBB|Marilyn Penketh
+King Of The Road|SSAA|Marilyn Penketh
+Silence Is Golden|TTBB|Marilyn Penketh
+Sing|TTBB|Marilyn Penketh
+The Sound Of Silence|SATB|Marilyn Penketh
+Take Me Home, Country Roads|TTBB|Marilyn Penketh
+What A Wonderful World|TTBB|Marilyn Penketh
+When Will I Be Loved|TTBB|Marilyn Penketh
+Where Is Love?|TTBB|Marilyn Penketh
+Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|TTBB|Marilyn Penketh
+'Tis the Gift to be Simple|SATB|Tamra Perez
+All About That Bass|SSAA|Tamra Perez
+How Far I'll Go|SSAA|Tamra Perez
+I Feel A Sin Comin' On|SATB|Tamra Perez
+It Is Well With My Soul|SATB|Tamra Perez
+The 59th Street Bridge Song (Feelin' Groovy)|SATB|Tamra Perez
+You And Me|SSAA|Tamra Perez
+You Can Fly|SSAA|Tamra Perez
+Baby Won't You Please Come Home|SSAA|Charlotte Pernert
+Cry Baby Blues|SSAA|Charlotte Pernert
+Everybody's Doin' It Now|SSAA|Charlotte Pernert
+Girl Talk|SSAA|Charlotte Pernert
+How About Me?|SSAA|Charlotte Pernert
+May I Never Love Again|SSAA|Charlotte Pernert
+My Melancholy Baby|SSAA|Charlotte Pernert
+S Wonderful|SSAA|Charlotte Pernert
+They Didn't Believe Me|SSAA|Charlotte Pernert
+You'd Be Surprised|SSAA|Charlotte Pernert
+Bibbidi Bobbidi Boo (From Cinderella)|SSAA|Jeanette Perry
+I Will Follow Him|SSAA|Jeanette Perry
+Let There Be Music Let There Be Love|SSAA|Jeanette Perry
+You've Lost That Lovin' Feelin|SSAA|Jeanette Perry
+After All I've Been To You|TTBB|Louis Perry
+Always Take A Girl Named Daisy|TTBB|Louis Perry
+At The Moving Picture Ball|TTBB|Louis Perry
+Back In Dad And Mother's Day|TTBB|Louis Perry
+Barbershop Rag|TTBB|Louis Perry
+Broadway Rose|TTBB|Louis Perry
+Can't You Hear Me Callin' Caroline|TTBB|Louis Perry
+Day Dreamin'|TTBB|Louis Perry
+Don't Blame Me|TTBB|Louis Perry
+Don't Tell Me The Same Things Over Again|TTBB|Louis Perry
+Don't Waste Your Tears Over Me|TTBB|Louis Perry
+Down In The Old Neighborhood|TTBB|Louis Perry
+Dreaming Sweet Dreams Of Mother|TTBB|Louis Perry
+Ever Since We Got That Water Bed|TTBB|Louis Perry
+Everybody Wants To Go To Heaven|TTBB|Louis Perry
+Everybody Wants To Go To Heaven|SSAA|Louis Perry
+Follow Your Heart|TTBB|Louis Perry
+From The First Hello To The Last Goodbye|TTBB|Louis Perry
+Garland Of Old Fashioned Roses|TTBB|Louis Perry
+Goodbye Boys|TTBB|Louis Perry
+Hold Me|TTBB|Louis Perry
+How Can I Miss You If You Won't Go Away?|TTBB, SSAA|Louis Perry
+How To Stay Married|TTBB|Louis Perry
+I Feel A Song Comin' On|TTBB|Louis Perry
+I Lost The Best Pal That I Had|TTBB|Louis Perry
+I Love An Old Fashioned Song|TTBB|Louis Perry
+I May Be Gone For A Long Long Time|TTBB|Louis Perry
+I Miss You Most Of All|TTBB|Louis Perry
+I Want You To Be My Sweetheart|TTBB|Louis Perry
+I Wish All My Children Were Babies Again|TTBB, SSAA|Louis Perry
+I Wonder Who's Kissing Her Now|TTBB|Louis Perry
+I'd Love To Meet That Old Sweetheart Of Mine|TTBB|Louis Perry
+I'll Forget You|TTBB|Louis Perry
+I'll Never Let You Cry|TTBB|Louis Perry
+I'll Take Care Of Your Cares|TTBB|Louis Perry
+I'm A Dreamer, Aren't We All|TTBB|Louis Perry
+I'm All Alone|TTBB|Louis Perry
+I'm Alone Because I Love You|TTBB|Louis Perry
+I'm Lonesome For You Dear Old Pal|TTBB|Louis Perry
+I'm Making Believe That I Don't Care|TTBB|Louis Perry
+I'm Sorry I Answered The Phone|TTBB|Louis Perry
+I'm Sorry I Made You Cry|TTBB|Louis Perry
+I've Come To Take You Back Home|TTBB|Louis Perry
+If All My Dreams Were Made Of Gold|TTBB|Louis Perry
+If She Looks Good To Mother, Don't Look For Another|TTBB|Louis Perry
+If The Rest Of The World Don't Want You|TTBB|Louis Perry
+If There'd Never Been An Ireland|TTBB|Louis Perry
+If You Saw All That I Saw In Arkansas|TTBB|Louis Perry
+In The Heart Of The City That Has No Heart|TTBB|Louis Perry
+In The Land Where The Shamrock Grows|TTBB|Louis Perry
+Just Like A Butterfly|TTBB|Louis Perry
+Last Time I Saw Paris|TTBB|Louis Perry
+Let The End Of The World Come Tomorrow|TTBB|Louis Perry
+Lil From Daffodil Hill|TTBB|Louis Perry
+Little Old Lady|TTBB|Louis Perry
+Little Pal|TTBB|Louis Perry
+Little Town In Ould County Down|TTBB|Louis Perry
+Many Happy Returns Of The Day|TTBB|Louis Perry
+Mary You're A Little Bit Old Fashioned|TTBB|Louis Perry
+Meet Me Tonight In Dreamland|TTBB|Louis Perry
+My Daddy Is Only A Picture|TTBB|Louis Perry
+My Melancholy Baby|TTBB|Louis Perry
+Old Pals Are The Best Pals After All|TTBB|Louis Perry
+Old Roses|TTBB|Louis Perry
+Old Songs Are Just Like Old Friends|SSAA|Louis Perry
+Old Songs Are Just Like Old Friends|TTBB|Louis Perry
+One In A Million Like Mary|TTBB|Louis Perry
+The Pal That I Loved Stole The Gal That I Loved|TTBB|Louis Perry
+Paper Doll|TTBB|Louis Perry
+Put Another Chair At The Table|TTBB|Louis Perry
+Roses Of Picardy|TTBB|Louis Perry
+Say Something Sweet To Your Sweetheart|TTBB|Louis Perry
+Seems Like Old Times|TTBB|Louis Perry
+Smilin' Through|TTBB|Louis Perry
+Song Without An Ending|TTBB|Louis Perry
+The Sweetest Song In The World|TTBB|Louis Perry
+The Sweetheart Of Sigma Chi|TTBB|Louis Perry
+Tell Me You'll Forgive Me|TTBB|Louis Perry
+That Old Irish Mother Of Mine|TTBB|Louis Perry
+That Old Quartet Of Mine|TTBB|Louis Perry
+That Tumble Down Shack In Athlone|TTBB|Louis Perry
+That Wonderful Mother Of Mine|TTBB|Louis Perry
+There's A Rose That Is Blooming In Ireland|TTBB|Louis Perry
+There's A Vacant Chair At Home Sweet Home|TTBB|Louis Perry
+There's Nobody Else But You|TTBB|Louis Perry
+There's Something About An Old-Fashioned Girl|TTBB|Louis Perry
+There's Something I Like About Broadway|TTBB|Louis Perry
+Til We Meet Again|TTBB|Louis Perry
+Walkin' My Baby Back Home|TTBB|Louis Perry
+We Kinda Miss Those Good Old Songs|TTBB|Louis Perry
+We'll Meet Again|TTBB|Louis Perry
+West Of The Great Divide|TTBB|Louis Perry
+Whiffenpoof Song|TTBB|Louis Perry
+Whispering|TTBB|Louis Perry
+Why Don't My Dreams Come True?|TTBB|Louis Perry
+Why Should I Cry Over You?|TTBB|Louis Perry
+You And I|TTBB|Louis Perry
+You Gotta Have Love|TTBB|Louis Perry
+You Only Want Me When You're Lonesome|TTBB|Louis Perry
+You're Some Pretty Doll|TTBB|Louis Perry
+You're The Flower Of My Heart, Sweet Adeline|TTBB|Louis Perry
+The Christmas Song|TTBB|George Peters
+If I'm Not At The Roll Call|TTBB|George Peters
+Let There Be Peace On Earth|TTBB|George Peters
+On A Slow Boat To China|TTBB|George Peters
+Seventy-Six Trombones|TTBB|John Peterson
+Amazing Grace|SSAA|Lynne Alice Peterson
+There'll Be Some Changes Made|TTBB|Richard Peterson
+Whatever Happened To The Old Songs / Tootsie Medley|TTBB|Stewart Peterson
+Full Fathom Five|SATB|Vince Peterson
+Go Where I Send Thee|SATB|Vince Peterson
+My Buddy|SATB|Vince Peterson
+Newborn Friend|SATB|Vince Peterson
+Nobody Knows You When You're Down And Out|SATB|Vince Peterson
+Somebody to Love|SATB|Vince Peterson
+Suzanne|SATB|Vince Peterson
+Temptation|SATB|Vince Peterson
+Top Of The World|SATB|Vince Peterson
+Unwritten|SATB|Vince Peterson
+The Water Is Wide|TTBB|Vince Peterson
+Old Time Radio Show|TTBB|Lyle Pettigrew
+Sharin' Sharon|TTBB|Lyle Pettigrew
+Slow Poke|TTBB|Lyle Pettigrew
+Game Of Love|TTBB|Chuck Pettis
+Sleep Warm|TTBB|Chuck Pettis
+Mississippi Squirrel Revival|TTBB|Meredith Phillips
+Sally-Mary Medley|TTBB|Len Pickel
+Sara Lee|SSAA|Fran Pickett
+Let's Talk About My Sweetie|TTBB|John Piercy
+Love Letters|TTBB|John Piercy
+Birth Of The Blues|SSAA|Lyle Pilcher
+Laugh Clown Laugh|TTBB|Lyle Pilcher
+Mickey|TTBB|Lyle Pilcher
+Moments To Remember|SSAA|Lyle Pilcher
+Pal Of My Cradle Days|SSAA|Lyle Pilcher
+Pal Of My Cradle Days|TTBB|Lyle Pilcher
+You're Getting To Be A Habit With Me|SSAA|Lyle Pilcher
+Sweet Violets|TTBB|Jeff Pipkins
+Banjo's Back In Town|TTBB|Bernie Pitkin
+This Is Worth Fighting For|TTBB|Bernie Pitkin
+Most Wonderful Time Of The Year|TTBB|Dave Plette
+Bless This House|TTBB|A Polaneczky
+Redhead|TTBB|A Polaneczky
+Not While I'm Around|TTBB|Jeremiah Pope
+Breaking Up Is Hard To Do|SSAA|Debbie Porter
+Home For The Holidays|SSAA|Debbie Porter
+Pomp And Circumstances|SSAA|Debbie Porter
+Seems Like Old Times|SSAA|Debbie Porter
+The Unbirthday Song|SSAA|Debbie Porter
+You're The Cream In My Coffee|SSAA|Debbie Porter
+Desperado|SSAA|Sylvia Posso
+Seasons of Love|SSAA|Sylvia Posso
+93 Million Miles|SATB|Ken Potter
+Blue Skies|TTBB|Ken Potter
+Christmas Time Is Here|TTBB|Ken Potter
+Communion Song|TTBB|Ken Potter
+Diddly Squat (You Ain't Gettin')|TTBB|Ken Potter
+Do You Believe In Magic|TTBB|Ken Potter
+Do you really love me|TTBB|Ken Potter
+Don't Stop Me Now|TTBB|Ken Potter
+Good Enough for Now|TTBB|Ken Potter
+Goodnight My Angel|SATB|Ken Potter
+Guilty|TTBB|Ken Potter
+I Love Being Here With You|TTBB|Ken Potter
+I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ken Potter
+If|TTBB|Ken Potter
+It's Christmas Time|SATB|Ken Potter
+Like A Sad Song|TTBB|Ken Potter
+Little Shop Of Horrors|SSAA|Ken Potter
+Magic|TTBB|Ken Potter
+One More Sleep 'til Christmas|TTBB|Ken Potter
+Oseh Shalom (grant peace)|TTBB|Ken Potter
+The Parting Glass|TTBB|Ken Potter
+A Piece of Sky|TTBB|Ken Potter
+Puff The Magic Dragon|TTBB|Ken Potter
+Route 66|TTBB|Ken Potter
+Seaside Rendezvous|TTBB|Ken Potter
+Sleep Well Little Children|SATB|Ken Potter
+Top Of The World|SATB|Ken Potter
+A Tree in the Meadow|SSAA|Ken Potter
+True Colors|TTBB|Ken Potter
+You'll Be In My Heart|SATB|Ken Potter
+True Love|TTBB|Charles Powers
+100 Years|SSAA|Carole Prietto
+After You, Who?|SSAA|Carole Prietto
+Ain't Misbehavin'|SSAA|Carole Prietto
+All Of Me|SSAA|Carole Prietto
+Alone|SSAA|Carole Prietto
+Angels We Have Heard On High|SSAA|Carole Prietto
+Ave Maria|TTBB, SSAA|Carole Prietto
+Away In A Manger|SSAA|Carole Prietto
+Better Place|SSAA|Carole Prietto
+Bless The Broken Road|SSAA|Carole Prietto
+Brave|SSAA|Carole Prietto
+Breakaway|SSAA|Carole Prietto
+Brighter Than The Sun|SSAA, Young SSAA|Carole Prietto
+Carry On Wayward Son|SSAA|Carole Prietto
+Charlie Brown Christmas|SSAA|Carole Prietto
+The Chipmunk Song|SSAA|Carole Prietto
+Christmas Canon|SSAA|Carole Prietto
+Christmastime is here|TTBB, SSAA|Carole Prietto
+The Climb|SSAA|Carole Prietto
+Coventry Carol|SSAA|Carole Prietto
+Dangerous Dan McGrew|TTBB|Carole Prietto
+Deck The Halls|SSAA|Carole Prietto
+Desire|SSAA|Carole Prietto
+Despacito|SSAA|Carole Prietto
+The Devil Went Down to Georgia|SSAA|Carole Prietto
+Doop Doo De Oop (A Doodlin' Song)|SSAA|Carole Prietto
+Everybody Step|TTBB|Carole Prietto
+Feels Like Home|SSAA|Carole Prietto
+Firework|SSAA|Carole Prietto
+For Good|SSAA|Carole Prietto
+Fum Fum Fum|SSAA|Carole Prietto
+God Rest Ye Merry, Gentlemen/We Three Kings of Orient Are|SSAA|Carole Prietto
+The Greatest Gift of All|SSAA|Carole Prietto
+How Can I Keep From Singing|TTBB|Carole Prietto
+I Can Sing A Rainbow|SSAA|Carole Prietto
+I Couldn't Be Happier|SSAA|Carole Prietto
+I Got Rhythm Medley|TTBB|Carole Prietto
+I Gotta Feeling|SSAA|Carole Prietto
+I Saw Three Ships|SSAA|Carole Prietto
+I'll Fight|SSAA|Carole Prietto
+I'm Yours|SSAA|Carole Prietto
+In My Daughter's Eyes|SSAA|Carole Prietto
+Joy To The World|SSAA|Carole Prietto
+Landslide|SSAA|Carole Prietto
+Let It Go|SSAA|Carole Prietto
+Let's Twist Again|TTBB, SSAA|Carole Prietto
+Light One Candle|SSAA|Carole Prietto
+Like A Prayer|SSAA|Carole Prietto
+Love Don't Need A Reason|SSAA|Carole Prietto
+Man In The Mirror|SSAA|Carole Prietto
+Mean Ol' Moon|SSAA|Carole Prietto
+Medley: Brighter Than The Sun, We Are Young|SSAA|Carole Prietto
+Medley: The Twist, Let's Twist Again|TTBB|Carole Prietto
+Music Of My Heart|SSAA|Carole Prietto
+Never Gonna Let You Down|SSAA, Young SSAA|Carole Prietto
+Nobody Know How I Miss You, Dear Old Pals|TTBB|Carole Prietto
+Nothing's Gonna Stop Us|SSAA, Young SSAA|Carole Prietto
+O Holy Night|SSAA|Carole Prietto
+One Fine Day|SSAA|Carole Prietto
+Ordinary Miracle|SSAA|Carole Prietto
+Over The Rainbow|SSAA|Carole Prietto
+People Like Us|SSAA|Carole Prietto
+The Place Where the Lost Things Go|SSAA|Carole Prietto
+Price Tag|SSAA|Carole Prietto
+Raise You Up|SSAA|Carole Prietto
+The River|SSAA|Carole Prietto
+The Rose|SSAA|Carole Prietto
+Santa Lucia|SSAA|Carole Prietto
+Shallow|SSAA, Young SSAA|Carole Prietto
+Shiver My Timbers|SSAA|Carole Prietto
+Sing|SSAA|Carole Prietto
+Sing A Rainbow|SSAA|Carole Prietto
+Snowbird|SSAA|Carole Prietto
+Something to Talk About|SSAA|Carole Prietto
+The Song That Goes Like This|SSAA|Carole Prietto
+Surface Pressure|SSAA|Carole Prietto
+Sway|SSAA|Carole Prietto
+That Man|SSAA|Carole Prietto
+That'll Be The Day|SSAA, Young SSAA|Carole Prietto
+The Twist Medley|SSAA|Carole Prietto
+They Say It's Wonderful|SSAA|Carole Prietto
+A Thousand Years|SSAA|Carole Prietto
+Time Of My Life|SSAA|Carole Prietto
+Too Darn Hot|SSAA|Carole Prietto
+Try Everything|SSAA|Carole Prietto
+The Twist|TTBB, SSAA|Carole Prietto
+Unwritten|SSAA|Carole Prietto
+Up On the House Top|SSAA|Carole Prietto
+Walking In The Air|SSAA|Carole Prietto
+We Just Couldn't Say Goodbye|SSAA|Carole Prietto
+Wexford Carol|SSAA|Carole Prietto
+What Is This Feeling?|SSAA|Carole Prietto
+When I Get My Name In Lights|TTBB|Carole Prietto
+When I Get My Name In Lights|SSAA|Carole Prietto
+When My Baby Smiles At Me|SSAA|Carole Prietto
+When The Organ Played At Twilight|SSAA|Carole Prietto
+When You Say Nothing At All|SSAA|Carole Prietto
+You Can't Stop The Beat|TTBB, SSAA|Carole Prietto
+You Oughta Be In Pictures|SSAA|Carole Prietto
+You Raise Me Up|SSAA|Carole Prietto
+You Will Be Found|SSAA|Carole Prietto
+The Longest Time|SSAA|Karen Procter
+Tuxedo Junction|SSAA|Judy Prothro
+Christmastime is here|SATB|Bryan W. Pulver
+Deck The Halls|SATB|Bryan W. Pulver
+God Rest Ye Merry, Gentlemen|TTBB|Bryan W. Pulver
+Lovely|SATB|Bryan W. Pulver
+Mary Did You Know|TTBB|Bryan W. Pulver
+Star Spangled Banner|SATB|Bryan W. Pulver
+Uninvited|SATB|Bryan W. Pulver
+Uptown Girl|TTBB|Bryan W. Pulver
+What A Wonderful World|SATB|Bryan W. Pulver
+Good Night My Darling|TTBB|Robert Pyper
+Molly Malone|TTBB|Robert Pyper
+Old Toy Trains|TTBB|Shelagh Radcliffe
+The Red Rose Rag|SSAA|Margaret Raeside
+Elvis Medley|SSAA|Kathleen Ramos
+Feliz Navidad|SSAA|Kathleen Ramos
+Hanukkah|SSAA|Kathleen Ramos
+Rudolph The Red Nosed Reindeer|SSAA|Kathleen Ramos
+The Nearness Of You|TTBB|Ron Rank
+Out Of This World|TTBB|Ron Rank
+It's The Same Old Shillelagh|TTBB|Rollie Ransom
+Beauty And The Beast|SSAA|Gayle Rastorfer
+Little Drummer Boy|TTBB|Jim Raycroft
+Give Me A Night In June|TTBB|Maurice Reagan
+Only A Broken String of Pearls|TTBB|Maurice Reagan
+Swing Low, Sweet Chariot|TTBB|Maurice Reagan
+Kokomo|TTBB|Don Reckenbeil
+Mary's Little Boy Child|TTBB|Don Reckenbeil
+On The Sunny Side Of The Street|TTBB|Don Reckenbeil
+Over The Rainbow|TTBB|Don Reckenbeil
+Amazing Grace|TTBB|Mo Rector
+Cruisin' Down The River|TTBB|Mo Rector
+Get Out Those Old Records Medley|TTBB|Mo Rector
+Heart Of A Clown|TTBB|Mo Rector
+I'd Give A Million Tomorrows|TTBB|Mo Rector
+I'll Be Walkin With My Honey|TTBB|Mo Rector
+I'm Afraid To Love You|TTBB|Mo Rector
+In The Shade Of The Old Apple Tree|TTBB|Mo Rector
+Let A Smile Be Your Umbrella|TTBB|Mo Rector
+Lida Rose / Will I Ever Tell You|SATB|Mo Rector
+Ma! (She's Makin' Eyes At Me)|TTBB|Mo Rector
+Mississippi Mud|TTBB|Mo Rector
+Music Music Music|TTBB|Mo Rector
+Old Piano Roll Blues|TTBB|Mo Rector
+Please Mr. Columbus|TTBB|Mo Rector
+Redhead|TTBB|Mo Rector
+Step To The Rear|TTBB|Mo Rector
+Tell Her You Love Her Today|TTBB|Mo Rector
+That's Life|TTBB, SSAA|Mo Rector
+Where Are The Smiles|TTBB|Mo Rector
+Wonderful Day like Today|TTBB|Mo Rector
+Breaking Up Is Hard To Do|SSAA|LaVeda Redfield
+Choo Choo Ch'Boogie|SSAA|LaVeda Redfield
+Hard Hearted Hannah|SSAA|LaVeda Redfield
+Heart of My Heart|SSAA|LaVeda Redfield
+Hometown Band|SSAA|LaVeda Redfield
+I Can't Believe Im Losing You|SSAA|LaVeda Redfield
+If I Were You|SSAA|LaVeda Redfield
+It's Christmas Again|SSAA|LaVeda Redfield
+Jolly Old St. Nicholas|SSAA|LaVeda Redfield
+Lead, Kindly Light|SSAA|LaVeda Redfield
+Love Me With All Your Heart|SSAA|LaVeda Redfield
+Rudolph The Red Nosed Reindeer|SSAA|LaVeda Redfield
+Somewhere Out There|SSAA|LaVeda Redfield
+Song's Gotta Come From The Heart|SSAA|LaVeda Redfield
+Who Put The Bomp|SSAA|LaVeda Redfield
+You'll Never Walk Alone|SSAA|LaVeda Redfield
+Streets Of Laredo|TTBB|William Redmon
+Muskrat Ramble|TTBB|Rex Reeve
+Gang That Sang Heart Of My Heart|TTBB|Don Reeves
+It's Time To Sing Sweet Adeline Again|TTBB|Don Reeves
+Ridin' Down The Canyon|TTBB|Don Reeves
+Send Me Away With A Smile|TTBB|Don Reeves
+They Go Wild, Simply Wild Over Me|TTBB|Don Reeves
+Walkin' My Baby Back Home|TTBB|Don Reeves
+Wedding Bells Are Ringing For Sally|TTBB|Don Reeves
+Just A Cottage Small|TTBB|Al Rehkop
+Are You The One|SSAA|Adam Reimnitz
+Are You The One|TTBB|Adam Reimnitz
+Away In A Manger|TTBB|Adam Reimnitz
+Be Careful, It's My Heart|SSAA|Adam Reimnitz
+Believe|TTBB|Adam Reimnitz
+Beyond the Sea|TTBB|Adam Reimnitz
+Blame It On My Youth|TTBB|Adam Reimnitz
+Bury Me Not On The Lone Prairie|TTBB|Adam Reimnitz
+Come Rain Or Come Shine|TTBB|Adam Reimnitz
+Everything's Comin' Up Roses|TTBB|Adam Reimnitz
+Five Minutes More|SSAA|Adam Reimnitz
+For Once In My Life|TTBB|Adam Reimnitz
+How Little We Know|TTBB|Adam Reimnitz
+I Get Along Without You Very Well|TTBB|Adam Reimnitz
+I Like The Likes of You|SSAA|Adam Reimnitz
+I Won't Send Roses|TTBB|Adam Reimnitz
+I'll Never Stop Loving You|SSAA|Adam Reimnitz
+I've Got My Love To Keep Me Warm|TTBB|Adam Reimnitz
+I've Got The World On A String|TTBB|Adam Reimnitz
+If I Were A Bell|SSAA|Adam Reimnitz
+It Snowed|SSAA|Adam Reimnitz
+Little White Lies|SSAA|Adam Reimnitz
+Mam'selle|TTBB|Adam Reimnitz
+The Nearness Of You|SSAA|Adam Reimnitz
+Now Is The Hour|TTBB|Adam Reimnitz
+Rockin' Around The Christmas Tree|SSAA|Adam Reimnitz
+Suddenly There's A Valley|TTBB|Adam Reimnitz
+Sugar (That Sugar Baby O'Mine)|TTBB|Adam Reimnitz
+Sunday Kind Of Love|TTBB|Adam Reimnitz
+Sweet Heaven Medley|TTBB|Adam Reimnitz
+This Could be the Start of Something Big|TTBB|Adam Reimnitz
+This Could be the Start of Something Big|SSAA|Adam Reimnitz
+Til The Season Comes Round Again|TTBB|Adam Reimnitz
+The Trolley Song|TTBB|Adam Reimnitz
+The Very Thought Of You|TTBB|Adam Reimnitz
+What A Difference A Day Made|TTBB|Adam Reimnitz
+When You Were Sweet Sixteen|TTBB|Adam Reimnitz
+Where Is Love?|TTBB|Adam Reimnitz
+You'll Never Walk Alone|TTBB, SSAA|Adam Reimnitz
+You're Never Fully Dressed Without A Smile|TTBB, SSAA|Adam Reimnitz
+Almost Like Being In Love|SATB|Ruby Rhea
+Do you really love me|TTBB|Ruby Rhea
+How Can You Mend a Broken Heart|TTBB|Ruby Rhea
+I Love Being Here With You|SSAA|Ruby Rhea
+I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ruby Rhea
+Route 66|TTBB|Ruby Rhea
+A Tree in the Meadow|SSAA|Ruby Rhea
+What Are You Doing New Year's Eve?|SSAA|Ruby Rhea
+The Sweetheart Of Sigma Chi|TTBB|Dave Richards
+The Christmas Song|SSAA|Judith Riley
+Eres Tu/Touch The Wind|SSAA|Judith Riley
+The Popcorn Song|SSAA|Judith Riley
+Gospel Ship|TTBB|Roy Ringwald
+Those Magnificent Men In Their Flying Machines|TTBB|Tom Roberts
+Happy Days Are Here Again|TTBB|Robert Robson
+Country Rock Medley|TTBB|Dick Rode
+Hooray For Captain Spaulding|TTBB|Dick Rode
+I'll Be Seeing You|TTBB|Dick Rode
+Money, Money|TTBB|Dick Rode
+On The Atchison, Topeka And The Santa Fe|TTBB|Dick Rode
+Penthouse Serenade|TTBB|Dick Rode
+Thanks For The Memory|TTBB|Dick Rode
+White Cliffs Of Dover|TTBB|Dick Rode
+You're Sixteen|TTBB|Dick Rode
+New Ashmolean Band|TTBB|Jerry Roland
+Sentimental Journey|TTBB|Jerry Roland
+All Over The World|SATB|Alexander Ronneburg
+Dancing In The Street|SATB|Alexander Ronneburg
+Give Me A Band and My Baby|TTBB|Alexander Ronneburg
+In The Mood|SATB|Alexander Ronneburg
+Mood Indigo|TTBB|Alexander Ronneburg
+Rainbow Connection|TTBB|Alexander Ronneburg
+Time Heals Everything|SATB|Alexander Ronneburg
+Am I Wasting My Time On You|TTBB|Kirk Roose
+Angels|TTBB|Kirk Roose
+Bad Buncha Boys Singin' Barbershop|TTBB|Kirk Roose
+Ballin' The Jack|TTBB|Kirk Roose
+Blues Serenade|TTBB|Kirk Roose
+Daddy's Little Girl|TTBB|Kirk Roose
+Dark Eyes|TTBB|Kirk Roose
+Dear Little Boy Of Mine|TTBB|Kirk Roose
+Down By The Old Mill Stream|TTBB|Kirk Roose
+House I Live In|TTBB|Kirk Roose
+I Love You Just The Same Sweet Adeline|TTBB|Kirk Roose
+I'll Have Vanilla|TTBB|Kirk Roose
+I'm All That's Left Of That Old Quartet|TTBB|Kirk Roose
+I'm Sorry I Made You Cry|TTBB|Kirk Roose
+If You Can't Get A Girl In The Summertime|TTBB|Kirk Roose
+Jimmy Valentine|TTBB|Kirk Roose
+Let The Rest Of The World Go By|TTBB|Kirk Roose
+Let There Be Peace On Earth|TTBB|Kirk Roose
+Lida Rose Opener|TTBB|Kirk Roose
+Little On The Lonely Side|TTBB|Kirk Roose
+Love Me Tender / Aura Lee Medley|TTBB|Kirk Roose
+My Hometown Is A One Horse Town|TTBB|Kirk Roose
+My Melancholy Baby|TTBB|Kirk Roose
+Oh, You Beautiful Doll|TTBB|Kirk Roose
+Rubber Duckie|TTBB|Kirk Roose
+Smiles|TTBB|Kirk Roose
+The Sweetheart Of Sigma Chi|TTBB|Kirk Roose
+Teasin' Medley|TTBB|Kirk Roose
+That Old Feeling|TTBB|Kirk Roose
+That Railroad Rag|TTBB|Kirk Roose
+Three Wonderful Letters from Home|TTBB|Kirk Roose
+Tuck Me To Sleep In My Old 'Tucky Home|TTBB|Kirk Roose
+Undersea Medley|TTBB|Kirk Roose
+We'll Meet Again|TTBB|Kirk Roose
+What A Wonderful Pal You Are|TTBB|Kirk Roose
+What Do You Want To Make Those Eyes At Me For|TTBB|Kirk Roose
+When Banana Skins Are Falling|TTBB|Kirk Roose
+Where The Black Eyed Susans Grow|TTBB|Kirk Roose
+You're In Style When You're Wearing A Smile|TTBB|Kirk Roose
+Dumb Ways To Die|SSAA|Kristina Roper
+The House Is Haunted|SSAA|Kristina Roper
+Pepeha|SSAA|Kristina Roper
+Please Don't Go|SATB|Kristina Roper
+Welcome Home|SSAA|Kristina Roper
+Summertime in the Park|TTBB|Charles Rose
+Wedding Bells Are Breaking Up That Old Gang Of Mine|TTBB|Charles Rose
+When Banana Skins Are Falling|TTBB|Charles Rose
+(Ghost) Riders In The Sky|TTBB|Anastasio Rossi
+Boogie Woogie Bugle Boy|TTBB|Anastasio Rossi
+Christmas Chopsticks|SSAA|Anastasio Rossi
+The Christmas Song|TTBB|Anastasio Rossi
+Christmas Waltz|TTBB, SSAA|Anastasio Rossi
+A Dance In TripleTime|SSAA|Anastasio Rossi
+Do - Re - Mi|TTBB|Anastasio Rossi
+Edelweiss|SATB|Anastasio Rossi
+I've Got My Love To Keep Me Warm|TTBB, SSAA|Anastasio Rossi
+L-O-V-E|SSAA|Anastasio Rossi
+Love Walked In|TTBB, SSAA|Anastasio Rossi
+Ma! (He's Making Eyes At Me)|SSAA|Anastasio Rossi
+Mele Kalikimaka|SSAA|Anastasio Rossi
+My Little Grass Shack In Kealakekua, Hawaii|SSAA|Anastasio Rossi
+Poinciana (Song of the Tree)|SSAA|Anastasio Rossi
+Swing Down Chariot|SSAA|Anastasio Rossi
+You Belong To My Heart|TTBB|Anastasio Rossi
+Over There|TTBB|Loren Roth
+Sweet Genevieve|TTBB|J. Cecil Rowe
+Cuddle Up A Little Closer|SSAA|Molly Rowland
+Hold Me Tight (And Say How Much You Love Me)|SSAA|Molly Rowland
+Jealous of the Angels|SSAA|Molly Rowland
+Spanish Eyes|SSAA|Molly Rowland
+Sugartime|SSAA|Molly Rowland
+Take Me To The Land Of Jazz|SSAA|Molly Rowland
+The Way We Were|SSAA|Molly Rowland
+You'll Never Walk Alone|SSAA|Molly Rowland
+Perhaps Love|SSAA|Charlotte Rubio
+What Kind Of King|SSAA|Charlotte Rubio
+Bundle Of Old Love Letters|TTBB|J. I. Ruehle
+By The Sea / In The Good Old Summertime Medley|TTBB|J. I. Ruehle
+I Wonder What's Become Of Sally|TTBB|J. I. Ruehle
+I'm Drifting Back To Dreamland|TTBB|J. I. Ruehle
+Little Mother|TTBB|J. I. Ruehle
+(He's A) Rag Picker|TTBB|Robert Rund
+All The Way|TTBB|Robert Rund
+Amazing|SATB|Robert Rund
+Astonishing|TTBB|Robert Rund
+Be Not Afraid|SATB|Robert Rund
+Blossom|TTBB|Robert Rund
+A Blossom Fell|TTBB|Robert Rund
+Blue, Turning Grey Over You|TTBB|Robert Rund
+Blues (My Naughty Sweetie Gives To Me)|TTBB|Robert Rund
+Both Sides Now|TTBB|Robert Rund
+Boyhood Medley|TTBB|Robert Rund
+Break It To Me Gently|TTBB|Robert Rund
+Bring Me Sunshine|TTBB|Robert Rund
+Carefully Taught Medley|TTBB|Robert Rund
+Carolina Blues|TTBB|Robert Rund
+Casey's Odyssey|TTBB|Robert Rund
+The Christmas Song|TTBB|Robert Rund
+Darn That Dream|TTBB|Robert Rund
+Day By Day|TTBB|Robert Rund
+Deep Purple|TTBB, SSAA, SATB|Robert Rund
+Don't Let Go|TTBB|Robert Rund
+Don't Wait Too Long|TTBB, SSAA|Robert Rund
+Everybody's Walkin' Down in New Orleans|TTBB|Robert Rund
+Fairly Odd Parents, The (Theme Song)|SSAA|Robert Rund
+Friend Like Me|TTBB|Robert Rund
+I Hope You Dance|TTBB|Robert Rund
+I Loved Her First|TTBB|Robert Rund
+I Never Thought It Would End This Way|TTBB|Robert Rund
+I Told You So|TTBB|Robert Rund
+I Won't Let Go|SSAA|Robert Rund
+I'm Gonna Live Till I Die|TTBB|Robert Rund
+I'm Putting All My Eggs In One Basket|TTBB|Robert Rund
+If I Loved You|TTBB|Robert Rund
+If I Only Knew Where She's Gone|TTBB|Robert Rund
+If I Ruled The World|SSAA|Robert Rund
+It's Time To Fall In Love|TTBB|Robert Rund
+It's You|TTBB, SSAA|Robert Rund
+Just A-Sittin' and A-Rockin'|TTBB|Robert Rund
+Just Once|TTBB|Robert Rund
+Landslide|TTBB|Robert Rund
+Laura|TTBB|Robert Rund
+Lights|SSAA|Robert Rund
+Little Man You've Had A Busy Day|TTBB|Robert Rund
+Lost (A Wonderful Girl)|TTBB|Robert Rund
+Love Me|TTBB|Robert Rund
+Love Medley|TTBB|Robert Rund
+Love Will Be Our Home|SSAA|Robert Rund
+Lovesick Blues|TTBB|Robert Rund
+Maybe I'm Amazed|TTBB, SSAA|Robert Rund
+Medley: Do You Know What It Means To Miss New Orleans with Basin Street Blues|TTBB|Robert Rund
+Medley: More with L-O-V-E|TTBB|Robert Rund
+Medley: Seasons Of Love with Turn! Turn! Turn!|SATB|Robert Rund
+Medley: Southern State Of Mind with Southern Nights|TTBB|Robert Rund
+Medley: Wells Fargo Wagon, Please Mr. Postman, Signed Sealed Delivered|SSAA|Robert Rund
+Moment of Silence|TTBB|Robert Rund
+My Future|TTBB|Robert Rund
+New York Medley|TTBB|Robert Rund
+Ol' MacDonald|TTBB|Robert Rund
+Old Folks|TTBB|Robert Rund
+Orange Colored Sky|TTBB|Robert Rund
+P.S. I Love You|TTBB|Robert Rund
+Pandemicats|TTBB|Robert Rund
+Penthouse Serenade|TTBB|Robert Rund
+Reaching For The Moon|TTBB|Robert Rund
+Rockin' Chair|TTBB|Robert Rund
+Run, Freedom Run!|TTBB|Robert Rund
+Seasons of Love|TTBB|Robert Rund
+Since I Fell For You|TTBB|Robert Rund
+So Rare|TTBB|Robert Rund
+So Wrong|TTBB|Robert Rund
+Southern Medley|TTBB|Robert Rund
+Storybook|SATB|Robert Rund
+Suddenly I See|SSAA|Robert Rund
+Supercalifragilisticexpialidocious|TTBB|Robert Rund
+Sweet Roses Of Morn|TTBB, SSAA, SATB|Robert Rund
+Till There Was You|TTBB|Robert Rund
+Tomorrow Is Promised To No One|TTBB|Robert Rund
+Tomorrow Is Promised To No One|SSAA|Robert Rund
+Triangle Love Song|TTBB|Robert Rund
+We'll be together again|TTBB, SSAA, SATB|Robert Rund
+We'll Meet Again|TTBB, SSAA, SATB|Robert Rund
+What More Can A Soldier Give|TTBB|Robert Rund
+What More Can a Woman Give?|SSAA|Robert Rund
+When Did You Leave Heaven?|TTBB, SSAA|Robert Rund
+When is Sometime|TTBB, SSAA, SATB|Robert Rund
+When Mother Played The Organ|TTBB|Robert Rund
+Who Can I Turn To? (When Nobody Needs Me)|TTBB|Robert Rund
+Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|SSAA|Robert Rund
+A Wink And A Smile|TTBB|Robert Rund
+Wonderful Christmastime|SATB|Robert Rund
+Woot Woot Song|SATB|Robert Rund
+You're an Education (in Yourself)|TTBB|Robert Rund
+Angels We Have Heard On High|TTBB, SSAA|Mark Rusch
+Behold, A Host, Arrayed in White|TTBB, SSAA|Mark Rusch
+Deck The Halls|TTBB, SSAA|Mark Rusch
+Follow Me|SSAA|Mark Rusch
+For The Sake Of Auld Lang Syne|SSAA|Mark Rusch
+For The Sake Of Auld Lang Syne|TTBB|Mark Rusch
+How Can I Keep From Singing|TTBB, SSAA|Mark Rusch
+I Love To Have The Boys Around Me|SSAA|Mark Rusch
+If I Had My Way|TTBB, SSAA|Mark Rusch
+O Come O Come Emmanuel|TTBB, SSAA|Mark Rusch
+O Come, All Ye Faithful|TTBB, SSAA|Mark Rusch
+O Holy Night|TTBB, SSAA|Mark Rusch
+Play A Simple Melody|TTBB|Mark Rusch
+Runnin' Wild|TTBB, SSAA|Mark Rusch
+The Great War Era Medley|TTBB|Mark Rusch
+The Great War Era Medley|SSAA|Mark Rusch
+They Go Wild, Simply Wild Over Me|SSAA|Mark Rusch
+They Go Wild, Simply Wild Over Me|TTBB|Mark Rusch
+Hymn Of Promise|TTBB|Douglas Russell
+A Life With You|TTBB|Eric Ruthenberg
+As Long as I got You|TTBB, SSAA, SATB|Eric Ruthenberg
+Because of You|TTBB|Eric Ruthenberg
+Blue Christmas|TTBB|Eric Ruthenberg
+Bring Me Sunshine|TTBB|Eric Ruthenberg
+Cheeseburger In Paradise|TTBB|Eric Ruthenberg
+Come Home Medley|TTBB|Eric Ruthenberg
+The Day After Thanksgiving|TTBB|Eric Ruthenberg
+Earth Angel|TTBB|Eric Ruthenberg
+Falling In Love With You|TTBB|Eric Ruthenberg
+Hang On Little Tomato|TTBB|Eric Ruthenberg
+Hang On Little Tomato|SSAA|Eric Ruthenberg
+I Just Decided To Stay|TTBB|Eric Ruthenberg
+I Love Being Here With You|TTBB|Eric Ruthenberg
+I Think About You Lots|TTBB, SSAA|Eric Ruthenberg
+I've Heard That Song Before|TTBB|Eric Ruthenberg
+In My Daughter's Eyes|TTBB|Eric Ruthenberg
+Let The River Run|SSAA|Eric Ruthenberg
+Lucille|TTBB|Eric Ruthenberg
+Make You Feel My Love|TTBB|Eric Ruthenberg
+My Old Man|TTBB|Eric Ruthenberg
+My Way|TTBB|Eric Ruthenberg
+Peace, Love and Understanding|TTBB|Eric Ruthenberg
+Rawhide|TTBB|Eric Ruthenberg
+Rhode Island Is Famous For You|TTBB|Eric Ruthenberg
+Save The Bones For Henry Jones|TTBB|Eric Ruthenberg
+Someone's Waiting For You|TTBB, SSAA|Eric Ruthenberg
+Still The One|SATB|Eric Ruthenberg
+The Airplane Song|TTBB|Eric Ruthenberg
+This Can't Be Love|TTBB|Eric Ruthenberg
+This Is A Very Special Day|TTBB|Eric Ruthenberg
+The Way|TTBB|Eric Ruthenberg
+What A Difference A Day Made|TTBB|Eric Ruthenberg
+When Did You Leave Heaven?|TTBB|Eric Ruthenberg
+Where Everybody Knows Your Name|TTBB|Eric Ruthenberg
+You've Got To Be Carefully Taught|TTBB|Eric Ruthenberg
+When A Peach In Georgia Weds A Rose From Alabam|TTBB|Jason Ryner
+Roses Of Yesterday|TTBB|Elling Sagen
+Tiny Toons Around The World|TTBB|Elling Sagen
+Fields of Athenry|TTBB|Reed Sampson
+Rudolph The Red Nosed Reindeer|TTBB|Cecil Sams
+If He Can Fight Like He Can Love, Good Night Germany|TTBB|C. J. Sams Jr.
+Love Is A Many Splendored Thing|TTBB|C. J. Sams Jr.
+Moon Medley|TTBB|C. J. Sams Jr.
+New York Medley|TTBB|C. J. Sams Jr.
+Alice Blue Gown|TTBB|Joe Samuel
+Down On 33rd And 3rd|TTBB|Joe Samuel
+For Sentimental Reasons|TTBB|Joe Samuel
+It's A Long Way To Tipperary|TTBB|Joe Samuel
+San Francisco|SSAA|Joe Samuel
+Butterfly|SSAA|Linda Samuelsson
+Deck The Halls|SSAA|Linda Samuelsson
+I'm In The Mood For Love|SSAA|Linda Samuelsson
+We Need A Little Christmas|SSAA|Linda Samuelsson
+Mam'selle|TTBB|Tom Sando
+I've Heard That Song Before|SSAA|Mary Santomeno
+A Marshmallow World|SSAA|Mary Santomeno
+She Was Five And He Was Ten|SSAA|Mary Santomeno
+Comin' In On A Wing And A Prayer|TTBB|Merle Savage
+Just A Baby's Prayer At Twilight|TTBB|Merle Savage
+If We Hold On Together|TTBB|Darwin Scheel
+Love Without End, Amen|TTBB|Darwin Scheel
+Song I Love|SSAA|Darwin Scheel
+Stompin' At The Savoy|SSAA|Darwin Scheel
+American Anthem|TTBB|Jack Schievelbein
+In The Cool Cool Cool Of The Evening|TTBB|Jack Schievelbein
+School Days|TTBB|Jack Schievelbein
+Ain't Misbehavin'|SSAA|Carolyn Schmidt
+All Dressed Up With A Broken Heart|SSAA|Carolyn Schmidt
+All For The Love Of Mike|SSAA|Carolyn Schmidt
+All My Loving|SSAA|Carolyn Schmidt
+All You Need Is Love|SSAA|Carolyn Schmidt
+Always|SSAA|Carolyn Schmidt
+Amapola (Pretty Little Poppy)|SATB|Carolyn Schmidt
+Amen! Christmas, Amen!|SSAA|Carolyn Schmidt
+And So It Goes|SSAA|Carolyn Schmidt
+Anytime / In My Honey's Lovin' Arms|SSAA|Carolyn Schmidt
+April In Paris|SSAA|Carolyn Schmidt
+Aquarius|TTBB, SSAA|Carolyn Schmidt
+Arthur Murray Taught Me Dancing In A Hurry|SSAA|Carolyn Schmidt
+As Long as He Needs Me|SSAA|Carolyn Schmidt
+As Time Goes By|SSAA|Carolyn Schmidt
+At The Beginning|SSAA|Carolyn Schmidt
+Atlantic City|SSAA|Carolyn Schmidt
+Atlantic City Medley|SSAA|Carolyn Schmidt
+Auld Lang Syne|SSAA|Carolyn Schmidt
+Baby Medley 1|SSAA|Carolyn Schmidt
+Beauty And The Beast|SSAA, Young SSAA|Carolyn Schmidt
+Before The Parade Passes By|SSAA|Carolyn Schmidt
+Birth Of The Blues|SSAA|Carolyn Schmidt
+Blame It On The Bossa Nova|SSAA|Carolyn Schmidt
+Blue Moon|SSAA|Carolyn Schmidt
+Bundle Of Old Love Letters|SSAA|Carolyn Schmidt
+Bye Bye Baby/Baby Won't You Please Come Home Medley|SSAA|Carolyn Schmidt
+Bye Bye Blackbird|SSAA|Carolyn Schmidt
+Caribbean Amphibian|SSAA|Carolyn Schmidt
+A Carol Medley|SSAA|Carolyn Schmidt
+Chances Are|SSAA|Carolyn Schmidt
+Changes/I Used To Love You|SSAA|Carolyn Schmidt
+Come Fly With Me|SSAA|Carolyn Schmidt
+Come To The Mardi Gras|SSAA|Carolyn Schmidt
+Crazy|SSAA|Carolyn Schmidt
+Dance With Me|SSAA|Carolyn Schmidt
+Diamonds Are Medley|SSAA|Carolyn Schmidt
+Do You Hear What I Hear|SSAA|Carolyn Schmidt
+Don Juan|SSAA|Carolyn Schmidt
+Don't It Make My Brown Eyes Blue|SSAA|Carolyn Schmidt
+Dream|SSAA|Carolyn Schmidt
+Everything's Comin' Up Roses|SSAA|Carolyn Schmidt
+Far Away Places Medley|SSAA|Carolyn Schmidt
+Food Blooz|SSAA|Carolyn Schmidt
+For Good|SSAA|Carolyn Schmidt
+Friend Like Me|SSAA|Carolyn Schmidt
+Frosty The Snowman|SSAA|Carolyn Schmidt
+Funniest Clown In The Big Top|SSAA|Carolyn Schmidt
+Get Me To The Church On Time|SSAA|Carolyn Schmidt
+Girls Just Wanna Have Fun|SSAA|Carolyn Schmidt
+Happy Together|SATB|Carolyn Schmidt
+Heat Wave|SSAA|Carolyn Schmidt
+Hello Dolly|SSAA|Carolyn Schmidt
+Hero|SSAA|Carolyn Schmidt
+Home For The Holidays|SSAA|Carolyn Schmidt
+House At Pooh Corner|SSAA|Carolyn Schmidt
+I Can't Begin To Tell You|SSAA|Carolyn Schmidt
+I Don't Want To Live On The Moon|SSAA|Carolyn Schmidt
+I Feel Pretty|SSAA|Carolyn Schmidt
+I Found A Million Dollar Baby|SSAA|Carolyn Schmidt
+I Remember It Well|SSAA|Carolyn Schmidt
+I Wanna Dance With Somebody|SSAA|Carolyn Schmidt
+I'm Flyin High Medley|SSAA|Carolyn Schmidt
+I'm Sending A Letter To Santa Claus|SSAA|Carolyn Schmidt
+If I Fell|SSAA|Carolyn Schmidt
+If I Had The Last Dream Left In The World|SSAA|Carolyn Schmidt
+In Heavens Eyes|SSAA|Carolyn Schmidt
+In My Life|SSAA|Carolyn Schmidt
+It Had To Be You|SSAA|Carolyn Schmidt
+It's A Good Day|SSAA|Carolyn Schmidt
+It's My Party|SSAA|Carolyn Schmidt
+It's Your Song|SSAA|Carolyn Schmidt
+Java Jive|SSAA|Carolyn Schmidt
+Jazz Me Blues|TTBB|Carolyn Schmidt
+Jersey Bounce|TTBB|Carolyn Schmidt
+Killing Me Softly|SSAA|Carolyn Schmidt
+Kokomo|SSAA|Carolyn Schmidt
+Let The Sunshine In|TTBB, SSAA|Carolyn Schmidt
+Let There Be Peace On Earth|SSAA|Carolyn Schmidt
+Let's Call The Whole Thing Off|SSAA|Carolyn Schmidt
+Let's Elope|SSAA|Carolyn Schmidt
+Let's Go to the Movies|SSAA|Carolyn Schmidt
+Light One Candle|SSAA|Carolyn Schmidt
+The Light That Shines Forever|SSAA|Carolyn Schmidt
+The Longest Time|SSAA|Carolyn Schmidt
+Love Me With All Your Heart|SSAA|Carolyn Schmidt
+Luck Be A Lady|SSAA|Carolyn Schmidt
+Magical Mystery Tour|SSAA|Carolyn Schmidt
+Married / Shuffle off to Buffalo Medley|SSAA|Carolyn Schmidt
+Memory|SSAA|Carolyn Schmidt
+Minnie The Mermaid|SSAA|Carolyn Schmidt
+The More I See You|SSAA|Carolyn Schmidt
+Murder, He Says|SSAA|Carolyn Schmidt
+Nice Work If You Can Get It|SSAA|Carolyn Schmidt
+Nobody Does It Better|SSAA|Carolyn Schmidt
+Ob-La-Di, Ob-La-Da|SSAA|Carolyn Schmidt
+Octopus's Garden|SSAA|Carolyn Schmidt
+Oh, Susanna Dust Off That Old Pianna|SSAA|Carolyn Schmidt
+The Old Horse And Buggy Had A Certain Swing|SSAA|Carolyn Schmidt
+The Old Maids Ball|SSAA|Carolyn Schmidt
+On The Road Again|SSAA|Carolyn Schmidt
+On The Way to Cape May|SSAA|Carolyn Schmidt
+One More Time|SSAA|Carolyn Schmidt
+Orange Colored Sky|SSAA|Carolyn Schmidt
+Part Of Your World|SSAA|Carolyn Schmidt
+Pigalle|SSAA|Carolyn Schmidt
+Please Please Me|TTBB|Carolyn Schmidt
+Rockin' Around The Christmas Tree|SSAA|Carolyn Schmidt
+Rudolph The Red Nosed Reindeer|SSAA|Carolyn Schmidt
+Salute to America|SSAA|Carolyn Schmidt
+Seasons of Love|SSAA, SATB|Carolyn Schmidt
+The Secret Of Christmas|SSAA|Carolyn Schmidt
+Shall We Dance|SSAA|Carolyn Schmidt
+Silver Bells|SSAA|Carolyn Schmidt
+Slipping Through My Fingers|SSAA|Carolyn Schmidt
+Smile|SSAA|Carolyn Schmidt
+Someone To Watch Over Me|SSAA|Carolyn Schmidt
+Something|SSAA|Carolyn Schmidt
+Somewhere|SSAA|Carolyn Schmidt
+South American Way|SSAA|Carolyn Schmidt
+Surfin' U.S.A.|SSAA|Carolyn Schmidt
+Sweet Georgia Brown|SSAA|Carolyn Schmidt
+They're Either Too Young Or Too Old|SSAA|Carolyn Schmidt
+This Is A Great Country|SSAA|Carolyn Schmidt
+Undecided|SSAA|Carolyn Schmidt
+Under Paris Skies|SSAA|Carolyn Schmidt
+Way Down Yonder In New Orleans|SSAA|Carolyn Schmidt
+We Can Work It Out|SSAA|Carolyn Schmidt
+We Go Together|SSAA, Young SSAA|Carolyn Schmidt
+We Wish You A Merry Christmas|SSAA|Carolyn Schmidt
+Weekend In New England|SSAA|Carolyn Schmidt
+What Are You Doing New Year's Eve?|SSAA|Carolyn Schmidt
+What I Did For Love|SSAA|Carolyn Schmidt
+When I Fall In Love|SSAA|Carolyn Schmidt
+When I Lost You|SSAA|Carolyn Schmidt
+When I'm Sixty Four|SSAA, Young SSAA|Carolyn Schmidt
+When You Wish Upon A Star|SSAA|Carolyn Schmidt
+White Christmas|SSAA|Carolyn Schmidt
+Why Should I Cry Over You?|SSAA|Carolyn Schmidt
+Willkommen|SSAA|Carolyn Schmidt
+With A Song In My Heart|SSAA|Carolyn Schmidt
+You Are The Sunshine Of My Life|SSAA|Carolyn Schmidt
+You Belong To Me|SSAA|Carolyn Schmidt
+You'll Never Walk Alone|SSAA|Carolyn Schmidt
+Your Feets Too Big|SSAA|Carolyn Schmidt
+Bluebird|SSAA|Ed Schubel
+How Did We Come To This?|SSAA|Ed Schubel
+Love, You Didn't Do Right By Me|SSAA|Ed Schubel
+You're Gonna Live Forever In Me|TTBB|Ed Schubel
+Abide With Me|TTBB|Adam Scott
+Always On My Mind|SSAA|Adam Scott
+And So It Goes|TTBB|Adam Scott
+Baby What You Gonna Be?|TTBB|Adam Scott
+Beautiful Crazy|TTBB|Adam Scott
+Before The Parade Passes By|TTBB|Adam Scott
+Better When I'm Dancin'|SSAA, SATB|Adam Scott
+Bohemian Rhapsody|TTBB|Adam Scott
+Break It To Me Gently|TTBB|Adam Scott
+Brown Eyed Girl|TTBB|Adam Scott
+Call Me Irresponsible|TTBB|Adam Scott
+Can't Take My Eyes Off Of You|TTBB|Adam Scott
+Candy Cane Lane|TTBB, SSAA|Adam Scott
+Cho Superstar|TTBB|Adam Scott
+Cinderella|TTBB|Adam Scott
+Counting Down To Christmas|TTBB|Adam Scott
+Cry|TTBB|Adam Scott
+Day In, Day Out|SSAA|Adam Scott
+Deck The Halls|TTBB|Adam Scott
+Do You Know The Muffin Man?|TTBB|Adam Scott
+Don't Stop Me Now|TTBB, SSAA|Adam Scott
+Every Little Thing She Does Is Magic|TTBB|Adam Scott
+Everything|TTBB|Adam Scott
+The Farmer And The Cowman|TTBB|Adam Scott
+Fly Me To The Moon|TTBB|Adam Scott
+For Sentimental Reasons|TTBB, SSAA, SATB|Adam Scott
+Forget About The Boy|TTBB|Adam Scott
+From Now On|TTBB|Adam Scott
+Give Me That Smile|TTBB|Adam Scott
+Hallelujah|TTBB, SSAA, SATB|Adam Scott
+Happy|TTBB, SSAA, SATB|Adam Scott
+Have Yourself A Merry Little Christmas|TTBB|Adam Scott
+Holiday Season/Happy Holiday Medley|SATB|Adam Scott
+Holiday Season/Happy Holiday Medley|TTBB, SSAA|Adam Scott
+I Can't Let You Throw Yourself Away|TTBB|Adam Scott
+I Don't Know How To Say Goodbye|TTBB|Adam Scott
+I Just Called To Say I Love You|TTBB|Adam Scott
+I Turned the Corner|TTBB|Adam Scott
+I Yi, Yi, Yi, Yi Like You Very Much|TTBB, SSAA|Adam Scott
+I'll Make A Man Out Of You|TTBB|Adam Scott
+I'm All Alone|TTBB|Adam Scott
+I'm Already There|TTBB|Adam Scott
+I'm Gonna Rise (When The Son Comes Down)|TTBB, SSAA|Adam Scott
+If I Didn't Have You|TTBB|Adam Scott
+If I Had My Way|SSAA|Adam Scott
+In a Very Unusual Way|TTBB|Adam Scott
+In Flander's Fields|TTBB|Adam Scott
+In The Wee Small Hours Of The Morning|TTBB|Adam Scott
+Into the Unknown|TTBB|Adam Scott
+Isn't She Lovely|SATB|Adam Scott
+It Is Well With My Soul|TTBB|Adam Scott
+It's All Right|TTBB|Adam Scott
+It's No Secret Anymore|TTBB|Adam Scott
+It's The Most Wonderful Time Of The Year|TTBB, SSAA|Adam Scott
+Joanna|TTBB|Adam Scott
+Joy To The World/Deck The Halls (Medley)|TTBB|Adam Scott
+Killer Queen|TTBB|Adam Scott
+La Marseillaise|TTBB|Adam Scott
+Let's Misbehave|TTBB, SSAA|Adam Scott
+Little Drummer Boy|TTBB|Adam Scott
+Little Red Riding Hood|TTBB|Adam Scott
+Lonely At The Top|TTBB|Adam Scott
+Looks Like You've Started Something|SSAA|Adam Scott
+Looks Like You've Started Something|TTBB|Adam Scott
+Love Is In The Air|TTBB|Adam Scott
+Love Potion No. 9|TTBB|Adam Scott
+A Marshmallow World|TTBB|Adam Scott
+More|TTBB|Adam Scott
+Mother Knows Best|SSAA|Adam Scott
+Moving Too Fast|TTBB|Adam Scott
+My Funny Valentine|TTBB|Adam Scott
+My Romance|TTBB|Adam Scott
+Naughty Lady Of Shady Lane|TTBB|Adam Scott
+Not A Day Goes By|TTBB|Adam Scott
+Nothing Is Too Wonderful To Be True|TTBB|Adam Scott
+On Bended Knee|TTBB|Adam Scott
+Open A New Window|TTBB|Adam Scott
+The Parting Glass|TTBB|Adam Scott
+Peace Like A River|TTBB|Adam Scott
+Play|TTBB|Adam Scott
+Please Don't Talk About Me When I'm Gone|TTBB|Adam Scott
+Poor Unfortunate Souls|SSAA|Adam Scott
+Richest Man In The World|TTBB|Adam Scott
+Riding With Private Malone|TTBB|Adam Scott
+Six Feet|TTBB|Adam Scott
+Siyahamba|TTBB|Adam Scott
+Still The One/Only One (Medley)|TTBB|Adam Scott
+Stop This Train|TTBB|Adam Scott
+Tennessee Whiskey|TTBB|Adam Scott
+Text Me Merry Christmas|TTBB, SSAA, SATB|Adam Scott
+They Didn't Believe Me|TTBB, SSAA|Adam Scott
+Too Late Now (from ROYAL WEDDING)|TTBB|Adam Scott
+Turn The Lights Back On|TTBB, SSAA, SATB|Adam Scott
+Until The Real Thing Comes Along|TTBB|Adam Scott
+We Are In Love|TTBB|Adam Scott
+Wellerman|TTBB|Adam Scott
+When Christmas Comes Around|TTBB, SSAA, SATB|Adam Scott
+When Christmas Comes To Town|TTBB, SSAA, SATB|Adam Scott
+When I See An Elephant Fly|SSAA|Adam Scott
+When You Say You Love Me|TTBB|Adam Scott
+Who Can I Turn To? (When Nobody Needs Me)|TTBB|Adam Scott
+You Can't Hurry Love|SATB|Adam Scott
+You Don't Bring Me Flowers|TTBB|Adam Scott
+You'll Never Walk Alone|TTBB|Adam Scott
+You're My Best Friend|TTBB, SATB|Adam Scott
+You're The Inspiration|TTBB|Adam Scott
+Little Old Mill|TTBB|W. Scrivnor
+I'm Forever Blowing Bubbles|TTBB|Joe Seegmiller
+Suppertime|TTBB|John Seirup
+After You've Gone|SSAA|Bev Sellers
+Ain't-A That Good News|SSAA|Bev Sellers
+Big Spender|SSAA|Bev Sellers
+Blue Bayou|SSAA|Bev Sellers
+Breaking Up Is Hard To Do|SSAA|Bev Sellers
+Broadway Baby|SSAA|Bev Sellers
+The Christmas Song|SSAA|Bev Sellers
+Dr. Jazz/Jazz Holiday Medley|SSAA|Bev Sellers
+Easy Street|SSAA|Bev Sellers
+The Gambler|SSAA|Bev Sellers
+Hernando's Hideaway|SSAA|Bev Sellers
+I Will Never Pass This Way Again|SSAA|Bev Sellers
+I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Bev Sellers
+I'm Looking Over A Four Leaf Clover|SSAA|Bev Sellers
+Jambalaya|SSAA|Bev Sellers
+Kokomo|SSAA, Young SSAA|Bev Sellers
+Love Me Tender|SSAA|Bev Sellers
+My Old Flame|SSAA|Bev Sellers
+Nobody's Sweetheart|SSAA|Bev Sellers
+Operator|SSAA|Bev Sellers
+Puttin' On The Ritz|SSAA|Bev Sellers
+Rock Around The Clock|SSAA|Bev Sellers
+Saxaphone Man|SSAA|Bev Sellers
+Sing And Celebrate!|SSAA|Bev Sellers
+Sit Down You're Rockin' The Boat|SSAA|Bev Sellers
+Smoke Gets In Your Eyes|SSAA|Bev Sellers
+Something's Coming|SSAA|Bev Sellers
+Song's Gotta Come From The Heart|SSAA|Bev Sellers
+Stormy Weather|SSAA|Bev Sellers
+Stray Cat Strut|SSAA|Bev Sellers
+Sweet Little Alice Blue Gown|SSAA|Bev Sellers
+That's What Friends Are For|SSAA, Young SSAA|Bev Sellers
+The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Bev Sellers
+When October Goes|SSAA|Bev Sellers
+With My Shillelagh Under My Arm|SSAA|Bev Sellers
+You Are The Sunshine Of My Life|SSAA|Bev Sellers
+You're Never Fully Dressed Without A Smile|SSAA|Bev Sellers
+Back In Those Days Gone By|TTBB|Mike Senter Music
+Back In Those Days Gone By|SSAA|Mike Senter Music
+Don't Bring Lulu|TTBB|Mike Senter Music
+Gotta Be On My Way|TTBB|Mike Senter Music
+Mary You're A Little Bit Old Fashioned|SSAA, Young SSAA|Mike Senter Music
+So Long, Mother|SSAA|Mike Senter Music
+What Ever Happened To Mary?|TTBB|Mike Senter Music
+Home Town|TTBB|Cal Sexton
+Old Bones|TTBB|Cal Sexton
+Mansions Of The Lord|TTBB|Bob Shami
+Rhythm Of The Rain|TTBB|Bob Shami
+Darling Medley|TTBB|Steve Shannon
+Whiffenpoof Song|TTBB|Steve Shannon
+Strike Up The Band / Mardi Gras March/Drummer's Beat Medley|TTBB|Terry Shannon
+Get Happy|SATB|Roland Sharette
+1957|SATB|Deke Sharon
+3 X5|SATB|Deke Sharon
+7|SSAA|Deke Sharon
+ABC|SATB|Deke Sharon
+Accidentally In Love|TTBB, SATB|Deke Sharon
+Across The Universe|SATB|Deke Sharon
+Adventure Day|TTBB|Deke Sharon
+Ain't No Mountain High Enough|SSAA, SATB|Deke Sharon
+Ain't Too Proud to Beg|SATB|Deke Sharon
+The Air That I Breathe|SATB|Deke Sharon
+Aladdin Medley|TTBB|Deke Sharon
+Alexander's Ragtime Band|TTBB|Deke Sharon
+All Away|TTBB|Deke Sharon
+All I Want|SATB|Deke Sharon
+All I Want For Christmas Is You|SSAA, SATB|Deke Sharon
+All I Want Is You|SATB|Deke Sharon
+All My Loving|TTBB|Deke Sharon
+All Night Long|SATB|Deke Sharon
+All Of Me|TTBB|Deke Sharon
+All Of Us|SATB|Deke Sharon
+All Or Nothing|TTBB|Deke Sharon
+All Shook Up|TTBB|Deke Sharon
+All These Things That I've Done|SATB|Deke Sharon
+All You Need Is Love|TTBB|Deke Sharon
+Almost There|SATB|Deke Sharon
+Always|SATB|Deke Sharon
+Always Be My Baby|TTBB, SSAA, SATB|Deke Sharon
+Amazing Grace|SATB|Deke Sharon
+Amazing Graceland|SATB|Deke Sharon
+Amber|SATB|Deke Sharon
+America|SATB|Deke Sharon
+America In Song|SATB|Deke Sharon
+America The Beautiful|TTBB, SSAA, SATB|Deke Sharon
+American Idol Bumper Medley|SATB|Deke Sharon
+Angels We Have Heard On High|TTBB, SATB|Deke Sharon
+Aniron (Theme for Aragorn and Arwen)|SSAA|Deke Sharon
+Annie Waits|TTBB|Deke Sharon
+Any Way You Want It|SATB|Deke Sharon
+Apologize|SATB|Deke Sharon
+Aquarius|SATB|Deke Sharon
+As|TTBB|Deke Sharon
+As She's Walking Away|TTBB|Deke Sharon
+Auld Lang Syne|SATB|Deke Sharon
+Autumn Leaves|SATB|Deke Sharon
+Ave Maria|TTBB, SATB|Deke Sharon
+Axel F|TTBB, SATB|Deke Sharon
+Baby, I Love Your Way|TTBB|Deke Sharon
+Back In The High Life Again|TTBB|Deke Sharon
+Back In The USA|SATB|Deke Sharon
+Back to Basics|SSAA|Deke Sharon
+Bad Romance|SATB|Deke Sharon
+Barbara Ann|TTBB|Deke Sharon
+Barefoot Blue Jean Night|TTBB|Deke Sharon
+Basketcase|TTBB|Deke Sharon
+Battlefield|SATB|Deke Sharon
+Be Careful What You Eat|TTBB|Deke Sharon
+Be Kind|TTBB, SSAA, SATB|Deke Sharon
+Be Our Guest|SATB|Deke Sharon
+Be True to Your School|TTBB, SATB|Deke Sharon
+Beatles Love Medley|TTBB, SATB|Deke Sharon
+Beautiful Day|SATB|Deke Sharon
+Beautiful Girls|TTBB|Deke Sharon
+Before He Cheats|TTBB|Deke Sharon
+Bein' Green|SATB|Deke Sharon
+Bellas Back to Basics|SSAA|Deke Sharon
+Bellas Final (mashup)|SSAA|Deke Sharon
+Bellas Finale|SSAA|Deke Sharon
+Bellas Opening|SSAA|Deke Sharon
+Beneath Your Beautiful|SATB|Deke Sharon
+Best Day of My Life|SATB|Deke Sharon
+Best Day/Good Life Medley|SATB|Deke Sharon
+Best Of My Love|SSAA|Deke Sharon
+Better Man|SSAA|Deke Sharon
+Between The Lines|SATB|Deke Sharon
+Beyonce Medley|TTBB|Deke Sharon
+Beyond the Sea|TTBB|Deke Sharon
+Bibbidi Bobbidi Boo (From Cinderella)|SATB|Deke Sharon
+Bicycle Race/Fat Bottom Girls|TTBB|Deke Sharon
+Big Girl (You Are Beautiful)|SATB|Deke Sharon
+Big Yellow Taxi|SATB|Deke Sharon
+Billy, Don't Be A Hero|TTBB|Deke Sharon
+Black and Gold|TTBB|Deke Sharon
+Black Horse And The Cherry Tree|SATB|Deke Sharon
+Black Water|SATB|Deke Sharon
+Blackbird|SSAA, SATB|Deke Sharon
+Blame It On The Boogie|SATB|Deke Sharon
+Bleeding Love|SATB|Deke Sharon
+Bless The Broken Road|TTBB|Deke Sharon
+Blue|TTBB|Deke Sharon
+Blue Moon|SATB|Deke Sharon
+Blue Skies|SATB|Deke Sharon
+Blues Vamp Warmup|TTBB|Deke Sharon
+Bohemian Rhapsody|TTBB, SSAA, SATB|Deke Sharon
+Boogie Woogie Bugle Boy|TTBB|Deke Sharon
+Bottle It Up|SSAA|Deke Sharon
+Boy Band Medley|TTBB|Deke Sharon
+The Boy From New York City|SSAA|Deke Sharon
+A Brand New Day|SATB|Deke Sharon
+Brave|SATB|Deke Sharon
+Breakeven|TTBB, SATB|Deke Sharon
+Breakfast at Tiffany's|TTBB, SATB|Deke Sharon
+Breed|TTBB|Deke Sharon
+Bridal Chorus from Lohengrin|SATB|Deke Sharon
+Bridge Over Troubled Water|SATB|Deke Sharon
+Bright Lights Bigger City/Magic|TTBB|Deke Sharon
+Bring Me To Life|SATB|Deke Sharon
+Broadway Reopening Medley|TTBB|Deke Sharon
+Brown Eyed Girl|TTBB, SATB|Deke Sharon
+Bubbly|SSAA, SATB|Deke Sharon
+Bye Bye Bye|TTBB|Deke Sharon
+California Dreamin'|TTBB, SATB|Deke Sharon
+Call Me|SATB|Deke Sharon
+Call Me|SSAA|Deke Sharon
+Can't Take My Eyes Off Of You|TTBB, SATB|Deke Sharon
+Caravan|SATB|Deke Sharon
+Carol Of The Bells|SATB|Deke Sharon
+Cecilia|TTBB|Deke Sharon
+The Chain|SSAA|Deke Sharon
+A Change In My Life|SATB|Deke Sharon
+Change The World|TTBB, SSAA, SATB|Deke Sharon
+Chasing Cars|TTBB|Deke Sharon
+Chasing Pavements|SSATB|Deke Sharon
+Cheap Thrills|SSAA|Deke Sharon
+Chicago|SATB|Deke Sharon
+Chill or Be Chilled|SATB|Deke Sharon
+Christmas (Baby Please Come Home)|SATB|Deke Sharon
+Christmas Time Is Here|TTBB|Deke Sharon
+Chuck E's In Love|SATB|Deke Sharon
+Cielito Lindo|SATB|Deke Sharon
+Circle of Life/He Lives In You Medley|SATB|Deke Sharon
+Clampdown|TTBB|Deke Sharon
+The Climb|TTBB|Deke Sharon
+Clocks|TTBB, SATB|Deke Sharon
+Close To You|SSAA|Deke Sharon
+Clouds|SATB|Deke Sharon
+Club At The End of the Street|SATB|Deke Sharon
+Come Fly With Me|SATB|Deke Sharon
+Come Softly To Me|TTBB|Deke Sharon
+Cowboy Casanova|SATB|Deke Sharon
+Crash Into Me|TTBB|Deke Sharon
+Crazy|SATB|Deke Sharon
+Crazy Amazing|SATB|Deke Sharon
+Crazy Little Thing Called Love|TTBB, SATB|Deke Sharon
+Crazy Train|TTBB|Deke Sharon
+Cry Me A River|SATB|Deke Sharon
+Cryin'|SATB|Deke Sharon
+Cups (When I'm Gone)|SSAA|Deke Sharon
+Dancin' In The Moonlight|TTBB|Deke Sharon
+Dancing In The Street|SSAA, SATB|Deke Sharon
+Dancing Queen|SSAA, SATB|Deke Sharon
+Dangerous Woman|SSAA, SATB|Deke Sharon
+Danny Boy|SATB|Deke Sharon
+Das Sound Machine Finale|SATB|Deke Sharon
+Death and All His Friends|SATB|Deke Sharon
+Deck The Halls|SATB|Deke Sharon
+Deep Beneath/Not There Yet|SATB|Deke Sharon
+Defying Gravity|TTBB, SSAA, SATB|Deke Sharon
+Descendants Medley|TTBB|Deke Sharon
+Diamonds Are A Girls Best Friend|SSAA|Deke Sharon
+Ding Dong Merrily On High|SATB|Deke Sharon
+Disappear|SATB|Deke Sharon
+Disco Inferno|SATB|Deke Sharon
+Disco Medley|TTBB|Deke Sharon
+Disney 'Jungle Lion' Medley|TTBB|Deke Sharon
+Disney 2020 Grammys Medley|TTBB|Deke Sharon
+Disney Friendship Mashup|TTBB|Deke Sharon
+Disney Hercules Muses Medley|TTBB|Deke Sharon
+Disney Mulan Medley|TTBB|Deke Sharon
+Disney Princess Mashup|TTBB|Deke Sharon
+Disney Princess Medley|TTBB|Deke Sharon
+Disney Villains Medley|TTBB|Deke Sharon
+Disneyland Medley|TTBB|Deke Sharon
+The Distance|SATB|Deke Sharon
+Disturbia|SATB|Deke Sharon
+Diversity|TTBB|Deke Sharon
+Dixie Chicken|SATB|Deke Sharon
+Do You Know The Way To San Jose|SATB|Deke Sharon
+Do You Know What It Means To Miss New Orleans|TTBB|Deke Sharon
+Dock Of The Bay, The (Sittin On)|TTBB|Deke Sharon
+Dock Of The Bay, The (Sittin On)|SATB|Deke Sharon
+Does Anybody Really Know What Time It Is?|SATB|Deke Sharon
+Don't Know Why|SATB|Deke Sharon
+Don't Let The Sun Go Down On Me|SATB|Deke Sharon
+Don't Lie|SATB|Deke Sharon
+Don't Speak|SATB|Deke Sharon
+Don't Start Now|SATB|Deke Sharon
+Don't Stop Believin'|TTBB, SSAA, SATB|Deke Sharon
+Don't Stop Me Now|SATB|Deke Sharon
+Don't Stop The Music|TTBB, SATB|Deke Sharon
+Down And Out|TTBB|Deke Sharon
+Dream On|SATB|Deke Sharon
+Dreaming With A Broken Heart|SATB|Deke Sharon
+Drift Away|SATB|Deke Sharon
+Drive|TTBB, SATB|Deke Sharon
+Drive My Car|SATB|Deke Sharon
+Drops of Jupiter|SATB|Deke Sharon
+East To West|SATB|Deke Sharon
+Eight Days a Week|TTBB, SATB|Deke Sharon
+Either Way|SSAA|Deke Sharon
+Elvis Medley|SATB|Deke Sharon
+End Of Time|SATB|Deke Sharon
+EPCOT Medley|TTBB|Deke Sharon
+Ev'rybody Wants To Be A Cat|SATB|Deke Sharon
+Everlong|TTBB|Deke Sharon
+Everybody Talks|SATB|Deke Sharon
+Everywhere I Go|TTBB|Deke Sharon
+Extraordinary Machine|SATB|Deke Sharon
+Eye Of The Tiger|SATB|Deke Sharon
+Faith|SSAA, SATB|Deke Sharon
+Fallin'|TTBB|Deke Sharon
+Feelin' Alright|SATB|Deke Sharon
+Feliz Navidad|SATB|Deke Sharon
+Fever|SATB|Deke Sharon
+Fidelity|SATB|Deke Sharon
+Fields Of Gold|SSAA|Deke Sharon
+Fill It Up Again|SATB|Deke Sharon
+Final Countdown|TTBB|Deke Sharon
+Fire And Rain|TTBB, SATB|Deke Sharon
+Firecracker|SATB|Deke Sharon
+Firework|SATB|Deke Sharon
+The First Noel|TTBB, SATB|Deke Sharon
+Fix You|SATB|Deke Sharon
+Flip Flop Fly|TTBB|Deke Sharon
+Flowers|SATB|Deke Sharon
+Fly|SATB|Deke Sharon
+Fly Away|SATB|Deke Sharon
+Fly Like An Eagle|TTBB, SATB|Deke Sharon
+For (S)He's a Jolly Good Fellow|SATB|Deke Sharon
+For Good|SATB|Deke Sharon
+For Your Love|SATB|Deke Sharon
+Forever Young|SSAA, SATB|Deke Sharon
+Forget About The Boy|SATB|Deke Sharon
+Fragile|TTBB, SATB|Deke Sharon
+Friday I'm In Love|SATB|Deke Sharon
+Friend Like Me|SATB|Deke Sharon
+Fun Medley|SATB|Deke Sharon
+Galileo|SSAA|Deke Sharon
+Get'cha Head in the Game|SATB|Deke Sharon
+Getting There|SATB|Deke Sharon
+Ghost Story|TTBB|Deke Sharon
+Girl|TTBB, SATB|Deke Sharon
+The Girl From Ipanema|TTBB|Deke Sharon
+Girls Just Wanna Have Fun|SSAA|Deke Sharon
+Give Me One Reason|SATB|Deke Sharon
+The Glory Days|SATB|Deke Sharon
+Go|SATB|Deke Sharon
+Go Tell It On The Mountain|TTBB, SATB|Deke Sharon
+Go The Distance|SATB|Deke Sharon
+God Bless America|SATB|Deke Sharon
+God Bless The U.S.A.|SATB|Deke Sharon
+God Only Knows|TTBB, SSAA|Deke Sharon
+Gone|SATB|Deke Sharon
+Gone, Gone, Gone|TTBB, SATB|Deke Sharon
+Good King Wenceslas|SATB|Deke Sharon
+Good Life|TTBB, SATB|Deke Sharon
+Good Lovin'|TTBB, SATB|Deke Sharon
+Good Old A Cappella|TTBB, SSAA, SATB|Deke Sharon
+Goodbye Earl|SSAA|Deke Sharon
+Goodnight, Sweetheart, Goodnight|TTBB, SATB|Deke Sharon
+Grace Kelly|SATB|Deke Sharon
+Graceland|SATB|Deke Sharon
+Great Big U.S.A.|TTBB|Deke Sharon
+Groove 66 Disney Medley|TTBB|Deke Sharon
+Groove Is In The Heart|SATB|Deke Sharon
+Guantanamera|SATB|Deke Sharon
+Hall Of Fame|SATB|Deke Sharon
+Hallelujah|TTBB, SSAA|Deke Sharon
+Halo|SATB|Deke Sharon
+Hands|SATB|Deke Sharon
+Hanginaround|SATB|Deke Sharon
+Hannukah Song|TTBB|Deke Sharon
+Hannukah, Oh Hannukah|SATB|Deke Sharon
+Happy|SSAA, SATB|Deke Sharon
+Happy Birthday To You|SATB|Deke Sharon
+Happy Ending|SATB|Deke Sharon
+Hard To Say I'm Sorry|TTBB, SATB|Deke Sharon
+Harder To Breathe|TTBB|Deke Sharon
+Hava Nagila|SATB|Deke Sharon
+Have A Good Time|SATB|Deke Sharon
+Have Yourself A Merry Little Christmas|SATB|Deke Sharon
+Haven't Met You Yet|SATB|Deke Sharon
+Hawaiian Roller Coaster Ride|SATB|Deke Sharon
+He Ain't Heavy, He's My Brother|TTBB|Deke Sharon
+Hear Me Out|SSAA|Deke Sharon
+Heart of Glass|SSAA, SATB|Deke Sharon
+Heartache Tonight|TTBB|Deke Sharon
+Heartbreak Hotel|TTBB|Deke Sharon
+Heartbreaker|SATB|Deke Sharon
+Heaven|SATB|Deke Sharon
+Help Me Rhonda|TTBB, SSAA|Deke Sharon
+Helplessly Hoping|SATB|Deke Sharon
+Her Diamonds|SATB|Deke Sharon
+Here Comes Elastigirl|SATB|Deke Sharon
+Here Comes The Sun|TTBB, SSAA, SATB|Deke Sharon
+Here It Goes Again|SATB|Deke Sharon
+Here We Come A-Caroling|SATB|Deke Sharon
+Hey Jude|TTBB, SSAA|Deke Sharon
+Hey, Soul Sister|TTBB|Deke Sharon
+Hi Ho|SATB|Deke Sharon
+His Eye Is On The Sparrow|SATB|Deke Sharon
+Hit Me With Your Best Shot|SSAA, SATB|Deke Sharon
+Hold On|SSAA|Deke Sharon
+Hold The Line|TTBB|Deke Sharon
+Holding Out For A Hero|TTBB, SSAA|Deke Sharon
+The Holly And The Ivy|SATB|Deke Sharon
+Holly Jolly Christmas|SATB|Deke Sharon
+Hollywood|SATB|Deke Sharon
+Home|TTBB|Deke Sharon
+Homeless|TTBB|Deke Sharon
+Homeward Bound|TTBB|Deke Sharon
+Honneur A Toi|TTBB, SATB|Deke Sharon
+Hooch|TTBB|Deke Sharon
+Hooked On A Feeling|TTBB|Deke Sharon
+House At Pooh Corner|SATB|Deke Sharon
+House Of The Rising Sun|TTBB|Deke Sharon
+How Far I'll Go|SATB|Deke Sharon
+How Sweet It Is To Be Loved By You|SATB|Deke Sharon
+Howl|SSAA|Deke Sharon
+Human|TTBB|Deke Sharon
+I 2 I|SATB|Deke Sharon
+I Can Do That|SATB|Deke Sharon
+I Can See Clearly Now|SATB|Deke Sharon
+I Can't Make You Love Me|SSAA, SATB|Deke Sharon
+I Can't Tell You Why|TTBB|Deke Sharon
+I Could Write a Book|SATB|Deke Sharon
+I Feel The Earth Move|SSAA|Deke Sharon
+I Followed Her Around|SATB|Deke Sharon
+I Get A Kick Out Of You|SATB|Deke Sharon
+I Got The Music In Me|SATB|Deke Sharon
+I Got You (I Feel Good)|SATB|Deke Sharon
+I Gotta Feeling|SATB|Deke Sharon
+I Heard It Through The Grapevine|SATB|Deke Sharon
+I Hope You Dance|SSAA, SATB|Deke Sharon
+I Just Can't Wait To Be King|SATB|Deke Sharon
+I Lived|SATB|Deke Sharon
+I Love A Rainy Night|SATB|Deke Sharon
+I Love L.A.|SATB|Deke Sharon
+I Only Have Eyes For You|TTBB|Deke Sharon
+I Put a Spell on You|SSAA|Deke Sharon
+I saw The Sign/Eternal Flame/Turn The Beat Around Medley|SSAA|Deke Sharon
+I See The Light (from Walt Disney Pictures' TANGLED)|SATB|Deke Sharon
+I Still Haven't Found What I'm Looking For|SATB|Deke Sharon
+I Swear|TTBB|Deke Sharon
+I Wanna Be Like You|SATB|Deke Sharon
+I Want A Hippopotamus For Christmas|SATB|Deke Sharon
+I Want It That Way|TTBB|Deke Sharon
+I Want You Back|SSAA, SATB|Deke Sharon
+I Will Always Love You|SATB|Deke Sharon
+I Wish|TTBB, SATB|Deke Sharon
+I Won't Say I'm In Love|SATB|Deke Sharon
+I'll Be Seeing You|SSAA|Deke Sharon
+I'll Be There|SSAA, SATB|Deke Sharon
+I'll Make A Man Out Of You|SATB|Deke Sharon
+I'll Stand By You|SATB|Deke Sharon
+I'm A Man of Constant Sorrow|TTBB|Deke Sharon
+I'm Into Something Good|TTBB|Deke Sharon
+I'm Not In Love|SATB|Deke Sharon
+I'm Sorry|TTBB|Deke Sharon
+I'm with you|SSAA|Deke Sharon
+I'm Yours|SATB|Deke Sharon
+I've Got My Love To Keep Me Warm|SATB|Deke Sharon
+I've Got The Music In Me|SATB|Deke Sharon
+If I Loved You|TTBB, SATB|Deke Sharon
+If I Only Had A Heart (Brain)|SATB|Deke Sharon
+If You Leave Me Now|SATB|Deke Sharon
+If You Love Somebody Set Them Free|SATB|Deke Sharon
+If You're Out There|SATB|Deke Sharon
+Imagine|SSAA, SATB|Deke Sharon
+Immortals|SATB|Deke Sharon
+In The Ghetto|SATB|Deke Sharon
+In The Light|TTBB|Deke Sharon
+In The Still Of The Night|SATB|Deke Sharon
+In Your Eyes|SATB|Deke Sharon
+Incomplete|TTBB|Deke Sharon
+Incredibles 2 Theme Songs Medley|TTBB|Deke Sharon
+Inside Out|SATB|Deke Sharon
+Into the Unknown|TTBB, SSAA, SATB|Deke Sharon
+Iridescent|TTBB|Deke Sharon
+Islands In The Stream|TTBB|Deke Sharon
+It Don't Mean A Thing|TTBB, SATB|Deke Sharon
+It's A Beautiful Morning|TTBB|Deke Sharon
+It's A Hanukkah Song|TTBB|Deke Sharon
+It's A Small World|SATB|Deke Sharon
+It's Alright|SATB|Deke Sharon
+It's My Party|SSAA|Deke Sharon
+It's So Hard To Say Goodbye To Yesterday|SATB|Deke Sharon
+It's Time|SATB|Deke Sharon
+Jackson 5 Medley|TTBB|Deke Sharon
+Jackson 5 Medley|SATB|Deke Sharon
+James Bond Theme|SATB|Deke Sharon
+Jessie's Girl|TTBB, SSAA|Deke Sharon
+Jesus Walks|SATB|Deke Sharon
+Jet Airliner|TTBB|Deke Sharon
+Jilted|SSAA|Deke Sharon
+Jingle Bells|SATB|Deke Sharon
+Jolly Old St. Nicholas|SATB|Deke Sharon
+Joy To The World|TTBB, SATB|Deke Sharon
+Jungle Book Medley|TTBB|Deke Sharon
+Just A Gigolo / I Ain't Got Nobody|TTBB|Deke Sharon
+Just A Ride|SATB|Deke Sharon
+Just The Way You Are|SSAA, SATB|Deke Sharon
+Just the Way You Are / Just A Dream (Mashup)|SSAA|Deke Sharon
+Karmastition|TTBB, SATB|Deke Sharon
+Kids In America|SATB|Deke Sharon
+Killing Me Softly|SSAA, SATB|Deke Sharon
+King of Anything|SSAA|Deke Sharon
+King of Wishful Thinking|TTBB|Deke Sharon
+Kiss From A Rose|TTBB, SATB|Deke Sharon
+Kiss Me|SSAA|Deke Sharon
+Kiss The Girl|SATB|Deke Sharon
+Knockin' On Heaven's Door|SATB|Deke Sharon
+La Bamba|SATB|Deke Sharon
+La Locomotive|SATB|Deke Sharon
+Lady Day and John Coltrane|SATB|Deke Sharon
+Land Of A Thousand Dances|SATB|Deke Sharon
+Landslide|TTBB, SSAA, SATB|Deke Sharon
+Larger Than Life|TTBB|Deke Sharon
+Last Name|SATB|Deke Sharon
+Lawdy Miss Clawdy|TTBB|Deke Sharon
+Lay Down Sally|SATB|Deke Sharon
+Leader Of The Pack|SSAA|Deke Sharon
+Lean On Me|TTBB, SATB|Deke Sharon
+Leave The Door Open|TTBB|Deke Sharon
+Leaving on a Jet Plane|SATB|Deke Sharon
+Let It Be|SSAA, SATB|Deke Sharon
+Let It Go|TTBB, SATB|Deke Sharon
+Let It Whip|TTBB|Deke Sharon
+Let's Get It On|TTBB|Deke Sharon
+Let's Hear It For The Boy|SSAA|Deke Sharon
+Li'l Red Riding Hood|SATB|Deke Sharon
+Like A Prayer|SATB|Deke Sharon
+Linin Track|SATB|Deke Sharon
+Lion Sleeps Tonight|SATB|Deke Sharon
+Listen to your Heart|SSAA|Deke Sharon
+Little Lion Man|TTBB|Deke Sharon
+Little Saint Nick|SATB|Deke Sharon
+Little Secrets|SATB|Deke Sharon
+Live and Let Die|TTBB|Deke Sharon
+Live Like We're Dying|SATB|Deke Sharon
+Living in the USA|SATB|Deke Sharon
+The Living Years|TTBB|Deke Sharon
+Locked Out Of Heaven|SATB|Deke Sharon
+The Loco-motion|SSAA|Deke Sharon
+Lollipop|TTBB, SSAA|Deke Sharon
+Lollipops & Roses|SATB|Deke Sharon
+Lonely No More|TTBB|Deke Sharon
+Long December. A|TTBB|Deke Sharon
+The Longest Time|SATB|Deke Sharon
+Love Is All Around|SSAA|Deke Sharon
+Love is an Open Door|SATB|Deke Sharon
+Love Me Like A Rock|TTBB|Deke Sharon
+Love Never Fails|TTBB|Deke Sharon
+Love On Top|SSAA, SATB|Deke Sharon
+Love Shack|SATB|Deke Sharon
+Love Song|SATB|Deke Sharon
+Love Story|SSAA|Deke Sharon
+Love The One You're With|SSAA|Deke Sharon
+Love Today|SSAA|Deke Sharon
+Love Will Come To You|TTBB|Deke Sharon
+Lovefool|TTBB|Deke Sharon
+Loves Me Like A Rock|TTBB|Deke Sharon
+Lullaby of Birdland|SATB|Deke Sharon
+Lullabye|SSAA|Deke Sharon
+Magic Carpet Ride|TTBB|Deke Sharon
+Mama, I'm a Big Girl now|TTBB, SSAA|Deke Sharon
+Man In The Mirror|TTBB, SSAA, SATB|Deke Sharon
+Man of Constant Sorrow|TTBB, SATB|Deke Sharon
+Man With The Bag|TTBB, SSAA|Deke Sharon
+Marry You|TTBB|Deke Sharon
+Mary Did You Know|TTBB|Deke Sharon
+Maybe|SATB|Deke Sharon
+Mayberry|SATB|Deke Sharon
+Me And Bobby Mcgee|SATB|Deke Sharon
+Me And Mrs. Jones|SATB|Deke Sharon
+Me And My Shadow|TTBB|Deke Sharon
+Medley: Arabian Nights, Prince Ali|SATB|Deke Sharon
+Medley: Be Our Guest, Under the Sea, Try Everything, Hakuna Matata, Friend Like Me|SATB|Deke Sharon
+Medley: Best Day Of My Life, Good Life|SATB|Deke Sharon
+Medley: Bicycle Race, Fat Bottomed Girls|TTBB|Deke Sharon
+Medley: Bye Bye Bye, I Want It That Way, Back Here, I'll Make Love To You..|TTBB|Deke Sharon
+Medley: Circle of Life with He Lives In You|SATB|Deke Sharon
+Medley: Colonel Hathi's March, Bare Necessities, I wan'na Be Like You..|TTBB|Deke Sharon
+Medley: Eight Days A Week, Drive My Car, All My Loving, Hey Jude, The End|TTBB, SATB|Deke Sharon
+Medley: Elastigirl's Theme with Frozone's Theme|SATB|Deke Sharon
+Medley: End Of Time, Love On Top, Crazy In Love, Halo, Xo|SATB|Deke Sharon
+Medley: Fly Me To The Moon, Rocket Man..|SATB|Deke Sharon
+Medley: For The First Time In Forever, A Whole New World, Can You Feel The Love|SATB|Deke Sharon
+Medley: Friend Like Me with You've Got A Friend In Me and We're All In This Together|SATB|Deke Sharon
+Medley: Got To Be Real, Best Of My Love, Play That Funky Music|SATB|Deke Sharon
+Medley: Grace Kelly, Love Today, Lollipop, Happy Ending|SSAA, SATB|Deke Sharon
+Medley: How Far I'll Go, Into The Unknown, Almost There, Starting Now|SATB|Deke Sharon
+Medley: I Saw The Sign with Eternal Flame and Turn The Beat|SSAA|Deke Sharon
+Medley: I Want You Back with ABC|SATB|Deke Sharon
+Medley: I Want You Back, I'll Be There, ABC|SATB|Deke Sharon
+Medley: Into The Unknow, Born To Be Brave, Carried Me With you, Collard Green..|SATB|Deke Sharon
+Medley: Just The Way You Are with Just A Dream|SSAA|Deke Sharon
+Medley: Karma with Superstition|TTBB, SATB|Deke Sharon
+Medley: Mad World, Titanium, My Shot|SATB|Deke Sharon
+Medley: Mickey, Like A Virgin, Hit MeWith Your Best Shot, It Must Have Been Love|SATB|Deke Sharon
+Medley: One Little Spark with Listen To The Land, New Horizons, Tomorrow's Child, Universe..|SATB|Deke Sharon
+Medley: Poor Unfortunate Souls, Trust In Me, Friends In The Other Side..|SATB|Deke Sharon
+Medley: Problem with Promises Skrillex and Nero Remix|SSAA|Deke Sharon
+Medley: Reflection, I'll Make A Man Out Of You|SATB|Deke Sharon
+Medley: Rotten To The Core with What's my Name and Good To Be Bad|SSAA|Deke Sharon
+Medley: Run The World (Girls), Where THem Girls At and Flashlight|SSAA|Deke Sharon
+Medley: Sing, Sing, Sing, I Wan'na Be Like You, The Bare Necessities..|SATB|Deke Sharon
+Medley: Sittin' On The Docl Of The Bay, Under The Boardwalk|SATB|Deke Sharon
+Medley: Suit and Tie, Rock Your Body|TTBB|Deke Sharon
+Medley: Teenage Mutant Ning Turtles, Inspector Gadget, Mighty Morphin Power Rangers..|SATB|Deke Sharon
+Medley: That's All Right, Heartbreak Hotel, In The Ghetto|SATB|Deke Sharon
+Medley: The Gospel Truth, Zero To Hero, A Star Is Born|SATB|Deke Sharon
+Medley: The Thong Song, Shake Your Booty, Low, Bootylicious, Baby Got Back|SATB|Deke Sharon
+Medley: This Is Halloween, What's This?, Oogie Boogie's Song|SATB|Deke Sharon
+Medley: Underneath The Tree, Rockin' around The Christmas Tree|SATB|Deke Sharon
+Medley: We Got The World, Timber and Wrecking Ball|SSAA|Deke Sharon
+Medley: Zero To Hero, Honor To Us All, Trashin' the Camp, A Star Is Born|SATB|Deke Sharon
+Mele Kalikimaka|TTBB|Deke Sharon
+Memories|SSAA|Deke Sharon
+Men|SATB|Deke Sharon
+Mercy|SSAA, SATB|Deke Sharon
+Merry Christmas Happy New Year|SATB|Deke Sharon
+Mexican Wine|TTBB|Deke Sharon
+Mickey Mouse Club March|SATB|Deke Sharon
+Midnight Train to Georgia|SATB|Deke Sharon
+Mika Medley|SSAA|Deke Sharon
+Mine|SATB|Deke Sharon
+Minnie The Moocher|SATB|Deke Sharon
+Misery Business|SATB|Deke Sharon
+Miss Otis Regrets|SSAA|Deke Sharon
+Mister Sandman|SSAA|Deke Sharon
+Misty Mountains Cold|SSAA|Deke Sharon
+Mockingbird|SSAA|Deke Sharon
+Moondance|SATB|Deke Sharon
+More Than Words|SSAA|Deke Sharon
+Most Wonderful Time Of The Year|SATB|Deke Sharon
+Motownphilly|TTBB|Deke Sharon
+Mr. Blue Sky|TTBB, SSAA, SATB|Deke Sharon
+Music For A Sushi Restaurant|SATB|Deke Sharon
+My Best Friend's Girl|TTBB|Deke Sharon
+My Boo|SATB|Deke Sharon
+My Foolish Heart|SATB|Deke Sharon
+My Girl|SATB|Deke Sharon
+My Happy Ending|SATB|Deke Sharon
+My Home|SATB|Deke Sharon
+My Kind Of Town (Chicago Is)|TTBB|Deke Sharon
+My Lovin'|SSAA|Deke Sharon
+Mysterious Ways|TTBB|Deke Sharon
+Na Na Hey Hey Kiss Him Goodbye|SATB|Deke Sharon
+Natural Woman (You Make Me Feel Like)|SSAA|Deke Sharon
+Never Gonna Give You Up|SATB|Deke Sharon
+Nickelodeon Medley|SATB|Deke Sharon
+The Night Chicago Died|TTBB|Deke Sharon
+Nightswimming|SSAA|Deke Sharon
+No Rain|TTBB|Deke Sharon
+No Scrubs|SSAA, SATB|Deke Sharon
+Nobody Does It Better|SATB|Deke Sharon
+Nobody Knows You When You're Down And Out|SATB|Deke Sharon
+Nobody Like U|SSAA, SATB|Deke Sharon
+Nothing Compares 2 U|SSAA|Deke Sharon
+Nothing Else Matters|SATB|Deke Sharon
+Now and Forever|SATB|Deke Sharon
+Now is the Month of Christmas|SATB|Deke Sharon
+O Canada!|SSAA, SATB|Deke Sharon
+O Christmas Tree|SATB|Deke Sharon
+O Come O Come Emmanuel|TTBB|Deke Sharon
+O Holy Night|SATB|Deke Sharon
+Oh Atlanta|TTBB|Deke Sharon
+Oh Happy Day|SATB|Deke Sharon
+Oh What A Beautiful Morning!|SATB|Deke Sharon
+OK, It's Alright With Me|TTBB|Deke Sharon
+Old Folks Boogie|TTBB|Deke Sharon
+Old Landmark|SATB|Deke Sharon
+One Fine Day|SSAA|Deke Sharon
+One More Minute|SATB|Deke Sharon
+One True Love|TTBB|Deke Sharon
+One Voice|TTBB|Deke Sharon
+Only One|SATB|Deke Sharon
+Only You|SATB|Deke Sharon
+Only You (And You Alone)|TTBB|Deke Sharon
+Orange Colored Sky|TTBB, SATB|Deke Sharon
+Ordinary|SATB|Deke Sharon
+Our Lips Are Sealed|SSAA|Deke Sharon
+Our Love Goes Deeper Than This|SSAA|Deke Sharon
+Over The River And Through The Woods|SATB|Deke Sharon
+Oye Como Va|SATB|Deke Sharon
+Paparazzi|SATB|Deke Sharon
+Paradise|SATB|Deke Sharon
+Part Of Your World|SATB|Deke Sharon
+Part of Your World / Whole New World|SATB|Deke Sharon
+Part of Your World / Whole New World|TTBB|Deke Sharon
+Party in the USA|SSAA, SATB|Deke Sharon
+Pastime Paradise|TTBB|Deke Sharon
+Patapan|SATB|Deke Sharon
+Peace On Earth/Little Drummer Boy medley|TTBB|Deke Sharon
+Peace, Love and Understanding|SATB|Deke Sharon
+Peel me a Grape|SSAA|Deke Sharon
+Perfect Day|SATB|Deke Sharon
+Picturing You|TTBB|Deke Sharon
+Pitch Perfect Riff Off 'Ladies of the 80s'|SATB|Deke Sharon
+Pitch Perfect Riff Off 'Songs About Sex'|SATB|Deke Sharon
+The Place Where the Lost Things Go|TTBB|Deke Sharon
+Pomp And Circumstances|SATB|Deke Sharon
+Pompeii|SATB|Deke Sharon
+Pow! Pow! Pow!|SATB|Deke Sharon
+The Prayer|SATB|Deke Sharon
+Pretty Young Thing|SATB|Deke Sharon
+Price Tag|SATB|Deke Sharon
+Price Tag/Don't You Forget About Me/Give Me Everything|SSAA|Deke Sharon
+Prince Ali|SATB|Deke Sharon
+Proud Mary|SATB|Deke Sharon
+Pump It|TTBB|Deke Sharon
+Puppy For Hanukkah|TTBB|Deke Sharon
+Put On A Happy Face|SATB|Deke Sharon
+Put Your Records On|SATB|Deke Sharon
+Queen of Hearts|SSAA|Deke Sharon
+Question|TTBB|Deke Sharon
+Quiet Moon|TTBB|Deke Sharon
+Radio Ga Ga|SATB|Deke Sharon
+Red Hands|SATB|Deke Sharon
+Reflection|SATB|Deke Sharon
+Rehab|SATB|Deke Sharon
+Relax (Take It Easy)|SATB|Deke Sharon
+Remember Me|SATB|Deke Sharon
+Renegade|TTBB|Deke Sharon
+Respect|SSAA, SATB|Deke Sharon
+Rhythm Of Love|TTBB, SSAA|Deke Sharon
+Right As Rain|SSAA|Deke Sharon
+Right Now|SATB|Deke Sharon
+Right Round|TTBB|Deke Sharon
+Ring Of Fire|TTBB|Deke Sharon
+River Deep Mountain High|SSAA|Deke Sharon
+The River Of Dreams|SATB|Deke Sharon
+Roar|TTBB|Deke Sharon
+Rock The Boat|SATB|Deke Sharon
+Rocket Man|SATB|Deke Sharon
+Rockin' Around The Christmas Tree|SATB|Deke Sharon
+Rockin' Robin|SSAA|Deke Sharon
+Rocky Mountain High|TTBB|Deke Sharon
+Rolling In The Deep|TTBB|Deke Sharon
+The Rose|SATB|Deke Sharon
+Route 66|TTBB, SATB|Deke Sharon
+Royals|SSAA, SATB|Deke Sharon
+Rudolph The Red Nosed Reindeer|SATB|Deke Sharon
+Rumor Has It|SSAA|Deke Sharon
+Run Rudolph Run|TTBB|Deke Sharon
+Run The World/Where Them Girls At/Flashlight Medley|SSAA|Deke Sharon
+Runaround Sue|TTBB|Deke Sharon
+Runaway|TTBB|Deke Sharon
+The Saltwater Room|SATB|Deke Sharon
+Santa Baby|SATB|Deke Sharon
+Santa Claus Is Back In Town|TTBB|Deke Sharon
+Santa Claus Is Comin' To Town|SATB|Deke Sharon
+Saturday In The Park|SATB|Deke Sharon
+Save Tonight|TTBB|Deke Sharon
+Say (All I Need)|SATB|Deke Sharon
+The Scientist|TTBB|Deke Sharon
+Seasons of Love|TTBB|Deke Sharon
+See You Again|SATB|Deke Sharon
+Semi Charmed Life|SATB|Deke Sharon
+Send Me On My Way|SATB|Deke Sharon
+Sentimental Journey|SSAA|Deke Sharon
+September|SATB|Deke Sharon
+Seven Bridges Road|TTBB|Deke Sharon
+Seven Nation Army|TTBB|Deke Sharon
+Sexyback|SATB|Deke Sharon
+Sh-Boom (Life Could Be A Dream)|TTBB|Deke Sharon
+Shake It Off|SATB|Deke Sharon
+Shark In The Water|SATB|Deke Sharon
+She Will Be Loved|SATB|Deke Sharon
+Shiny|SATB|Deke Sharon
+Shoop-Shoop Song, The (It's In His Kiss)|SSAA|Deke Sharon
+Shout!|TTBB, SATB|Deke Sharon
+Shut Up And Dance|SATB|Deke Sharon
+Sign Your Name|SATB|Deke Sharon
+The Sign|SATB|Deke Sharon
+Signed, Sealed, Delivered|TTBB, SATB|Deke Sharon
+Silent All These Years|SSAA|Deke Sharon
+Silent Night|TTBB|Deke Sharon
+Silhouettes|SATB|Deke Sharon
+Simple Gifts|TTBB|Deke Sharon
+Since U Been Gone|TTBB, SSAA, SATB|Deke Sharon
+Sing A Song|TTBB|Deke Sharon
+Sing Off Halloween Medley|SATB|Deke Sharon
+Sing Sing Sing|SATB|Deke Sharon
+Sir Duke|TTBB, SATB|Deke Sharon
+Sit Still, Look Pretty|SSAA|Deke Sharon
+Sitting on The Dock of the Bay/Under the Boardwalk|TTBB|Deke Sharon
+Sixty Minute Man|TTBB, SATB|Deke Sharon
+Sleigh Ride|TTBB, SATB|Deke Sharon
+The Sleigh|SATB|Deke Sharon
+Smooth Operator|TTBB, SATB|Deke Sharon
+So Far Away|SATB|Deke Sharon
+So What|SATB|Deke Sharon
+Soak Up The Sun|SATB|Deke Sharon
+Sold|TTBB|Deke Sharon
+Some Nights|TTBB, SSAA, SATB|Deke Sharon
+Somebody Like You|SATB|Deke Sharon
+Somebody to Love|SATB|Deke Sharon
+Something to Talk About|SATB|Deke Sharon
+Somewhere|TTBB|Deke Sharon
+Son of a Preacherman|TTBB|Deke Sharon
+Songbird|SSAA|Deke Sharon
+Songs of Love|TTBB|Deke Sharon
+Soulful Hallelujah|TTBB|Deke Sharon
+Soulmate|SATB|Deke Sharon
+Sound Check|TTBB|Deke Sharon
+The Sound Of Silence|SATB|Deke Sharon
+Space Medley|TTBB|Deke Sharon
+Spanish Flea|TTBB|Deke Sharon
+Speechless|SATB|Deke Sharon
+Spiderwebs|SSAA|Deke Sharon
+Stacy's Mom|SATB|Deke Sharon
+Stand By Me|TTBB, SATB|Deke Sharon
+Star Spangled Banner|TTBB, SSAA, SATB|Deke Sharon
+Stars|TTBB|Deke Sharon
+Stars And Stripes Forever|TTBB|Deke Sharon
+Stay|SSAA, SATB|Deke Sharon
+Stayin' Alive|TTBB, SSAA|Deke Sharon
+Steal My Kisses|TTBB, SATB|Deke Sharon
+Step In Time|SSAA|Deke Sharon
+Steppin' Out With My Baby|TTBB, SATB|Deke Sharon
+Still Crazy After All These Years|TTBB|Deke Sharon
+Still Haven't Found What I'm Looking For|TTBB|Deke Sharon
+Still The One|TTBB, SSAA, SATB|Deke Sharon
+Stitches|SSAA, SATB|Deke Sharon
+Stop Thinkin'|TTBB|Deke Sharon
+Stray Cat Strut|SSAA|Deke Sharon
+Suit & Tie / Rock your body Medley|TTBB|Deke Sharon
+Suite: Judy Blue Eyes|TTBB|Deke Sharon
+Summertime|TTBB|Deke Sharon
+Sunday Morning|TTBB|Deke Sharon
+Sunny Came Home|SSAA|Deke Sharon
+Sunshine On My Shoulders|SSAA|Deke Sharon
+Super Trouper|SSAA|Deke Sharon
+Supercalifragilisticexpialidocious|SATB|Deke Sharon
+Superman (It's Not Easy)|TTBB, SATB|Deke Sharon
+Superstition|TTBB, SATB|Deke Sharon
+Surface Pressure|SATB|Deke Sharon
+Suspicious Minds|SATB|Deke Sharon
+Sweet Dreams (Are Made of These)|SSAA|Deke Sharon
+The Sweet Escape|SATB|Deke Sharon
+Sweet Home Chicago|TTBB|Deke Sharon
+Tainted Love|SATB|Deke Sharon
+Take Me Home Tonight|TTBB|Deke Sharon
+Take Me Home, Country Roads|SATB|Deke Sharon
+Take Me Out|SATB|Deke Sharon
+Take Me Out To The Ball Game|SATB|Deke Sharon
+Take On Me|TTBB|Deke Sharon
+Teach Your Children|SSAA|Deke Sharon
+Teardrop|SATB|Deke Sharon
+Tears Hit The Ground|SATB|Deke Sharon
+Tempted|TTBB|Deke Sharon
+Thank You|SATB|Deke Sharon
+Thank You For The Music|SSAA|Deke Sharon
+That'll Be The Day|TTBB|Deke Sharon
+The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Deke Sharon
+The Nightmare Before Chrismas Medley|TTBB|Deke Sharon
+The Way You Look Tonight|TTBB|Deke Sharon
+Theme from The Simpsons|SATB|Deke Sharon
+There's a Fine Fine Line|SATB|Deke Sharon
+There's More To Me Than You|SSAA|Deke Sharon
+They|SATB|Deke Sharon
+They Can't Take That Away From Me|SATB|Deke Sharon
+Thinking Out Loud|SATB|Deke Sharon
+This Christmas|TTBB|Deke Sharon
+This Is Me|SATB|Deke Sharon
+This Love|TTBB|Deke Sharon
+This Nearly Was Mine|SATB|Deke Sharon
+Thong Song/Shake Your booty/Low/Bootylicious/ Baby Got Back Medley|SATB|Deke Sharon
+A Thousand Years|SSAA|Deke Sharon
+The Thrill Is Gone|SATB|Deke Sharon
+Thriller|SATB|Deke Sharon
+Timber|SSAA|Deke Sharon
+Time After Time|SSAA, SATB|Deke Sharon
+Time Of My Life|SATB|Deke Sharon
+Time Of Season/What's Your Name|SATB|Deke Sharon
+Timeless To Me|SATB|Deke Sharon
+Titanium|TTBB, SSAA|Deke Sharon
+Tomorrow Never Dies|SATB|Deke Sharon
+Too Fat Polka|SSAA|Deke Sharon
+Total Eclipse of the Heart|SATB|Deke Sharon
+Toxic|TTBB, SSAA|Deke Sharon
+Trashin' The Camp|SATB|Deke Sharon
+Travelin' Band|TTBB, SATB|Deke Sharon
+True Colors|TTBB, SSAA, SATB|Deke Sharon
+Try|SATB|Deke Sharon
+Try Everything|SATB|Deke Sharon
+Turn The Beat Around|SSAA, SATB|Deke Sharon
+The Twelve Days Of Christmas|TTBB|Deke Sharon
+Twenty Nine Ways to My Baby's Door|SSAA|Deke Sharon
+Two Points For Honesty|TTBB|Deke Sharon
+Two Weeks|SATB|Deke Sharon
+Unchained Melody|SATB|Deke Sharon
+Uncle John's Band|TTBB|Deke Sharon
+Under Pressure|TTBB, SATB|Deke Sharon
+Under The Boardwalk|SSAA, SATB|Deke Sharon
+Under The Bridge|TTBB, SATB|Deke Sharon
+Under The Sea|SATB|Deke Sharon
+Underdog|SATB|Deke Sharon
+Unforgettable|SATB|Deke Sharon
+Untouched|SSAA|Deke Sharon
+Unwritten|SSAA, SATB|Deke Sharon
+Up On the House Top|SATB|Deke Sharon
+Up On The Roof|TTBB, SATB|Deke Sharon
+Up, Up And Away (My Beautiful Balloon)|SATB|Deke Sharon
+Uprising|TTBB|Deke Sharon
+Upside Down|SSAA|Deke Sharon
+Uptown Funk!|SATB|Deke Sharon
+Uptown Girl|TTBB|Deke Sharon
+Use Somebody|SATB|Deke Sharon
+Valerie|SATB|Deke Sharon
+Video Killed The Radio Star|SATB|Deke Sharon
+Virtual Insanity|SSAA|Deke Sharon
+Viva La Vida|SATB|Deke Sharon
+Waiting On The World To Change|SATB|Deke Sharon
+Wake Me Up!|TTBB, SSAA|Deke Sharon
+Wake Up|SATB|Deke Sharon
+The Walk|TTBB|Deke Sharon
+Walkin' My Baby Back Home|SATB|Deke Sharon
+Walking in Memphis|TTBB, SATB|Deke Sharon
+Walking In The Air|TTBB|Deke Sharon
+Walking On Sunshine|SSAA, SATB|Deke Sharon
+Wannabe|TTBB|Deke Sharon
+Warwick Avenue|SATB|Deke Sharon
+The Water Is Wide|SATB|Deke Sharon
+Waterloo|TTBB|Deke Sharon
+Watershed|TTBB|Deke Sharon
+Wavin' Flag|TTBB|Deke Sharon
+The Way You Do|TTBB|Deke Sharon
+Way You Look Tonight|TTBB|Deke Sharon
+We All Need Saving|TTBB|Deke Sharon
+We Are Young|SATB|Deke Sharon
+We Don't Talk About Bruno|SATB|Deke Sharon
+We Got The World/Timber/Wrecking Ball|SSAA|Deke Sharon
+We Need A Little Christmas|SATB|Deke Sharon
+We Shall Overcome|SATB|Deke Sharon
+We Three Kings|TTBB|Deke Sharon
+We Wish You A Merry Christmas|SATB|Deke Sharon
+We'll Be A Dream|TTBB|Deke Sharon
+Welcome|SATB|Deke Sharon
+What Goes Around|TTBB|Deke Sharon
+What I Like About You|TTBB|Deke Sharon
+What The Hell|SSAA|Deke Sharon
+What'll I Do?|SATB|Deke Sharon
+What's Going On|TTBB|Deke Sharon
+When Doves Cry|SATB|Deke Sharon
+When I Rise|SATB|Deke Sharon
+When I'm Sixty Four|TTBB, SSAA|Deke Sharon
+When She Loved Me|SATB|Deke Sharon
+When The Saints Go Marching In|SATB|Deke Sharon
+When Will I Be Loved|SSAA, SATB|Deke Sharon
+When You Come Back To Me Again|SSAA|Deke Sharon
+Where Is The Love|SATB|Deke Sharon
+White Christmas|TTBB, SATB|Deke Sharon
+White Wedding|TTBB|Deke Sharon
+Who Loves You|TTBB|Deke Sharon
+Whole Lotta Love|SATB|Deke Sharon
+Why Can't We Be Friends?|SATB|Deke Sharon
+Why Do Fools Fall In Love|SATB|Deke Sharon
+Wichita Lineman|TTBB|Deke Sharon
+Wicked Game|TTBB|Deke Sharon
+Wide Open Spaces|TTBB|Deke Sharon
+With A Little Help From My Friends|SATB|Deke Sharon
+Wo Ai Ni|TTBB|Deke Sharon
+Wonderful Tonight|SATB|Deke Sharon
+Wonderwall|TTBB|Deke Sharon
+The World Es Mi Familia|SATB|Deke Sharon
+Ya Gotta Be|SATB|Deke Sharon
+Yacht Rock TV Theme Medley|TTBB|Deke Sharon
+Yankee Doodle|SATB|Deke Sharon
+Yellow|SATB|Deke Sharon
+You And I|SATB|Deke Sharon
+You Are My Sunshine|SATB|Deke Sharon
+You Can Call Me Al|TTBB|Deke Sharon
+You Can Fly|SATB|Deke Sharon
+You Don't Own Me|SATB|Deke Sharon
+You Found Me|SATB|Deke Sharon
+You Gotta Be|SSAA, SATB|Deke Sharon
+You Haven't Done Nothin'|TTBB|Deke Sharon
+You Know My Name|SATB|Deke Sharon
+You Make My Dreams|SATB|Deke Sharon
+You Will Be Found|SATB|Deke Sharon
+You'll Be In My Heart|TTBB|Deke Sharon
+You're All I Need to Get By|TTBB|Deke Sharon
+You're My Best Friend|TTBB|Deke Sharon
+You're Welcome|SATB|Deke Sharon
+You've Got A Friend In Me|SATB|Deke Sharon
+Your Song|SATB|Deke Sharon
+Zanzibar|TTBB|Deke Sharon
+Zip A Dee Doo Dah|SATB|Deke Sharon
+Zombie Jamboree|TTBB|Deke Sharon
+It's So Nice To Have A Man Around The House|SSAA|Sandy Sharpe
+Cups (When I'm Gone)|TTBB, SSAA, SATB|Kirby Shaw
+I'm Yours|TTBB, SSAA, SATB|Kirby Shaw
+Shut De Do|TTBB|Kirby Shaw
+Thinking Out Loud|TTBB, SSAA|Kirby Shaw
+Recycle Song|TTBB|Murray Shaw
+Little Drummer Boy|TTBB|Tracy Shirk
+Louisville Lou|TTBB|James Shisler
+Brother Loves Travelin' Salvation Show|SSAA|Jean Shook
+Carolina In The Morning|SSAA|Jean Shook
+Christmas Island|SSAA|Jean Shook
+Crazy|SSAA|Jean Shook
+Edelweiss|SSAA|Jean Shook
+Goodnight Little Soldier|SSAA|Jean Shook
+I'm Gonna Lock My Heart|SSAA|Jean Shook
+Let Me Call You Sweetheart|SSAA|Jean Shook
+Man On The Flying Trapeze|SSAA|Jean Shook
+So What's New|SSAA|Jean Shook
+Tuxedo Junction|SSAA|Jean Shook
+Up, Up And Away (My Beautiful Balloon)|SSAA|Jean Shook
+World War I Medley|SSAA|Jean Shook
+You Can Have Every Light On Broadway|SSAA|Jean Shook
+Let There Be Peace On Earth|SSAA|Donna Shorkey
+Nothing Seems The Same Anymore|SSAA|Donna Shorkey
+Somebody Stole My Gal|SSAA|Donna Shorkey
+You're Nobody 'Til Somebody Loves You|SSAA|Donna Shorkey
+Aquarius|SSAA|Dorothy Short
+Do Lord|SSAA|Dorothy Short
+I Wanna Be Around|SSAA|Dorothy Short
+Moments To Remember|SSAA|Dorothy Short
+Muskrat Ramble|SSAA|Dorothy Short
+Seems Like Old Times|SSAA|Dorothy Short
+Somebody Loves You|SSAA|Dorothy Short
+Steppin' Out With My Baby|SSAA|Dorothy Short
+First Cousin|TTBB|Austin Shortes
+Whatever Lola Wants|SATB|Austin Shortes
+White Christmas|TTBB|Austin Shortes
+(Love Is) The Tender Trap|TTBB|Jim Shubert
+A, You're Adorable|TTBB|Jim Shubert
+Ac-cent-tchu-ate The Positive|TTBB|Jim Shubert
+Achy Breaky Heart|TTBB|Jim Shubert
+After You Get What You Want You Don't Want It|TTBB|Jim Shubert
+Alice Blue Gown|TTBB|Jim Shubert
+All Alone|TTBB|Jim Shubert
+Allegheny Moon|TTBB|Jim Shubert
+Almost Like Being In Love|TTBB|Jim Shubert
+Along The Navaho Trail|TTBB|Jim Shubert
+Alright, Okay , You Win|TTBB|Jim Shubert
+Always On My Mind|TTBB|Jim Shubert
+Always Take A Girl Named Daisy|TTBB|Jim Shubert
+Another Somebody Done Somebody Wrong Song|TTBB|Jim Shubert
+Anything Goes|TTBB|Jim Shubert
+At The Cross|SATB|Jim Shubert
+Baby, Save Your Kisses For Me|TTBB|Jim Shubert
+Ballin' The Jack|TTBB|Jim Shubert
+Beat Me Daddy, Eight To The Bar|TTBB|Jim Shubert
+Big Bad Bill Is Sweet William Now|TTBB|Jim Shubert
+Blue Skies|TTBB|Jim Shubert
+Breezin' Along With The Breeze|TTBB|Jim Shubert
+The Bunny Hug|TTBB|Jim Shubert
+By The Light Of The Silvery Moon|TTBB|Jim Shubert
+Can You Tame Wild Wimmen|TTBB|Jim Shubert
+Christmas Time Is Here|TTBB|Jim Shubert
+Christmas Waltz|TTBB|Jim Shubert
+Crazy|TTBB|Jim Shubert
+Cross Over The Bridge|TTBB|Jim Shubert
+Cry|TTBB|Jim Shubert
+Daddy Sang Bass|SATB|Jim Shubert
+Darling, Je Vous Aime Beaucoup|TTBB|Jim Shubert
+Day By Day|TTBB|Jim Shubert
+Deep River|TTBB, SATB|Jim Shubert
+Devil Sounds Just Like Me. The|TTBB|Jim Shubert
+Doggie In The Window (How Much Is That)|TTBB|Jim Shubert
+Don't Fence Me In|TTBB|Jim Shubert
+Don't Get Around Much Anymore|TTBB|Jim Shubert
+Dream|TTBB|Jim Shubert
+Dreamer's Holiday|TTBB|Jim Shubert
+Early Bird Blues|TTBB|Jim Shubert
+Elmer's Tune|TTBB|Jim Shubert
+Embraceable You|TTBB|Jim Shubert
+Enjoy Yourself (It's Later Than You Think)|TTBB|Jim Shubert
+Everybody Loves My Baby|TTBB|Jim Shubert
+Everybody Step|TTBB|Jim Shubert
+Five Minutes More|TTBB|Jim Shubert
+Flat Foot Floogie|TTBB|Jim Shubert
+A Foggy Day|TTBB|Jim Shubert
+Folks Who Live On The Hill|TTBB|Jim Shubert
+For Sentimental Reasons|TTBB|Jim Shubert
+Forever And Ever, Amen|TTBB|Jim Shubert
+Get Happy|TTBB|Jim Shubert
+Glad Rag Doll|TTBB|Jim Shubert
+God Bless The Child|TTBB|Jim Shubert
+The Green Side of the Grass|TTBB|Jim Shubert
+Gulf Coast Blues|TTBB|Jim Shubert
+Happy Days Are Here Again|TTBB|Jim Shubert
+Hey Good Lookin'|TTBB|Jim Shubert
+Hey! Baby!|TTBB|Jim Shubert
+High Hopes|TTBB|Jim Shubert
+I Ain't Got No Body|TTBB|Jim Shubert
+I Don't Stand A Ghost Of A Chance|TTBB|Jim Shubert
+I Don't Want To Walk Without You|TTBB|Jim Shubert
+I Only Have Eyes For You|TTBB|Jim Shubert
+I Saw Three Ships|SATB|Jim Shubert
+I Used To Love You But It's All Over|TTBB|Jim Shubert
+I Want To Be Happy|TTBB|Jim Shubert
+I'd Really Love To Spend This Time With You|TTBB|Jim Shubert
+I'll Be Home For Christmas|TTBB|Jim Shubert
+I'll Be Seeing You|TTBB|Jim Shubert
+I'll Be The Words and You'll Be The Music|TTBB|Jim Shubert
+I'll Never Smile Again|TTBB|Jim Shubert
+I'll String Along with You|TTBB|Jim Shubert
+I'll Take You Home Again, Kathleen|TTBB|Jim Shubert
+I'm Gonna Eat at the Welcome Table|SATB|Jim Shubert
+I'm Henry VIII I Am|TTBB|Jim Shubert
+I'm Putting All My Eggs In One Basket|TTBB|Jim Shubert
+I've Got A Crush On You|TTBB|Jim Shubert
+If I Had You|TTBB|Jim Shubert
+If You Were The Only Girl In The World|TTBB|Jim Shubert
+In The Cool Cool Cool Of The Evening|TTBB|Jim Shubert
+Isn't This A Lovely Day|TTBB|Jim Shubert
+It Takes All Day for Me to Do (What I Did All Day Long)|TTBB|Jim Shubert
+It's A Lovely Day Today|TTBB|Jim Shubert
+Ja-Da|TTBB|Jim Shubert
+Jesus Loves Me|SATB|Jim Shubert
+Kickin' 'n' Screamin'|TTBB|Jim Shubert
+King Of The Road|TTBB|Jim Shubert
+Let There Be Peace On Earth|TTBB|Jim Shubert
+Lil Darlin'|TTBB|Jim Shubert
+Lois|TTBB|Jim Shubert
+Love and Marriage|TTBB|Jim Shubert
+Love Is Just Around The Corner|TTBB|Jim Shubert
+Love Letters|TTBB|Jim Shubert
+Love Walked In|TTBB|Jim Shubert
+Margie|TTBB|Jim Shubert
+A Marshmallow World|TTBB|Jim Shubert
+Mele Kalikimaka|TTBB|Jim Shubert
+Midnight Sun|TTBB|Jim Shubert
+Misty|TTBB|Jim Shubert
+Molly Malone|TTBB|Jim Shubert
+Moonglow|TTBB|Jim Shubert
+My Darling, My Darling|TTBB|Jim Shubert
+Nature Boy|TTBB|Jim Shubert
+The Nearness Of You|TTBB|Jim Shubert
+Nevertheless|TTBB|Jim Shubert
+Nice Work If You Can Get It|TTBB|Jim Shubert
+Ob-La-Di, Ob-La-Da|TTBB|Jim Shubert
+Oh! Look At Me Now|TTBB|Jim Shubert
+Oh! What It Seemed To Be|TTBB|Jim Shubert
+Ole Buttermilk Sky|TTBB|Jim Shubert
+On Green Dolphin Street|TTBB|Jim Shubert
+Once In A While|TTBB|Jim Shubert
+Once In Love With Amy|TTBB|Jim Shubert
+The One I Love Belongs to Somebody Else|TTBB|Jim Shubert
+One Meat Ball|TTBB|Jim Shubert
+Orange Colored Sky|TTBB|Jim Shubert
+Pain, Pain, Pain|TTBB|Jim Shubert
+Paper Doll|TTBB|Jim Shubert
+Peg O' My Heart|TTBB|Jim Shubert
+Please Don't Take That Baby Grand|TTBB|Jim Shubert
+Poor Little Rhode Island|TTBB|Jim Shubert
+Puff The Magic Dragon|TTBB|Jim Shubert
+Put Your Dreams Away (For Another Day)|TTBB|Jim Shubert
+Put Your Head On My Shoulder|TTBB|Jim Shubert
+Ragtime Cowboy Joe|TTBB|Jim Shubert
+Ramblin' Rose|TTBB|Jim Shubert
+Right Here In Your Arms|TTBB|Jim Shubert
+Rubber Duckie|TTBB|Jim Shubert
+Santa Lost His Keys|TTBB|Jim Shubert
+School Days|TTBB|Jim Shubert
+The Sears Christmas Catalog|TTBB|Jim Shubert
+September In The Rain|TTBB|Jim Shubert
+Singin' In The Rain|TTBB|Jim Shubert
+Somebody Loves Me|TTBB|Jim Shubert
+Somebody New Is Breaking Your Heart|TTBB|Jim Shubert
+South America, Take It Away!|TTBB|Jim Shubert
+St Louis Blues|TTBB|Jim Shubert
+Straighten Up And Fly Right|TTBB|Jim Shubert
+Sunbonnet Sue|TTBB|Jim Shubert
+Taking A Chance On Love|TTBB|Jim Shubert
+Tenderly|TTBB|Jim Shubert
+They Didn't Believe Me|TTBB|Jim Shubert
+This Is All I Ask|TTBB|Jim Shubert
+Those Lazy Hazy Crazy Days Of Summer|TTBB|Jim Shubert
+Toyland|TTBB|Jim Shubert
+Tumbling Tumbleweeds|TTBB|Jim Shubert
+Undecided|TTBB|Jim Shubert
+Under The Anheuser Bush|TTBB|Jim Shubert
+Valentine's Day|TTBB|Jim Shubert
+The Very Thought Of You|TTBB|Jim Shubert
+Watermelon Man|TTBB|Jim Shubert
+Wave|TTBB|Jim Shubert
+We Are The Senior Moments|TTBB|Jim Shubert
+We Wish You The Merriest|TTBB|Jim Shubert
+We'd Make A Peach Of A Pair|TTBB|Jim Shubert
+What Are You Doing New Year's Eve?|TTBB|Jim Shubert
+What The World Needs Now Is Love|TTBB|Jim Shubert
+What's Left To Sing About Christmas|TTBB|Jim Shubert
+When Irish Eyes Are Smiling|TTBB|Jim Shubert
+When October Goes|TTBB|Jim Shubert
+Witchcraft|TTBB|Jim Shubert
+Wrap Your Troubles In Dreams|TTBB|Jim Shubert
+Yesterday|TTBB|Jim Shubert
+You Are The Sunshine Of My Life|TTBB|Jim Shubert
+You Brought A New Kind Of Love To Me|TTBB|Jim Shubert
+You Made Me Love You|TTBB|Jim Shubert
+You Must Have Been A Beautiful Baby|TTBB|Jim Shubert
+You Were Meant For Me|TTBB|Jim Shubert
+You're Sixteen You're Beautiful And You're Mine|TTBB|Jim Shubert
+Help, I'm Turning Into My Parents|SSAA|Nancy Shumard
+Lean On Me|SSAA|Nancy Shumard
+Rocky Top|SSAA|Nancy Shumard
+Everything Old Is New Again|TTBB|Henry Shuster
+Lazy|TTBB|Alan Siegal
+Are You Making Any Money|TTBB|Joe Simone
+Do You Take This Woman for Your Lawful Wife|TTBB|Joe Simone
+I Love A Parade|TTBB|H. R. Skinner
+Hunting Song|TTBB|Marvin Skupski
+So What's New|TTBB|Marvin Skupski
+I'll Be Seeing You/You're Breaking In A New Heart (While You're Breaking Mine)|TTBB|Chris Slacke
+Arrah Go On I'm Gonna Go Back To Oregon|TTBB|Douglas Smith
+Christmas Waltz|TTBB|Douglas Smith
+Down By The Old Mill Stream|TTBB|Douglas Smith
+Goofus|TTBB, SSAA|Douglas Smith
+I Write The Songs|TTBB|Douglas Smith
+If You Were The Only Girl In The World|TTBB|Douglas Smith
+In Flander's Fields|TTBB|Douglas Smith
+Jesus Loves Me|SSAA|Douglas Smith
+"Kentucky's Way Of Sayin', ""Good Morning"""|TTBB|Douglas Smith
+Little Jazz Bird|TTBB|Douglas Smith
+Love's Been Good To Me|TTBB|Douglas Smith
+O Christmas Tree|TTBB|Douglas Smith
+Oh, You Beautiful Doll|TTBB|Douglas Smith
+On The Beaches Of Normandy|TTBB|Douglas Smith
+Our Vets Of 'Nam|TTBB|Douglas Smith
+Sleep Soldier (Sailor) Boy|TTBB|Douglas Smith
+Sometimes|TTBB, SSAA|Douglas Smith
+There Will Never Be Another You|TTBB|Douglas Smith
+Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Douglas Smith
+Weekend In New England|TTBB|Douglas Smith
+When You Were A Baby And I Was The Kid Next Door|TTBB|Douglas Smith
+White Lines, Dark, Dark Lies|TTBB|Douglas Smith
+You Keep Coming Back Like A Song|TTBB|Douglas Smith
+Old Virginia Moon|TTBB|Edwin Smith
+Won't You Take A Sail With Me, Dear|TTBB|Edwin Smith
+Sing Me That Song Again|TTBB|Frank Smith
+South Rampart Street Parade|TTBB|Frank Smith
+God Bless America|SSAA|Joan Smith
+If You Feel Like Singing|TTBB|Joan Smith
+It's Beginning To Look A Lot Like Christmas|SSAA|Joan Smith
+God Bless The U.S.A.|SSAA|Linda Smith
+A Special Wish|SSAA|Linda Smith
+If The Lord Be Willin'|TTBB|Mark Smith
+Jingle Bells / Sleigh Ride Medley|TTBB|Mark Smith
+Sweet, Sweet Spirit|TTBB|Mark Smith
+Baby Won't You Please Come Home|TTBB|Paul Smith
+My Christmas Prayer|TTBB|Paul Smith
+Accident Waiting To Happen|SSAA|Kyle Snook
+Bad Moon Rising|SATB|Kyle Snook
+Big Bad Bill Is Sweet William Now|TTBB, SSAA, SATB|Kyle Snook
+Bounce Me Brother With A Solid Four|SSAA|Kyle Snook
+Close Your Eyes|SSAA|Kyle Snook
+Come In From The Cold|TTBB|Kyle Snook
+Getting Some Fun Out Of Life|TTBB|Kyle Snook
+Good Night My Someone|TTBB|Kyle Snook
+Hate Is The Basis (of Love)|SSAA|Kyle Snook
+Hey Pretty Moon|TTBB|Kyle Snook
+I've Come To Realize|TTBB|Kyle Snook
+If I Only Had A Brain|SATB|Kyle Snook
+It Hurt So Bad|TTBB|Kyle Snook
+It's Always You|TTBB|Kyle Snook
+Let Them Talk|TTBB|Kyle Snook
+Let Yourself Go|SSAA|Kyle Snook
+The Love Bug Will Bite You|TTBB|Kyle Snook
+Meet Me After The Show|TTBB|Kyle Snook
+Mister Sandman|SSAA|Kyle Snook
+More|TTBB|Kyle Snook
+Nobody Does It Like Me!|TTBB|Kyle Snook
+On The Road Again|SATB|Kyle Snook
+Please Come Home For Christmas|TTBB|Kyle Snook
+Please Please Please|SSAA|Kyle Snook
+Pretty Good At Drinkin' Beer|TTBB|Kyle Snook
+Public Melody Number One|SATB|Kyle Snook
+Say Si Si|TTBB|Kyle Snook
+She Thinks I Still Care|TTBB|Kyle Snook
+Smoke Rings|TTBB|Kyle Snook
+Somethin' Stupid|SATB|Kyle Snook
+Tacos, Enchiladas and Beans|TTBB|Kyle Snook
+Tell All The World About You|TTBB|Kyle Snook
+That's The Way Love Is|TTBB|Kyle Snook
+The Things We Did Last Summer|TTBB|Kyle Snook
+There's A Rainbow 'Round My Shoulder|TTBB|Kyle Snook
+Too Easy|TTBB|Kyle Snook
+Turn The Lights Back On|TTBB|Kyle Snook
+Wells Fargo Wagon|TTBB|Kyle Snook
+What Baking Can Do|SSAA|Kyle Snook
+The Winner Takes It All|SATB|Kyle Snook
+Yearning (Just for You)|TTBB|Kyle Snook
+You've Got Me Under Your Thumb|TTBB|Kyle Snook
+Your Smiling Face|TTBB|Kyle Snook
+Santa Claus Is Comin' To Town|TTBB|Steve Snow
+After You've Gone|TTBB|Hal Snyder
+Don't Cry Out Loud|TTBB|Hal Snyder
+Fill My Cup, Lord|TTBB|Hal Snyder
+Great Is Thy Faithfulness|TTBB|Hal Snyder
+I'm Making Believe That I Don't Care|TTBB|Hal Snyder
+If I Ruled The World|TTBB|Hal Snyder
+Let Me Entertain You|TTBB|Hal Snyder
+Look For The Silver Lining|TTBB|Hal Snyder
+Rural Rhythm|TTBB|Hal Snyder
+Somewhere Out There|TTBB|Hal Snyder
+Strike Up The Band / I Love A Parade Medley|TTBB|Hal Snyder
+The Clouds Will Soon Roll By|SSAA|Zona Snyder
+Cuanto Le Gusta|SSAA|Zona Snyder
+Dunk-Dunk-Dunk|SSAA|Zona Snyder
+Johnny Fedora and Alice Blue Bonnet|SSAA|Zona Snyder
+Let's All Sing Like The Birdies Sing|SSAA|Zona Snyder
+If I Loved You|TTBB|Mike Sobeleski
+All About That Bass|SSAA|Ray Sofio
+You Light Up My Life|TTBB|Ray Sofio
+CHRISTmas|SSAA|Greta Somers
+Glory Of Love|SSAA|Greta Somers
+June In January|SSAA|Greta Somers
+Mr. Custer|SSAA|Greta Somers
+Running Bear|SSAA|Greta Somers
+Someday (You'll Want Me To Want You)|SSAA|Greta Somers
+By The Sea / In The Good Old Summertime Medley|TTBB|Mike Sotiriou
+Danny Boy|TTBB|Mike Sotiriou
+Hi Neighbor|TTBB|Mike Sotiriou
+Powder Your Face With Sunshine / Let A Smile Be Your Umbrella Medley|TTBB|Mike Sotiriou
+Will I Ever Tell You|TTBB|Mike Sotiriou
+Yes, We Have No Bananas|TTBB|Sigmund Spaeth
+Kiss To Build A Dream On/Dreams Medley|SSAA|Anthony Sparks
+To Morrow|TTBB|Anthony Sparks
+Step To The Rear|TTBB|Gary Sparks
+Jeepers Creepers|TTBB|C. J. Spatafora
+Teddy Bears' Picnic|TTBB|C. J. Spatafora
+Alice Blue Gown|TTBB|SPEBSQSA
+All That I Ask Of You Is Love|TTBB|SPEBSQSA
+America|TTBB|SPEBSQSA
+Asleep In The Deep|TTBB|SPEBSQSA
+At The End Of A Cobblestone Road|TTBB|SPEBSQSA
+Auld Lang Syne/I Love You Truly/Tell Me Why|TTBB|SPEBSQSA
+Aura Lee|TTBB|SPEBSQSA
+Ball Game Medley|TTBB|SPEBSQSA
+Bright Was The Night|TTBB|SPEBSQSA
+Bundle Of Old Love Letters|TTBB|SPEBSQSA
+Bye Bye Blues|TTBB|SPEBSQSA
+Civil War Medley|TTBB|SPEBSQSA
+Cocktails For Two|TTBB|SPEBSQSA
+Coney Island Baby / We All Fall Medley|TTBB|SPEBSQSA
+Coventry Carol|TTBB|SPEBSQSA
+Darkness On The Delta|TTBB|SPEBSQSA
+Dear Hearts And Gentle People|TTBB|SPEBSQSA
+Dear Little Boy Of Mine|TTBB|SPEBSQSA
+Dear Old Girl|TTBB|SPEBSQSA
+Dearie|TTBB|SPEBSQSA
+Firefly|TTBB|SPEBSQSA
+For Me And My Gal|TTBB|SPEBSQSA
+George M. Cohan Medley|TTBB|SPEBSQSA
+Get Out Those Old Records|TTBB|SPEBSQSA
+Give Me Your Tired, Your Poor|TTBB|SPEBSQSA
+Good Night Ladies|TTBB|SPEBSQSA
+Goodbye Rose|TTBB|SPEBSQSA
+Hang On The Bell, Nellie|TTBB|SPEBSQSA
+Heritage Medley|TTBB|SPEBSQSA
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|SPEBSQSA
+I Believe|TTBB|SPEBSQSA
+I Love You The Best Of All|TTBB|SPEBSQSA
+I Miss You Most Of All|TTBB|SPEBSQSA
+I Want A Girl|TTBB|SPEBSQSA
+I Want To Wish You A Merry Christmas|TTBB|SPEBSQSA
+I Was Born Seventy Years Too Late|TTBB|SPEBSQSA
+I Wish I Had A Girl|TTBB|SPEBSQSA
+I'll Take You Home Again, Kathleen|TTBB|SPEBSQSA
+I'm So Alone With The Crowd|TTBB|SPEBSQSA
+If The Lord Be Willin'|TTBB|SPEBSQSA
+If You Had All The World And Its Gold|TTBB|SPEBSQSA
+If You Knew Susie|TTBB|SPEBSQSA
+In The Good Old Summertime|TTBB|SPEBSQSA
+It's The Same Old Shillelagh|TTBB|SPEBSQSA
+Jazz Came Up The River From New Orleans|TTBB|SPEBSQSA
+Last Night Was The End Of The World|TTBB, SSAA|SPEBSQSA
+The Last Time I Saw Henry|TTBB|SPEBSQSA
+Let Me Call You Sweetheart|TTBB|SPEBSQSA
+Let's Talk About My Sweetie|TTBB|SPEBSQSA
+Lida Rose|TTBB|SPEBSQSA
+Little Boy That Santa Claus Forgot|TTBB|SPEBSQSA
+Lonesomest Girl In Town|TTBB|SPEBSQSA
+Love Me And The World Is Mine|TTBB|SPEBSQSA
+MacNamara's Band|TTBB|SPEBSQSA
+Memories|TTBB|SPEBSQSA
+Memory Medley|TTBB|SPEBSQSA
+Old Boffo Medley|TTBB|SPEBSQSA
+Old Fashioned Girl|TTBB|SPEBSQSA
+On San Francisco Bay|TTBB|SPEBSQSA
+Pals Of The Little Red School|TTBB|SPEBSQSA
+Poody Poo|TTBB|SPEBSQSA
+Put On An Old Pair Of Shoes|TTBB|SPEBSQSA
+Red Hot Mamma|TTBB|SPEBSQSA
+Red River Valley|TTBB|SPEBSQSA
+Rock Me to Sleep In An Old Rocking Chair|TTBB|SPEBSQSA
+Roll On, Mississippi, Roll On|TTBB|SPEBSQSA
+Rose Of No Man's Land|TTBB|SPEBSQSA
+The Santa Claus Express|TTBB|SPEBSQSA
+Side by Side|TTBB|SPEBSQSA
+Silent Night|TTBB|SPEBSQSA
+Soft Shoe Song|TTBB|SPEBSQSA
+Somebody Knows|TTBB|SPEBSQSA
+A Son Of The Sea|TTBB|SPEBSQSA
+Southern Medley|TTBB|SPEBSQSA
+Spring|TTBB|SPEBSQSA
+The Sweetheart Of Sigma Chi|TTBB|SPEBSQSA
+Swing Down Chariot|SSAA|SPEBSQSA
+Ta-Ra-Ra Boom-De-Ay / Hot Time Medley|TTBB|SPEBSQSA
+Take Me Out To The Ball Game|TTBB|SPEBSQSA
+That Tumble Down Shack In Athlone|TTBB|SPEBSQSA
+There Is A Tavern In The Town|TTBB|SPEBSQSA
+There's A Rainbow 'Round My Shoulder|TTBB|SPEBSQSA
+They Go Wild, Simply Wild Over Me|TTBB|SPEBSQSA
+Time After Time|TTBB|SPEBSQSA
+Time To Dance|TTBB|SPEBSQSA
+Under The Boardwalk|TTBB, SSAA, SATB|SPEBSQSA
+Wedding Bells Are Breaking Up That Old Gang Of Mine|TTBB|SPEBSQSA
+When I Leave The World Behind|TTBB|SPEBSQSA
+When I Lost You|TTBB|SPEBSQSA
+When I Wore My Daddy's Brown Derby|TTBB|SPEBSQSA
+When You Wish Upon A Star|TTBB|SPEBSQSA
+When You're Smiling|TTBB|SPEBSQSA
+Who Threw The Overalls In Mrs. Murphy's Chowder|TTBB|SPEBSQSA
+Won't You Please Come Back To Me|TTBB|SPEBSQSA
+Yona From Arizona|TTBB|SPEBSQSA
+I (Who Have Nothing)|SSAA, SATB|Gabriel Spector
+Poor Monty|SSAA|Gabriel Spector
+Fortune Teller|TTBB|John Spence
+It's A Sin To Tell A Lie|TTBB|John Spence
+Sh Boom|TTBB|John Spence
+Those Were The Days|TTBB|John Spence
+I'll Always Be Mother's Boy|TTBB|Rick Spencer
+Perfect|TTBB|Rick Spencer
+Silent Night|TTBB|Rick Spencer
+Walkin' After Midnight|TTBB, SSAA|Rick Spencer
+The Water Is Wide|SSAA|Rick Spencer
+Wonderful Tonight|TTBB|Rick Spencer
+Diamond's Are A Girls Best Friend|SSAA|Jarmela Speta
+Every Street's A Boulevard|SSAA|Jarmela Speta
+Gang That Sang Heart Of My Heart|TTBB|Jarmela Speta
+God Bless America|SSAA|Jarmela Speta
+I Feel A Song Comin' On|SSAA|Jarmela Speta
+I Wanna Be Loved By You|SSAA|Jarmela Speta
+Make Believe|TTBB|Jarmela Speta
+The Secret Of Christmas|SSAA|Jarmela Speta
+That Great Come And Get It Day|SSAA|Jarmela Speta
+That's Life|SSAA|Jarmela Speta
+There Is Nothing Like A Dame|TTBB|Jarmela Speta
+Blaydon Races|SATB|Matthew Spinner
+Blow The Winds Southerly|SATB|Matthew Spinner
+Lessons In Love|SATB|Matthew Spinner
+London Girls|TTBB|Matthew Spinner
+Margate|TTBB|Matthew Spinner
+Nine To Five|SATB|Matthew Spinner
+The Power of Love|SATB|Matthew Spinner
+Rabbit|SATB|Matthew Spinner
+The Roast Beef of Old England|SATB|Matthew Spinner
+When I'm Cleaning Windows|SATB|Matthew Spinner
+With My Little Stick of Blackpool Rock|SATB|Matthew Spinner
+Your Funny Uncle|SATB|Matthew Spinner
+We Just Couldn't Say Goodbye|TTBB|Howie Sponseller
+Rocky Top|TTBB|Terry Sproule
+All Of Me|SSAA|Jen Squires
+Blame It On The Boogie|SSAA|Jen Squires
+Count On Me|SSAA|Jen Squires
+Crazy Dreams|SSAA|Jen Squires
+Fever|SSAA|Jen Squires
+Flintstones|SSAA|Jen Squires
+Grease Medley|SSAA|Jen Squires
+Greased Lightning|SSAA|Jen Squires
+Happy Birthday|SSAA|Jen Squires
+Heart Of Stone|SSAA|Jen Squires
+Holding Out For A Hero|SSAA|Jen Squires
+It's A Beautiful Day|SSAA|Jen Squires
+Medley: Christmas Day, Three Drovers, Five Australian Christmas Carols|SSAA|Jen Squires
+Medley: Just The Way You Are with Just A Dream|SSAA|Jen Squires
+Medley: Little Drummer Boy, Do You Hear What I Hear?|SATB|Jen Squires
+Never Getting Rid Of Me|SSAA|Jen Squires
+On A Mission|SSAA|Jen Squires
+Santa Tell Me|SSAA|Jen Squires
+She Used To Be Mine|SSAA|Jen Squires
+Take On Me|SSAA|Jen Squires
+Thank God I'm Old|SSAA|Jen Squires
+This Night|SSAA|Jen Squires
+Who Would Imagine A King|SSAA|Jen Squires
+Xanadu|SSAA|Jen Squires
+There's a Rose On Your Cheek|TTBB|Hal Staab
+Turn Your Radio On|TTBB|Burt Staffen
+Callin' Baton Rouge|TTBB|Don Staffin
+Don't Pay The Ferryman|TTBB, SATB|Don Staffin
+Hang Fire|TTBB, SATB|Don Staffin
+Heaven Can Wait|TTBB, SATB|Don Staffin
+I Do Wanna Know|TTBB, SATB|Don Staffin
+In My Dreams|TTBB, SATB|Don Staffin
+Keep Me Warm|SATB|Don Staffin
+Kodachrome|TTBB, SSAA|Don Staffin
+No Hopers, Jokers & Rogues|TTBB, SSAA, SATB|Don Staffin
+Our Country|TTBB|Don Staffin
+Please Come To Boston|TTBB, SATB|Don Staffin
+Ship To Shore|SATB|Don Staffin
+Strangers Like Me|TTBB, SATB|Don Staffin
+Whatever Happened To Saturday Night?|TTBB, SATB|Don Staffin
+Call It Nostalgia|TTBB|Sam Stahl
+Santa Claus Is Comin' To Town|TTBB|Sam Stahl
+Huckleberry Finn|TTBB|Jim Stahly
+Reach Out And Touch|TTBB|Jim Stahly
+Bounce Me Brother With A Solid Four|SSAA|Joyce Stanbery
+Sister Suffragette|SSAA|Joyce Stanbery
+Amazing Grace|TTBB|Robert Standley
+Cabaret|TTBB|Robert Standley
+I'll Be With You In Apple Blossom Time|TTBB|Robert Standley
+When I Grow Too Old To Dream|TTBB|Robert Standley
+Whispering|TTBB|Robert Standley
+Brave|SSAA|Julie Starr
+Celebrate Diversity|SSAA|Julie Starr
+Cold-Hearted|SSAA|Julie Starr
+Feliz Navidad|SSAA|Julie Starr
+Mary Did You Know|SSAA|Julie Starr
+Remember Me|SSAA|Julie Starr
+True Colors|SSAA|Julie Starr
+Wind Beneath My Wings|SSAA|Julie Starr
+Wishing You Were Somehow Here Again|SSAA|Julie Starr
+Send Me The Pillow You Dream On|SSAA|Betty Steele
+You'd Be So Nice To Come Home To|SSAA|Betty Steele
+Fascinating Rhythm|TTBB|Archie Steen
+I Wish That I'd Been Satisfied With Mary|TTBB|Archie Steen
+I Won't Send Roses|TTBB|Archie Steen
+If You Are But A Dream|TTBB|Archie Steen
+Indian Love Call|TTBB|Archie Steen
+The Majesty and Glory of Your Name|TTBB|Archie Steen
+Old Time Religion|TTBB|Archie Steen
+Pine Cones And Holly Berries|TTBB|Archie Steen
+Rosie Medley|TTBB|Archie Steen
+Step To The Rear|TTBB|Archie Steen
+The Twelve Days After Christmas|TTBB|Archie Steen
+When Your Old Wedding Ring Was New|TTBB|Archie Steen
+Carolina Moon|TTBB|John Stefero
+Charmaine|TTBB|John Stefero
+Almost Like Being In Love|TTBB|Sonny Steffan
+At The Hop|SSAA, Young SSAA|Sonny Steffan
+Bosom Buddies|SSAA|Sonny Steffan
+The Boy (Girl) Friend|SSAA|Sonny Steffan
+The Brooklyn Bridge|SSAA|Sonny Steffan
+Destination Moon|SSAA|Sonny Steffan
+Don't Be A Baby, Baby|SSAA|Sonny Steffan
+Freedom From Shenandoah|SSAA|Sonny Steffan
+Hometown Band|SSAA|Sonny Steffan
+I Could Have Told You|SSAA|Sonny Steffan
+I Don't Wanna Go Home|SSAA|Sonny Steffan
+I Get Along Without You Very Well|SSAA|Sonny Steffan
+Isn't This A Lovely Day To Be Caught In The Rain|SSAA|Sonny Steffan
+It Can't Be Wrong|SSAA|Sonny Steffan
+It Only Happens When I Dance With You|SSAA|Sonny Steffan
+Jerusalem, Jerusalem|SSAA|Sonny Steffan
+Memory|SSAA|Sonny Steffan
+Money, Money|SSAA|Sonny Steffan
+My Best To You|SSAA|Sonny Steffan
+My Cutey's Due At Two-To-Two To-day|SSAA|Sonny Steffan
+Once In A Lifetime|SSAA|Sonny Steffan
+Pretend You Dont See Her (Him)|SSAA|Sonny Steffan
+Ricochet Romance|SSAA|Sonny Steffan
+Thank You Very Much|SSAA|Sonny Steffan
+Tuxedo Junction|SSAA|Sonny Steffan
+Where Did The Good Times Go?|SSAA|Sonny Steffan
+You Gotta Start Off Each Day with a Song|SSAA|Sonny Steffan
+You Should Have Told Me|SSAA|Sonny Steffan
+Let Us Entertain You / It's A Good Day Medley|TTBB|Sonny Steffon
+Daddy's Little Girl|TTBB|Lloyd Steinkamp
+Ding-Dong! The Witch Is Dead|TTBB|Lloyd Steinkamp
+Heart Of A Clown|TTBB|Lloyd Steinkamp
+Heart Of A Clown|SSAA|Lloyd Steinkamp
+If He Can Fight Like He Can Love, Good Night Germany|TTBB|Lloyd Steinkamp
+If I Only Had A Brain / Heart Medley|TTBB|Lloyd Steinkamp
+If I Were King Of The Forest|TTBB|Lloyd Steinkamp
+Inka Dinka Doo|TTBB|Lloyd Steinkamp
+It's A Good Day|TTBB, SSAA, SATB|Lloyd Steinkamp
+Just A Closer Walk With Thee / When The Saints Go Marching In Medley|TTBB|Lloyd Steinkamp
+Lucky Day|TTBB|Lloyd Steinkamp
+Lydia (The Tattooed Lady)|TTBB|Lloyd Steinkamp
+M-O-T-H-E-R|TTBB|Lloyd Steinkamp
+Merry Old Land Of Oz|TTBB|Lloyd Steinkamp
+One More Time|TTBB|Lloyd Steinkamp
+One Rose|TTBB|Lloyd Steinkamp
+Optimistic Voices|TTBB|Lloyd Steinkamp
+Over The Rainbow|TTBB|Lloyd Steinkamp
+Put Your Arms Around Me Honey|TTBB|Lloyd Steinkamp
+A Ring to the Name of Rosie|TTBB|Lloyd Steinkamp
+Rock-A-Bye Baby Days|TTBB|Lloyd Steinkamp
+Rose (A Ring To The Name Of Rose)|TTBB|Lloyd Steinkamp
+Somebody's Coming To My House|TTBB|Lloyd Steinkamp
+Tie Me To Your Apron Strings Again|TTBB|Lloyd Steinkamp
+Tuck Me To Sleep In My Old 'Tucky Home|TTBB|Lloyd Steinkamp
+Wizard Of Oz Medley|TTBB|Lloyd Steinkamp
+Everything Is Beautiful|TTBB|Jim Stenson
+Ireland Must Be Heaven|TTBB|Jim Stenson
+Pal Of My Dreams|TTBB|Jim Stenson
+There's An Old Easy Chair By The Fireplace|TTBB|Jim Stenson
+Wagon Wheels|TTBB|Jim Stenson
+Waltz You Saved For Me|TTBB|Jim Stenson
+What A Wonderful World|TTBB|Jim Stenson
+I'm A Ding Dong Daddy from Dumas|TTBB|Dick Stern
+Last Night Was The End Of The World|TTBB|Dick Stern
+American Revolution Medley|TTBB|Dave Stevens
+Baby Face|TTBB|Dave Stevens
+Barbershop Harmony Time|TTBB, SSAA|Dave Stevens
+California Here I Come|TTBB|Dave Stevens
+Come With Me|TTBB|Dave Stevens
+Down South|TTBB|Dave Stevens
+The Girl In My Memory|TTBB|Dave Stevens
+Girls, Girls|TTBB|Dave Stevens
+Give Me That Barbershop Style|TTBB|Dave Stevens
+Hard Hearted Hannah|SSAA|Dave Stevens
+I'd Like To Teach The World To Sing|TTBB|Dave Stevens
+Ma! (He's Making Eyes At Me)|SSAA|Dave Stevens
+Mandy 'N' Me|TTBB|Dave Stevens
+Minstrel Medley|TTBB|Dave Stevens
+San Francisco Bay Blues|SSAA|Dave Stevens
+Strolling Home With Jennie|TTBB|Dave Stevens
+That Certain Party|TTBB|Dave Stevens
+That Old Fashioned Sweeetheart Of Mine|TTBB|Dave Stevens
+Them There Eyes|SSAA|Dave Stevens
+What A Country|TTBB|Dave Stevens
+When Johnny Comes Marching Home|TTBB|Dave Stevens
+(I'll) Tell My Ma|SATB|Mark Stevens
+Ain't No Love In Oklahoma|TTBB|Mark Stevens
+All Out Of Love|TTBB|Mark Stevens
+Alone|SATB|Mark Stevens
+Angel Eyes|TTBB|Mark Stevens
+Angel Of The Morning|TTBB|Mark Stevens
+Arms Of A Stranger|TTBB|Mark Stevens
+Arthur's Theme|TTBB|Mark Stevens
+Aspenglow|TTBB|Mark Stevens
+Azizam|SATB|Mark Stevens
+Baby, I'm-A Want You|TTBB|Mark Stevens
+Baby, Now that I've Found You|TTBB|Mark Stevens
+Be Her|SATB|Mark Stevens
+Beautiful Things|TTBB|Mark Stevens
+Beautiful Things|SATB|Mark Stevens
+Because|TTBB|Mark Stevens
+The Bluest Eyes In Texas|TTBB|Mark Stevens
+Both Sides Now|TTBB, SATB|Mark Stevens
+Break It To Me Gently|SATB|Mark Stevens
+Broken Wings|TTBB|Mark Stevens
+Buy Dirt|TTBB|Mark Stevens
+Christmas Time|TTBB|Mark Stevens
+Close To You|SATB|Mark Stevens
+Coming Around Again|SATB|Mark Stevens
+Coming Up Roses|SATB|Mark Stevens
+Copperline|TTBB|Mark Stevens
+Daisies|SATB|Mark Stevens
+Dance With Me|TTBB|Mark Stevens
+Die For You|SATB|Mark Stevens
+Dixieland Delight|TTBB|Mark Stevens
+Doctor, My Eyes|TTBB|Mark Stevens
+Don't Forget Me When I'm Gone|TTBB|Mark Stevens
+Evergreen|TTBB|Mark Stevens
+Everywhere|TTBB|Mark Stevens
+Eye In The Sky|TTBB|Mark Stevens
+Fading Like A Flower|TTBB|Mark Stevens
+Faithfully|TTBB|Mark Stevens
+The Fate of Ophelia|SATB|Mark Stevens
+Flowers on the Wall|TTBB|Mark Stevens
+Folsom Prison Blues|TTBB|Mark Stevens
+For All We Know|SATB|Mark Stevens
+Forever Young|TTBB|Mark Stevens
+Gabriela|SATB|Mark Stevens
+Gone, Gone, Gone|SATB|Mark Stevens
+Good News|TTBB|Mark Stevens
+Good News|SATB|Mark Stevens
+Head Over Heels|TTBB|Mark Stevens
+Here Comes That Rainy Day Feeling|TTBB|Mark Stevens
+Hold On|SATB|Mark Stevens
+I Can Dream About You|TTBB|Mark Stevens
+I Can See Clearly Now|TTBB|Mark Stevens
+I Can't Tell You Why|TTBB|Mark Stevens
+I Go Back|TTBB|Mark Stevens
+I Go To Pieces|TTBB|Mark Stevens
+I Got Better|SATB|Mark Stevens
+I Guess That's Why They Call It The Blues|TTBB|Mark Stevens
+I Had Some Help|TTBB|Mark Stevens
+I just Fall In Love Again|TTBB|Mark Stevens
+I Love A Rainy Night|TTBB|Mark Stevens
+I Will Play a Rhapsody|TTBB|Mark Stevens
+I'll Be The One|TTBB|Mark Stevens
+I'll Have To Say I Love You In A Song|TTBB, SATB|Mark Stevens
+I'll Still Be Loving You|TTBB|Mark Stevens
+I'm In A Hurry (And Don't Know Why)|TTBB|Mark Stevens
+I'm On Fire|TTBB|Mark Stevens
+I've Been Workin' On The Railroad|TTBB|Mark Stevens
+I've Seen It|SATB|Mark Stevens
+Imagine That|SATB|Mark Stevens
+In The Air Tonight|TTBB|Mark Stevens
+In This Life|TTBB|Mark Stevens
+It's Just A Matter Of Time|TTBB|Mark Stevens
+Just Another Day|TTBB|Mark Stevens
+Kiss Me|TTBB|Mark Stevens
+Let Your Love Flow|TTBB|Mark Stevens
+Life In A Northern Town|TTBB|Mark Stevens
+The Life of a Showgirl|SATB|Mark Stevens
+Lights|TTBB|Mark Stevens
+Lights|SATB|Mark Stevens
+Lonely Road With Jelly Roll|SATB|Mark Stevens
+Lovers In A Dangers Time|TTBB|Mark Stevens
+Man I Need|SATB|Mark Stevens
+Man I Need|TTBB|Mark Stevens
+Meet In The Middle|TTBB|Mark Stevens
+Mele Kalikimaka|TTBB|Mark Stevens
+Memories|TTBB|Mark Stevens
+Monday, Monday|TTBB|Mark Stevens
+My Girl (Gone, Gone, Gone)|TTBB|Mark Stevens
+My Town|TTBB|Mark Stevens
+My Wish|TTBB|Mark Stevens
+No Rain|TTBB|Mark Stevens
+Old Upright Piano|TTBB|Mark Stevens
+Only Wanna Be With You|TTBB|Mark Stevens
+Opalite|SATB|Mark Stevens
+Open Arms|TTBB|Mark Stevens
+Ordinary Day|TTBB|Mark Stevens
+Poems, Prayers, and Promises|TTBB|Mark Stevens
+Rein Me In|SATB|Mark Stevens
+Restless|TTBB|Mark Stevens
+Roll On (Eighteen Wheeler)|TTBB|Mark Stevens
+Sad Songs (Say So Much)|TTBB|Mark Stevens
+Sailing|TTBB|Mark Stevens
+See Clearly|TTBB|Mark Stevens
+Separate Ways (Worlds Apart)|SATB|Mark Stevens
+So Easy (To Fall In Love)|SATB|Mark Stevens
+Somebody|SATB|Mark Stevens
+Southern Cross|TTBB|Mark Stevens
+Southern Nights|TTBB|Mark Stevens
+Stand A Little Rain|TTBB|Mark Stevens
+The Subway|SATB|Mark Stevens
+Summer Breeze|TTBB|Mark Stevens
+Take It To The Limit|TTBB|Mark Stevens
+Take Me Home|TTBB|Mark Stevens
+Take On Me|TTBB|Mark Stevens
+The Flame|TTBB|Mark Stevens
+The Safety Dance|SATB|Mark Stevens
+The Safety Dance|TTBB|Mark Stevens
+They Don't Know (About Us)|TTBB|Mark Stevens
+Throw Your Arms Around Me|TTBB|Mark Stevens
+Top Of The World|TTBB|Mark Stevens
+Vincent (Starry Starry Night)|TTBB|Mark Stevens
+Waiting For A Star To Fall|TTBB|Mark Stevens
+Walk On By|TTBB, SATB|Mark Stevens
+We Are The World|TTBB|Mark Stevens
+We Built This City|TTBB|Mark Stevens
+We Built This City|SATB|Mark Stevens
+We've Only Just Begun|TTBB|Mark Stevens
+When I'm With You|SATB|Mark Stevens
+When The Night Feels My Song|TTBB|Mark Stevens
+When You Say Nothing At All|TTBB|Mark Stevens
+Wide Open Spaces|TTBB|Mark Stevens
+Wild World|TTBB|Mark Stevens
+Wish I Didn't|SATB|Mark Stevens
+Woman|TTBB|Mark Stevens
+Yesterday Once More|TTBB|Mark Stevens
+You've Got A Friend|TTBB|Mark Stevens
+Your Back Yard|TTBB|Mark Stevens
+Your Love|TTBB|Mark Stevens
+Zoot Suit Riot|TTBB|Mark Stevens
+All Of Me|TTBB|Luke Stevenson
+Can You Feel The Love Tonight?|TTBB|Luke Stevenson
+Can't Help Falling In Love|TTBB|Luke Stevenson
+Don't Wait Too Long|TTBB|Luke Stevenson
+Exactly Like You|TTBB|Luke Stevenson
+Feed The Birds|TTBB|Luke Stevenson
+For Once In My Life|SATB|Luke Stevenson
+Into My Arms|TTBB|Luke Stevenson
+Isn't This A Lovely Day To Be Caught In The Rain|TTBB|Luke Stevenson
+Love Of My Life|TTBB|Luke Stevenson
+Make You Feel My Love|TTBB|Luke Stevenson
+Two Sleepy People|TTBB|Luke Stevenson
+When She Loved Me|TTBB|Luke Stevenson
+After The Gold Rush|SSAA|Donna Stewart
+Give Me Your Tired, Your Poor|SSAA|Donna Stewart
+Good Night|SSAA|Donna Stewart
+My Romance|SSAA|Donna Stewart
+You're All I Want For Christmas|SSAA|Donna Stewart
+Pirate's Life|TTBB|Denny Stiers
+They're Off|TTBB|Denny Stiers
+Wahoo|TTBB|Denny Stiers
+Broken Hearted|TTBB|Johann Stoessel
+Looking At The World Through Rose Colored Glasses|TTBB|Johann Stoessel
+Walkin' My Baby Back Home|TTBB|M. Stollen
+Garland Of Old Fashioned Roses|TTBB|Robert Strand
+Little Skipper|TTBB|Robert Strand
+My Best To You|TTBB|Robert Strand
+Auld Lang Syne|SSAA|Roberta Street
+Camelot|TTBB|Dick Stuart
+I Hate Kids|TTBB|Dick Stuart
+I Wonder What The King Is Doing Tonight|TTBB|Dick Stuart
+Inch Worm|TTBB|Dick Stuart
+It's A Most Unusual Day|TTBB|Dick Stuart
+Playground Life|TTBB|Dick Stuart
+Send The Girls Over There|TTBB|Dick Stuart
+Sound Of Music|TTBB|Dick Stuart
+Stouthearted Men|TTBB|Dick Stuart
+If My Nose Was Running Money|TTBB|Steven Sturgis
+In A Shanty In Old Shanty Town|TTBB|Purcell Stybr
+Blame It On The Bossa Nova|SSAA|Cheryl Suhr
+Choo Choo Ch'Boogie|SSAA|Cheryl Suhr
+Don't Worry, Be Happy|SSAA|Cheryl Suhr
+Happy Holiday|SSAA|Cheryl Suhr
+I Had The Craziest Dream|SSAA|Cheryl Suhr
+I'll Be Seeing You|SSAA|Cheryl Suhr
+Long Ago (And Far Away)|SSAA|Cheryl Suhr
+Lullabye|SSAA|Cheryl Suhr
+Serenade In Blue|SSAA|Cheryl Suhr
+The Syncopated Clock|SSAA|Cheryl Suhr
+Tico-Tico|SSAA|Cheryl Suhr
+What A Wonderful World|SSAA|Cheryl Suhr
+When God Fearin' Women Get The Blues|SSAA|Cheryl Suhr
+High Middle Low|SSAA|Sally Summey
+I'm Making Believe That I Don't Care|TTBB|Carl Surfler
+Have A Smile|TTBB|Steve Sutherland
+Call Me Back Pal O' Mine|TTBB|Lee Sutter
+Give Me The Simple Life|TTBB|Lee Sutter
+Moonlight Serenade|TTBB|Lee Sutter
+As You Go On Your Way - A Benediction|TTBB|Heimer Swanson
+Alabama Jubilee|TTBB|Harry Swenson
+Give Me The Simple Life|TTBB|Harry Swenson
+I Love A Piano|TTBB|Harry Swenson
+In A Shanty In Old Shanty Town|TTBB|Harry Swenson
+It Had To Be You|TTBB|Harry Swenson
+Let's Misbehave|TTBB|Harry Swenson
+Little Boy That Santa Claus Forgot|TTBB|Harry Swenson
+Ma! (She's Makin' Eyes At Me)|TTBB|Harry Swenson
+So In Love|TTBB|Harry Swenson
+Who's Sorry Now|TTBB|Harry Swenson
+Zing! Went The Strings Of My Heart|TTBB|Harry Swenson
+He|SSAA|Margaret Swift
+He Started The Whole World Singing|SSAA|Margaret Swift
+Those Were The Days|SSAA|Margaret Swift
+Carolina In The Morning|TTBB|Frank Sysel
+San Francisco Bay Blues|TTBB|Frank Sysel
+A Good Old Barbershop Song|TTBB|Burt Szabo
+After All That I've Been To You|TTBB|Burt Szabo
+Alabamy Bound|TTBB|Burt Szabo
+Alexander's Ragtime Band|TTBB|Burt Szabo
+All In The Wearing|SSAA|Burt Szabo
+All The World Will Be Jealous Of Me|TTBB|Burt Szabo
+All Through The Night|TTBB|Burt Szabo
+Amazing Grace|TTBB|Burt Szabo
+America The Beautiful|SATB|Burt Szabo
+Anchors Aweigh|TTBB|Burt Szabo
+And I Am All Alone|TTBB|Burt Szabo
+Angels We Have Heard On High|TTBB|Burt Szabo
+Another Somebody Done Somebody Wrong Song|TTBB|Burt Szabo
+Any Little Girl Can Make A Bad Man Good|TTBB|Burt Szabo
+At The End Of A Cobblestone Road|TTBB|Burt Szabo
+At The End Of A Lane|TTBB|Burt Szabo
+At the End of the Road|TTBB|Burt Szabo
+Back In The Good Old Days|TTBB|Burt Szabo
+Before I Grew Up To Love You|TTBB|Burt Szabo
+The Bells Of St. Mary's|SSAA|Burt Szabo
+Billie|SSAA|Burt Szabo
+Blame It On The Beautiful Girls|TTBB|Burt Szabo
+The Boys Who Won't Come Home|TTBB|Burt Szabo
+Bring Me A Letter From My Old Home Town|TTBB|Burt Szabo
+The Broadway Blues|TTBB|Burt Szabo
+A Broken Heart|TTBB|Burt Szabo
+By The Sea|TTBB|Burt Szabo
+California And You|TTBB|Burt Szabo
+California Medley|TTBB|Burt Szabo
+Can You Bring Back The Heart I Gave You|TTBB|Burt Szabo
+The Captain Of The Toy Brigade|TTBB|Burt Szabo
+Carolina Rolling Stone|TTBB|Burt Szabo
+Carolina Sunshine|TTBB|Burt Szabo
+The Church In The Wildwood|TTBB|Burt Szabo
+Come Along My Mandy|TTBB|Burt Szabo
+Come, Josephine, In My Flying Machine|TTBB|Burt Szabo
+Crossing The Bar|TTBB|Burt Szabo
+Cuddle Up A Little Closer|TTBB|Burt Szabo
+Dancing Our Worries Away|TTBB|Burt Szabo
+Danny Boy|TTBB|Burt Szabo
+Dear Little Boy Of Mine|TTBB|Burt Szabo
+Dear Old Gal, Who's You Pal Tonight|TTBB|Burt Szabo
+Dear Old Girl|TTBB|Burt Szabo
+Dear Old Pal Of Mine|TTBB|Burt Szabo
+Deck The Halls|TTBB|Burt Szabo
+Don't Blame Me For What Happens In The Moonlight|TTBB|Burt Szabo
+Don't Break My Heart With Goodbye|TTBB|Burt Szabo
+Don't Bring Lulu|TTBB|Burt Szabo
+Don't Fence Me In|TTBB|Burt Szabo
+Don't Put A Tax On The Beautiful Girls|TTBB|Burt Szabo
+Doodle Doo Doo|TTBB|Burt Szabo
+Down By The Erie Canal|TTBB|Burt Szabo
+Down By The Old Mill Stream|TTBB|Burt Szabo
+Down In The Lane|TTBB|Burt Szabo
+Eliza|TTBB|Burt Szabo
+Every Tear Is A Smile|TTBB|Burt Szabo
+Everything Is Peaches Down In Georgia|TTBB|Burt Szabo
+For Every Boy Who's On The Level|TTBB|Burt Szabo
+Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Burt Szabo
+The Girl on the Magazine Cover|TTBB|Burt Szabo
+Girl On The Police Gazette|TTBB|Burt Szabo
+Give My Regards To Broadway|TTBB|Burt Szabo
+God Rest Ye Merry, Gentlemen|TTBB|Burt Szabo
+Good Night Little Girl|TTBB|Burt Szabo
+Goodbye My Lady Love|TTBB|Burt Szabo
+Goodbye, Rose|TTBB|Burt Szabo
+Grandmother's Love Letters|TTBB|Burt Szabo
+The Hand That Rocked My Cradle Rules My Heart|TTBB|Burt Szabo
+Hark! The Herald Angels Sing|TTBB|Burt Szabo
+Harrigan / Mulligan Medley|TTBB|Burt Szabo
+He'd Have To Get Under - Get Out And Get Under|TTBB|Burt Szabo
+Heart Of My Heart, Story Of The Rose|TTBB|Burt Szabo
+Heart-breaking Baby Doll|TTBB|Burt Szabo
+Heaven Will Protect The Working Girl|TTBB|Burt Szabo
+Heiveinu Shalom Aleichem|TTBB|Burt Szabo
+Hello Ma Baby|TTBB|Burt Szabo
+Her Eyes Don't Shine Like Diamonds|TTBB|Burt Szabo
+Home For The Holidays|TTBB|Burt Szabo
+Home For The Holidays|SSAA, SATB|Burt Szabo
+The House At The End Of The Lane|TTBB|Burt Szabo
+How Soon|TTBB|Burt Szabo
+I Ain't Gonna Be Nobody's Fool|TTBB|Burt Szabo
+I Ain't Got No Body|TTBB|Burt Szabo
+I Can't Begin To Tell You|SSAA|Burt Szabo
+I Can't See The Good In Goodbye|TTBB|Burt Szabo
+I Cannot Sing The Old Songs|TTBB|Burt Szabo
+I Guess I'll Take The Train Back Home|TTBB|Burt Szabo
+I Love The Whole United States|TTBB|Burt Szabo
+I May Be Gone For A Long Long Time|TTBB|Burt Szabo
+I Saw Mommy Kissing Santa Claus|TTBB|Burt Szabo
+I Wish I Had Another Girl|TTBB|Burt Szabo
+I Wish I Had My Old Girl Back Again|TTBB|Burt Szabo
+I Wonder What's Become Of Sally|TTBB|Burt Szabo
+I'd Build a World In The Heart Of A Rose|TTBB|Burt Szabo
+I'll Be With You In Apple Blossom Time|TTBB|Burt Szabo
+I'll Be Your Regular Sweetie|TTBB|Burt Szabo
+I'll Change The Shadows To Sunshine|TTBB|Burt Szabo
+I'll Do It All Over Again|TTBB|Burt Szabo
+I'll Fly Away|TTBB|Burt Szabo
+I'll Forget You|TTBB|Burt Szabo
+I'm A Wild And Wooly Son Of The West|TTBB|Burt Szabo
+I'm Drifting Back To Dreamland|TTBB|Burt Szabo
+I'm Forever Blowing Bubbles|TTBB|Burt Szabo
+I'm Glad I Can Make You Cry|TTBB|Burt Szabo
+I'm Gonna Meet My Sweetie Now|TTBB|Burt Szabo
+I'm Just A Little Blue|TTBB|Burt Szabo
+I'm Just Too Mean To Cry|TTBB|Burt Szabo
+I'm Lonesome For You Dear Old Pal|TTBB|Burt Szabo
+I'm Making A Study Of Beautiful Girls|TTBB|Burt Szabo
+I'm Nobody's Baby|TTBB|Burt Szabo
+I'm The Good Man That Was So Hard To Find|TTBB|Burt Szabo
+I'm Waiting For Ships That Never Come In|TTBB|Burt Szabo
+I'm Wishing My Life Away|TTBB|Burt Szabo
+If She Means What I Think She Means|TTBB|Burt Szabo
+If We Can't Be The Same Old Sweethearts|TTBB|Burt Szabo
+If You Had All The World And Its Gold|TTBB|Burt Szabo
+In My Merry Oldsmobile|TTBB|Burt Szabo
+In The City Of God Knows Where|TTBB|Burt Szabo
+In The City Where Nobody Cares|TTBB|Burt Szabo
+In The Heart Of A Fool|TTBB|Burt Szabo
+In The Heart Of An Irish Rose|TTBB|Burt Szabo
+In The Land Of Beginning Again|TTBB|Burt Szabo
+In The Little Red Schoolhouse|TTBB|Burt Szabo
+In The Shade Of The Old Apple Tree|TTBB|Burt Szabo
+Infant Holy, Infant Lowly|TTBB|Burt Szabo
+Ireland, My Ireland|TTBB|Burt Szabo
+It Came Upon A Midnight Clear|TTBB|Burt Szabo
+It Is Well With My Soul|TTBB|Burt Szabo
+It Was Only A Fool's Paradise|TTBB|Burt Szabo
+It's All Over Now|TTBB|Burt Szabo
+It's Only The End Of A Romance To You|TTBB|Burt Szabo
+It's Raining|TTBB|Burt Szabo
+Ja-Da|TTBB|Burt Szabo
+Jane|TTBB|Burt Szabo
+Jeanie With The Light Brown Hair|TTBB|Burt Szabo
+Jingle Jangle Jingle|TTBB|Burt Szabo
+Jingle-Bell Rock|TTBB, SSAA, SATB|Burt Szabo
+Just A Baby's Prayer At Twilight|TTBB|Burt Szabo
+Last Night On The Back Porch|TTBB|Burt Szabo
+Let It Rain Let It Pour|TTBB|Burt Szabo
+Linda|TTBB|Burt Szabo
+Little Street Where Old Friends Meet|TTBB|Burt Szabo
+A Little Talk With Jesus|TTBB|Burt Szabo
+Little White House In The Glen|TTBB|Burt Szabo
+Ma! (She's Makin' Eyes At Me)|TTBB|Burt Szabo
+Margie|TTBB|Burt Szabo
+Mary's A Grand Old Name|TTBB|Burt Szabo
+Me And Marie|TTBB|Burt Szabo
+Meet Me In St. Louis, Louis|TTBB|Burt Szabo
+Mickey|TTBB|Burt Szabo
+Musical Moon|SATB|Burt Szabo
+My Best Girl|TTBB|Burt Szabo
+My Buddy|TTBB|Burt Szabo
+My New Sweetie Is Plenty Sweet|TTBB|Burt Szabo
+My Romance|TTBB, SSAA|Burt Szabo
+My Sunny Tennessee|TTBB|Burt Szabo
+New York Medley|TTBB|Burt Szabo
+The Night Before Christmas|TTBB|Burt Szabo
+No Gold Can Buy The Silver In Your Hair|TTBB|Burt Szabo
+No, No, Nora|TTBB|Burt Szabo
+Nobody Knows, Nobody Cares|TTBB|Burt Szabo
+Nobody's Gal|TTBB|Burt Szabo
+Nobody's Rose|TTBB|Burt Szabo
+O Come, All Ye Faithful|TTBB|Burt Szabo
+O Little Town Of Bethlehem|TTBB|Burt Szabo
+O'Brien Is Tryin' To Learn To Talk Hawaiian|TTBB|Burt Szabo
+Oh, You Wonderful Boy|SATB|Burt Szabo
+Old Love Letters|TTBB|Burt Szabo
+Old-Tyme, Gay-Nineties, Parlour-Piano Medley|TTBB|Burt Szabo
+On An Island Surrounded By Girls|TTBB|Burt Szabo
+On The Mississippi|TTBB|Burt Szabo
+On The Old Dominion Line|TTBB|Burt Szabo
+On The Old Front Porch|TTBB|Burt Szabo
+Patriotic Medley|TTBB|Burt Szabo
+Peg O' My Heart|TTBB|Burt Szabo
+Powder Your Face With Sunshine|TTBB|Burt Szabo
+Put Me To Sleep With An Old Fashioned Melody|TTBB|Burt Szabo
+Put Your Arms Around Me Honey|TTBB|Burt Szabo
+Radio Jingles|TTBB|Burt Szabo
+Redhead|TTBB|Burt Szabo
+Rise, Shine, For The Light Is A-Comin'|TTBB|Burt Szabo
+Sailing Down The Chesapeake Bay|TTBB|Burt Szabo
+School Days|TTBB|Burt Szabo
+Shenandoah|TTBB, SSAA, SATB|Burt Szabo
+Shenandoah|TTBB, SATB|Burt Szabo
+Smile, Darn Ya, Smile|TTBB|Burt Szabo
+Sonny Boy|TTBB|Burt Szabo
+The Spaniard That Blighted My Life|TTBB|Burt Szabo
+Standing In The Need Of Prayer|TTBB|Burt Szabo
+The Streets Of New York|TTBB|Burt Szabo
+The Sweetest Story Ever Told|TTBB|Burt Szabo
+Swingin' Down The Lane|TTBB|Burt Szabo
+Tain't No Sin|TTBB|Burt Szabo
+Take Me To My Alabam'|TTBB|Burt Szabo
+Take Your Girlie To The Movies|TTBB|Burt Szabo
+Tears|TTBB|Burt Szabo
+That Wonderful Mother Of Mine|TTBB|Burt Szabo
+That's A Plenty|TTBB|Burt Szabo
+That's What Friends Are For|SATB|Burt Szabo
+The Letter|TTBB|Burt Szabo
+There's A Meetin' Here Tonight|TTBB|Burt Szabo
+They Didn't Believe Me|TTBB|Burt Szabo
+They're All Sweeties|TTBB|Burt Szabo
+"Tho' I'm Not The First To Call You ""Sweetheart"""|TTBB|Burt Szabo
+Those Wedding Bells Shall Not Ring Out|TTBB|Burt Szabo
+Tired Of Me|SSAA|Burt Szabo
+Tired Of Me|TTBB|Burt Szabo
+Toot, Toot, Tootsie|TTBB|Burt Szabo
+Toyland|TTBB|Burt Szabo
+Tumbling Tumbleweeds|TTBB|Burt Szabo
+Wagon Wheels|TTBB|Burt Szabo
+Was I A Fool|TTBB|Burt Szabo
+We'll Have A Jubilee In My Old Kentucky Home|TTBB|Burt Szabo
+We'll Sing Another Jolson Song|TTBB|Burt Szabo
+We're Behind You All the Way|TTBB|Burt Szabo
+What A Friend We Have In Jesus Medley|TTBB|Burt Szabo
+What Child Is This|TTBB|Burt Szabo
+What Do You Mean By Loving Somebody Else|TTBB|Burt Szabo
+When Everything Seems To Go Wrong|TTBB|Burt Szabo
+When Georgia Smiles|TTBB|Burt Szabo
+When I Lost You|TTBB|Burt Szabo
+When It's Springtime In The Rockies|TTBB|Burt Szabo
+When My Baby Smiles At Me|TTBB|Burt Szabo
+When The Circus Came To Town|TTBB|Burt Szabo
+When The Grown Up Ladies Act Like Babies|TTBB|Burt Szabo
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|Burt Szabo
+When The Rest Of The World Don't Want You|TTBB|Burt Szabo
+When The Right Little Girl Comes Along|TTBB|Burt Szabo
+When The Sunshine Of Tomorrow Meets The Shadows Of Today|TTBB|Burt Szabo
+When The Whole World Has Gone Back On You|TTBB|Burt Szabo
+When They're Old Enough To Know Better|TTBB|Burt Szabo
+When You And I Were Young Maggie|TTBB|Burt Szabo
+When You Find Her Remind Her Of Me|TTBB|Burt Szabo
+When You Long For A Pal Who Would Care|TTBB|Burt Szabo
+When You Play With The Heart Of A Girl|TTBB|Burt Szabo
+When You Sang Soprano|TTBB|Burt Szabo
+When You Were The Blossom Of Buttercup Lane And I Was You're Little Boy Blue|TTBB|Burt Szabo
+When You Whispered I Love You|TTBB|Burt Szabo
+When You're A Long, Long Way From Home|TTBB|Burt Szabo
+Where Have You Been Hiding All These Years|TTBB|Burt Szabo
+Who Cares|TTBB|Burt Szabo
+Who Said So|TTBB|Burt Szabo
+Who'll Dry Your Tears When You Cry?|TTBB|Burt Szabo
+Who's Going To Love You When I'm Gone|TTBB|Burt Szabo
+Why Don't We Do This More Often|TTBB|Burt Szabo
+Why Should I Cry Over You?|TTBB|Burt Szabo
+The World Can't Go Round Without You|TTBB|Burt Szabo
+The World is Waiting For The Sunrise|TTBB|Burt Szabo
+World War Medley|TTBB|Burt Szabo
+You Broke My Heart To Pass The Time Away|TTBB|Burt Szabo
+You Made Me Forget How To Cry|TTBB|Burt Szabo
+You May Be A Doggone Dangerous Girl But I'm A Desparet Guy|TTBB|Burt Szabo
+You're A Dangerous Girl|TTBB|Burt Szabo
+Your Eyes Have Told Me So|TTBB|Burt Szabo
+I Feel A Song Comin' On|TTBB|Roger Tarpy
+Where Or When|SSAA|Roger Tarpy
+Autumn In New Hampshire|TTBB|Brad Taylor
+Christmas Carol Medley Singalong|TTBB|Carl Taylor
+Let All Mortal Flesh Keep Silence|TTBB|Jeff Taylor
+Ma! (She's Makin' Eyes At Me)|TTBB|Jeff Taylor
+Ten Little Soldiers|TTBB|Jeff Taylor
+Colors Of The Wind|SSAA|Katie Taylor
+The Next Right Thing|SSAA|Katie Taylor
+Silver Bells|SSAA|Katie Taylor
+Sister Act|SSAA|Katie Taylor
+California Dreamin'|SSAA|Mike Taylor
+Defying Gravity|SSAA|Mike Taylor
+Fame|SSAA|Mike Taylor
+Moon River|SSAA|Mike Taylor
+My Love Is Like a Red, Red Rose|SSAA|Mike Taylor
+The Parting Glass|SSAA|Mike Taylor
+Stormy Weather|TTBB|Mike Taylor
+You're So Vain|SSAA|Mike Taylor
+Darktown Strutters' Ball|TTBB|Milton Teitel
+Goody Goody|TTBB|Milton Teitel
+Jezebel|TTBB|Milton Teitel
+On A Slow Boat To China|TTBB|Milton Teitel
+When Your Old Wedding Ring Was New|TTBB|Milton Teitel
+Flintstones|TTBB|Andrew Tepe
+Will You Love Me Tomorrow-Doo Wop|TTBB|Dave Theile
+Aquarius|TTBB|Gary Thiel
+At The Hop|TTBB|Gary Thiel
+Babe|TTBB|Gary Thiel
+Blackbird|TTBB|Gary Thiel
+Hallelujah|TTBB|Gary Thiel
+Here Comes The Sun|TTBB|Gary Thiel
+I Just Called To Say I Love You|TTBB|Gary Thiel
+In The Blood|TTBB|Gary Thiel
+Jackson|SATB|Gary Thiel
+La Vie en Rose|TTBB|Gary Thiel
+Live Like You Were Dying|TTBB|Gary Thiel
+Love Me|TTBB|Gary Thiel
+Mack The Knife|TTBB|Gary Thiel
+Make You Feel My Love|SATB|Gary Thiel
+Mr. Blue|TTBB|Gary Thiel
+The One That You Love|TTBB|Gary Thiel
+Only You|TTBB|Gary Thiel
+Piano Man|TTBB|Gary Thiel
+That Lonesome Road|TTBB|Gary Thiel
+Wichita Lineman|TTBB|Gary Thiel
+Words|TTBB|Gary Thiel
+You Are the New Day|TTBB|Gary Thiel
+Somebody Loves You|TTBB|F. W. Thom
+Oh Happy Day|TTBB|Don Thomson
+Over The Rainbow|TTBB|Don Thomson
+After You Get What You Want You Don't Want It|SSAA|Lyndal Thorburn
+For Once In My Life|SSAA|Lyndal Thorburn
+Friday on My Mind|SSAA|Lyndal Thorburn
+Goodnight My Angel|SSAA|Lyndal Thorburn
+I'd Rather Be Blue|TTBB, SSAA|Lyndal Thorburn
+It Will Have To Do Until The Real Thing Comes Along|SSAA|Lyndal Thorburn
+Little Gomez|SSAA|Lyndal Thorburn
+Love Is In The Air|SSAA, SATB|Lyndal Thorburn
+Medley: Raise Your Voice, Spread The Love Around|SSAA|Lyndal Thorburn
+My Melancholy Baby|SSAA|Lyndal Thorburn
+Somebody Knows|SSAA|Lyndal Thorburn
+Sunday Kind Of Love|SSAA|Lyndal Thorburn
+Sway|SSAA|Lyndal Thorburn
+The Luckiest|SSAA|Lyndal Thorburn
+Until The Real Thing Comes Along|SSAA|Lyndal Thorburn
+We Got Love|SSAA|Lyndal Thorburn
+When You Believe|SSAA|Lyndal Thorburn
+Wings|SSAA|Lyndal Thorburn
+Now The Day is Over|TTBB|Frank Thorne
+O Joe|TTBB|Frank Thorne
+Silent Night|TTBB|Frank Thorne
+Star Spangled Banner|TTBB|Frank Thorne
+The Sweetheart of Sigma Nu|TTBB|Frank Thorne
+Violets Sweet|TTBB|Frank Thorne
+Cups (When I'm Gone)|SSAA|Timari Thorstenson
+Home|SSAA|Timari Thorstenson
+Rumor Has It|SSAA|Timari Thorstenson
+It's Magic|TTBB|Ken Tillmanns
+Silver Bells|SSAA|Carole Townsend
+In A Little Red Barn|TTBB|Jerry Tracey
+(Love Is) The Tender Trap|TTBB, SSAA|Steve Tramack
+Against All Odds|TTBB|Steve Tramack
+All In Love Is Fair|TTBB|Steve Tramack
+All The Time|TTBB|Steve Tramack
+America|TTBB|Steve Tramack
+American Tune|TTBB|Steve Tramack
+Anthem|TTBB|Steve Tramack
+Back In The Old Routine|TTBB|Steve Tramack
+Be The Hero|TTBB|Steve Tramack
+The Best Things Happen While You're Dancing|SSAA|Steve Tramack
+Better Place|SSAA|Steve Tramack
+A Bit of Earth|SSAA|Steve Tramack
+Christmas Waltz|SSAA|Steve Tramack
+Cocktails For Two|TTBB|Steve Tramack
+Coffee In A Cardboard Cup|TTBB|Steve Tramack
+Come Follow The Band|TTBB|Steve Tramack
+Come Rain Or Come Shine|SSAA|Steve Tramack
+Dancing In The Street|TTBB|Steve Tramack
+Defying Gravity|SATB|Steve Tramack
+Don't Rain on My Parade|SSAA|Steve Tramack
+Down With Love|SSAA|Steve Tramack
+The First Toymaker To The King|SATB|Steve Tramack
+For Good|TTBB, SSAA|Steve Tramack
+For Once In My Life|TTBB, SSAA|Steve Tramack
+From The Start|SATB|Steve Tramack
+From This Moment On|TTBB|Steve Tramack
+God Only Knows|TTBB|Steve Tramack
+Good Day Sunshine|SSAA|Steve Tramack
+Grown-Up Christmas List|TTBB|Steve Tramack
+A Handful Of Stars|TTBB|Steve Tramack
+Heat Miser|TTBB|Steve Tramack
+Home|TTBB|Steve Tramack
+Homeward Bound|TTBB|Steve Tramack
+A House Is Not A Home|TTBB|Steve Tramack
+I Don't Care If The Sun Don't Shine|TTBB, SSAA|Steve Tramack
+I Hope You Dance|TTBB|Steve Tramack
+I Saw Mommy Kissing Santa Claus|TTBB|Steve Tramack
+I Won't Let Go|TTBB|Steve Tramack
+I Write The Songs|TTBB|Steve Tramack
+I'm Beginning To See The Light|SSAA|Steve Tramack
+I'm Not That Girl|SSAA|Steve Tramack
+I'm Still Standing|TTBB, SSAA|Steve Tramack
+I'm Yours|TTBB|Steve Tramack
+In My Room|TTBB|Steve Tramack
+It Don't Mean A Thing|SSAA|Steve Tramack
+It's Over Isn't It|SSAA|Steve Tramack
+It's The Same Old Song|TTBB|Steve Tramack
+Just Give Me A Reason|SSAA|Steve Tramack
+Landslide|SSAA|Steve Tramack
+Loch Lomond|TTBB|Steve Tramack
+Loch Lomond|SSAA|Steve Tramack
+Love Can Turn The World|SSAA|Steve Tramack
+Lullaby of Birdland|TTBB|Steve Tramack
+Maybe This Time|TTBB, SSAA|Steve Tramack
+Medley: Does Anybody Really Know What Time It Is?, Just You 'n' Me, Sat in the Park|TTBB|Steve Tramack
+Medley: Rainbow with The Rainbow Connection|TTBB|Steve Tramack
+Medley: The Best Things Happen While Your're Dancing, Cheek to Cheek|TTBB|Steve Tramack
+Mission: Impossible Theme|TTBB, SSAA|Steve Tramack
+My Heart Stood Still|TTBB|Steve Tramack
+Nowhere Man|TTBB|Steve Tramack
+On The Street Where You Live|TTBB, SSAA|Steve Tramack
+One Short Day|TTBB, SSAA, SATB|Steve Tramack
+Out There|TTBB|Steve Tramack
+Personality|TTBB|Steve Tramack
+The Place Where the Lost Things Go|SSAA|Steve Tramack
+Please Come Home For Christmas|TTBB|Steve Tramack
+Popular|SSAA|Steve Tramack
+Prince Ali|TTBB|Steve Tramack
+Proud of Your Boy|TTBB|Steve Tramack
+Put One Foot In Front of the Other|TTBB|Steve Tramack
+Rainbow|SATB|Steve Tramack
+Ripple|SSAA|Steve Tramack
+Santa Claus Is Comin' To Town|TTBB|Steve Tramack
+Saturday In The Park|TTBB|Steve Tramack
+September|SSAA|Steve Tramack
+She Used To Be Mine|SSAA|Steve Tramack
+Smile|TTBB, SSAA|Steve Tramack
+Someone Like You|TTBB, SSAA|Steve Tramack
+The Sweetheart Of Sigma Chi|TTBB|Steve Tramack
+Taylor The Latte Boy|SSAA|Steve Tramack
+The Luckiest|TTBB|Steve Tramack
+The Songs We Sang Together|TTBB|Steve Tramack
+There's A Long, Long Trail|TTBB|Steve Tramack
+They Just Keep Moving the Line|TTBB, SSAA|Steve Tramack
+Unchained Melody|TTBB|Steve Tramack
+We've Got A World That Swings|SSAA|Steve Tramack
+What Kind Of Fool Am I|TTBB|Steve Tramack
+When A Man Loves A Woman|TTBB|Steve Tramack
+When I Lost You|TTBB|Steve Tramack
+When I Lost You|SSAA|Steve Tramack
+When My Heart Finds Christmas|TTBB|Steve Tramack
+White Christmas|TTBB|Steve Tramack
+Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|TTBB|Steve Tramack
+With A Little Help From My Friends|TTBB|Steve Tramack
+You and Me (But Mostly Me)|TTBB|Steve Tramack
+You Couldn't Be Cuter|TTBB|Steve Tramack
+You Will Be Found|SATB|Steve Tramack
+Evening Sun Descended|TTBB|James Trapp
+Hallelujah|TTBB, SSAA|Jordan Travis
+(Ghost) Riders In The Sky|SATB|Larry Triplett
+A Band Of Brothers|TTBB|Larry Triplett
+A Dream Is A Wish Your Heart Makes|TTBB, SSAA, SATB|Larry Triplett
+A Thousand Thoughts Of You|TTBB, SSAA, SATB|Larry Triplett
+A Woman Like You|TTBB|Larry Triplett
+All I Want For Christmas Is You|TTBB, SSAA, SATB|Larry Triplett
+All I Want For Christmas Is You|TTBB, SSAA|Larry Triplett
+All The World Will Be Jealous Of Me|TTBB|Larry Triplett
+An Uptune In Search Of A Song|TTBB, SSAA|Larry Triplett
+Christmas Through Your Eyes|TTBB|Larry Triplett
+Christmas Through Your Eyes|SSAA, SATB|Larry Triplett
+Cloudburst|TTBB|Larry Triplett
+Dream Vacation|TTBB, SATB|Larry Triplett
+Everybody Loves Somebody|TTBB, SSAA|Larry Triplett
+Feed The Birds|TTBB, SSAA, SATB|Larry Triplett
+Fum Fum Fum|TTBB, SSAA, SATB|Larry Triplett
+Gloucester Wassail|TTBB, SSAA, SATB|Larry Triplett
+Grim Grinning Ghosts|SATB|Larry Triplett
+He Will Carry You|TTBB, SSAA, SATB|Larry Triplett
+The Headless Horseman|TTBB|Larry Triplett
+Here's To Adventure|TTBB, SATB|Larry Triplett
+A House Is Not A Home|TTBB, SSAA, SATB|Larry Triplett
+How Can I Keep From Singing|TTBB, SSAA, SATB|Larry Triplett
+How Can I Keep From Singing Your Praise|TTBB|Larry Triplett
+How Far Is It To Bethlehem|TTBB, SSAA, SATB|Larry Triplett
+I Don't Want To Live On The Moon|SSAA, SATB|Larry Triplett
+I Feel A Song Comin' On|TTBB, SSAA, SATB|Larry Triplett
+I Miss You Most Of All|TTBB, SSAA, SATB|Larry Triplett
+I Wish I Could Be Santa Claus|TTBB, SSAA, SATB|Larry Triplett
+I Wish You Love|TTBB, SSAA, SATB|Larry Triplett
+I'll Take You Dreaming|TTBB|Larry Triplett
+I'm A Fool To Want You|TTBB|Larry Triplett
+I'm A Fool To Want You|SSAA, SATB|Larry Triplett
+If|SSAA, SATB|Larry Triplett
+If|TTBB|Larry Triplett
+If I Didn't Care|TTBB, SSAA, SATB|Larry Triplett
+If You Can't Get A Girl In The Summertime|TTBB|Larry Triplett
+It's a Hanukkah Song (In a Major Key)|TTBB|Larry Triplett
+It's The Girl|TTBB, SSAA|Larry Triplett
+L-O-V-E|TTBB, SSAA, SATB|Larry Triplett
+Love Me|TTBB, SSAA|Larry Triplett
+Magic To Do|SATB|Larry Triplett
+The Man In the Looking Glass|TTBB|Larry Triplett
+Mary's Little Boy Child|TTBB, SSAA|Larry Triplett
+More Music|TTBB, SATB|Larry Triplett
+My Lucky Day|TTBB|Larry Triplett
+Old Bones|TTBB|Larry Triplett
+Old World Christmas Melody|SSAA, SATB|Larry Triplett
+Old World Christmas Melody|TTBB|Larry Triplett
+On The Way to Cape May|TTBB, SSAA, SATB|Larry Triplett
+One Voice|SATB|Larry Triplett
+Paid In Full|TTBB|Larry Triplett
+Smilin' Through|TTBB|Larry Triplett
+Softly As I Leave You|TTBB, SSAA, SATB|Larry Triplett
+The Frustrated Quartet Montage|TTBB|Larry Triplett
+They Can't Take That Away From Me|TTBB, SSAA, SATB|Larry Triplett
+This Ole House|TTBB|Larry Triplett
+Tomorrow Tonight|TTBB, SSAA, SATB|Larry Triplett
+Too Young|TTBB, SSAA, SATB|Larry Triplett
+Travelin' Man|TTBB|Larry Triplett
+Wait Till The Sun Shines, Nellie|TTBB, SSAA, SATB|Larry Triplett
+We'll Have A Jubilee In My Old Kentucky Home|TTBB, SSAA, SATB|Larry Triplett
+When A Child Is Born|TTBB, SSAA, SATB|Larry Triplett
+When I Look In Your Eyes|TTBB, SSAA, SATB|Larry Triplett
+White Cliffs Of Dover|TTBB, SSAA, SATB|Larry Triplett
+Who's In The Strawberry Patch With Sally?|TTBB|Larry Triplett
+You Are So Much of Christmas To Me|TTBB|Larry Triplett
+You Brought A New Kind Of Love To Me|TTBB, SSAA|Larry Triplett
+You're All The World To Me|TTBB|Larry Triplett
+Abilene|TTBB|Todd Troutman
+Allegheny Moon|TTBB|Todd Troutman
+Back In The Saddle Again|TTBB|Todd Troutman
+Bandstand Boogie|TTBB|Todd Troutman
+Beatles Medley|TTBB|Todd Troutman
+Blue Christmas|TTBB|Todd Troutman
+Blue World|TTBB|Todd Troutman
+Buffalo Gals|TTBB|Todd Troutman
+Car Wash|TTBB|Todd Troutman
+Carolina Moon|TTBB|Todd Troutman
+Chugwater|TTBB|Todd Troutman
+Cocktails For Two|TTBB|Todd Troutman
+Colorado Trail|TTBB|Todd Troutman
+Come Be My Own|TTBB|Todd Troutman
+Cool Water|TTBB|Todd Troutman
+Count your blessings|TTBB|Todd Troutman
+Crazy|TTBB|Todd Troutman
+Dancing Queen|TTBB|Todd Troutman
+Deep River|TTBB|Todd Troutman
+Disney Song Medley|TTBB|Todd Troutman
+Do You Know The Way To San Jose|TTBB|Todd Troutman
+Down By The Riverside|TTBB|Todd Troutman
+Dream Along With Me|TTBB|Todd Troutman
+Dream Train|TTBB|Todd Troutman
+The End of the World|TTBB|Todd Troutman
+Evergreen|TTBB|Todd Troutman
+Everly Brothers Medley|TTBB|Todd Troutman
+Everybody Loves Somebody|TTBB|Todd Troutman
+Faded Love|TTBB|Todd Troutman
+Feelin' Fine|TTBB|Todd Troutman
+Fit As A Fiddle|TTBB|Todd Troutman
+Fly Me To The Moon|TTBB|Todd Troutman
+Follow Me|TTBB|Todd Troutman
+Girl I Left Behind|TTBB|Todd Troutman
+Good Night Sweetheart|TTBB|Todd Troutman
+Grandma Got Run Over By A Reindeer|TTBB|Todd Troutman
+The Greatest Love Of All|TTBB|Todd Troutman
+Greenfields|TTBB|Todd Troutman
+Grizzly Bear|TTBB|Todd Troutman
+Happy Trails|TTBB|Todd Troutman
+Hard Hearted Hannah|TTBB|Todd Troutman
+Have I Told You Lately|TTBB|Todd Troutman
+Holly Jolly Christmas|TTBB|Todd Troutman
+Homeward Bound|TTBB|Todd Troutman
+Honey Pie|TTBB|Todd Troutman
+I'm So Glad You Chose Me|TTBB|Todd Troutman
+I've Got The World On A String|TTBB|Todd Troutman
+If I Ruled The World|TTBB|Todd Troutman
+In My Room|TTBB|Todd Troutman
+It Was A Very Good Year|TTBB|Todd Troutman
+It's Gonna Rain|TTBB|Todd Troutman
+Jesus Loves Me|TTBB|Todd Troutman
+Johnny Rae Medley|TTBB|Todd Troutman
+Just An Old Fashioned Love Song|TTBB|Todd Troutman
+Just One Person|TTBB|Todd Troutman
+Leader Of The Pack|TTBB|Todd Troutman
+Lemmon in the Garden|TTBB|Todd Troutman
+Little Drummer Boy|TTBB|Todd Troutman
+Little Girl|TTBB|Todd Troutman
+Little Old Lady|TTBB|Todd Troutman
+Little Red School|TTBB|Todd Troutman
+Love Boat|TTBB|Todd Troutman
+Lullaby|TTBB|Todd Troutman
+Mack The Knife|TTBB|Todd Troutman
+Makin' Whoopee|TTBB|Todd Troutman
+Making Memories|TTBB|Todd Troutman
+Martha, My Dear|TTBB|Todd Troutman
+Maybe|TTBB|Todd Troutman
+Memory Medley|TTBB|Todd Troutman
+Michael Jackson Medley|TTBB|Todd Troutman
+Mockin' Bird Hill|TTBB|Todd Troutman
+Monkees Medley|TTBB|Todd Troutman
+Morning Glow|TTBB|Todd Troutman
+Muskrat Ramble|TTBB|Todd Troutman
+My Defenses Are Down|TTBB|Todd Troutman
+My Dream Girl|TTBB|Todd Troutman
+My Tribute|TTBB|Todd Troutman
+Navy Hymn|TTBB|Todd Troutman
+Near You|TTBB|Todd Troutman
+Once In A While|TTBB|Todd Troutman
+Only Make Believe|TTBB|Todd Troutman
+Only You|TTBB|Todd Troutman
+Play That Barbershop Chord|TTBB|Todd Troutman
+Red Sails In The Sunset|TTBB|Todd Troutman
+Righteous Brothers Medley|TTBB|Todd Troutman
+River Road|TTBB|Todd Troutman
+Rockin' Around The Christmas Tree|TTBB|Todd Troutman
+Roger Whittaker Medley|TTBB|Todd Troutman
+The Rose|TTBB|Todd Troutman
+Santa Catalina|TTBB|Todd Troutman
+Santa is Watching|TTBB|Todd Troutman
+Scarborough Fair|TTBB|Todd Troutman
+September Song|TTBB|Todd Troutman
+Sierra Sue|TTBB|Todd Troutman
+Silver Bells|TTBB|Todd Troutman
+Smiles|TTBB|Todd Troutman
+Smoke Gets In Your Eyes|TTBB|Todd Troutman
+Soft Summer Breeze|TTBB|Todd Troutman
+Somewhere Out There|TTBB|Todd Troutman
+Starry, Starry Night|TTBB|Todd Troutman
+Stompin' At The Savoy|TTBB|Todd Troutman
+Strangers In The Night|TTBB|Todd Troutman
+Sunshine On My Shoulders|TTBB|Todd Troutman
+Sweet Man|TTBB|Todd Troutman
+Sweetheart Tree|TTBB|Todd Troutman
+Tell Her That You Love Her|TTBB|Todd Troutman
+That's America to Me|TTBB|Todd Troutman
+The Unicorn|TTBB|Todd Troutman
+Their Hearts Were Full Of Spring|TTBB|Todd Troutman
+There Goes That Song Again|TTBB|Todd Troutman
+They Rode to Glory|TTBB|Todd Troutman
+This Land is Home|TTBB|Todd Troutman
+Those Magnificent Men In Their Flying Machines|TTBB|Todd Troutman
+Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Todd Troutman
+A Time For Love|TTBB|Todd Troutman
+Treasures|TTBB|Todd Troutman
+A Tree in the Meadow|TTBB|Todd Troutman
+The Twelfth Of Never|TTBB|Todd Troutman
+The U. S. Air Force|TTBB|Todd Troutman
+What Are You Doing?|TTBB|Todd Troutman
+When I Was Young|TTBB|Todd Troutman
+Where Is Love?|TTBB|Todd Troutman
+Where, Oh Where?|TTBB|Todd Troutman
+Wing and a Prayer|TTBB|Todd Troutman
+Would Jesus Wear a Rolex|TTBB|Todd Troutman
+Yesterday|TTBB|Todd Troutman
+You Make Me Feel So Young|TTBB|Todd Troutman
+You've Got A Friend In Me|TTBB|Todd Troutman
+You, You, You|TTBB|Todd Troutman
+Zing! Went The Strings Of My Heart|TTBB|Todd Troutman
+Holiday Season/Happy Holiday Medley|TTBB|Scott Turnbull
+Lion Sleeps Tonight|TTBB, SSAA, SATB|Scott Turnbull
+So Tired|TTBB|Jesse Turner
+After You've Gone|TTBB|Robert Turner
+I Hate To Get Up In The Morning|TTBB|Robert Turner
+Laughter Is Good (For Every One)|TTBB|Robert Turner
+May Each Day|TTBB|Robert Turner
+Heart Of A Clown|TTBB|James Turnmire
+After I've Called You Sweetheart|SSAA|Doris Twardosky
+At The Codfish Ball|SSAA|Doris Twardosky
+At The Mississippi Cabaret|SSAA|Doris Twardosky
+Auctioneer|SSAA|Doris Twardosky
+Bewitched|SSAA|Doris Twardosky
+Eres Tu/Touch The Wind|SSAA|Doris Twardosky
+The Eyes Of A Child|SSAA|Doris Twardosky
+Five Minutes More|SSAA|Doris Twardosky
+Give Us This Day|SSAA|Doris Twardosky
+Green Acres Theme|SSAA|Doris Twardosky
+Here's To The Heroes|SSAA|Doris Twardosky
+It's Not Where You Start It's Where You Finish|SSAA|Doris Twardosky
+Love Is Just Around The Corner|SSAA|Doris Twardosky
+Marvelous Toy|SSAA|Doris Twardosky
+Moon River|SSAA|Doris Twardosky
+My Girl|SSAA|Doris Twardosky
+Nice 'n Easy|SSAA|Doris Twardosky
+Poor Unfortunate Souls|SSAA|Doris Twardosky
+Ruby Gentry|SSAA|Doris Twardosky
+There I've Said It Again|SSAA|Doris Twardosky
+There Used To Be A Ballpark Right Here|TTBB, SSAA|Doris Twardosky
+We Have This Moment|SSAA|Doris Twardosky
+Where's The Line To See Jesus|SSAA|Doris Twardosky
+Why We Sing|SSAA|Doris Twardosky
+Wouldja Be My Valentine|SSAA|Doris Twardosky
+He Touched Me|TTBB|Jack Tyne
+How We Sang Today!|SSAA|Vicki Uhr
+In The Garden|SSAA|Vicki Uhr
+You Are My Sunshine|TTBB, SSAA, SATB|Vicki Uhr
+Candy Man|TTBB|Harold Ulring
+My Sally, Just The Same|TTBB|Harold Ulring
+Sonny Boy|TTBB|Harold Ulring
+Auld Lang Syne|TTBB|Donn Updegrove
+Here We Come A-Caroling|TTBB|Donn Updegrove
+Just When The Lights Are Low|TTBB|Donn Updegrove
+Love Came Down At Christmas/Away In A Manger Medley|TTBB|Donn Updegrove
+Molly Malone|TTBB|Donn Updegrove
+Tijuana Jail|TTBB|Donn Updegrove
+Breath Of Life|TTBB|Ralph Urquhart
+Loving You|TTBB|Ralph Urquhart
+Sailing|TTBB|Ralph Urquhart
+Summer's Over|TTBB|Ralph Urquhart
+Will Ye Go Lassie Go|TTBB|Ralph Urquhart
+Swing Down Chariot|TTBB, SSAA, SATB|The Vagabonds
+Perfect Stranger|SSAA|Bram Van Leer
+I'm Gonna Live Till I Die|SSAA|Jeannie Vercillo
+At The Codfish Ball|SSAA|Jeff Veteto
+Do You Hear What I Hear|SSAA|Judy Vidal
+If You Could Read My Mind|SSAA|Judy Vidal
+Lulu's Back In Town|SSAA|Judy Vidal
+There's Something About A Soldier|SSAA|Judy Vidal
+Through The Years|SSAA|Judy Vidal
+Glow Worm|TTBB|Mark Vile
+All Dressed Up With A Broken Heart|SSAA|Sharon Vitkovsky
+Hail Holy Queen|SSAA|Sharon Vitkovsky
+Together Again|SSAA|Sharon Vitkovsky
+Any Time|TTBB|Greg Volk
+Don't Break The Heart That Loves You|SSAA|Greg Volk
+I'm Gonna Live Till I Die|TTBB|Greg Volk
+Mona Lisa|TTBB|Greg Volk
+I'll Walk With God|TTBB|Hank Vomacka
+Somewhere Out There|SSAA|Roger Von Haden
+Muskrat Ramble|TTBB|Robert Wachter
+Roaring Twenties|TTBB|Robert Wachter
+After The Ball|TTBB|Ed Waesche
+After The War Is Over|TTBB|Ed Waesche
+After You've Gone|TTBB|Ed Waesche
+Alabama Jubilee|TTBB|Ed Waesche
+Alexander's Ragtime Band|TTBB|Ed Waesche
+All American Girl|TTBB|Ed Waesche
+All That I Ask Is Love|TTBB|Ed Waesche
+America I Love You|TTBB|Ed Waesche
+At The End Of The Day With You|TTBB|Ed Waesche
+B & O Line / My Cutey's Due At Two To Two Today Medley|TTBB|Ed Waesche
+Baby Medley 1|TTBB|Ed Waesche
+Be A Clown|TTBB|Ed Waesche
+Bill Bailey, Won't You Please Come Home?|TTBB|Ed Waesche
+Bird In A Gilded Cage|TTBB|Ed Waesche
+Black And Blue|TTBB|Ed Waesche
+Blue Skies|TTBB|Ed Waesche
+Bright Was The Night|TTBB|Ed Waesche
+Bring Back Those Days|TTBB|Ed Waesche
+Broadway|TTBB|Ed Waesche
+But After The Ball Was Over|TTBB|Ed Waesche
+Button Up Your Overcoat / You Were Meant for Me Medley|TTBB|Ed Waesche
+Call Me Back Pal O' Mine|TTBB|Ed Waesche
+Carolina In The Morning|TTBB|Ed Waesche
+Cheek To Cheek|SSAA|Ed Waesche
+Chicago Medley|SSAA|Ed Waesche
+Chicago Medley|TTBB|Ed Waesche
+Chloe|TTBB|Ed Waesche
+The Church Bells Are Ringing For Mary|TTBB|Ed Waesche
+Consider Yourself|TTBB|Ed Waesche
+Danny Boy|TTBB|Ed Waesche
+Darktown Strutters' Ball|TTBB|Ed Waesche
+Down By The Old Mill Stream|TTBB|Ed Waesche
+Driving Home The Cows From Pasture|TTBB|Ed Waesche
+Easter Parade|TTBB|Ed Waesche
+Embraceable You|TTBB|Ed Waesche
+Embraceable You|TTBB, SSAA|Ed Waesche
+Fare Thee Well Annabelle|TTBB|Ed Waesche
+Firefly|TTBB|Ed Waesche
+For The Sake Of Auld Lang Syne|TTBB|Ed Waesche
+Gang That Sang Heart Of My Heart|TTBB|Ed Waesche
+Garland Of Old Fashioned Roses|TTBB|Ed Waesche
+Get Out And Get Under The Moon|TTBB|Ed Waesche
+Girls Medley|TTBB|Ed Waesche
+Glory Of Love|TTBB|Ed Waesche
+Gone|TTBB|Ed Waesche
+Gonna Build A Mountain|TTBB|Ed Waesche
+Happy Feet Medley|TTBB|Ed Waesche
+Hard To Get Gertie|TTBB|Ed Waesche
+Heart|TTBB|Ed Waesche
+Heart Of A Clown|TTBB|Ed Waesche
+Hello Broadway|TTBB|Ed Waesche
+Hello Dolly|TTBB|Ed Waesche
+Honeysuckle Rose|TTBB|Ed Waesche
+How Deep Is The Ocean|TTBB|Ed Waesche
+How Do You Open A Show|TTBB|Ed Waesche
+I Called You My Sweetheart|TTBB|Ed Waesche
+I Can Dream, Can't I?|TTBB|Ed Waesche
+I Cried For You|TTBB|Ed Waesche
+I Dream Of You|TTBB|Ed Waesche
+I Feel A Song Comin' On / Hallelujah Medley|TTBB|Ed Waesche
+I Found The End Of The Rainbow|TTBB|Ed Waesche
+I Gotta Right To Sing The Blues|TTBB|Ed Waesche
+I Miss You Most Of All|TTBB|Ed Waesche
+I Told Them All About You / You Dear|SSAA|Ed Waesche
+I Told Them All About You / You Dear|TTBB|Ed Waesche
+I Tore Up Your Picture When You Said Goodbye|TTBB|Ed Waesche
+I'll Be Home For Christmas|TTBB|Ed Waesche
+I'll See You In My Dreams|TTBB|Ed Waesche
+I'm Always Chasing Rainbows|TTBB|Ed Waesche
+I'm Forever Blowing Bubbles|TTBB|Ed Waesche
+I'm Goin' South|TTBB|Ed Waesche
+I'm Gonna Lock My Heart|TTBB|Ed Waesche
+I'm Looking For A Girl Named Mary|TTBB|Ed Waesche
+I'm Looking Over A Four Leaf Clover|SSAA|Ed Waesche
+I'm Looking Over A Four Leaf Clover|TTBB|Ed Waesche
+I'm Nobody's Baby|TTBB|Ed Waesche
+I'm Sorry I Made You Cry|TTBB|Ed Waesche
+I'm The Last One Left On The Corner Of That Old Gang Of Mine|TTBB|Ed Waesche
+I've Found My Sweetheart Sally|TTBB|Ed Waesche
+If I Could Be With You|TTBB|Ed Waesche
+If I Had You|TTBB|Ed Waesche
+If I Love Again|SSAA|Ed Waesche
+If I Love Again|TTBB|Ed Waesche
+If I Ruled The World|SSAA|Ed Waesche
+If I Ruled The World|TTBB|Ed Waesche
+If You Were The Only Girl In The World|TTBB, SSAA|Ed Waesche
+In The Little Red Schoolhouse|TTBB|Ed Waesche
+Indiana|TTBB|Ed Waesche
+Ireland Must Be Heaven|TTBB|Ed Waesche
+Isn't It A Pity|TTBB|Ed Waesche
+It All Depends On You|TTBB|Ed Waesche
+It Had To Be You|TTBB|Ed Waesche
+It Only Takes A Moment|TTBB|Ed Waesche
+It's All Over Now / Please Don't Talk About When I'm Gone Medley|TTBB|Ed Waesche
+Jeanie With The Light Brown Hair|TTBB|Ed Waesche
+Just A Cottage Small|TTBB|Ed Waesche
+Just A Kid Named Joe|TTBB|Ed Waesche
+Keep On The Sunny Side|TTBB|Ed Waesche
+L-O-V-E|TTBB|Ed Waesche
+Let A Smile Be Your Umbrella / Powder Your Face With Sunshine / When You're Smiling Medley|TTBB|Ed Waesche
+Little Kiss Each Morning|TTBB|Ed Waesche
+Liza|TTBB|Ed Waesche
+Looking At The World Through Rose Colored Glasses|TTBB|Ed Waesche
+Louisville Lou|TTBB|Ed Waesche
+Love Is Just Around The Corner|TTBB|Ed Waesche
+Love's Old Sweet Song|TTBB|Ed Waesche
+Lover|TTBB|Ed Waesche
+Lover Come Back To Me|TTBB, SSAA|Ed Waesche
+Lucky Day / Lucky In Love Medley|TTBB|Ed Waesche
+Lulu's Back In Town|TTBB|Ed Waesche
+Make Believe|TTBB|Ed Waesche
+Make Someone Happy|TTBB|Ed Waesche
+Man On The Flying Trapeze|TTBB|Ed Waesche
+The Masquerade Is Over|TTBB, SSAA|Ed Waesche
+Meet Me In Rosetime Rosie|TTBB|Ed Waesche
+Memories|TTBB|Ed Waesche
+Midnight Rose|TTBB|Ed Waesche
+Mills Brothers Medley|TTBB|Ed Waesche
+Miss You|TTBB|Ed Waesche
+Mister Broadway Medley|TTBB|Ed Waesche
+Mister Touchdown, U.S.A.|TTBB|Ed Waesche
+Moments To Remember|TTBB|Ed Waesche
+Moonlight Bay|TTBB|Ed Waesche
+Moonlight Becomes You|TTBB|Ed Waesche
+Music Man Medley|TTBB|Ed Waesche
+My Buddy|TTBB|Ed Waesche
+My Gal Sal|TTBB|Ed Waesche
+My Melancholy Baby|TTBB|Ed Waesche
+My Mother's Eyes|TTBB|Ed Waesche
+New York, New York|TTBB|Ed Waesche
+Nice Work If You Can Get It|TTBB|Ed Waesche
+Night And Day|TTBB|Ed Waesche
+Night And Day|SSAA|Ed Waesche
+Nobody's Sweetheart|TTBB|Ed Waesche
+Once In A While|TTBB|Ed Waesche
+One Alone|TTBB|Ed Waesche
+One Rose|TTBB|Ed Waesche
+Over The Rainbow|TTBB, SSAA, SATB|Ed Waesche
+Pack Up Your Sins And Go To The Devil|TTBB|Ed Waesche
+Pal Of My Cradle Days|TTBB|Ed Waesche
+Peg O' My Heart|TTBB|Ed Waesche
+Play That Barbershop Chord|TTBB|Ed Waesche
+Please Don't Talk About Me When I'm Gone|TTBB|Ed Waesche
+Put Me To Sleep With An Old Fashioned Melody|TTBB|Ed Waesche
+Put On Your Sunday Clothes|TTBB|Ed Waesche
+Reach Out And Touch|TTBB|Ed Waesche
+Redhead|TTBB|Ed Waesche
+River, Stay 'Way from My Door|TTBB|Ed Waesche
+Rock Me to Sleep In An Old Rocking Chair|TTBB|Ed Waesche
+Rose Of Washington Square|TTBB|Ed Waesche
+Roses Of Picardy|TTBB|Ed Waesche
+Runnin' Wild|SSAA|Ed Waesche
+Runnin' Wild|TTBB|Ed Waesche
+Saloon|TTBB|Ed Waesche
+Send Me Away With A Smile|TTBB|Ed Waesche
+Sentimental Gentleman From Georgia|SSAA|Ed Waesche
+Sentimental Gentleman From Georgia|TTBB|Ed Waesche
+Shine Medley|TTBB|Ed Waesche
+Sing Me That Song Again|TTBB|Ed Waesche
+Sing Me That Song Again|SSAA|Ed Waesche
+Smile Medley|TTBB|Ed Waesche
+Smiles|TTBB|Ed Waesche
+Smiles / Blues Medley|TTBB|Ed Waesche
+Smilin' Through|TTBB|Ed Waesche
+Smilin' Through|SSAA|Ed Waesche
+So Long, Mother|TTBB|Ed Waesche
+Some Of These Days|TTBB|Ed Waesche
+Somebody Stole My Gal|TTBB|Ed Waesche
+Somebody Stole My Gal / Five Foot Two Medley|TTBB|Ed Waesche
+A Son Of The Sea|TTBB|Ed Waesche
+The Song Is Ended|TTBB|Ed Waesche
+Soon|TTBB|Ed Waesche
+Steppin' Out Medley|TTBB|Ed Waesche
+Sunny Side Up|TTBB|Ed Waesche
+The Sunshine Of Your Smile|TTBB|Ed Waesche
+Sweet Georgia Brown|TTBB|Ed Waesche
+Sweet Lorraine|TTBB|Ed Waesche
+The Sweetheart Of Sigma Chi|TTBB|Ed Waesche
+Take Me To The Land Of Jazz|SSAA|Ed Waesche
+Take Me To The Land Of Jazz|TTBB|Ed Waesche
+Taking A Chance On Love|TTBB|Ed Waesche
+Taking A Chance On Love|SSAA|Ed Waesche
+TAPS|TTBB|Ed Waesche
+That Rhythm Man|TTBB|Ed Waesche
+That Tumble Down Shack In Athlone|TTBB|Ed Waesche
+That's An Irish Lullaby|TTBB|Ed Waesche
+That's What I Call A Pal|TTBB|Ed Waesche
+The Chapters Of Life|TTBB|Ed Waesche
+There Goes My Heart|TTBB, SSAA|Ed Waesche
+There'll Be Some Changes Made|TTBB|Ed Waesche
+There'll Be Some Changes Made|SSAA|Ed Waesche
+There's A Broken Heart For Every Light On Broadway|TTBB|Ed Waesche
+Throw Me Something, Mister|TTBB|Ed Waesche
+Time After Time|TTBB|Ed Waesche
+Time After Time|SSAA|Ed Waesche
+Too Many Parties And Too Many Pals|TTBB|Ed Waesche
+Toot, Toot, Tootsie|TTBB|Ed Waesche
+Toyland|TTBB|Ed Waesche
+Try A Little Tenderness|TTBB|Ed Waesche
+Way Down Yonder In New Orleans / When The Saints Go Marching In Medley|TTBB|Ed Waesche
+Wet / Dry Medley|TTBB|Ed Waesche
+What I Did For Love|TTBB|Ed Waesche
+What! No Women?|TTBB|Ed Waesche
+What'll I Do?|TTBB, SSAA, SATB|Ed Waesche
+When Day Is Done|SSAA|Ed Waesche
+When Day Is Done|TTBB|Ed Waesche
+When I Grow Too Old To Dream|TTBB|Ed Waesche
+When It Comes To Lovin' The Girls / They're All Sweeties Medley|TTBB|Ed Waesche
+When My Sugar Walks Down The Street|TTBB|Ed Waesche
+When The Grown Up Ladies Act Like Babies|TTBB|Ed Waesche
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|Ed Waesche
+When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Ed Waesche
+When You're Smiling|TTBB|Ed Waesche
+When Your Hair Has Turned To Silver|TTBB|Ed Waesche
+Who'll Take The Place Of Mary|TTBB|Ed Waesche
+Why Do They All Take The Night Boat To Albany|TTBB|Ed Waesche
+Why Should I Cry Over You?|TTBB|Ed Waesche
+Willow Weep For Me|SSAA|Ed Waesche
+Willow Weep For Me|TTBB|Ed Waesche
+Winter Wonderland|TTBB, SSAA, SATB|Ed Waesche
+Won't You Sing Me An Old Time Love Song|TTBB|Ed Waesche
+You Can Have Every Light On Broadway|TTBB|Ed Waesche
+You Made Me Love You|TTBB|Ed Waesche
+You Must Have Been A Beautiful Baby|TTBB|Ed Waesche
+A Mighty Fortress|SATB|David Wallace
+All I Do Is Dream Of You|TTBB|David Wallace
+All That I Ask Is Love|SSAA|David Wallace
+Always A Bridesmaid|SSAA|David Wallace
+Angels We Have Heard On High|SATB|David Wallace
+Any Man Of Mine|SSAA|David Wallace
+Ave Maria|SATB|David Wallace
+Charleston|SSAA|David Wallace
+Dig A Little Deeper In Gods (His) Love|TTBB|David Wallace
+Do You Know You Are My Sunshine|TTBB|David Wallace
+He Never Failed Me Yet|SSAA|David Wallace
+I Love You Just The Same Sweet Adeline|TTBB|David Wallace
+I Want A Hippopotamus For Christmas|SSAA|David Wallace
+I'm A Believer|SSAA|David Wallace
+I'm All Alone|TTBB, SSAA|David Wallace
+I'm Yours|SSAA|David Wallace
+Little Girl|SSAA|David Wallace
+Ma! (She's Makin' Eyes At Me)|TTBB|David Wallace
+Medley: There'll Be Some Changes, If My Friends Could See Me Now|SSAA|David Wallace
+More Than You Know|TTBB, SSAA|David Wallace
+The Peace Carol|SSAA|David Wallace
+The Rhythm Of Life|SSAA|David Wallace
+Silent Night|SSAA|David Wallace
+So Long, Mother|TTBB|David Wallace
+There'll Be Some Changes Made|SSAA|David Wallace
+Toot, Toot, Tootsie|TTBB|David Wallace
+When I'm Sixty Four|SSAA|David Wallace
+Wings|SSAA|David Wallace
+Wonderful Day like Today|TTBB|Mike Wallen
+Doin' The Raccoon|TTBB|Carl Walters
+Jean|SSAA|Carl Walters
+Jean|TTBB|Carl Walters
+Rosie|TTBB|Carl Walters
+Sweet Georgia Brown|TTBB|Carl Walters
+Old Fashioned Girl|TTBB|Doug Ward
+Old Songs Medley|TTBB|Jack Ware
+Embraceable You|TTBB|Charles Warren
+Sentimental Journey|TTBB|Charles Warren
+Let It Be|SSAA|Dan Warschauer
+Fields of Athenry|TTBB|Neil Watkins
+Have Yourself A Merry Little Christmas|SSAA|Barb Watson
+Boar's Head Carol|SATB|Marshall Webb
+Bring A Torch, Jeanette, Isabella|SSAA|Marshall Webb
+Good King Wenceslas|SATB|Marshall Webb
+Here Comes Santa Claus|TTBB, SSAA, SATB|Marshall Webb
+I Saw Three Ships|SATB|Marshall Webb
+I Won't Give Up|TTBB|Marshall Webb
+I'll Take Romance|SSAA|Marshall Webb
+If I Had My Way|SATB|Marshall Webb
+Take Me Out To The Ball Game|SATB|Marshall Webb
+All By Myself|TTBB|Michael Webber
+Amazing Grace|TTBB|Michael Webber
+Baby on Board|TTBB|Michael Webber
+Broken|TTBB|Michael Webber
+Brooklyn Kind Of Love|TTBB|Michael Webber
+Coffee In A Cardboard Cup|TTBB|Michael Webber
+Don't Worry, Be Happy|TTBB|Michael Webber
+Funny But I Still Love You|TTBB|Michael Webber
+Get On Board (The Gospel Train)|TTBB|Michael Webber
+Girl Next Door|TTBB|Michael Webber
+Good News|TTBB|Michael Webber
+Hoedown|TTBB|Michael Webber
+How D'Ya Like Your Eggs in the Morning|TTBB|Michael Webber
+I Go Crazy|TTBB|Michael Webber
+I Wanna Say Hello|TTBB|Michael Webber
+If The Devil Danced|TTBB|Michael Webber
+It's You I Like|TTBB, SATB|Michael Webber
+Let's Take A Walk|TTBB|Michael Webber
+Little Things Mean A Lot|TTBB|Michael Webber
+Look What The Dog Drug In|TTBB|Michael Webber
+Luke's Desk|TTBB|Michael Webber
+Many Tears Ago|TTBB|Michael Webber
+Marry You|TTBB|Michael Webber
+Mii Channel Theme|TTBB|Michael Webber
+Mister Booze|TTBB|Michael Webber
+Monsters Inc.|TTBB|Michael Webber
+The Muppet Show Theme|TTBB|Michael Webber
+My Little Buttercup|TTBB|Michael Webber
+Nobody Cares Like Me|TTBB|Michael Webber
+The Out of Tune Song|TTBB|Michael Webber
+Peter Cottontail|TTBB|Michael Webber
+Place in the Choir|TTBB|Michael Webber
+Please Don't Ask Me|TTBB|Michael Webber
+Real Emotional Girl|TTBB|Michael Webber
+Sesame Street Theme|TTBB|Michael Webber
+She Chose Me|TTBB|Michael Webber
+Short People|TTBB|Michael Webber
+Skeleton In The Closet|TTBB|Michael Webber
+Summer's Gone|TTBB|Michael Webber
+There Is Always One More Time|TTBB|Michael Webber
+This Is The Life|TTBB|Michael Webber
+Traffic Jam|TTBB|Michael Webber
+Two Strong Hearts|TTBB|Michael Webber
+Welcome To Duloc|TTBB|Michael Webber
+What Do You Do?|TTBB|Michael Webber
+What's The Use Of Wond'rin'|TTBB|Michael Webber
+When I See An Elephant Fly|TTBB|Michael Webber
+When I'm Gone|TTBB|Michael Webber
+The Wobblin' Goblin With The Broken Broom|TTBB|Michael Webber
+You Are There|TTBB|Michael Webber
+Smoke Rings Curling In The Air|TTBB|Don Webster
+Sweet And Low|TTBB|Don Webster
+There's Something About That Name|TTBB|Randall Weir
+True Love|TTBB|Randall Weir
+Affair To Remember|TTBB|Bob Weiss
+Great Day|TTBB|Bob Weiss
+I Don't Know Why|TTBB|Bob Weiss
+I Only Have Eyes For You|TTBB|Bob Weiss
+I'll Walk With God|TTBB|Bob Weiss
+Softly As I Leave You|TTBB|Bob Weiss
+Somewhere In Time|TTBB|Bob Weiss
+Thinking Of You|TTBB|Bob Weiss
+Singin' In The Rain|SSAA|Susan Wells
+Your First Day In Heaven|SSAA|Susan Wells
+There's A Vacant Chair At Home Sweet Home|TTBB|Dick Welsh
+At The End Of A Cobblestone Road|TTBB|Bruce Wenner
+Sonny Boy|TTBB|Bruce Wenner
+A, You're Adorable|TTBB|Dan Wessler
+Amazing|TTBB|Dan Wessler
+Artificial Flowers|TTBB|Dan Wessler
+Back To The River|SATB|Dan Wessler
+Banana Split For My Baby|TTBB, SSAA, SATB|Dan Wessler
+Be Thou My Vision|TTBB|Dan Wessler
+Big City Blues|TTBB|Dan Wessler
+Blues In The Night|TTBB|Dan Wessler
+Boot Scootin' Boogie|TTBB|Dan Wessler
+Boot Scootin' Boogie|TTBB, SSAA, SATB|Dan Wessler
+Breathless|TTBB|Dan Wessler
+Bridge Over Troubled Water|TTBB|Dan Wessler
+Bring Me Sunshine|TTBB, SSAA, SATB|Dan Wessler
+Build Me Up Buttercup|TTBB|Dan Wessler
+Butter Outta Cream|TTBB|Dan Wessler
+Celestial|TTBB|Dan Wessler
+Cleopatra, Queen of Denial|SSAA|Dan Wessler
+The Coffee Song|SATB|Dan Wessler
+Comfortable|TTBB|Dan Wessler
+Cuando Nos Volvamos A Encontrar|SATB|Dan Wessler
+Don't Break the Rules|TTBB|Dan Wessler
+Don't Get Around Much Anymore|TTBB|Dan Wessler
+Don't Know Why|TTBB, SSAA, SATB|Dan Wessler
+Evil Like Me|SATB|Dan Wessler
+Farmer Tan|TTBB|Dan Wessler
+Floatin' Along|TTBB|Dan Wessler
+For Forever|TTBB|Dan Wessler
+For Her|TTBB|Dan Wessler
+Fortuosity|SSAA|Dan Wessler
+Fun And Fancy Free|TTBB, SSAA, SATB|Dan Wessler
+Gimme That Wine|TTBB|Dan Wessler
+Glory Of Love|TTBB|Dan Wessler
+Glow Worm|TTBB|Dan Wessler
+Goodbye Yellow Brick Road|SSAA, SATB|Dan Wessler
+Have It All|TTBB|Dan Wessler
+Have You Met Miss Jones|TTBB|Dan Wessler
+Heat Wave|TTBB|Dan Wessler
+Hit That Jive Jack|TTBB|Dan Wessler
+Homegrown Tomatoes|SSAA|Dan Wessler
+How Lucky You Are|TTBB, SSAA|Dan Wessler
+I Don't Want to Miss a Thing|TTBB, SSAA, SATB|Dan Wessler
+I Love Betsy|TTBB|Dan Wessler
+I Never Like It When You Leave|TTBB|Dan Wessler
+I Was A Fool To Let You Go|SSAA|Dan Wessler
+I Was Doing All Right|TTBB, SATB|Dan Wessler
+I Wish I Knew|SSAA|Dan Wessler
+I Won't Dance|TTBB|Dan Wessler
+I'd Order Love|TTBB|Dan Wessler
+I'm Into Something Good|TTBB|Dan Wessler
+If I Had You|TTBB|Dan Wessler
+Isn't That Just Like Love?|SATB|Dan Wessler
+It's A Beautiful Day|TTBB|Dan Wessler
+It's All Right|TTBB|Dan Wessler
+Johnny One Note|TTBB|Dan Wessler
+Just A Little Talk With Jesus|TTBB|Dan Wessler
+Just As I Am|TTBB|Dan Wessler
+Just Sing|TTBB, SSAA, SATB|Dan Wessler
+Let's Have Another One|TTBB|Dan Wessler
+The Life Of The Party|TTBB, SATB|Dan Wessler
+The Light In The Piazza|TTBB|Dan Wessler
+Lost In The Woods|TTBB|Dan Wessler
+Lovin', Touchin', Squeezin'|TTBB|Dan Wessler
+Lucille|SSAA|Dan Wessler
+Make Them Hear You|TTBB|Dan Wessler
+Maybe I'm Amazed|TTBB|Dan Wessler
+Me And My Shadow|TTBB|Dan Wessler
+Mister Sandman|TTBB, SSAA, SATB|Dan Wessler
+More|TTBB|Dan Wessler
+Movin' Right Along|TTBB|Dan Wessler
+Mr. Music Man|TTBB|Dan Wessler
+Mr. Pinstripe Suit|TTBB, SSAA|Dan Wessler
+A Musical|TTBB|Dan Wessler
+My Kind Of Town (Chicago Is)|TTBB|Dan Wessler
+My Little Buttercup|TTBB, SSAA, SATB|Dan Wessler
+My New Philosophy|TTBB|Dan Wessler
+Never Get Old To Me|TTBB|Dan Wessler
+Never Say Never|TTBB|Dan Wessler
+A New Life|SSAA|Dan Wessler
+New York, New York|TTBB, SSAA|Dan Wessler
+No One Else|TTBB|Dan Wessler
+Nowhere to Go but Up|TTBB, SSAA, SATB|Dan Wessler
+Old Mother Hubbard|TTBB|Dan Wessler
+On A Slow Boat To China|SSAA|Dan Wessler
+Once More I Can See|TTBB|Dan Wessler
+Pass Me By|SSAA|Dan Wessler
+Please Please Please|SSAA|Dan Wessler
+Poor Little Millionaire|TTBB|Dan Wessler
+Popular|TTBB|Dan Wessler
+The Power of Love|TTBB|Dan Wessler
+Public Melody Number One|TTBB|Dan Wessler
+Rainbow|SSAA|Dan Wessler
+Rainbow Connection|SATB|Dan Wessler
+The Rattlin' Bog|TTBB|Dan Wessler
+Route 66|TTBB, SSAA, SATB|Dan Wessler
+Scenes From An Italian Restaurant|TTBB|Dan Wessler
+Scooby Doo, Where Are You?|TTBB|Dan Wessler
+She Chose Me|TTBB|Dan Wessler
+She's Got A Way|TTBB|Dan Wessler
+Sir Duke|TTBB, SATB|Dan Wessler
+Skyfall|TTBB|Dan Wessler
+Smooth As Tennessee Whiskey|TTBB|Dan Wessler
+Some Like It Hot|TTBB|Dan Wessler
+Someone's Waiting For You|TTBB|Dan Wessler
+A Song For You|TTBB|Dan Wessler
+St. James Infirmary|TTBB|Dan Wessler
+Strangers In The Night|TTBB|Dan Wessler
+Strawberry Moon|TTBB|Dan Wessler
+Tain't Nobody's Business If I Do|TTBB|Dan Wessler
+Take A Look At Us Now|TTBB|Dan Wessler
+Take On Me|TTBB, SSAA, SATB|Dan Wessler
+Taller Stronger Better|SATB|Dan Wessler
+Tennessee Waltz|TTBB|Dan Wessler
+The Things We Did Last Summer|TTBB|Dan Wessler
+Then I'll Be Happy|TTBB|Dan Wessler
+This Guy's In Love With You|TTBB|Dan Wessler
+Three Little Words|TTBB|Dan Wessler
+The Thunder Rolls|TTBB|Dan Wessler
+Travel Song|TTBB|Dan Wessler
+Trip A Little Light Fantastic|TTBB|Dan Wessler
+Waltzing Matilda|TTBB|Dan Wessler
+We Are In Love|TTBB|Dan Wessler
+We Three Kings|TTBB|Dan Wessler
+What You'd Call A Dream|TTBB|Dan Wessler
+Whatever Lola Wants|SSAA|Dan Wessler
+When Love Is Gone|TTBB|Dan Wessler
+Where Do You Start?|TTBB|Dan Wessler
+Who I'd Be|TTBB|Dan Wessler
+You Never Had It So Good|TTBB|Dan Wessler
+You Won't Be Satisfied (until you break my heart)|TTBB|Dan Wessler
+You'll Be In My Heart|TTBB|Dan Wessler
+You're a Heavenly Thing|TTBB, SSAA, SATB|Dan Wessler
+You're Welcome|TTBB|Dan Wessler
+You've Got A Friend In Me|TTBB, SSAA, SATB|Dan Wessler
+Your Heart Is As Black As Night|TTBB, SSAA, SATB|Dan Wessler
+Your Song|TTBB|Dan Wessler
+Ac-cent-tchu-ate The Positive|TTBB|Jim West
+After You Get What You Want You Don't Want It|TTBB|Jim West
+Ain't-A That Good News|TTBB|Jim West
+Alexander's Ragtime Band|TTBB|Jim West
+All Through The Night|TTBB|Jim West
+Allegheny Moon|TTBB|Jim West
+Along The Navaho Trail|TTBB|Jim West
+Always|TTBB|Jim West
+Amen|TTBB|Jim West
+Angels We Have Heard On High|TTBB|Jim West
+Angry|TTBB|Jim West
+Anywhere I Wonder|TTBB|Jim West
+Ar Hyd Y Nos (All Through The Night)|TTBB|Jim West
+Auf Wiederseh'n, Sweetheart|TTBB|Jim West
+Baby Mine|TTBB|Jim West
+Be Like A Blue Bird|TTBB|Jim West
+Benediction Of Aaron|TTBB|Jim West
+Bill Grogan's Goat|TTBB|Jim West
+Bless This House|TTBB|Jim West
+Blow The Man Down|TTBB|Jim West
+Blue Bayou|TTBB|Jim West
+Bridge Over Troubled Water|TTBB|Jim West
+By The Time I Get To Phoenix|TTBB|Jim West
+Can You Tame Wild Women?|TTBB|Jim West
+Candleglow|TTBB|Jim West
+Charmaine|TTBB|Jim West
+Christmas Chopsticks|TTBB|Jim West
+Cold Jordan|TTBB|Jim West
+Columbus '92|TTBB|Jim West
+Comin' In On A Wing And A Prayer|TTBB|Jim West
+Daddy's Little Girl|TTBB|Jim West
+Danny Boy|TTBB|Jim West
+Dayton, Ohio 1903|TTBB|Jim West
+Dear Hearts And Gentle People|TTBB|Jim West
+Doggie In The Window (How Much Is That)|TTBB|Jim West
+Down To The River To Pray|TTBB|Jim West
+Dream Medley|TTBB|Jim West
+Drunken Sailor|TTBB|Jim West
+Edelweiss|TTBB|Jim West
+End Of The Way|TTBB|Jim West
+Everybody Loves A Lover|TTBB|Jim West
+Exodus|TTBB|Jim West
+Fine and Dandy|TTBB|Jim West
+Folks Who Live On The Hill|TTBB|Jim West
+Galway Bay|TTBB|Jim West
+Girl Of My Dreams|TTBB|Jim West
+Give Me Your Tired, Your Poor|TTBB|Jim West
+Gonna Build A Mountain|TTBB|Jim West
+Goodbye People|TTBB|Jim West
+Grandma Got Run Over By A Reindeer|TTBB|Jim West
+Grandmas Feather Bed|TTBB|Jim West
+Happy Birthday - Beautiful Baby|TTBB|Jim West
+Happy Man|TTBB|Jim West
+Harmony|TTBB|Jim West
+Hey, Good Lookin'|TTBB|Jim West
+Hi Neighbor|TTBB|Jim West
+Hillbilly Love Song|TTBB|Jim West
+How Great Thou Art|TTBB|Jim West
+I Asked The Lord|TTBB|Jim West
+I Don't Know Why|TTBB|Jim West
+I Like Mountain Music|TTBB|Jim West
+I Wish I Had My Old Gal Back Again|TTBB|Jim West
+I Wish I Had Someone To Love|TTBB|Jim West
+I Wish I Was Eighteen Again|TTBB|Jim West
+I'm All Prayed Up|TTBB|Jim West
+I'm Gonna' Be A Star|TTBB|Jim West
+I'm Pretty Good At Drinkin' Beer|TTBB|Jim West
+I'm Proud To Be An American|TTBB|Jim West
+I'm Still A Guy|TTBB|Jim West
+I've Heard That Song Before|TTBB|Jim West
+If|TTBB|Jim West
+In The Evening By The Moonlight|TTBB|Jim West
+In The Good Old Summertime|TTBB|Jim West
+It's A Blue World|TTBB|Jim West
+It's A Brand New Day|TTBB|Jim West
+It's Hard To Be Humble (Oh, Lord)|TTBB|Jim West
+Just A Closer Walk With Thee|SSAA|Jim West
+Just Because|TTBB|Jim West
+Kid Days|TTBB|Jim West
+King Of The Road|TTBB|Jim West
+Laura Bell Lee|TTBB|Jim West
+Life's Railway To Heaven|TTBB|Jim West
+Linda|TTBB|Jim West
+Little Man You've Had A Busy Day|TTBB|Jim West
+Lone Prairie|TTBB|Jim West
+Lord, We Thank Thee|TTBB|Jim West
+Lost In The Stars|TTBB|Jim West
+Lulajze Jezuniu|TTBB|Jim West
+Lullaby|TTBB|Jim West
+Maria Elena|TTBB|Jim West
+May I?|TTBB|Jim West
+May The Good Lord Bless And Keep You|SSAA|Jim West
+May The Lord|TTBB|Jim West
+Mermaid|TTBB|Jim West
+Mississippi Mud|TTBB|Jim West
+Moments To Remember|TTBB|Jim West
+Muskrat Ramble|TTBB|Jim West
+My Cup Runneth Over With Love|TTBB|Jim West
+My Grandfather's Clock|TTBB|Jim West
+My Ideal|TTBB|Jim West
+My Little Buckaroo|TTBB|Jim West
+My Melody Of Love|TTBB|Jim West
+My Old Blue Jeans|TTBB|Jim West
+My Wife Is On A Diet|TTBB|Jim West
+Nellie Introduction|TTBB|Jim West
+New York, New York|TTBB|Jim West
+Nobody Knows De Trouble I've Seen|TTBB|Jim West
+Now Is The Hour|TTBB|Jim West
+Old Folks|TTBB|Jim West
+Old St. Louie|TTBB|Jim West
+On Moonlight Bay|TTBB|Jim West
+One More Song|SSAA|Jim West
+One Pair Of Hands|TTBB|Jim West
+Opus One|TTBB|Jim West
+Peace, It Is I|TTBB|Jim West
+People Don't Know How Much You Know|TTBB|Jim West
+Pig Song|TTBB|Jim West
+Pittsburgh's Welcome|TTBB|Jim West
+Pittsburgh, Pennsylvania|TTBB|Jim West
+Portrait Of My Love|TTBB|Jim West
+Praise The Lord And Pass The Ammunition|TTBB|Jim West
+Queen of the Senior Prom|TTBB|Jim West
+Railroad Man|TTBB|Jim West
+Razzle Dazzle|TTBB|Jim West
+Ro-Ro-Rollin' Along|TTBB|Jim West
+Rock Of Ages, Let Our Song|TTBB|Jim West
+Semper Paratus|TTBB|Jim West
+Sentimental Journey|TTBB|Jim West
+Serenade Of The Bells|TTBB|Jim West
+Side by Side|TTBB|Jim West
+Silent Night|TTBB|Jim West
+Sisters In Song|TTBB|Jim West
+Sleep|TTBB|Jim West
+Some Children See Him|TTBB|Jim West
+Somewhere|TTBB|Jim West
+Somewhere My Love|TTBB|Jim West
+Stouthearted Men|TTBB|Jim West
+Sunrise, Sunset|TTBB|Jim West
+Sweet Violets|TTBB|Jim West
+Sweetheart Tree|TTBB|Jim West
+Swing Low|TTBB|Jim West
+Take Me Home, Country Roads|TTBB|Jim West
+Take Me Out To The Ball Game|TTBB|Jim West
+Tequila Makes Her Clothes Fall Off|TTBB|Jim West
+Thank God I'm a Country Boy|TTBB|Jim West
+That Old Bible On The Bookcase|TTBB|Jim West
+The Cranky Old Yank|TTBB|Jim West
+The Fruit Cake|TTBB|Jim West
+The Lord Is Good To Me|TTBB|Jim West
+The Nittany Lion|TTBB|Jim West
+"The Restroom Door Said ""Gentlemen"""|TTBB|Jim West
+The Unicorn|TTBB|Jim West
+There goes My Everything|TTBB|Jim West
+They Call The Wind Maria|TTBB|Jim West
+This Land Is Your Land|TTBB|Jim West
+Thoughts Of Home|TTBB|Jim West
+Today|TTBB|Jim West
+Too Soon|TTBB|Jim West
+Toyland|TTBB|Jim West
+Tri-State Tribute|TTBB|Jim West
+U.S. Coast Guard|TTBB|Jim West
+Unchained Melody|TTBB|Jim West
+Undecided|TTBB|Jim West
+Up On the House Top|TTBB|Jim West
+Watchin' Scotty Grow|TTBB|Jim West
+The Way We Were|TTBB|Jim West
+We Wish You A Merry Christmas|TTBB|Jim West
+We'll Be Right Back|TTBB|Jim West
+Wedding Bells Are Breaking Up That Old Gang Of Mine|TTBB|Jim West
+Wedding Song (There is Love)|TTBB|Jim West
+A Whale Of A Tale|TTBB|Jim West
+What A Wonderful World|TTBB|Jim West
+When Grandma Sings The Songs She Loved At The End Of A Perfect Day|TTBB|Jim West
+When Honey Sings An Old Time Song|TTBB|Jim West
+When There's Love At Home|TTBB|Jim West
+While By My Sheep|TTBB|Jim West
+Whispering Hope|TTBB|Jim West
+Who Am I|TTBB|Jim West
+Why Don't We Do This More Often|SSAA|Jim West
+Wild In The Country|TTBB|Jim West
+Will The Angels Let Me Play|TTBB|Jim West
+You Ain't Much Fun (Since I Quit Drinkin')|TTBB|Jim West
+You Belong To Me|TTBB|Jim West
+You Raise Me Up|SSAA|Jim West
+You Should Read Your Gideon Bible|TTBB|Jim West
+Battle Hymn Of The Republic|SSAA, Young SSAA|Judy West
+Blue Moon|SSAA|Jan-Ake Westin
+Canadian Pride|SSAA|Jan-Ake Westin
+Ding Dong Merrily On High|SSAA|Jan-Ake Westin
+Do You Want To Know a Secret!|SSAA|Jan-Ake Westin
+Hold Me Thrill Me Kiss Me|SSAA|Jan-Ake Westin
+Hot! Hot! Hot!|SSAA, SATB|Jan-Ake Westin
+I'm A Believer|SATB|Jan-Ake Westin
+In The Good Old Summertime|SSAA|Jan-Ake Westin
+Lean On Me|SSAA|Jan-Ake Westin
+Medley: Next Door To An Angel, Johnny Angel|SSAA|Jan-Ake Westin
+Next Door Angel Medley|SSAA|Jan-Ake Westin
+Once You Lose Your Heart|SSAA|Jan-Ake Westin
+Silver Bells|SSAA|Jan-Ake Westin
+Summertime|SSAA|Jan-Ake Westin
+When I Was A Dreamer|TTBB|Jan-Ake Westin
+When I Was A Dreamer|SSAA|Jan-Ake Westin
+Why We Sing|TTBB|Jan-Ake Westin
+Yellow Submarine|TTBB, SSAA|Jan-Ake Westin
+Heart Of Gold|SSAA|Claudia Westland
+Please Don't Talk About Me When I'm Gone|SSAA, Young SSAA|Ozzie Westley
+Redhead|TTBB|Ozzie Westley
+Sugarcane Jubilee|TTBB|Ozzie Westley
+All The Things You Are|SSAA|Janice Wheeler
+Give Me A Band and My Baby|SSAA|Janice Wheeler
+Look For Me At Jesus Feet|SSAA|Janice Wheeler
+Somebody Loves You|SSAA|Janice Wheeler
+Sunday Kind Of Love|SSAA|Janice Wheeler
+What Are You Doing New Year's Eve?|SSAA|Janice Wheeler
+Galway Bay|TTBB|Tim Wheeler
+There's Yes Yes In Your Eyes|TTBB|Tim Wheeler
+When I Grow Too Old To Dream|TTBB|Tim Wheeler
+Cruella De Vil|TTBB|Tom Wheeler
+The Very Thought Of You|SSAA|Tom Wheeler
+South Rampart Street Parade|TTBB|Charles White
+Tumbling Tumbleweeds|TTBB|Max White
+This Land Is Your Land|TTBB|Dick Whitehouse
+I Think You're Absolutely Wonderful|TTBB|John Whitener
+I'm Goin' South|TTBB|John Whitener
+You Can't Go On Forever Breaking My Heart|SSAA|Lois Whitney
+Topping The Bill|TTBB|John Wiggins
+Just A Kid Named Joe|SSAA|Don Wilkenson
+Choo Choo Ch'Boogie|SSAA|Becky Wilkins
+The Chordbuster March|SSAA|Becky Wilkins
+Goodnight, Sweetheart, Goodnight|SSAA|Becky Wilkins
+Man! I Feel Like A Woman|SSAA|Becky Wilkins
+My Boyfriends Back|SSAA|Becky Wilkins
+The River Of Dreams|SSAA|Becky Wilkins
+Run To You|SSAA|Becky Wilkins
+Shambala|SSAA|Becky Wilkins
+That Little Boy Of Mine|SSAA|Dave Wilkinson
+That's How I Spell Ireland|TTBB|Dave Wilkinson
+Looking At The World Through Rose Colored Glasses|TTBB|Chuck Williams
+Whiffenpoof Song|TTBB|David Williams
+When Your Old Wedding Ring Was New|TTBB|Tom Williams
+How About Me?|SSAA|Wilma Williams
+Soft Summer Breeze|SSAA|Wilma Williams
+Johnny Doughboy Found A Rose In Ireland|TTBB|Ed Williamson
+Sonny Boy|TTBB|Ed Williamson
+That Old Home Town Of Mine|TTBB|Loton Willson
+Frog Kissin'|TTBB|Dan Wilson
+Hero Of The Game Medley|TTBB|Dan Wilson
+I'm Off To See My Sweetness|TTBB|Dan Wilson
+Join The Circus|TTBB|Dan Wilson
+Look For Me Honey|TTBB|Dan Wilson
+My Little Miss Right Medley|TTBB|Dan Wilson
+The Old Lamplighter|TTBB|Dan Wilson
+On A Rainy Day Medley|TTBB|Dan Wilson
+Play A Vaudeville Song Tonight|TTBB|Dan Wilson
+Roll On You Riverboat, Roll On|TTBB|Dan Wilson
+Those Old Midnight Blues|TTBB|Dan Wilson
+To The Swimmin' Hole With A Fishin' Pole|TTBB|Dan Wilson
+What Would Christmas Be Without A Song|TTBB|Dan Wilson
+When Sunshine Comes Along|TTBB|Dan Wilson
+When You've Got A Song In Your Heart|TTBB|Dan Wilson
+Anthem For The Millennium (America My Home)|TTBB|Fran Wilson
+Bad, Bad Leroy Brown|TTBB|Fran Wilson
+Forever And A Day|TTBB|Fran Wilson
+I Said My Pajamas|TTBB|Fran Wilson
+I'll Make The Pies Like Mother Made (If You Make The Dough Like Dad)|TTBB|Fran Wilson
+King Of The Road|TTBB|Fran Wilson
+My Blue Heaven|TTBB|Fran Wilson
+Sentimental Journey|TTBB|Fran Wilson
+Sweet Violets|TTBB|Fran Wilson
+Unchained Melody|TTBB|Fran Wilson
+How Ya Gonna Keep 'Em Down On The Farm|TTBB|David Wilt
+Deep In The Heart Of Texas / Back In The Saddle Again Medley|TTBB|Ken Wimbish
+Just A Girl That Men Forget|TTBB|Ken Wimbish
+Nobody's Sweetheart|TTBB|Ken Wimbish
+Tears (For Souvenirs)|TTBB|Rick Witte
+Who's Sorry Now|SSAA|Rick Witte
+Can't Fight This Feeling|TTBB|Andrew Wittenberg
+The Hairbrush Song|TTBB|Andrew Wittenberg
+Have Yourself A Merry Little Christmas|TTBB|Andrew Wittenberg
+Holly Jolly Christmas|TTBB|Andrew Wittenberg
+I Believe In Santa Claus|TTBB|Andrew Wittenberg
+Join Me In A Dream|TTBB|Andrew Wittenberg
+The Laundromat Swing|TTBB|Andrew Wittenberg
+Let You Break My Heart Again|TTBB, SSAA, SATB|Andrew Wittenberg
+Silver And Gold|TTBB|Andrew Wittenberg
+Take It Easy|TTBB|Andrew Wittenberg
+The Time Of Your Life|TTBB|Andrew Wittenberg
+Why Do I?|TTBB|Andrew Wittenberg
+You Always Hurt the One You Love|TTBB|Andrew Wittenberg
+The Game|TTBB|Andy Wolf
+Girl Who Sells Sea Shells By The Seashore|TTBB|Andy Wolf
+Goodbye Dear Old Friend|TTBB|Andy Wolf
+I Don't Want To Be A Lady|TTBB|Andy Wolf
+Infomercials|TTBB|Andy Wolf
+Pondering, Or What Does Ernest Hemingway|TTBB|Andy Wolf
+The Thing|TTBB|Andy Wolf
+I Won't Say I'm In Love|SSAA|Jeana Womble
+Angels|SSAA, Young SSAA|Rebecca J. Wood
+Button Up Your Overcoat|SSAA|Rebecca J. Wood
+Dungaree Doll|SSAA, Young SSAA|Rebecca J. Wood
+A Heart Like Thine|SSAA|Rebecca J. Wood
+Lady Bug|SSAA|Rebecca J. Wood
+Lover Come Back To Me|SSAA|Rebecca J. Wood
+Make Believe|SSAA|Rebecca J. Wood
+Nearer, Still Nearer|TTBB|Rebecca J. Wood
+O Holy Night|SSAA|Rebecca J. Wood
+Powder Your Face With Sunshine|SSAA|Rebecca J. Wood
+There Is No Greater Love|SSAA|Rebecca J. Wood
+With A Song In My Heart|SSAA|Rebecca J. Wood
+Hair|TTBB|Wayne Woodward
+I Want A Girl Medley|TTBB|Wayne Woodward
+'Round Midnight|TTBB|David Wright
+A Little Less Conversation|SSAA|David Wright
+ABC|TTBB, SSAA, SATB|David Wright
+Above My Head, I Hear Music In The Air|TTBB|David Wright
+Ain't Misbehavin' Medley|SSAA|David Wright
+Alexander's Ragtime Band|TTBB, SSAA|David Wright
+All By Myself|SSAA|David Wright
+All I Know|SATB|David Wright
+All The Things You Are|TTBB, SSAA|David Wright
+All The World Will Be Jealous Of Me|TTBB|David Wright
+American Tune|TTBB|David Wright
+An American In Paris|TTBB|David Wright
+And This is My Beloved|TTBB|David Wright
+Angel Of Music / Phantom Of The Opera Medley|SSAA|David Wright
+April Fooled Me|TTBB|David Wright
+As Long As I'm Singing|TTBB|David Wright
+At Last|TTBB, SSAA|David Wright
+At The Jazz Band Ball|TTBB|David Wright
+Baby Love|SSAA|David Wright
+Back In Business|TTBB|David Wright
+Ballin' The Jack|TTBB, SSAA|David Wright
+Basin Street Blues|TTBB, SSAA|David Wright
+Be The Hero|SATB|David Wright
+Beautiful Dreamer|TTBB|David Wright
+Beautiful Dreamer|SSAA|David Wright
+Beethoven 5.1|TTBB|David Wright
+Being Alive|SSAA|David Wright
+Between The Devil And The Deep Blue Sea|TTBB, SATB|David Wright
+Birth Of The Blues|TTBB|David Wright
+The Birthday Of A King|TTBB|David Wright
+Blue, Turning Grey Over You|TTBB, SSAA|David Wright
+Blues In The Night|TTBB|David Wright
+Boogie Woogie Bugle Boy|TTBB, SSAA|David Wright
+Boyfriend Medley|SSAA|David Wright
+Bread And Gravy|TTBB|David Wright
+Breaking Up Is Hard To Do|TTBB, SSAA|David Wright
+Bright Was The Night|TTBB|David Wright
+Brother Can You Spare A Dime|TTBB|David Wright
+Bundle Of Old Love Letters|SSAA|David Wright
+Bye Bye Blackbird|SSAA|David Wright
+California Here I Come|TTBB|David Wright
+Can't Help Falling In Love|TTBB|David Wright
+Can't Help Lovin' Dat Man|SSAA|David Wright
+Can't You Hear Me Callin' Caroline|TTBB|David Wright
+Canticle of the Sun|SSAA|David Wright
+Carol Of The Bells|TTBB, SSAA|David Wright
+The Cat Is High|SSAA|David Wright
+Change The World|TTBB, SSAA|David Wright
+Come In From The Rain|SSAA|David Wright
+Corner Of The Sky|TTBB|David Wright
+A Cover Is Not The Book|TTBB|David Wright
+Cruella De Vil|TTBB|David Wright
+Cruella De Vil|SSAA|David Wright
+Crying|TTBB|David Wright
+Daddy's Little Girl|TTBB|David Wright
+Dancing In The Street|SSAA|David Wright
+Dear Old Girl|TTBB|David Wright
+Deep River|TTBB|David Wright
+Dinah|TTBB, SSAA|David Wright
+Doggone, I've Done It|TTBB|David Wright
+Don't Fence Me In|TTBB|David Wright
+Dream Is A Wish Your Heart Makes|TTBB|David Wright
+Elijah Rock|TTBB|David Wright
+Every Which-a-way|SATB|David Wright
+Everybody Loves My Baby|SSAA|David Wright
+Everything's Comin' Up Roses|TTBB, SSAA|David Wright
+Ezekiel Saw The Wheel|TTBB|David Wright
+Fare Thee Well Love|TTBB|David Wright
+Find Out What They Like And How They Like It|SSAA|David Wright
+Fit As A Fiddle|TTBB, SSAA|David Wright
+For Once In My Life|SSAA, SATB|David Wright
+Friend Like Me|TTBB|David Wright
+Friends|TTBB, SSAA|David Wright
+Friends Medley|TTBB|David Wright
+Friends Medley|SSAA|David Wright
+Get Me To The Church On Time/The Joint is Jumpin|TTBB|David Wright
+Gloria|TTBB|David Wright
+Go Down Moses|TTBB|David Wright
+Go Tell It On The Mountain|TTBB, SSAA|David Wright
+God Only Knows|TTBB|David Wright
+Going Home|TTBB|David Wright
+Good Day Sunshine|TTBB|David Wright
+Good Old A Cappella|TTBB, SSAA|David Wright
+Good Old-fashioned Lover Boy|SSAA|David Wright
+Good Vibrations|TTBB|David Wright
+Goodbye World Goodbye|TTBB, SSAA|David Wright
+Great Day|TTBB, SSAA|David Wright
+Hakunah Matata|TTBB|David Wright
+Hallelujah Chorus|TTBB|David Wright
+Handful Of Keys|SSAA|David Wright
+Happy Days Are Here Again|TTBB|David Wright
+Happy Together|TTBB, SSAA|David Wright
+Hard Times Come Again No More|TTBB|David Wright
+Harmony|TTBB, SSAA|David Wright
+Heat Wave|SSAA|David Wright
+Hello|SATB|David Wright
+Hello Mary Lou|TTBB|David Wright
+Here Comes The Showboat|TTBB|David Wright
+Hey Good Lookin'|TTBB, SSAA|David Wright
+Hey Look Me Over|TTBB|David Wright
+Hey There|TTBB, SSAA|David Wright
+Higher And Higher|TTBB, SSAA, SATB|David Wright
+Hold On|TTBB, SSAA|David Wright
+Honeysuckle Rose|TTBB|David Wright
+How Can I Keep From Singing|TTBB|David Wright
+How Do You Keep The Music Playing?|SATB|David Wright
+How Far I'll Go|SSAA|David Wright
+How'dja Like to Love Me|TTBB, SSAA|David Wright
+I Don't Want Him To Love You When I'm Gone Medley|TTBB, SSAA|David Wright
+I Dreamed A Dream|SSAA|David Wright
+I Got Rhythm|TTBB, SSAA|David Wright
+I Have Dreamed|TTBB, SSAA|David Wright
+I Love Jazz Medley|TTBB, SSAA|David Wright
+I Never Knew I Could Love Anybody|TTBB, SSAA|David Wright
+I Still Can See Your Face|SSAA|David Wright
+I Wanna Be Like You|TTBB|David Wright
+I Will|TTBB, SSAA|David Wright
+I Will Follow You|TTBB|David Wright
+I Wish You Love|SSAA|David Wright
+I Write The Songs|SATB|David Wright
+I'm In The Mood For Love|SSAA|David Wright
+I'm The Music Man|TTBB|David Wright
+I've Got A Feeling I'm Falling|TTBB, SSAA|David Wright
+I've Got A Golden Ticket|TTBB|David Wright
+I've Never Been In Love Before|SATB|David Wright
+If You Go Away|TTBB|David Wright
+If You Leave Me Now|SSAA|David Wright
+If You Love Me, Really Love Me|TTBB, SSAA|David Wright
+The Impossible Dream|TTBB|David Wright
+In The Blood|TTBB|David Wright
+Into the Unknown|TTBB, SSAA, SATB|David Wright
+It Ain't Necessarily So|SSAA|David Wright
+It Must Have Been Love|SSAA|David Wright
+It Only Takes A Moment|TTBB, SSAA|David Wright
+It's A Dangerous Game|TTBB|David Wright
+It's A Good Day|TTBB|David Wright
+It's A Most Unusual Day|TTBB|David Wright
+It's A Sin To Tell A Lie|TTBB, SSAA|David Wright
+Jazz Came Up The River From New Orleans|TTBB|David Wright
+Jazz Ladies Ride|SSAA|David Wright
+Joint Is Jumping|TTBB, SSAA|David Wright
+Joshua Fit The Battle Of Jericho|TTBB, SSAA|David Wright
+Joy To The World|TTBB|David Wright
+Just A Kid Named Joe|TTBB|David Wright
+Keepin' Out Of Mischief Now|SSAA|David Wright
+Last Night Was The End Of The World|TTBB|David Wright
+Lately|SATB|David Wright
+Lazy Day|TTBB, SSAA|David Wright
+Lazybones|TTBB|David Wright
+Let Yourself Go|TTBB, SSAA|David Wright
+Let's Face The Music And Dance|SSAA|David Wright
+Let's Sing Again|SSAA|David Wright
+Liar With An Achin' Breakin' Heart Medley|TTBB|David Wright
+Light My Fire|TTBB|David Wright
+Little Drummer Boy|TTBB|David Wright
+Lonely Nights Medley|TTBB, SSAA|David Wright
+Looking At The World Through Rose Colored Glasses|TTBB, SSAA|David Wright
+Louise|TTBB|David Wright
+Lounging At The Waldorf|SSAA|David Wright
+Love Is Here To Stay|SSAA|David Wright
+Love Me And The World Is Mine|TTBB, SSAA|David Wright
+Love Me Tender|TTBB, SSAA|David Wright
+Love Of My Life|SSAA|David Wright
+Love Walked In|SSAA|David Wright
+Magic To Do|TTBB, SSAA|David Wright
+Man I Love|SSAA|David Wright
+Man of La Mancha|TTBB, SSAA|David Wright
+Mandy Lee|TTBB|David Wright
+Marching Along With Time|TTBB|David Wright
+Mardi Gras March / South Rampart Street Parade Medley|TTBB|David Wright
+Mary Did You Know|TTBB|David Wright
+Mary Had A Baby|TTBB, SSAA|David Wright
+Mean To Me|TTBB|David Wright
+Midnight Serenade|TTBB, SSAA|David Wright
+Minute Waltz|SSAA|David Wright
+Mississippi Mud|TTBB, SSAA|David Wright
+Mobile|TTBB|David Wright
+Moonlight Serenade|TTBB, SSAA|David Wright
+More|SSAA|David Wright
+Music Of The Night|TTBB, SSAA|David Wright
+Muskrat Ramble|TTBB|David Wright
+My Baby Just Cares For Me|SSAA|David Wright
+My Honey's Lovin' Arms|TTBB, SSAA|David Wright
+My Romance|TTBB|David Wright
+Natural Woman (You Make Me Feel Like)|SSAA|David Wright
+Never Let No Man Worry Your Mind|SSAA|David Wright
+Never Neverland|SATB|David Wright
+New Ashmolean Band|TTBB|David Wright
+New York, New York|SSAA|David Wright
+The Night Has a Thousand Eyes|TTBB, SSAA|David Wright
+Nine To Five|TTBB|David Wright
+No Other Love|TTBB|David Wright
+Nobody's Sweetheart|TTBB|David Wright
+O Holy Night|TTBB|David Wright
+Ode To New Orleans|TTBB, SSAA|David Wright
+Oh Happy Day|SSAA|David Wright
+Oh, Lonesome Me|TTBB, SSAA|David Wright
+Oh, Susanna Dust Off That Old Pianna|TTBB, SSAA|David Wright
+Old Fashioned Love|TTBB|David Wright
+Old Folks At Home|TTBB|David Wright
+Old Piano Roll Blues|TTBB, SSAA|David Wright
+Old St. Louie|TTBB, SSAA|David Wright
+On Moonlight Bay|TTBB|David Wright
+On The Banks Of The Wabash|TTBB|David Wright
+On The Street Where You Live|TTBB|David Wright
+One Alone|TTBB, SSAA|David Wright
+One Fine Day|SSAA|David Wright
+One Moment in Time|TTBB, SSAA|David Wright
+One More Minute|SSAA|David Wright
+Original Dixieland One-Step|TTBB, SSAA|David Wright
+Play That Barbershop Chord|TTBB|David Wright
+Proud Mary|TTBB, SSAA|David Wright
+Proud of Your Boy|TTBB|David Wright
+Puttin' On The Ritz|TTBB, SSAA|David Wright
+Putting It Together|TTBB|David Wright
+A Red Red Rose|TTBB|David Wright
+Rhapsody of New York|SSAA|David Wright
+Ride The Chariot|TTBB, SSAA|David Wright
+Right From The Start She Had My Heart|TTBB|David Wright
+Ring Of Fire|TTBB|David Wright
+Rise Like A Phoenix|SSAA|David Wright
+Roxie|SSAA|David Wright
+Royal Garden Blues|TTBB, SSAA|David Wright
+Runnin' Wild|TTBB, SSAA|David Wright
+S Wonderful|TTBB|David Wright
+Seventy-Six Trombones|TTBB|David Wright
+She's Got A Way|TTBB|David Wright
+Shine|TTBB|David Wright
+The Show Must Go On|SATB|David Wright
+Sing, Sing, Sing|TTBB|David Wright
+Singin' In The Rain|TTBB, SSAA|David Wright
+Sit Down You're Rockin' The Boat|TTBB, SSAA|David Wright
+Sixteen Tons|TTBB|David Wright
+Small Fry|TTBB|David Wright
+Smilin' Through|TTBB|David Wright
+So In Love|TTBB|David Wright
+Some Enchanted Evening|TTBB, SSAA|David Wright
+Somebody Knows|TTBB|David Wright
+Someday|TTBB|David Wright
+Something Good|TTBB|David Wright
+Something's Coming|TTBB, SSAA|David Wright
+A Song For The Little Guy|TTBB|David Wright
+Song's Gotta Come From The Heart|TTBB, SSAA|David Wright
+Sonny Boy|TTBB|David Wright
+Soon Ah Will Be Done|TTBB|David Wright
+Sound Of Music|TTBB|David Wright
+South Rampart Street Parade|TTBB, SSAA|David Wright
+Spread The Love Around|SATB|David Wright
+Stand By Me|TTBB|David Wright
+Stars And Stripes Forever|TTBB, SSAA, SATB|David Wright
+Stars Fell On Alabama|TTBB, SSAA|David Wright
+Steal Away|TTBB, SSAA|David Wright
+Step In Time|TTBB|David Wright
+Stormy Weather|TTBB|David Wright
+Strike Up The Band|TTBB, SSAA|David Wright
+Sudden Love|TTBB|David Wright
+Sugarcane Jubilee|TTBB|David Wright
+Sweet Lorraine|TTBB|David Wright
+Sweet Sugar Baby Medley|TTBB|David Wright
+Take Five|TTBB|David Wright
+Take It Up A Step|SATB|David Wright
+Thank You For The Music|SSAA|David Wright
+Thanks Again|SSAA|David Wright
+That Lucky Old Sun|TTBB|David Wright
+That Old Feeling|TTBB|David Wright
+That's How Rhythm Was Born|TTBB|David Wright
+They Didn't Believe Me|TTBB|David Wright
+They Just Keep Moving the Line|TTBB|David Wright
+This Can't Be Love|TTBB, SSAA|David Wright
+This Is Halloween|SATB|David Wright
+This Ole House|TTBB|David Wright
+Time After Time|TTBB, SSAA|David Wright
+Titanium|TTBB, SSAA|David Wright
+Today|TTBB|David Wright
+Toora Loora Loora|TTBB|David Wright
+Toy Song|TTBB|David Wright
+The Trolley Song|SSAA|David Wright
+True Colors|TTBB|David Wright
+Unchained Melody|TTBB|David Wright
+Undecided|TTBB, SSAA|David Wright
+Unusual Way|TTBB|David Wright
+Use What You Got|TTBB|David Wright
+Via Dolorosa|TTBB|David Wright
+Victory Road|TTBB|David Wright
+Vincent (Starry Starry Night)|TTBB, SSAA|David Wright
+Water Under Bridges|TTBB|David Wright
+We Never Really Say Goodbye|TTBB|David Wright
+We Shall Overcome|TTBB, SSAA|David Wright
+We're the Children/Harmonize the World|SSAA|David Wright
+Wedding Bells Are Breaking Up That Old Gang Of Mine|TTBB, SSAA|David Wright
+Weekend In New England|TTBB|David Wright
+Weekend In New England|SSAA|David Wright
+Welcome Christmas|TTBB|David Wright
+What A Wonderful World|TTBB|David Wright
+What I Did For Love|TTBB, SSAA|David Wright
+What's This?|TTBB|David Wright
+When I Fall In Love|TTBB, SSAA|David Wright
+When I Lift Up My Head|TTBB, SSAA|David Wright
+When I Look In Your Eyes|SSAA|David Wright
+When Johnny Comes Marching Home|TTBB|David Wright
+When The Midnight Choo Choo Leaves For Alabam'|TTBB|David Wright
+When Will I Be Loved|SSAA|David Wright
+When You And I Were Young Maggie|TTBB|David Wright
+Where The Southern Roses Grow|TTBB, SSAA|David Wright
+Who Wants To Live Forever|SSAA|David Wright
+A Whole New World|SSAA|David Wright
+Why Do Fools Fall In Love|SSAA|David Wright
+Wichita Lineman|TTBB|David Wright
+Will You Love Me In December As You Do In May|TTBB|David Wright
+Wishing You Were Somehow Here Again|TTBB|David Wright
+With You|TTBB|David Wright
+Wonderful One|TTBB|David Wright
+Wonderful Time Up There|TTBB|David Wright
+Yes Indeed|TTBB|David Wright
+Yes Sir, That's My Baby|TTBB, SSAA|David Wright
+"You Can't Play ""Sweet Adeline"" On No Piano"|TTBB|David Wright
+You Can't Stop The Beat|TTBB|David Wright
+You Don't Bring Me Flowers|SSAA|David Wright
+You Light Up My Life|TTBB, SSAA|David Wright
+You There In The Back Row|SSAA|David Wright
+You're As Welcome As the Flowers In May|TTBB|David Wright
+You're From Heaven And You're Mine|TTBB, SSAA|David Wright
+Zoot Suit Riot|TTBB|David Wright
+Today|TTBB|Gerald Wright
+('til) I Kissed You|TTBB|Larry Wright
+(Ghost) Riders In The Sky|TTBB, SSAA|Larry Wright
+(You're My) Soul and Inspiration|TTBB|Larry Wright
+A Cup Of Coffee A Sandwich And You|TTBB, SATB|Larry Wright
+A Good Old Barbershop Song|TTBB, SSAA|Larry Wright
+A Moment Like This|SSAA|Larry Wright
+A Whole New World|TTBB|Larry Wright
+A Whole New World|SSAA|Larry Wright
+ABBA Medley|TTBB, SSAA|Larry Wright
+ABBA Medley|SSAA|Larry Wright
+ABC|SSAA|Larry Wright
+The Addams Family|TTBB|Larry Wright
+Adelaide's Lament|SSAA|Larry Wright
+Ain't Misbehavin'|TTBB|Larry Wright
+Ain't No Mountain High Enough|SSAA|Larry Wright
+Alfie|TTBB, SSAA|Larry Wright
+All About That Bass|SSAA|Larry Wright
+All I Have To Do Is Dream|TTBB|Larry Wright
+All Of My Life|TTBB, SSAA|Larry Wright
+All The Way|SSAA|Larry Wright
+Always On My Mind|SSAA|Larry Wright
+American Anthem|SSAA|Larry Wright
+American Rock n' Roll|TTBB|Larry Wright
+Andrews Sisters Medley|SSAA|Larry Wright
+Annie Medley|TTBB, SSAA|Larry Wright
+Anything You Can Do I Can Do Better|SSAA|Larry Wright
+Anything You Can Do I Can Do Better|SSAA, SATB|Larry Wright
+April Showers|TTBB, SSAA|Larry Wright
+Aquarius|SSAA|Larry Wright
+Aquarius|TTBB, SSAA|Larry Wright
+Armed Forces Medley|TTBB|Larry Wright
+Around the World|SSAA|Larry Wright
+As Long As I'm Singing My Song|TTBB, SSAA|Larry Wright
+Association Medley|TTBB|Larry Wright
+Baby Love|SSAA|Larry Wright
+Bach Fugue In D Minor|TTBB, SSAA|Larry Wright
+Back Home Again In Indiana|TTBB, SSAA|Larry Wright
+Back In Business|TTBB, SSAA|Larry Wright
+The Ballad Of Bonnie And Clyde|TTBB, SSAA|Larry Wright
+Ballad of Gilligan's Isle|TTBB, SSAA|Larry Wright
+Barbara Ann|TTBB|Larry Wright
+Barstool Cowboy|TTBB|Larry Wright
+Be-bop-a-lula|TTBB|Larry Wright
+Because You Loved Me|SSAA|Larry Wright
+Best Seat In The House|TTBB, SSAA|Larry Wright
+The Best Times I Ever Had|TTBB, SSAA|Larry Wright
+Big Hair|SSAA|Larry Wright
+Bill Bailey Fugue|TTBB, SSAA|Larry Wright
+Bird Dog|TTBB|Larry Wright
+Bless You For Being An Angel|TTBB, SSAA|Larry Wright
+Boogie Woogie Bugle Boy|SSAA|Larry Wright
+Boondocks|SSAA|Larry Wright
+The Boy From New York City|SSAA|Larry Wright
+Breaking Up Is Hard To Do|TTBB, SSAA|Larry Wright
+Breaking Up Is Hard To Do|TTBB|Larry Wright
+Bridge Over Troubled Water|TTBB, SSAA|Larry Wright
+By The Time I Get To Phoenix|TTBB, SSAA|Larry Wright
+By The Time I Get To Phoenix|SSAA|Larry Wright
+Bye Bye Baby/Baby Won't You Please Come Home Medley|TTBB, SSAA|Larry Wright
+Bye Bye Blackbird|TTBB, SSAA|Larry Wright
+Bye Bye Blackbird/Bye Bye Baby Medley|TTBB, SSAA|Larry Wright
+Bye Bye Love|TTBB|Larry Wright
+Cabaret|TTBB, SSAA|Larry Wright
+Call Me Back Pal O' Mine|TTBB|Larry Wright
+Can't Smile Without You|SSAA|Larry Wright
+Can't Stop Talking|SSAA|Larry Wright
+Can't Take My Eyes Off Of You|TTBB, SSAA|Larry Wright
+Candle On The Water|SSAA|Larry Wright
+Carol Medley|TTBB, SSAA|Larry Wright
+Caroling, Caroling|TTBB, SSAA|Larry Wright
+Casper The Friendly Ghost|TTBB|Larry Wright
+Cecilia|TTBB|Larry Wright
+Celebrate/Goody Goodbye|TTBB, SSAA|Larry Wright
+Celebrate/Happy Birthday|TTBB, SSAA|Larry Wright
+Charlie Brown|TTBB, SSAA|Larry Wright
+Cherish|TTBB|Larry Wright
+Christmas Children|SSAA|Larry Wright
+Christmas Chopsticks|TTBB, SSAA|Larry Wright
+Christmas In Kilarney|TTBB, SSAA|Larry Wright
+The Christmas Song|TTBB, SSAA|Larry Wright
+Clancy Lowered The Boom|TTBB, SSAA|Larry Wright
+Climb Ev'ry Mountain|SSAA|Larry Wright
+The Climb|TTBB, SSAA, Young SSAA|Larry Wright
+Come Back And See Us|TTBB, SSAA|Larry Wright
+Come Dance With Me|TTBB, SSAA|Larry Wright
+Crazy|TTBB, SSAA|Larry Wright
+Daddy Sang Bass/Will The Circle Be Unbroken|TTBB, SSAA|Larry Wright
+Dancing In The Street|TTBB, SSAA|Larry Wright
+Deed I Do|TTBB, SSAA|Larry Wright
+Deep River|TTBB, SSAA|Larry Wright
+Defying Gravity|SSAA|Larry Wright
+Diamond's Are A Girls Best Friend|SSAA|Larry Wright
+Diamonds are Forever|SSAA|Larry Wright
+Didn't We|TTBB, SSAA|Larry Wright
+Dig A Little Deeper In The Well|TTBB, SSAA|Larry Wright
+Ding-Dong! The Witch Is Dead|TTBB|Larry Wright
+Do - Re - Mi|SSAA|Larry Wright
+Do You Hear What I Hear|TTBB, SSAA|Larry Wright
+Do You Know The Way To San Jose|TTBB, SSAA|Larry Wright
+Don't Blame Me|TTBB, SSAA|Larry Wright
+Don't Rain on My Parade|SSAA|Larry Wright
+Don't Sit under The Apple Tree|SSAA|Larry Wright
+Don't Stop|SSAA|Larry Wright
+Don't Take Your Lines From Dimestore Novels|TTBB|Larry Wright
+Down In The Boondocks|SSAA|Larry Wright
+Dream Lover|TTBB, SSAA|Larry Wright
+Dreamer's Holiday|TTBB, SSAA|Larry Wright
+Each Time I Fall In Love|TTBB, SSAA|Larry Wright
+Ease On Down The Road|SSAA|Larry Wright
+Edelweiss|SSAA|Larry Wright
+Eight Candles|TTBB, SSAA|Larry Wright
+Eighteen Holes|TTBB|Larry Wright
+Empire State Of Mind|SSAA|Larry Wright
+Everly Brothers Medley|TTBB|Larry Wright
+Everything|TTBB, SSAA|Larry Wright
+Everything|TTBB|Larry Wright
+Everything|SSAA|Larry Wright
+For Always|TTBB, SSAA|Larry Wright
+For Good|SSAA|Larry Wright
+For Just A Little While|SSAA|Larry Wright
+Forget It, I've Had It|SSAA|Larry Wright
+Future Days|TTBB|Larry Wright
+Galway Bay|TTBB, SSAA|Larry Wright
+Georgia Camp Meeting|TTBB, SSAA|Larry Wright
+Getting To Know You|TTBB, SSAA|Larry Wright
+Gilligan's Island Theme Song|TTBB, SSAA|Larry Wright
+Go The Distance|TTBB, SSAA|Larry Wright
+God Bless America|TTBB|Larry Wright
+God Bless The U.S.A.|TTBB, SSAA, SATB|Larry Wright
+God Bless The U.S.A.|TTBB, SSAA|Larry Wright
+God Didn't Make Little Green Apples|TTBB, SSAA|Larry Wright
+God Rest Ye Merry, Gentlemen|SSAA|Larry Wright
+Goin' Out Of My Head|TTBB, SSAA|Larry Wright
+Goober Peas|TTBB|Larry Wright
+Good Old Days|TTBB, SSAA|Larry Wright
+Good Vibrations|TTBB|Larry Wright
+Grandma Got Run Over By A Reindeer|TTBB, SSAA|Larry Wright
+Great Day|SSAA|Larry Wright
+Great Day Medley|TTBB, SSAA|Larry Wright
+Great Is Thy Faithfulness|SSAA|Larry Wright
+The Greatest Show|SSAA|Larry Wright
+Grim Grinning Ghosts|TTBB|Larry Wright
+Grow Old With You|TTBB|Larry Wright
+Guys And Dolls|TTBB|Larry Wright
+Happy|SSAA|Larry Wright
+Happy Birthday (non Traditional)|SSAA|Larry Wright
+Happy Birthday To You|SSAA, Young SSAA|Larry Wright
+Happy Together|TTBB, SSAA|Larry Wright
+Happy Together|SSAA|Larry Wright
+Happy Trails|TTBB|Larry Wright
+Happy/All About That Bass Medley|SSAA|Larry Wright
+Hard Hearted Hannah|TTBB, SSAA|Larry Wright
+Haunted House|TTBB|Larry Wright
+Have Yourself A Merry Little Christmas|TTBB, SSAA|Larry Wright
+He Touched Me|SSAA|Larry Wright
+Heart (You Gotta Have)|TTBB, SSAA|Larry Wright
+Hearts Desire|SSAA|Larry Wright
+Hearts Desire|TTBB, SSAA|Larry Wright
+Here You Are Back Again|TTBB, SSAA|Larry Wright
+Hokey Pokey|TTBB, SSAA|Larry Wright
+Holiday Blessing/Jingle Bells Medley|TTBB, SSAA, SATB|Larry Wright
+Holiday Show Opener/Closer|TTBB, SSAA|Larry Wright
+Hooked On Classics medley|TTBB, SSAA|Larry Wright
+Hooray For Love|TTBB, SSAA|Larry Wright
+How Come I Can't Get The Girls|TTBB|Larry Wright
+How Come I Can't Get The Guys|SSAA|Larry Wright
+How Deep Is Your Love?|TTBB, SSAA|Larry Wright
+How Sweet It Is To Be Loved By You|TTBB|Larry Wright
+I Can Only Imagine|SSAA|Larry Wright
+I Cross My Heart|TTBB, SSAA|Larry Wright
+I Did It My Way|TTBB|Larry Wright
+I Don't Know Enough About You|SSAA|Larry Wright
+I Don't Know Enough About You|TTBB, SSAA|Larry Wright
+I Feel The Earth Move|SSAA|Larry Wright
+I Get Around|TTBB, SSAA|Larry Wright
+I Got Lost In His Arms|SSAA|Larry Wright
+I Got The Sun In The Morning|SSAA|Larry Wright
+I Heard It Through The Grapevine|TTBB|Larry Wright
+I Heard It Through The Grapevine|SSAA|Larry Wright
+I Hope You Dance|SSAA|Larry Wright
+I Left My Heart In San Francisco|TTBB, SSAA|Larry Wright
+I Was Here|SSAA|Larry Wright
+I Will Follow Him|SSAA|Larry Wright
+I Will Survive|SSAA|Larry Wright
+I Wish I Was Eighteen Again|TTBB|Larry Wright
+I Wish I Was Eighteen Again|SSAA|Larry Wright
+I Won't Grow Up|SSAA|Larry Wright
+I'll Be Home For Christmas|TTBB, SSAA|Larry Wright
+I'll Be There|SSAA|Larry Wright
+I'll Never Fall in Love Again|SSAA|Larry Wright
+I'm Flying|SSAA|Larry Wright
+I'm Having A Ball|SSAA|Larry Wright
+I'm Just Wild About Harry|TTBB|Larry Wright
+I'm Just Wild About Harry|SSAA|Larry Wright
+I'm Just Wild About Harry|TTBB, SSAA, SATB|Larry Wright
+I'm Looking Over A Four Leaf Clover|TTBB, SSAA|Larry Wright
+I've Got The World On A String|TTBB, SSAA|Larry Wright
+I've Gotta Be Me|SSAA|Larry Wright
+I've Gotta Crow|SSAA|Larry Wright
+If I Could|SSAA|Larry Wright
+If I Had Rhythm In My Nursery Rhymes|SSAA|Larry Wright
+If I Loved You|SSAA|Larry Wright
+If I Were You I'd Fall In Love With Me|TTBB, SSAA|Larry Wright
+If She Means What I Think She Means|TTBB|Larry Wright
+Imagine|SSAA|Larry Wright
+The Impossible Dream|TTBB, SSAA|Larry Wright
+In A Mellow Tone|TTBB, SSAA|Larry Wright
+In The Still Of The Night|TTBB, SSAA|Larry Wright
+In Your Eyes|TTBB, SSAA|Larry Wright
+Ireland Must Be Heaven|TTBB, SSAA|Larry Wright
+Irish Medley|TTBB, SSAA|Larry Wright
+It Is Well With My Soul|TTBB, SSAA|Larry Wright
+It Was A Very Good Year|TTBB|Larry Wright
+It's A Good Day|TTBB, SSAA|Larry Wright
+It's A Great Day For The Irish|TTBB, SSAA|Larry Wright
+It's A Lovely Day Today|SSAA|Larry Wright
+It's A Lovely Day Today/I Love To Singa Medley|SSAA|Larry Wright
+It's Delovely/Steppin' Out Medley|SSAA|Larry Wright
+It's Not Where You Start It's Where You Finish|TTBB, SSAA|Larry Wright
+It's Sand, Man|TTBB, SSAA|Larry Wright
+It's So Hard To Say Goodbye To Yesterday|TTBB|Larry Wright
+It's The Most Wonderful Time Of The Year|SSAA|Larry Wright
+It's The Most Wonderful Time Of The Year|TTBB|Larry Wright
+It's You|TTBB|Larry Wright
+Jailhouse Rock|TTBB, SSAA|Larry Wright
+Java Jive|TTBB, SSAA|Larry Wright
+Jesus Take The Wheel|SSAA|Larry Wright
+Jingle Jangle Jingle|TTBB|Larry Wright
+Jump Shout Boogie|TTBB, SSAA|Larry Wright
+Kid's Song/Coney Island Washboard|TTBB, SSAA|Larry Wright
+Kiss The Girl|TTBB|Larry Wright
+Leader Of The Pack|SSAA|Larry Wright
+Leaning On A Lamppost|TTBB, SSAA|Larry Wright
+Let Freedom Ring|TTBB, SSAA|Larry Wright
+Let It Be Me|SSAA|Larry Wright
+Let It Go|SSAA|Larry Wright
+Let The Sunshine In|SSAA|Larry Wright
+Let Yourself Go|TTBB, SSAA|Larry Wright
+Let Yourself Go/Stepping Out With My Baby|TTBB, SSAA|Larry Wright
+Let's Get Away From It All|TTBB, SSAA|Larry Wright
+Let's Go to the Movies|SSAA|Larry Wright
+Let's Start the New Year Right|SSAA|Larry Wright
+Let's Start Tomorrow Tonight|SSAA|Larry Wright
+Lida Rose|TTBB|Larry Wright
+Lida Rose/Dream Of Now|TTBB, SSAA, SATB|Larry Wright
+Linus and Lucy|SSAA|Larry Wright
+Listen To My Heart|SSAA|Larry Wright
+Little Green Apples|TTBB, SSAA|Larry Wright
+Little Jazz Bird|TTBB, SSAA|Larry Wright
+Little Man You've Had A Busy Day|TTBB, SSAA|Larry Wright
+Little Saint Nick|TTBB, SSAA|Larry Wright
+Love Again|SSAA|Larry Wright
+Lovely Way To Spend An Evening|TTBB, SSAA|Larry Wright
+Lover's Lane Is Crowded Again|TTBB, SSAA|Larry Wright
+Lullaby of Birdland|TTBB, SSAA|Larry Wright
+Mack The Knife|TTBB|Larry Wright
+The Man I Can Love|SSAA|Larry Wright
+Mary's Little Boy Child|TTBB, SSAA|Larry Wright
+Material Girl|SSAA|Larry Wright
+May Each Day|TTBB, SSAA|Larry Wright
+May Each Day/Goody Goodbye|TTBB, SSAA|Larry Wright
+Medley: A Wonderful Day Like Today, Zip-A-Dee-Doo-Dah, It's A Good Day|TTBB|Larry Wright
+Medley: Boogie Woogie Bugle Boy, Don't Sit Under The Apple Tree|SSAA|Larry Wright
+Medley: Bye Bye Baby, Baby, Won't You Please Come Home|SSAA|Larry Wright
+Medley: Come Dance With Me, Sway (Quien Sera)|SSAA|Larry Wright
+Medley: Happy, All About That Bass|SSAA|Larry Wright
+Medley: I'll Be There, Baby Love, Stop In The Name Of Love, Shop Around, Ain't No Mountain|SSAA|Larry Wright
+Medley: Let Yourself Go, Steppin' Out With My Baby|SSAA|Larry Wright
+Medley: Sound of Music, Do-Re-Mi, Edelweiss, My Favorite Things, Climb Every Mountain|SSAA|Larry Wright
+Medley: Thank You For The Music, S.O.S., Dancing Queen|SSAA|Larry Wright
+Medley: What's The Matter With Kids Today?, Coney Island Washboard|SSAA|Larry Wright
+Millionaire's Hoedown|SSAA|Larry Wright
+Mom|SSAA|Larry Wright
+Mona Lisa|SSAA|Larry Wright
+Monster Mash|TTBB|Larry Wright
+More Than You Know|SSAA|Larry Wright
+Most Wonderful Time Of The Year|SSAA|Larry Wright
+Most Wonderful Time Of The Year|TTBB, SSAA|Larry Wright
+Motown Medley|SSAA|Larry Wright
+The Muppet Show Theme|TTBB, SSAA|Larry Wright
+Music Maestro Please|TTBB, SSAA|Larry Wright
+My Alabama|TTBB, SSAA|Larry Wright
+My Baby Just Cares For Me|SSAA|Larry Wright
+My Favorite Things|SSAA|Larry Wright
+My Guy|SSAA|Larry Wright
+My Guy/I Will Follow Him|SSAA|Larry Wright
+My Man|SSAA|Larry Wright
+My Name Is America|TTBB|Larry Wright
+My Old Friend(s) (My Old Man)|TTBB|Larry Wright
+My Old Man|TTBB|Larry Wright
+My Romance|TTBB, SSAA|Larry Wright
+Natural Woman (You Make Me Feel Like)|SSAA|Larry Wright
+Naturally|TTBB, SSAA|Larry Wright
+Never-Never Land|TTBB, SSAA|Larry Wright
+New Attitude|SSAA|Larry Wright
+New York, New York|SSAA|Larry Wright
+Next Time I Love|SSAA|Larry Wright
+A Nightingale Sang In Berkeley Square|TTBB, SSAA|Larry Wright
+Nineteen Twenty Seven|TTBB, SSAA|Larry Wright
+No Strings (I'm Fancy Free)|SSAA|Larry Wright
+Nobody's Sweetheart / I'm Nobody's Baby Medley|SSAA|Larry Wright
+Now That I've Found You|TTBB, SSAA|Larry Wright
+Octopus's Garden|TTBB, SSAA|Larry Wright
+Ode To Joy (Joyful, Joyful)|TTBB, SSAA|Larry Wright
+Oh Happy Day|TTBB, SSAA|Larry Wright
+Oh, How I Miss You Tonight|TTBB, SSAA|Larry Wright
+Old Cape Cod|TTBB, SSAA|Larry Wright
+Old Fashioned Girl|TTBB|Larry Wright
+Old Irish Blessing|SSAA|Larry Wright
+The Old Man|TTBB|Larry Wright
+On The South Side Of Chicago|SSAA|Larry Wright
+On The Sunny Side Of The Street|TTBB, SSAA|Larry Wright
+Once Upon A Time|TTBB, SSAA|Larry Wright
+One For My Baby (And One More For The Road)|TTBB|Larry Wright
+One For My Baby (And One More For The Road)|SSAA|Larry Wright
+One Note Samba|TTBB, SSAA|Larry Wright
+Orange Colored Sky|TTBB, SSAA|Larry Wright
+Overture Curtain Lights (This Is It)|TTBB, SSAA|Larry Wright
+Party in the USA|SSAA|Larry Wright
+Passing The Faith Along|TTBB|Larry Wright
+Patriotic Medley|TTBB|Larry Wright
+Peter Pan Medley|SSAA|Larry Wright
+Poker Face|SSAA|Larry Wright
+Polka Dots And Moonbeams|TTBB|Larry Wright
+Popular|SSAA|Larry Wright
+Popular Song|SSAA|Larry Wright
+Portrait Of My Love|SSAA|Larry Wright
+Portrait Of My Love|TTBB|Larry Wright
+Pure Imagination|SSAA|Larry Wright
+Puttin' On The Ritz|TTBB, SSAA|Larry Wright
+Raindrops Keep Falling On My Head|TTBB, SSAA|Larry Wright
+Raise Your Voice|SSAA|Larry Wright
+Red Head|TTBB, SSAA|Larry Wright
+Red Hot Mama Medley|TTBB, SSAA|Larry Wright
+Respect|SSAA|Larry Wright
+Rhode Island Is Famous For You|TTBB|Larry Wright
+Rhythm In My Nursery Rhymes/ABC Medley|SSAA|Larry Wright
+Rhythm Medley|TTBB, SSAA|Larry Wright
+Rock And Roll Is Here To Stay|TTBB|Larry Wright
+Rosie The Riveter|SSAA|Larry Wright
+Roy Rogers Medley|TTBB|Larry Wright
+Santa Baby|SSAA|Larry Wright
+Seattle|SSAA|Larry Wright
+Seattle/Blue Skies Medley|SSAA|Larry Wright
+Secondhand White Baby Grand|SSAA|Larry Wright
+Send In The Clowns|TTBB, SSAA|Larry Wright
+Sentimental Journey|TTBB, SSAA|Larry Wright
+The Shadow Of Your Smile|TTBB, SSAA|Larry Wright
+She Used To Be Mine|SSAA|Larry Wright
+Shoo-shoo Baby|SSAA|Larry Wright
+Shop Around|SSAA|Larry Wright
+Short People|SSAA|Larry Wright
+Short People|TTBB|Larry Wright
+Sincere|TTBB|Larry Wright
+Sing|SSAA|Larry Wright
+Sing Back The Good Old Days|TTBB, SSAA|Larry Wright
+Sing Me That Song Again|TTBB, SSAA|Larry Wright
+Sing Sing Sing|SSAA|Larry Wright
+Singin' In The Rain|SSAA|Larry Wright
+Sister Act|SSAA|Larry Wright
+Skyfall|TTBB, SSAA|Larry Wright
+Skyfall|SSAA|Larry Wright
+Soldier Soldier Will You Marry Me|TTBB|Larry Wright
+Some Enchanted Evening|TTBB, SSAA|Larry Wright
+Someone Like You|SSAA|Larry Wright
+Someone To Watch Over Me|SSAA|Larry Wright
+Someone You Loved|SSAA|Larry Wright
+Something|SSAA|Larry Wright
+Somewhere Out There|SSAA|Larry Wright
+The Song Is Ended|SSAA|Larry Wright
+The Song Is Ended|TTBB|Larry Wright
+Sound Of Music|SSAA|Larry Wright
+Sound of Music Medley|TTBB, SSAA|Larry Wright
+The Sound Of Silence|SSAA|Larry Wright
+South Rampart Street Parade/Way Down Yonder in New Orleans Medley|SSAA|Larry Wright
+Stars Fell On Alabama|SSAA|Larry Wright
+Step To The Rear|TTBB, SSAA|Larry Wright
+Steppin' On The Clouds|TTBB|Larry Wright
+Steppin' Out With My Baby|SSAA|Larry Wright
+Stop In The Name of Love|SSAA|Larry Wright
+Sunshine Lollipops And Rainbows|TTBB, SSAA|Larry Wright
+Survivor|SSAA|Larry Wright
+Sway|SSAA|Larry Wright
+Sway|TTBB, SSAA|Larry Wright
+Sweet Lorraine|TTBB|Larry Wright
+Taylor The Latte Boy|SSAA|Larry Wright
+Text Me Merry Christmas|SSAA|Larry Wright
+Thank You For The Music|TTBB, SSAA|Larry Wright
+Thank You World|SSAA|Larry Wright
+That Old Irish Mother Of Mine|TTBB, SSAA|Larry Wright
+That Tumble Down Shack In Athlone|TTBB, SSAA|Larry Wright
+The Last Note Of My Song|TTBB, SSAA|Larry Wright
+The Things We Did Last Summer|TTBB, SSAA|Larry Wright
+The Way You Look Tonight|TTBB, SSAA|Larry Wright
+Them Was The Good Old Days|TTBB, SSAA|Larry Wright
+Theme from Cheers|TTBB, SSAA|Larry Wright
+There Is Nothing Like A Dame|TTBB|Larry Wright
+There You'll Be|SSAA|Larry Wright
+There's A Meeting Here Tonight|TTBB, SSAA|Larry Wright
+These Are The Special Times|SSAA|Larry Wright
+This Could be the Start of Something Big|SSAA|Larry Wright
+This Is It!|TTBB, SSAA|Larry Wright
+This Is Me|SSAA|Larry Wright
+This One's For The Girls|SSAA|Larry Wright
+Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Larry Wright
+Time For Livin'|TTBB|Larry Wright
+Try A Little Tenderness|TTBB|Larry Wright
+Turn Your Radio On|TTBB, SSAA|Larry Wright
+Tuxedo Junction|TTBB, SSAA|Larry Wright
+Unchained Melody|TTBB, SSAA|Larry Wright
+Under The Sea|TTBB, SSAA|Larry Wright
+Unforgettable|TTBB, SSAA, SATB|Larry Wright
+Up, Up And Away (My Beautiful Balloon)|TTBB, SSAA|Larry Wright
+Uptown Country Woman|SSAA|Larry Wright
+Valentine-Gram/Crazy 'Bout Ya Baby|TTBB, SSAA|Larry Wright
+Valentine-Gram/Let Me Call You Sweetheart|TTBB, SSAA|Larry Wright
+Wait Till The Sun Shines, Nellie|TTBB|Larry Wright
+Wake Up Little Susie|TTBB|Larry Wright
+Walkin' My Baby Back Home|TTBB, SSAA|Larry Wright
+Way You Look Tonight|TTBB, SSAA|Larry Wright
+We Wish You A Merry Christmas|TTBB, SSAA|Larry Wright
+We'll Be Seeing You/Come Back And See Us|TTBB, SSAA|Larry Wright
+We'll Be Seeing You/Goody Goodbye|SSAA|Larry Wright
+We'll Be Seeing You/Goody Goodbye Closer|TTBB|Larry Wright
+What A Wonderful World|SSAA|Larry Wright
+What Are You Doing New Year's Eve?|TTBB, SSAA|Larry Wright
+What's The Matter With Kids Today?|TTBB, SSAA|Larry Wright
+Whatever Lola Wants|SSAA|Larry Wright
+When I Look In Your Eyes|TTBB, SSAA|Larry Wright
+When I See All The Lovin' They Waste On Babies|TTBB|Larry Wright
+When It's Sleepy Time Down South|TTBB, SSAA|Larry Wright
+When Santa Claus Gets Your Letter|TTBB, SSAA|Larry Wright
+Where Did You Get That Girl?|TTBB|Larry Wright
+Where Everybody Knows Your Name|TTBB, SSAA|Larry Wright
+White Christmas|TTBB, SSAA|Larry Wright
+White Christmas (doo wop)|TTBB|Larry Wright
+Why Did It Have To Be Me?|TTBB, SSAA|Larry Wright
+Why Do People Fall In Love|SSAA|Larry Wright
+Why Don't You Fall In Love With Me?|TTBB|Larry Wright
+Why Don't You Fall In Love With Me?|SSAA|Larry Wright
+Wichita Lineman|TTBB|Larry Wright
+Windy|TTBB, SSAA|Larry Wright
+Wiz/Wizard Of Oz Medley|TTBB, SSAA|Larry Wright
+Wonderful Day like Today|SSAA|Larry Wright
+You Are The Sunshine Of My Life|TTBB, SSAA|Larry Wright
+You Hit the Spot|SSAA|Larry Wright
+You Raise Me Up|TTBB, SSAA|Larry Wright
+You're My Best Friend|SSAA|Larry Wright
+You're My Best Friend|TTBB|Larry Wright
+You've Got A Friend In Me|TTBB, SSAA|Larry Wright
+You've Lost That Lovin' Feelin|TTBB|Larry Wright
+Your Mother and Mine|SSAA|Larry Wright
+Zip A Dee Doo Dah|TTBB|Larry Wright
+Nearer, My God, To Thee|SSAA|Leola Wright
+20 Years|SATB|Nicholas Wright
+22|SATB|Nicholas Wright
+24K Magic|TTBB|Nicholas Wright
+8 (circle)|TTBB|Nicholas Wright
+About Damn Time|SATB|Nicholas Wright
+Afire Love|SATB|Nicholas Wright
+Africa|TTBB|Nicholas Wright
+Against All Odds|TTBB|Nicholas Wright
+Alive|SATB|Nicholas Wright
+All About That Bass|SSAA|Nicholas Wright
+All Of Me|TTBB|Nicholas Wright
+All Of The Lights|TTBB|Nicholas Wright
+All The Small Things|SATB|Nicholas Wright
+All Time Low|TTBB|Nicholas Wright
+All Too Well|SATB|Nicholas Wright
+Almost (sweet music)|SATB|Nicholas Wright
+Already Gone|TTBB|Nicholas Wright
+Am I Wrong|SATB|Nicholas Wright
+Animal|SATB|Nicholas Wright
+Animals|SATB|Nicholas Wright
+Anna Sun|SATB|Nicholas Wright
+Anyway|SATB|Nicholas Wright
+As It Was|SATB|Nicholas Wright
+As Long as He Needs Me|TTBB|Nicholas Wright
+Awake My Soul|SSAA|Nicholas Wright
+Back Home|TTBB|Nicholas Wright
+Bad Blood|TTBB, SATB|Nicholas Wright
+Bang Bang|TTBB, SSAA|Nicholas Wright
+Bang My Head|SATB|Nicholas Wright
+Bangarang|TTBB|Nicholas Wright
+Before He Cheats|SSAA, SATB|Nicholas Wright
+Believer|SATB|Nicholas Wright
+Below My Feet|TTBB|Nicholas Wright
+Best Day of My Life|SATB|Nicholas Wright
+Big Girls Cry|SATB|Nicholas Wright
+Blame It On The Boogie|SATB|Nicholas Wright
+Blank Space|SATB|Nicholas Wright
+Blue Ocean Floor|TTBB|Nicholas Wright
+Bluebird|TTBB|Nicholas Wright
+Brand New|SATB|Nicholas Wright
+Bravado|SATB|Nicholas Wright
+Brave|TTBB, SSAA, SATB|Nicholas Wright
+Breathe Again|TTBB, SATB|Nicholas Wright
+Breezeblocks|TTBB|Nicholas Wright
+Bright Lights and Cityscapes|SATB|Nicholas Wright
+Brighter Than The Sun|SSAA|Nicholas Wright
+Bring Me To Life|TTBB|Nicholas Wright
+Brother|TTBB|Nicholas Wright
+Budapest|SATB|Nicholas Wright
+Bulletproof|SSAA|Nicholas Wright
+Burn|SSAA, SATB|Nicholas Wright
+Cake By The Ocean|TTBB|Nicholas Wright
+Call Me Maybe|TTBB, SSAA, SATB|Nicholas Wright
+Call Your Girlfriend|SSAA|Nicholas Wright
+Can't Fight This Feeling|TTBB|Nicholas Wright
+Can't Stop the Feeling!|SATB|Nicholas Wright
+Carol Of The Bells|TTBB|Nicholas Wright
+Carry On|SATB|Nicholas Wright
+The Cave|SATB|Nicholas Wright
+Centuries|SATB|Nicholas Wright
+Chains|SATB|Nicholas Wright
+Chandelier|SSAA, SATB|Nicholas Wright
+Clarity|SATB|Nicholas Wright
+Classic|SATB|Nicholas Wright
+Clean|SATB|Nicholas Wright
+Cloud|SSAA|Nicholas Wright
+Cold Water|TTBB|Nicholas Wright
+Come and Get Your Love|TTBB|Nicholas Wright
+Come Home|SATB|Nicholas Wright
+Come Wake Me Up|SATB|Nicholas Wright
+Countdown|SATB|Nicholas Wright
+Counting Stars|TTBB, SATB|Nicholas Wright
+Crazy Little Thing Called Love|TTBB|Nicholas Wright
+Cruel Summer|SATB|Nicholas Wright
+Dance With Me Tonight|TTBB|Nicholas Wright
+Dancing On My Own|SATB|Nicholas Wright
+Danger Zone|TTBB|Nicholas Wright
+Dark Horse|SSAA|Nicholas Wright
+Death Of A Bachelor|TTBB, SATB|Nicholas Wright
+Demons|TTBB, SATB|Nicholas Wright
+Details In The Fabric (sewing machine)|TTBB|Nicholas Wright
+Don't|SSAA|Nicholas Wright
+Don't Blame Me|SATB|Nicholas Wright
+Don't Start Now|SATB|Nicholas Wright
+Don't Stop Me Now|TTBB|Nicholas Wright
+Don't U Wait No More|SATB|Nicholas Wright
+Don't You Worry Child|SATB|Nicholas Wright
+Done|SSAA|Nicholas Wright
+Down Under|TTBB|Nicholas Wright
+Drag Me Down|TTBB, SATB|Nicholas Wright
+Dreams|SATB|Nicholas Wright
+Dreams|SSAA|Nicholas Wright
+Drivers License|SATB|Nicholas Wright
+A Drop in the Ocean|SATB|Nicholas Wright
+Drops of Jupiter|SSAA|Nicholas Wright
+Drumming Song|SATB|Nicholas Wright
+Dumb Ways To Die|TTBB|Nicholas Wright
+Easier|TTBB|Nicholas Wright
+Elastic Heart|TTBB, SATB|Nicholas Wright
+Emily I'm Sorry|SATB|Nicholas Wright
+Empire State of Mind (part II) Broken Dawn|SSAA|Nicholas Wright
+Evermore|SATB|Nicholas Wright
+Every Breath You Take|TTBB|Nicholas Wright
+Everybody (backstreet's Back)|TTBB|Nicholas Wright
+Everybody Talks|SATB|Nicholas Wright
+Eye Of The Tiger|TTBB|Nicholas Wright
+Fallin'|SSAA, SATB|Nicholas Wright
+Fallingwater|SATB|Nicholas Wright
+Fast Car|TTBB|Nicholas Wright
+Feel Again|TTBB|Nicholas Wright
+Fight Song|TTBB, SSAA|Nicholas Wright
+Final Song|SSAA|Nicholas Wright
+Find My Way|TTBB|Nicholas Wright
+Fine By Me|TTBB|Nicholas Wright
+Fire N Gold|SSAA|Nicholas Wright
+Fireflies|TTBB|Nicholas Wright
+Fitzpleasure|TTBB|Nicholas Wright
+Fly Me To The Moon|TTBB, SATB|Nicholas Wright
+Follow Me|TTBB|Nicholas Wright
+Forever|TTBB, SATB|Nicholas Wright
+Freedom|SATB|Nicholas Wright
+Gang Of Rhythm|SATB|Nicholas Wright
+Get Home|SATB|Nicholas Wright
+Get Lucky|TTBB|Nicholas Wright
+Girl on Fire|SSAA|Nicholas Wright
+Gold|SATB|Nicholas Wright
+Golden Hour|SATB|Nicholas Wright
+Gone|SATB|Nicholas Wright
+Gone, Gone, Gone|SATB|Nicholas Wright
+Good 4 U|SATB|Nicholas Wright
+Good Life|TTBB|Nicholas Wright
+Good To Be Alive|TTBB|Nicholas Wright
+Goodbye In Her Eyes|TTBB|Nicholas Wright
+Gorilla|TTBB|Nicholas Wright
+Gravity|SSAA, SATB|Nicholas Wright
+The Great Escape|SATB|Nicholas Wright
+The Greatest|SATB|Nicholas Wright
+Greedy|SATB|Nicholas Wright
+Grenade|SATB|Nicholas Wright
+Handclap|SATB|Nicholas Wright
+Hang Me Up To Dry|SATB|Nicholas Wright
+Happiness|SSAA|Nicholas Wright
+Happy|TTBB|Nicholas Wright
+Harmony Hall|SATB|Nicholas Wright
+Havana|SSAA|Nicholas Wright
+He's A Pirate|TTBB|Nicholas Wright
+Heart Attack|SATB|Nicholas Wright
+Heartbeat Song|SATB|Nicholas Wright
+Heaven|SATB|Nicholas Wright
+Heavenly Father|SATB|Nicholas Wright
+Hello|TTBB, SATB|Nicholas Wright
+Heroes (we could be)|SSAA, SATB|Nicholas Wright
+Hey Look Ma, I Made It|SATB|Nicholas Wright
+Hey, Soul Sister|SATB|Nicholas Wright
+High Hopes|SATB|Nicholas Wright
+Ho Hey|TTBB|Nicholas Wright
+Hold Back The River|SSAA, SATB|Nicholas Wright
+Hold On, We're Going Home|TTBB|Nicholas Wright
+Holding On To You|SATB|Nicholas Wright
+Home|SSAA|Nicholas Wright
+Homesick|SATB|Nicholas Wright
+Honey, I'm Good|TTBB|Nicholas Wright
+Hooked On A Feeling|TTBB|Nicholas Wright
+Hotel Song|SATB|Nicholas Wright
+Hurricane|SATB|Nicholas Wright
+Hurts So Good|SSAA|Nicholas Wright
+I Ain't Leaving Without Your Love|SATB|Nicholas Wright
+I Bet My Life|SATB|Nicholas Wright
+I Don't Care|SSAA|Nicholas Wright
+I Knew You Were Trouble|SATB|Nicholas Wright
+I Like Me Better|TTBB|Nicholas Wright
+I Lived|SATB|Nicholas Wright
+I Love You Always Forever|SATB|Nicholas Wright
+I See Fire|TTBB|Nicholas Wright
+I Wanna Dance With Somebody|SSAA, SATB|Nicholas Wright
+I Want It That Way|TTBB|Nicholas Wright
+I Want It To Be|SATB|Nicholas Wright
+I Want You Back|SATB|Nicholas Wright
+I Will Wait|TTBB, SATB|Nicholas Wright
+I Won't Give Up|TTBB, SSAA, SATB|Nicholas Wright
+I'll Always Remember You|SATB|Nicholas Wright
+I'll Be Waiting|SATB|Nicholas Wright
+I'm A Believer|TTBB|Nicholas Wright
+I'm A Mess|SATB|Nicholas Wright
+I'm Just A Kid|SATB|Nicholas Wright
+I'm Not The Only One|SSAA|Nicholas Wright
+I'm Ready|TTBB|Nicholas Wright
+I'm Still Standing|TTBB|Nicholas Wright
+Icarus|SATB|Nicholas Wright
+If I Can't Have You|SATB|Nicholas Wright
+If I Lose Myself|TTBB, SSAA|Nicholas Wright
+If You Could Only See|SATB|Nicholas Wright
+Impossible Year|SATB|Nicholas Wright
+In The Name of Love|SATB|Nicholas Wright
+In Your Eyes|SATB|Nicholas Wright
+Into the Unknown|TTBB, SATB|Nicholas Wright
+Is She Really Going Out With Him|SATB|Nicholas Wright
+It Don't Have to Change|SATB|Nicholas Wright
+It Was Always You|TTBB|Nicholas Wright
+It's Still Rock and Roll to Me|SATB|Nicholas Wright
+James Bond Theme|TTBB|Nicholas Wright
+Jump Right In|SATB|Nicholas Wright
+Just Like Fire|SSAA|Nicholas Wright
+Just The Way You Are|TTBB, SSAA|Nicholas Wright
+Keep Your Head Up|TTBB|Nicholas Wright
+Kehna Hi Kya|TTBB|Nicholas Wright
+King Of My Heart|SATB|Nicholas Wright
+Kings And Queens|TTBB|Nicholas Wright
+Kiss From A Rose|TTBB|Nicholas Wright
+Latch|TTBB, SATB|Nicholas Wright
+Latika's Theme|SATB|Nicholas Wright
+Lay Me Down|TTBB, SATB|Nicholas Wright
+Let It Go|TTBB|Nicholas Wright
+Let The Rain|SATB|Nicholas Wright
+Levitating|SATB|Nicholas Wright
+Liability|SATB|Nicholas Wright
+Life In Technicolor II|TTBB|Nicholas Wright
+Life Is A Highway|TTBB|Nicholas Wright
+Lights|TTBB|Nicholas Wright
+Like I Can|SSAA, SATB|Nicholas Wright
+Like I'm Gonna Lose You|SATB|Nicholas Wright
+Livin' On A Prayer|TTBB|Nicholas Wright
+Locked Out Of Heaven|SATB|Nicholas Wright
+Lost Boy|TTBB, SATB|Nicholas Wright
+Lost Without You|SSAA|Nicholas Wright
+Love Me Like You Do|SSAA, SATB|Nicholas Wright
+Love On Top|TTBB|Nicholas Wright
+Love Runs Out|TTBB, SATB|Nicholas Wright
+Love The Way You Lie, Pt. 2|SSAA|Nicholas Wright
+Love You Like A Love Song|SSAA, SATB|Nicholas Wright
+Lovely Day|TTBB|Nicholas Wright
+The Man Who Can't Be Moved|SATB|Nicholas Wright
+Manhattan|SSAA|Nicholas Wright
+Marry Me|TTBB|Nicholas Wright
+Medley: Brave, Nothing's Gonna Stop Us Now|TTBB|Nicholas Wright
+Mercy|SATB|Nicholas Wright
+The Middle|SATB|Nicholas Wright
+Mine|SSAA|Nicholas Wright
+Mirrors|TTBB, SATB|Nicholas Wright
+Miss Independent|SSAA|Nicholas Wright
+Monster|SATB|Nicholas Wright
+Mr. Brightside|SATB|Nicholas Wright
+Music For A Sushi Restaurant|TTBB|Nicholas Wright
+My Heart Is Open|SATB|Nicholas Wright
+My Immortal|TTBB|Nicholas Wright
+Need You Now|SATB|Nicholas Wright
+Never Forget You|SATB|Nicholas Wright
+Never Gonna Give You Up|TTBB|Nicholas Wright
+Never Knew Love Like This Before|TTBB|Nicholas Wright
+New Year's Day|SATB|Nicholas Wright
+Night Changes|TTBB|Nicholas Wright
+No Scrubs|SSAA|Nicholas Wright
+Nobody Love|SSAA, SATB|Nicholas Wright
+O|SATB|Nicholas Wright
+O Come O Come Emmanuel|TTBB|Nicholas Wright
+Ocean Eyes|SATB|Nicholas Wright
+Oh My God|TTBB|Nicholas Wright
+Omen|TTBB|Nicholas Wright
+On My Mind|SATB|Nicholas Wright
+One And Only|SSAA, SATB|Nicholas Wright
+One Day|TTBB, SATB|Nicholas Wright
+One Last Time|TTBB|Nicholas Wright
+Open Arms|SATB|Nicholas Wright
+Open Your Eyes|TTBB|Nicholas Wright
+Ordinary People|TTBB, SSAA, SATB|Nicholas Wright
+Our Own House|SSAA|Nicholas Wright
+Out Of The Woods|SATB|Nicholas Wright
+Paradise|SATB|Nicholas Wright
+The Parting Glass|TTBB|Nicholas Wright
+Payphone|TTBB, SATB|Nicholas Wright
+People Like Us|SATB|Nicholas Wright
+The Perfect Fan|TTBB|Nicholas Wright
+Photograph|TTBB|Nicholas Wright
+Poison|SATB|Nicholas Wright
+Pompeii|TTBB, SATB|Nicholas Wright
+Powerful|SATB|Nicholas Wright
+Primetime|SSAA|Nicholas Wright
+Private Eyes|SATB|Nicholas Wright
+Pusher Love Girl|TTBB|Nicholas Wright
+Radioactive|TTBB, SATB|Nicholas Wright
+The Rains of Castamere|TTBB|Nicholas Wright
+Rather Be|SSAA, SATB|Nicholas Wright
+Red|SATB|Nicholas Wright
+Reflections|SSAA|Nicholas Wright
+Rewrite The Stars|TTBB|Nicholas Wright
+Rise|TTBB|Nicholas Wright
+River|SSAA, SATB|Nicholas Wright
+River Of Tears|SATB|Nicholas Wright
+Roar|SSAA, SATB|Nicholas Wright
+Rockstar|SATB|Nicholas Wright
+Rocky Mountain High|SATB|Nicholas Wright
+Royals|SATB|Nicholas Wright
+Run On|SATB|Nicholas Wright
+Run-around|SATB|Nicholas Wright
+Runaway Baby|SSAA|Nicholas Wright
+Running Up That Hill|SATB|Nicholas Wright
+Samson|SATB|Nicholas Wright
+Save Tonight|SATB|Nicholas Wright
+Say (All I Need)|SATB|Nicholas Wright
+Say My Name|TTBB|Nicholas Wright
+Say Something|SATB|Nicholas Wright
+Say You Love Me|SSAA, SATB|Nicholas Wright
+Scream|SATB|Nicholas Wright
+September|TTBB|Nicholas Wright
+Settle Down|SSAA, SATB|Nicholas Wright
+Settlin'|SSAA|Nicholas Wright
+Shake It Out|SATB|Nicholas Wright
+Shape Of You|TTBB|Nicholas Wright
+She Will Be Loved|SATB|Nicholas Wright
+Should Have Been Us|SSAA|Nicholas Wright
+The Show Must Go On|SATB|Nicholas Wright
+Shut Up And Dance|TTBB, SATB|Nicholas Wright
+A Sky Full of Stars|SATB|Nicholas Wright
+Skyfall|SSAA|Nicholas Wright
+Slow Down|TTBB|Nicholas Wright
+Some Nights|TTBB, SATB|Nicholas Wright
+Somebody to Love|TTBB|Nicholas Wright
+Something I Need|SATB|Nicholas Wright
+Something to Talk About|SSAA|Nicholas Wright
+Sorry|TTBB|Nicholas Wright
+The Sound|TTBB|Nicholas Wright
+Sparks|TTBB|Nicholas Wright
+Stacy's Mom|TTBB|Nicholas Wright
+Starboy|TTBB|Nicholas Wright
+Starlight|SATB|Nicholas Wright
+Stay|SATB|Nicholas Wright
+Stay Alive|TTBB|Nicholas Wright
+Still Falling For You|SATB|Nicholas Wright
+Stitches|TTBB, SATB|Nicholas Wright
+Story of My Life|TTBB|Nicholas Wright
+Stronger (What Doesn't Kill You)|SSAA|Nicholas Wright
+Stupid Deep|SATB|Nicholas Wright
+Style|SATB|Nicholas Wright
+Sucker|SATB|Nicholas Wright
+Sugar|SATB|Nicholas Wright
+Suit & Tie|TTBB|Nicholas Wright
+Summer Love|TTBB|Nicholas Wright
+Sunday Candy|SSAA|Nicholas Wright
+Supermarket Flowers|SATB|Nicholas Wright
+Surface Pressure|TTBB|Nicholas Wright
+Sweet Caroline|TTBB|Nicholas Wright
+The Sweet Escape|SSAA|Nicholas Wright
+Sweet Nothing|SATB|Nicholas Wright
+Take Me Home|TTBB|Nicholas Wright
+Take Me To Church|TTBB, SATB|Nicholas Wright
+Take On Me|TTBB|Nicholas Wright
+Talking to the Moon|SATB|Nicholas Wright
+Tattooed Heart|SSAA|Nicholas Wright
+Tear In My Heart|SATB|Nicholas Wright
+Tears|SATB|Nicholas Wright
+The Tears of a Clown|SATB|Nicholas Wright
+Texas Hold 'em|TTBB|Nicholas Wright
+The Man|SSAA|Nicholas Wright
+There's No Way|TTBB|Nicholas Wright
+This Life|SATB|Nicholas Wright
+A Thousand Years|SSAA|Nicholas Wright
+Time Of Our Lives|SATB|Nicholas Wright
+Titanium|TTBB, SSAA, SATB|Nicholas Wright
+To Build A Home|TTBB|Nicholas Wright
+Touches You|SATB|Nicholas Wright
+Traitor|SATB|Nicholas Wright
+Treasure|TTBB|Nicholas Wright
+Troublemaker|SATB|Nicholas Wright
+Turn Me On|SATB|Nicholas Wright
+Unchained Melody|TTBB|Nicholas Wright
+Uncharted|SATB|Nicholas Wright
+Up|SATB|Nicholas Wright
+Uptown Funk!|TTBB, SATB|Nicholas Wright
+Uptown Girl|TTBB|Nicholas Wright
+Use Somebody|SSAA|Nicholas Wright
+Verge|SATB|Nicholas Wright
+Victorious|SATB|Nicholas Wright
+Viva La Vida|SATB|Nicholas Wright
+Wait|TTBB|Nicholas Wright
+Waiting For The End|TTBB, SATB|Nicholas Wright
+Walk Away|TTBB|Nicholas Wright
+Walk With You|SATB|Nicholas Wright
+Walkin on Broken Glass|SSAA, SATB|Nicholas Wright
+Wanted Dead Or Alive|SATB|Nicholas Wright
+Warriors|TTBB|Nicholas Wright
+Watermelon Sugar|SSAA|Nicholas Wright
+Waves|TTBB|Nicholas Wright
+Waving Through A Window|TTBB|Nicholas Wright
+We Are Never Ever Getting Back Together|TTBB, SSAA|Nicholas Wright
+We Are Young|SATB|Nicholas Wright
+We Don't Talk About Bruno|TTBB|Nicholas Wright
+We Owned The Night|SATB|Nicholas Wright
+The Weekend|TTBB|Nicholas Wright
+What About Us|SSAA|Nicholas Wright
+What Do You Mean?|TTBB|Nicholas Wright
+What Makes You Beautiful|TTBB|Nicholas Wright
+Whatever It Takes|TTBB, SATB|Nicholas Wright
+When We Dance|TTBB|Nicholas Wright
+When We Were Young|TTBB|Nicholas Wright
+Wherever You Are|SATB|Nicholas Wright
+Who You Are|TTBB|Nicholas Wright
+Whole Lot Of Heart|SATB|Nicholas Wright
+Why Don't We Just Dance|SATB|Nicholas Wright
+Wild Ones|SATB|Nicholas Wright
+Wild Things|SSAA|Nicholas Wright
+Wildest Dreams|SSAA|Nicholas Wright
+Without Me|SATB|Nicholas Wright
+The Wolf|SATB|Nicholas Wright
+Wonder|SATB|Nicholas Wright
+Wonderland|TTBB, SSAA|Nicholas Wright
+Work Song|SATB|Nicholas Wright
+A World Alone|SATB|Nicholas Wright
+Wrecking Ball|TTBB, SSAA, SATB|Nicholas Wright
+Writing's On the Wall|TTBB|Nicholas Wright
+Xo|SATB|Nicholas Wright
+You Give Love a Bad Name|SATB|Nicholas Wright
+You Make My Dreams|TTBB, SATB|Nicholas Wright
+You're Welcome|TTBB|Nicholas Wright
+Yours|SSAA|Nicholas Wright
+Youth|SATB|Nicholas Wright
+Rhythm Of Love|TTBB|Sharon Wright
+The Chordbuster March|TTBB, SSAA, SATB|W. A. Wyatt
+That Old Black Magic|TTBB|W. A. Wyatt
+A Friend of Yours|SSAA|Mary Ann Wydra
+It's Time To Sing Sweet Adeline Again|SSAA|Mary Ann Wydra
+Let's Hear It For The Boy|SSAA|Mary Ann Wydra
+The Music and the Mirror|SSAA|Mary Ann Wydra
+They Never Told Me|SSAA|Mary Ann Wydra
+The Winners Song|SSAA|Mary Ann Wydra
+Anything You Can Do I Can Do Better|SSAA|Charlene Yazurlo
+Auld Lang Syne|SSAA|Charlene Yazurlo
+Aw Heck|SSAA|Charlene Yazurlo
+Buttons And Bows|SSAA|Charlene Yazurlo
+Could I Have This Dance|SSAA|Charlene Yazurlo
+Crabs Walk Sideways|SSAA|Charlene Yazurlo
+Dock Of The Bay, The (Sittin On)|SSAA|Charlene Yazurlo
+Edelweiss|SSAA|Charlene Yazurlo
+Far From The Home I Love|SSAA|Charlene Yazurlo
+Get A Job|SSAA|Charlene Yazurlo
+Girls Night Out|SSAA|Charlene Yazurlo
+Glory Of Love|SSAA|Charlene Yazurlo
+God Bless The U.S.A.|SSAA|Charlene Yazurlo
+Goodnight, Well Its Time To Go|SSAA|Charlene Yazurlo
+I Heard It Through The Grapevine|SSAA|Charlene Yazurlo
+I Swear|SSAA|Charlene Yazurlo
+Just In Case You Change Your Mind|SSAA|Charlene Yazurlo
+Lion Sleeps Tonight|SSAA|Charlene Yazurlo
+MacNamara's Band|SSAA|Charlene Yazurlo
+Mary, Mary Aka Mary Rock|SSAA|Charlene Yazurlo
+Money, Money|SSAA|Charlene Yazurlo
+No More (My Baby Don't Love Me)|SSAA|Charlene Yazurlo
+One Size Fits All|SSAA|Charlene Yazurlo
+Operator|SSAA|Charlene Yazurlo
+The River Of Dreams|SSAA|Charlene Yazurlo
+Rock And Roll Is Here To Stay|SSAA|Charlene Yazurlo
+Sing|SSAA|Charlene Yazurlo
+Somebody Loves Me|SSAA|Charlene Yazurlo
+Thank You World|SSAA|Charlene Yazurlo
+They Say It's Wonderful|SSAA|Charlene Yazurlo
+Under The Boardwalk|SSAA|Charlene Yazurlo
+When I'm Sixty Four|SSAA|Charlene Yazurlo
+Y'all Come|SSAA|Charlene Yazurlo
+Amazing Grace|TTBB|Kirk Young
+And So It Goes|TTBB|Kirk Young
+Bein' Green|TTBB|Kirk Young
+Chattanooga Choo Choo|TTBB|Kirk Young
+Christmas Time Is Here|SATB|Kirk Young
+Friend Like Me|TTBB|Kirk Young
+If You Go|SATB|Kirk Young
+Lullabye|TTBB, SSAA, SATB|Kirk Young
+The Muppet Show Theme|TTBB, SSAA|Kirk Young
+My Melancholy Blues|TTBB|Kirk Young
+Part Of A Painting|TTBB|Kirk Young
+Sesame Street Theme|TTBB|Kirk Young
+Still Crazy After All These Years|TTBB|Kirk Young
+Welcome Home|TTBB|Kirk Young
+What Do I Need With Love|TTBB|Kirk Young
+What Was I Made For?|SSAA|Kirk Young
+When She Loved Me|TTBB|Kirk Young
+Where've You Been|TTBB|Kirk Young
+Who Will Buy|TTBB|Kirk Young
+Flaming Agnes|TTBB|Bryan Ziegler
+Flaming Agnes|SSAA|Bryan Ziegler
+Friendship|SATB|Bryan Ziegler
+Heart And Soul|TTBB, SSAA, SATB|Bryan Ziegler
+New Year Medley|SSAA, SATB|Bryan Ziegler
+Ribbons Down My Back|SSAA|Bryan Ziegler
+Bewitched|TTBB|David Zimmerman
+By The Time I Get To Phoenix|TTBB|David Zimmerman
+Do I Love You?|TTBB, SSAA|David Zimmerman
+Dust In The Wind|TTBB, SSAA|David Zimmerman
+I Can Dream, Can't I?|TTBB|David Zimmerman
+I Get Along Without You Very Well|TTBB|David Zimmerman
+It Is Well With My Soul|TTBB|David Zimmerman
+My Romance|TTBB|David Zimmerman
+My Wish|TTBB|David Zimmerman
+Rise Up|SATB|David Zimmerman
+She Walks In Beauty|SATB|David Zimmerman
+Simple Gifts / Shenandoah|TTBB|David Zimmerman
+A Spoonful Of Sugar|TTBB|David Zimmerman
+Wellerman|TTBB, SSAA, SATB|David Zimmerman
+When I Have Sung My Songs|TTBB|David Zimmerman
+Comedy Tonight|TTBB|Vincent Zito
+Pennies from Heaven|TTBB|Vincent Zito
+Puff The Magic Dragon|TTBB|Vincent Zito
+All I Do Is Dream Of You|SSAA|Marsha Zwicker
+Angry|SSAA|Marsha Zwicker
+Big Girls Don't Cry|SSAA|Marsha Zwicker
+Book Of Love|SSAA|Marsha Zwicker
+Bosom Buddies|SSAA|Marsha Zwicker
+Can't Help Falling In Love|SSAA|Marsha Zwicker
+Charleston|SSAA, Young SSAA|Marsha Zwicker
+Cry Baby Blues|SSAA|Marsha Zwicker
+Do Wah Ditty Ditty|SSAA|Marsha Zwicker
+Dungaree Doll|SSAA|Marsha Zwicker
+God Help The Outcasts|SSAA|Marsha Zwicker
+Heart And Soul|SSAA|Marsha Zwicker
+Heartaches|SSAA|Marsha Zwicker
+Hooray For Love/Glory Of Love|SSAA|Marsha Zwicker
+I Got Out Of Bed On The Right Side|SSAA|Marsha Zwicker
+I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Marsha Zwicker
+I'm Gonna Lock My Heart|SSAA|Marsha Zwicker
+I'm Nobody's Baby|SSAA|Marsha Zwicker
+Ja-Da|SSAA|Marsha Zwicker
+Jeepers Creepers|SSAA|Marsha Zwicker
+Love and Marriage|SSAA|Marsha Zwicker
+My Boyfriends Back|SSAA|Marsha Zwicker
+Nice Work If You Can Get It|SSAA|Marsha Zwicker
+No More (My Baby Don't Love Me)|SSAA|Marsha Zwicker
+On A Slow Boat To China|SSAA|Marsha Zwicker
+One Fine Day|SSAA|Marsha Zwicker
+Put 'em In A Box, Tie 'em With A Ribbon|SSAA|Marsha Zwicker
+Rhythm Is Our Business|SSAA|Marsha Zwicker
+River In Judea|SSAA|Marsha Zwicker
+Rockin' Around The Christmas Tree|SSAA|Marsha Zwicker
+Row, Row, Row|SSAA|Marsha Zwicker
+Sh Boom|SSAA|Marsha Zwicker
+Someone To Watch Over Me|SSAA|Marsha Zwicker
+Swingin' Down The Lane|SSAA|Marsha Zwicker
+Teamwork|SSAA|Marsha Zwicker
+Tears On My Pillow|SSAA|Marsha Zwicker
+Ten Feet Off The Ground|SSAA|Marsha Zwicker
+Thanks For The Memory|SSAA|Marsha Zwicker
+That Old Irish Mother Of Mine|SSAA|Marsha Zwicker
+We Wish You A Merry Christmas|SSAA|Marsha Zwicker
+What I Did For Love|SSAA|Marsha Zwicker
+Where Do I Go From You?|SSAA|Marsha Zwicker
+Where The Boys Are|SSAA, Young SSAA|Marsha Zwicker
+You Belong To Me|SSAA|Marsha Zwicker
+You'd Be Surprised|SSAA|Marsha Zwicker
+You're Driving Me Crazy|SSAA|Marsha Zwicker

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -62,6 +62,12 @@ has an active quartet, the app refreshes that user's
 `session_participants.repertoire` snapshot so quartet results derive from the
 database snapshot instead of stale local component state.
 
+When adding repertoire, song-title autocomplete suggestions come from distinct
+song identities already entered in `user_repertoire` plus optional reference
+rows in `song_suggestion_catalog`. These suggestions only prefill the form.
+Users can ignore them, edit all fields, or enter a song that is not in the
+catalog.
+
 ## Matching
 
 Matching uses the current `session_participants` rows. A valid quartet match

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -109,17 +109,51 @@ Required database contract:
   private `sung_song_events` row in one database operation.
 - `public.search_repertoire_song_suggestions(p_query text, p_limit integer)`
   is a security-definer RPC available only to authenticated users. It returns
-  distinct global song identity suggestions from all repertoire rows:
-  `song_title`, `voicing`, and `arranger_name`. It must not return `user_id`,
-  singer names, notes, parts, confidence, timestamps, or other per-user
-  repertoire details. Blank `arranger_name` values remain `null`/blank in app
-  display and are distinct from a literal entered value such as `Unknown`.
+  distinct global song identity suggestions from all repertoire rows and
+  reference rows from `song_suggestion_catalog`: `song_title`, `voicing`, and
+  `arranger_name`. It must not return `user_id`, singer names, notes, parts,
+  confidence, timestamps, or other per-user repertoire details. Blank
+  `arranger_name` values remain `null`/blank in app display and are distinct
+  from a literal entered value such as `Unknown`.
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
 - `20260428142000_add_part_confidences_to_repertoire.sql`
 - `20260428145000_add_repertoire_sung_metadata.sql`
 - `20260428223000_add_global_song_suggestions.sql`
+
+### `song_suggestion_catalog`
+
+Purpose: optional autocomplete reference data for song entry, imported from
+`data/song_suggestion_catalog.psv`.
+
+Code:
+- Imported by `scripts/import-song-suggestions.mjs`
+- Read only through `public.search_repertoire_song_suggestions`
+- Parsed/deduplicated by `lib/__tests__/songSuggestionCatalogImport.test.ts`
+
+Expected context:
+- Server/local import script with `SUPABASE_SERVICE_ROLE_KEY`
+- Browser authenticated users through the security-definer suggestion RPC only
+
+Required database contract:
+- `id uuid primary key`
+- `title text not null`
+- `normalized_title text not null`
+- `voicing text not null`
+- `arranger text`
+- `normalized_arranger text`
+- `source text not null default 'Barbershop Connections'`
+- `created_at timestamptz not null default now()`
+- Unique index on `(normalized_title, voicing, coalesce(normalized_arranger, ''))`
+- Index on `normalized_title`
+- Trigram index on `title`
+- RLS enabled; no direct browser table access is required
+- Catalog rows are suggestions only and must never be inserted into
+  `user_repertoire` unless a user explicitly saves a repertoire item
+
+Established by migrations:
+- `20260429060000_add_song_suggestion_catalog.sql`
 
 ### `sessions`
 

--- a/lib/__tests__/repertoireSongSuggestions.test.ts
+++ b/lib/__tests__/repertoireSongSuggestions.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repertoireManager = readFileSync(
+  join(process.cwd(), "components/RepertoireManager.tsx"),
+  "utf8"
+);
+
+describe("repertoire song suggestion UI", () => {
+  it("keeps catalog suggestions optional and limited", () => {
+    expect(repertoireManager).toContain(
+      "Start typing to see suggestions, or enter your own song"
+    );
+    expect(repertoireManager).toContain(
+      "No suggestion found. You can still add this song"
+    );
+    expect(repertoireManager).toContain("setTimeout(async () =>");
+    expect(repertoireManager).toContain("}, 250)");
+    expect(repertoireManager).toContain("songSuggestionSubtitle");
+  });
+});

--- a/lib/__tests__/songSuggestionCatalogImport.test.ts
+++ b/lib/__tests__/songSuggestionCatalogImport.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const {
+  normalizeSearchText,
+  parseSongSuggestionCatalog,
+} = await import("../../scripts/import-song-suggestions.mjs");
+
+const catalogSource = readFileSync(
+  join(process.cwd(), "data/song_suggestion_catalog.psv"),
+  "utf8"
+);
+
+describe("song suggestion catalog import", () => {
+  it("normalizes search text like the database RPC", () => {
+    expect(normalizeSearchText("  The End of the World! ")).toBe(
+      "the end of the world"
+    );
+    expect(normalizeSearchText("Mam'selle")).toBe("mam selle");
+  });
+
+  it("parses and deduplicates pipe-delimited catalog rows", () => {
+    const rows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
+The End of the World|TTBB|Hilary Allen
+The End of the World|TTBB|Hilary Allen
+A Winter's Tale|SSAA|Hilary Allen
+No Arranger Song|TTBB|
+`);
+
+    expect(rows).toEqual([
+      {
+        title: "A Winter's Tale",
+        normalized_title: "a winter s tale",
+        voicing: "SSAA",
+        arranger: "Hilary Allen",
+        normalized_arranger: "hilary allen",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "No Arranger Song",
+        normalized_title: "no arranger song",
+        voicing: "TTBB",
+        arranger: null,
+        normalized_arranger: null,
+        source: "Barbershop Connections",
+      },
+      {
+        title: "The End of the World",
+        normalized_title: "the end of the world",
+        voicing: "TTBB",
+        arranger: "Hilary Allen",
+        normalized_arranger: "hilary allen",
+        source: "Barbershop Connections",
+      },
+    ]);
+  });
+
+  it("keeps the generated catalog source in the expected format", () => {
+    expect(catalogSource.startsWith("Song Title|Voicing|Arranger\n")).toBe(true);
+    const parsedRows = parseSongSuggestionCatalog(catalogSource);
+
+    expect(parsedRows.length).toBeGreaterThan(1000);
+    expect(parsedRows[0]).toHaveProperty("title");
+    expect(parsedRows[0]).toHaveProperty("voicing");
+    expect(parsedRows[0]).toHaveProperty("normalized_title");
+  });
+});

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -44,6 +44,13 @@ const songSuggestionsMigration = readFileSync(
   ),
   "utf8"
 );
+const songSuggestionCatalogMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260429060000_add_song_suggestion_catalog.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -132,16 +139,39 @@ describe("Supabase contract guardrails", () => {
   it("documents and migrates global song identity suggestions", () => {
     expect(contract).toContain("search_repertoire_song_suggestions");
     expect(contract).toContain("distinct global song identity suggestions");
+    expect(contract).toContain("song_suggestion_catalog");
     expect(contract).toContain("must not return `user_id`");
     expect(songSuggestionsMigration).toContain(
       "search_repertoire_song_suggestions"
     );
+    expect(songSuggestionCatalogMigration).toContain(
+      "song_suggestion_catalog"
+    );
+    expect(songSuggestionCatalogMigration).toContain("pg_trgm");
+    expect(songSuggestionCatalogMigration).toContain(
+      "song_suggestion_catalog_unique_idx"
+    );
+    expect(songSuggestionCatalogMigration).toContain(
+      "song_suggestion_catalog_title_trgm_idx"
+    );
+    expect(songSuggestionCatalogMigration).toContain("enable row level security");
+    expect(songSuggestionCatalogMigration).toContain(
+      "search_repertoire_song_suggestions"
+    );
     expect(songSuggestionsMigration).toContain("security definer");
+    expect(songSuggestionCatalogMigration).toContain("security definer");
     expect(songSuggestionsMigration).toContain("auth.role() = 'authenticated'");
+    expect(songSuggestionCatalogMigration).toContain(
+      "auth.role() = 'authenticated'"
+    );
     expect(songSuggestionsMigration).toContain("song_title text");
     expect(songSuggestionsMigration).toContain("voicing text");
     expect(songSuggestionsMigration).toContain("arranger_name text");
     expect(songSuggestionsMigration).toContain("grant execute");
+    expect(songSuggestionCatalogMigration).toContain("grant execute");
     expect(songSuggestionsMigration).not.toContain("returns table (\n  user_id");
+    expect(songSuggestionCatalogMigration).not.toContain(
+      "returns table (\n  user_id"
+    );
   });
 });

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -111,7 +111,7 @@ export async function getMyRepertoire() {
 
 export async function searchRepertoireSongSuggestions(
   query: string,
-  limit = 6
+  limit = 10
 ): Promise<SongSuggestion[]> {
   const { data, error } = await supabase.rpc(
     "search_repertoire_song_suggestions",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "posthog:dashboards:check": "node scripts/posthog/sync-dashboards.mjs --check",
     "posthog:dashboards:sync": "node scripts/posthog/sync-dashboards.mjs",
+    "song-suggestions:import": "node scripts/import-song-suggestions.mjs",
     "test": "vitest",
     "test:run": "vitest run",
     "ship": "./scripts/ship.sh",

--- a/scripts/import-song-suggestions.mjs
+++ b/scripts/import-song-suggestions.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { createClient } from "@supabase/supabase-js";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const defaultCatalogPath = path.join(
+  repoRoot,
+  "data/song_suggestion_catalog.psv"
+);
+const batchSize = 500;
+
+export function normalizeSearchText(value) {
+  return value
+    .toLowerCase()
+    .replace(/[’']/g, "'")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function cleanText(value) {
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+export function parseSongSuggestionCatalog(contents) {
+  const lines = contents.split(/\r?\n/).filter((line) => line.trim());
+  const [header, ...rows] = lines;
+
+  if (header !== "Song Title|Voicing|Arranger") {
+    throw new Error("Expected PSV header: Song Title|Voicing|Arranger");
+  }
+
+  const deduped = new Map();
+
+  for (const [index, row] of rows.entries()) {
+    const columns = row.split("|");
+    if (columns.length !== 3) {
+      throw new Error(`Invalid PSV row ${index + 2}: expected 3 columns.`);
+    }
+
+    const [titleValue, voicingValue, arrangerValue] = columns;
+    const title = cleanText(titleValue);
+    const voicing = cleanText(voicingValue);
+    const arranger = cleanText(arrangerValue);
+
+    if (!title || !voicing) continue;
+
+    const normalizedTitle = normalizeSearchText(title);
+    const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
+    const key = [normalizedTitle, voicing, normalizedArranger ?? ""].join("|");
+
+    if (deduped.has(key)) continue;
+
+    deduped.set(key, {
+      title,
+      normalized_title: normalizedTitle,
+      voicing,
+      arranger,
+      normalized_arranger: normalizedArranger,
+      source: "Barbershop Connections",
+    });
+  }
+
+  return Array.from(deduped.values()).sort((a, b) => {
+    return (
+      a.title.localeCompare(b.title) ||
+      a.voicing.localeCompare(b.voicing) ||
+      (a.arranger ?? "").localeCompare(b.arranger ?? "")
+    );
+  });
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+async function replaceCatalogRows(supabase, rows) {
+  const { error: deleteError } = await supabase
+    .from("song_suggestion_catalog")
+    .delete()
+    .neq("id", "00000000-0000-0000-0000-000000000000");
+
+  if (deleteError) throw deleteError;
+
+  for (let index = 0; index < rows.length; index += batchSize) {
+    const batch = rows.slice(index, index + batchSize);
+    const { error } = await supabase
+      .from("song_suggestion_catalog")
+      .insert(batch);
+    if (error) throw error;
+  }
+}
+
+export async function importSongSuggestionCatalog({
+  catalogPath = defaultCatalogPath,
+  dryRun = false,
+} = {}) {
+  const contents = await readFile(catalogPath, "utf8");
+  const rows = parseSongSuggestionCatalog(contents);
+
+  if (dryRun) return { rowsImported: rows.length, dryRun: true };
+
+  const supabaseUrl =
+    process.env.SUPABASE_URL || requiredEnv("NEXT_PUBLIC_SUPABASE_URL");
+  const serviceRoleKey = requiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  await replaceCatalogRows(supabase, rows);
+
+  return { rowsImported: rows.length, dryRun: false };
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const dryRun = args.has("--dry-run");
+  const pathArg = process.argv.find((arg) => arg.startsWith("--path="));
+  const catalogPath = pathArg
+    ? path.resolve(pathArg.slice("--path=".length))
+    : defaultCatalogPath;
+
+  const result = await importSongSuggestionCatalog({ catalogPath, dryRun });
+  console.log(
+    `${dryRun ? "Parsed" : "Imported"} ${result.rowsImported} catalog rows.`
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}

--- a/supabase/migrations/20260429060000_add_song_suggestion_catalog.sql
+++ b/supabase/migrations/20260429060000_add_song_suggestion_catalog.sql
@@ -1,0 +1,132 @@
+create extension if not exists pg_trgm;
+
+create table if not exists public.song_suggestion_catalog (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  normalized_title text not null,
+  voicing text not null,
+  arranger text,
+  normalized_arranger text,
+  source text not null default 'Barbershop Connections',
+  created_at timestamptz not null default now()
+);
+
+alter table public.song_suggestion_catalog enable row level security;
+
+create unique index if not exists song_suggestion_catalog_unique_idx
+on public.song_suggestion_catalog (
+  normalized_title,
+  voicing,
+  coalesce(normalized_arranger, '')
+);
+
+create index if not exists song_suggestion_catalog_normalized_title_idx
+on public.song_suggestion_catalog (normalized_title);
+
+create index if not exists song_suggestion_catalog_title_trgm_idx
+on public.song_suggestion_catalog using gin (title gin_trgm_ops);
+
+drop function if exists public.search_repertoire_song_suggestions(text, integer);
+
+create or replace function public.search_repertoire_song_suggestions(
+  p_query text,
+  p_limit integer default 10
+)
+returns table (
+  song_title text,
+  voicing text,
+  arranger_name text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with normalized_input as (
+    select
+      btrim(coalesce(p_query, '')) as raw_query,
+      btrim(
+        lower(
+          regexp_replace(coalesce(p_query, ''), '[^[:alnum:]]+', ' ', 'g')
+        )
+      ) as query
+  ),
+  user_suggestions as (
+    select distinct
+      btrim(user_repertoire.song_title) as song_title,
+      user_repertoire.voicing,
+      nullif(btrim(coalesce(user_repertoire.arranger_name, '')), '') as arranger_name,
+      lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g')) as normalized_title,
+      1 as source_rank
+    from public.user_repertoire
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(user_repertoire.song_title) <> ''
+      and (
+        lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+        or lower(regexp_replace(coalesce(user_repertoire.arranger_name, ''), '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  catalog_suggestions as (
+    select distinct
+      btrim(song_suggestion_catalog.title) as song_title,
+      song_suggestion_catalog.voicing,
+      nullif(btrim(coalesce(song_suggestion_catalog.arranger, '')), '') as arranger_name,
+      song_suggestion_catalog.normalized_title,
+      2 as source_rank
+    from public.song_suggestion_catalog
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(song_suggestion_catalog.title) <> ''
+      and (
+        song_suggestion_catalog.normalized_title like normalized_input.query || '%'
+        or song_suggestion_catalog.normalized_title like '%' || normalized_input.query || '%'
+        or song_suggestion_catalog.title ilike '%' || normalized_input.raw_query || '%'
+        or coalesce(song_suggestion_catalog.normalized_arranger, '')
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  combined_suggestions as (
+    select * from user_suggestions
+    union all
+    select * from catalog_suggestions
+  ),
+  deduped_suggestions as (
+    select
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title,
+      min(combined_suggestions.source_rank) as source_rank
+    from combined_suggestions
+    group by
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title
+  )
+  select
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name
+  from deduped_suggestions
+  order by
+    case
+      when deduped_suggestions.normalized_title = (select query from normalized_input) then 0
+      when deduped_suggestions.normalized_title like (select query from normalized_input) || '%' then 1
+      else 2
+    end,
+    deduped_suggestions.source_rank,
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name nulls first
+  limit least(greatest(coalesce(p_limit, 10), 1), 20);
+$$;
+
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from public;
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from anon;
+grant execute on function public.search_repertoire_song_suggestions(text, integer) to authenticated;


### PR DESCRIPTION
Closes #232

## Summary

- Added `data/song_suggestion_catalog.psv` with the generated Barbershop Connections song suggestion catalog.
- Added `song_suggestion_catalog` via Supabase migration, including trigram/index support and RLS enabled.
- Extended `search_repertoire_song_suggestions` so the existing autocomplete path returns distinct song identity suggestions from both `user_repertoire` and `song_suggestion_catalog` without exposing private repertoire details.
- Added `scripts/import-song-suggestions.mjs` and `npm run song-suggestions:import` to parse/deduplicate/import the PSV catalog.
- Updated the add-song UI with optional-suggestion helper text, loading/empty states, 250ms debounce, and a 10-result default limit.
- Updated Supabase/app docs and tests for the catalog contract.

## Tests

- `npm run song-suggestions:import -- --dry-run` parsed 18,364 catalog rows.
- `npm run test:run`
- `npm run build`

## Supabase / Manual Step

After this PR merges and migrations are applied, the catalog table exists but must be populated. Run the import from a trusted local/server environment with a service role key:

```bash
SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
```

Do not expose `SUPABASE_SERVICE_ROLE_KEY` in browser code or commit it. The catalog is suggestion-only data; rows are not added to any user's repertoire unless the user explicitly saves a repertoire item.