### PR TITLE
Use Supabase database URL secret for migrations

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -24,8 +24,7 @@ jobs:
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
     steps:
       - uses: actions/checkout@v4
@@ -38,21 +37,7 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SUPABASE_ACCESS_TOKEN"
-          test -n "$SUPABASE_DB_PASSWORD"
-          test -n "$SUPABASE_PROJECT_ID"
-
-      - name: Build IPv4 pooler database URL
-        run: |
-          set -euo pipefail
-          DB_PASSWORD_ENCODED="$(python3 - <<'PY'
-          import os
-          import urllib.parse
-          print(urllib.parse.quote(os.environ['SUPABASE_DB_PASSWORD'], safe=''))
-          PY
-          )"
-          DB_URL="postgresql://postgres.${SUPABASE_PROJECT_ID}:${DB_PASSWORD_ENCODED}@aws-1-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require"
-          echo "::add-mask::$DB_URL"
-          echo "SUPABASE_DB_URL=$DB_URL" >> "$GITHUB_ENV"
+          test -n "$SUPABASE_DB_URL"
 
       - name: Apply migrations
         run: supabase --yes db push --db-url "$SUPABASE_DB_URL"

--- a/docs/deployment-automation.md
+++ b/docs/deployment-automation.md
@@ -36,14 +36,12 @@ manually with `workflow_dispatch`.
 The workflow:
 - installs the Supabase CLI
 - verifies required GitHub Actions secrets are present
-- links the intended Supabase project
-- runs `supabase --yes db push`
-- fails visibly if linking or migration deployment fails
+- runs `supabase --yes db push` against the configured database URL
+- fails visibly if migration deployment fails
 
 Required GitHub Actions secrets:
 - `SUPABASE_ACCESS_TOKEN`: Supabase personal access token for CI
-- `SUPABASE_PROJECT_ID`: production Supabase project ref
-- `SUPABASE_DB_PASSWORD`: production database password
+- `SUPABASE_DB_URL`: production Supabase session-pooler database URI used by `supabase db push`
 - `NEXT_PUBLIC_SUPABASE_URL`: used by the app build in CI
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: used by the app build in CI
 

--- a/lib/__tests__/deploymentAutomation.test.ts
+++ b/lib/__tests__/deploymentAutomation.test.ts
@@ -34,11 +34,7 @@ describe("deployment automation guardrails", () => {
   });
 
   it("keeps production Supabase credentials in GitHub Actions secrets", () => {
-    for (const secretName of [
-      "SUPABASE_ACCESS_TOKEN",
-      "SUPABASE_DB_PASSWORD",
-      "SUPABASE_PROJECT_ID",
-    ]) {
+    for (const secretName of ["SUPABASE_ACCESS_TOKEN", "SUPABASE_DB_URL"]) {
       expect(migrationWorkflow).toContain(`secrets.${secretName}`);
       expect(deploymentDocs).toContain(secretName);
     }


### PR DESCRIPTION
## Summary

Simplifies the Supabase migrations workflow to use a single `SUPABASE_DB_URL` secret for `supabase db push`.

This removes the workflow-built connection string and avoids guessing the correct pooler/user/password format in CI.

## Required secret

Add this GitHub Actions repository secret before the workflow runs:

```text
SUPABASE_DB_URL
```

Set it to the exact database connection string copied from Supabase for the project.

## Testing

Not run locally. Workflow-only change; the GitHub Actions run after merge is the test.