### PR TITLE
Use explicit Supabase pooler URL for migrations

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -41,8 +41,18 @@ jobs:
           test -n "$SUPABASE_DB_PASSWORD"
           test -n "$SUPABASE_PROJECT_ID"
 
-      - name: Link production Supabase project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_ID" --password "$SUPABASE_DB_PASSWORD" --skip-pooler
+      - name: Build IPv4 pooler database URL
+        run: |
+          set -euo pipefail
+          DB_PASSWORD_ENCODED="$(python3 - <<'PY'
+          import os
+          import urllib.parse
+          print(urllib.parse.quote(os.environ['SUPABASE_DB_PASSWORD'], safe=''))
+          PY
+          )"
+          DB_URL="postgresql://postgres.${SUPABASE_PROJECT_ID}:${DB_PASSWORD_ENCODED}@aws-1-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require"
+          echo "::add-mask::$DB_URL"
+          echo "SUPABASE_DB_URL=$DB_URL" >> "$GITHUB_ENV"
 
       - name: Apply migrations
-        run: supabase --yes db push
+        run: supabase --yes db push --db-url "$SUPABASE_DB_URL"


### PR DESCRIPTION
## Summary

Replaces the failed `--skip-pooler` migration workflow path with an explicit IPv4 Supabase pooler database URL for `supabase db push`.

The direct connection path is not reachable from GitHub-hosted runners because it requires IPv6. This workflow builds a masked `SUPABASE_DB_URL` from the project ref and URL-encoded DB password, then runs:

```bash
supabase --yes db push --db-url "$SUPABASE_DB_URL"
```

## Testing

Not run locally. Workflow-only change; the GitHub Actions run after merge is the test.