### PR TITLE
Use valid Supabase CLI version for migrations

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -32,10 +32,7 @@ jobs:
 
       - uses: supabase/setup-cli@v2
         with:
-          # Use the beta CLI so we can bypass the connection pooler. The
-          # pooler has repeatedly failed SASL auth during db push even after
-          # refreshing the DB password secret.
-          version: beta
+          version: latest
 
       - name: Verify required secrets
         run: |


### PR DESCRIPTION
## Summary

Fixes the Supabase migrations workflow after the previous change used `version: beta`, which `supabase/setup-cli@v2` rejects as invalid SemVer.

This keeps `--skip-pooler` on `supabase link`, but uses:

```yaml
version: latest
```

## Testing

Not run locally. Workflow-only change; the GitHub Actions run after merge is the test.