### PR TITLE
Split multi-voicing song suggestion catalog rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The Supabase project should have the current production schema applied:
 - `song_suggestion_catalog` stores optional reference suggestions imported from
   `data/song_suggestion_catalog.psv`. It is used only for autocomplete; catalog
   rows are not added to anyone's repertoire unless a user chooses to save one.
+  Import expands comma-separated voicing values into one row per supported
+  voicing (`TTBB`, `SSAA`, `SATB`).
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes
@@ -102,8 +104,9 @@ supabase db push
 If the project is not linked locally, run `supabase link --project-ref <project-ref>`
 first, then `supabase db push`.
 
-To refresh the optional song suggestion catalog after migrations are applied,
-run the import script with a server-side Supabase service role key:
+To refresh the optional song suggestion catalog after migrations are applied, or
+after the catalog import behavior changes, run the import script with a
+server-side Supabase service role key:
 
 ```bash
 SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -114,7 +114,8 @@ Required database contract:
   `arranger_name`. It must not return `user_id`, singer names, notes, parts,
   confidence, timestamps, or other per-user repertoire details. Blank
   `arranger_name` values remain `null`/blank in app display and are distinct
-  from a literal entered value such as `Unknown`.
+  from a literal entered value such as `Unknown`. It returns only supported
+  single voicing values: `TTBB`, `SATB`, and `SSAA`.
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
@@ -148,12 +149,16 @@ Required database contract:
 - Unique index on `(normalized_title, voicing, coalesce(normalized_arranger, ''))`
 - Index on `normalized_title`
 - Trigram index on `title`
+- Supported voicings are `TTBB`, `SATB`, and `SSAA`
 - RLS enabled; no direct browser table access is required
+- Import expands comma-separated source voicings into one row per supported
+  voicing and ignores unsupported voicing values
 - Catalog rows are suggestions only and must never be inserted into
   `user_repertoire` unless a user explicitly saves a repertoire item
 
 Established by migrations:
 - `20260429060000_add_song_suggestion_catalog.sql`
+- `20260429162000_limit_song_suggestions_to_supported_voicings.sql`
 
 ### `sessions`
 

--- a/lib/__tests__/songSuggestionCatalogImport.test.ts
+++ b/lib/__tests__/songSuggestionCatalogImport.test.ts
@@ -56,6 +56,83 @@ No Arranger Song|TTBB|
     ]);
   });
 
+  it("expands comma-separated voicings into one row per supported voicing", () => {
+    const rows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
+'C' is for cookie|TTBB, SSAA, SATB|Jay Dougherty
+Unsupported Song|TTBB, XYZ|Test Arranger
+`);
+
+    expect(rows).toEqual([
+      {
+        title: "'C' is for cookie",
+        normalized_title: "c is for cookie",
+        voicing: "SATB",
+        arranger: "Jay Dougherty",
+        normalized_arranger: "jay dougherty",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "'C' is for cookie",
+        normalized_title: "c is for cookie",
+        voicing: "SSAA",
+        arranger: "Jay Dougherty",
+        normalized_arranger: "jay dougherty",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "'C' is for cookie",
+        normalized_title: "c is for cookie",
+        voicing: "TTBB",
+        arranger: "Jay Dougherty",
+        normalized_arranger: "jay dougherty",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "Unsupported Song",
+        normalized_title: "unsupported song",
+        voicing: "TTBB",
+        arranger: "Test Arranger",
+        normalized_arranger: "test arranger",
+        source: "Barbershop Connections",
+      },
+    ]);
+  });
+
+  it("deduplicates expanded voicing rows by normalized title, voicing, and arranger", () => {
+    const rows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
+Mamselle|TTBB, SATB|Lou Perry
+Mam'selle|SATB|Lou Perry
+Mamselle|ttbb|Lou Perry
+`);
+
+    expect(rows).toEqual([
+      {
+        title: "Mam'selle",
+        normalized_title: "mam selle",
+        voicing: "SATB",
+        arranger: "Lou Perry",
+        normalized_arranger: "lou perry",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "Mamselle",
+        normalized_title: "mamselle",
+        voicing: "SATB",
+        arranger: "Lou Perry",
+        normalized_arranger: "lou perry",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "Mamselle",
+        normalized_title: "mamselle",
+        voicing: "TTBB",
+        arranger: "Lou Perry",
+        normalized_arranger: "lou perry",
+        source: "Barbershop Connections",
+      },
+    ]);
+  });
+
   it("keeps the generated catalog source in the expected format", () => {
     expect(catalogSource.startsWith("Song Title|Voicing|Arranger\n")).toBe(true);
     const parsedRows = parseSongSuggestionCatalog(catalogSource);

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -51,6 +51,13 @@ const songSuggestionCatalogMigration = readFileSync(
   ),
   "utf8"
 );
+const songSuggestionSupportedVoicingMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260429162000_limit_song_suggestions_to_supported_voicings.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -172,6 +179,24 @@ describe("Supabase contract guardrails", () => {
     expect(songSuggestionsMigration).not.toContain("returns table (\n  user_id");
     expect(songSuggestionCatalogMigration).not.toContain(
       "returns table (\n  user_id"
+    );
+    expect(contract).toContain(
+      "single voicing values: `TTBB`, `SATB`, and `SSAA`"
+    );
+    expect(contract).toContain(
+      "Import expands comma-separated source voicings"
+    );
+    expect(songSuggestionSupportedVoicingMigration).toContain(
+      "song_suggestion_catalog_supported_voicing_chk"
+    );
+    expect(songSuggestionSupportedVoicingMigration).toContain(
+      "voicing in ('TTBB', 'SATB', 'SSAA')"
+    );
+    expect(songSuggestionSupportedVoicingMigration).toContain(
+      "user_repertoire.voicing in ('TTBB', 'SATB', 'SSAA')"
+    );
+    expect(songSuggestionSupportedVoicingMigration).toContain(
+      "song_suggestion_catalog.voicing in ('TTBB', 'SATB', 'SSAA')"
     );
   });
 });

--- a/scripts/import-song-suggestions.mjs
+++ b/scripts/import-song-suggestions.mjs
@@ -13,6 +13,7 @@ const defaultCatalogPath = path.join(
   "data/song_suggestion_catalog.psv"
 );
 const batchSize = 500;
+const supportedVoicings = new Set(["TTBB", "SATB", "SSAA"]);
 
 export function normalizeSearchText(value) {
   return value
@@ -26,6 +27,13 @@ export function normalizeSearchText(value) {
 function cleanText(value) {
   const trimmed = value.trim();
   return trimmed || null;
+}
+
+function splitSupportedVoicings(value) {
+  return value
+    .split(",")
+    .map((voicing) => voicing.trim().toUpperCase())
+    .filter((voicing) => supportedVoicings.has(voicing));
 }
 
 export function parseSongSuggestionCatalog(contents) {
@@ -46,25 +54,28 @@ export function parseSongSuggestionCatalog(contents) {
 
     const [titleValue, voicingValue, arrangerValue] = columns;
     const title = cleanText(titleValue);
-    const voicing = cleanText(voicingValue);
+    const voicings = splitSupportedVoicings(voicingValue);
     const arranger = cleanText(arrangerValue);
 
-    if (!title || !voicing) continue;
+    if (!title || voicings.length === 0) continue;
 
     const normalizedTitle = normalizeSearchText(title);
     const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
-    const key = [normalizedTitle, voicing, normalizedArranger ?? ""].join("|");
 
-    if (deduped.has(key)) continue;
+    for (const voicing of voicings) {
+      const key = [normalizedTitle, voicing, normalizedArranger ?? ""].join("|");
 
-    deduped.set(key, {
-      title,
-      normalized_title: normalizedTitle,
-      voicing,
-      arranger,
-      normalized_arranger: normalizedArranger,
-      source: "Barbershop Connections",
-    });
+      if (deduped.has(key)) continue;
+
+      deduped.set(key, {
+        title,
+        normalized_title: normalizedTitle,
+        voicing,
+        arranger,
+        normalized_arranger: normalizedArranger,
+        source: "Barbershop Connections",
+      });
+    }
   }
 
   return Array.from(deduped.values()).sort((a, b) => {

--- a/supabase/migrations/20260429162000_limit_song_suggestions_to_supported_voicings.sql
+++ b/supabase/migrations/20260429162000_limit_song_suggestions_to_supported_voicings.sql
@@ -1,0 +1,118 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'song_suggestion_catalog_supported_voicing_chk'
+      and conrelid = 'public.song_suggestion_catalog'::regclass
+  ) then
+    alter table public.song_suggestion_catalog
+      add constraint song_suggestion_catalog_supported_voicing_chk
+      check (voicing in ('TTBB', 'SATB', 'SSAA')) not valid;
+  end if;
+end $$;
+
+create or replace function public.search_repertoire_song_suggestions(
+  p_query text,
+  p_limit integer default 10
+)
+returns table (
+  song_title text,
+  voicing text,
+  arranger_name text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with normalized_input as (
+    select
+      btrim(coalesce(p_query, '')) as raw_query,
+      btrim(
+        lower(
+          regexp_replace(coalesce(p_query, ''), '[^[:alnum:]]+', ' ', 'g')
+        )
+      ) as query
+  ),
+  user_suggestions as (
+    select distinct
+      btrim(user_repertoire.song_title) as song_title,
+      user_repertoire.voicing,
+      nullif(btrim(coalesce(user_repertoire.arranger_name, '')), '') as arranger_name,
+      lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g')) as normalized_title,
+      1 as source_rank
+    from public.user_repertoire
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(user_repertoire.song_title) <> ''
+      and user_repertoire.voicing in ('TTBB', 'SATB', 'SSAA')
+      and (
+        lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+        or lower(regexp_replace(coalesce(user_repertoire.arranger_name, ''), '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  catalog_suggestions as (
+    select distinct
+      btrim(song_suggestion_catalog.title) as song_title,
+      song_suggestion_catalog.voicing,
+      nullif(btrim(coalesce(song_suggestion_catalog.arranger, '')), '') as arranger_name,
+      song_suggestion_catalog.normalized_title,
+      2 as source_rank
+    from public.song_suggestion_catalog
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(song_suggestion_catalog.title) <> ''
+      and song_suggestion_catalog.voicing in ('TTBB', 'SATB', 'SSAA')
+      and (
+        song_suggestion_catalog.normalized_title like normalized_input.query || '%'
+        or song_suggestion_catalog.normalized_title like '%' || normalized_input.query || '%'
+        or song_suggestion_catalog.title ilike '%' || normalized_input.raw_query || '%'
+        or coalesce(song_suggestion_catalog.normalized_arranger, '')
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  combined_suggestions as (
+    select * from user_suggestions
+    union all
+    select * from catalog_suggestions
+  ),
+  deduped_suggestions as (
+    select
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title,
+      min(combined_suggestions.source_rank) as source_rank
+    from combined_suggestions
+    group by
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title
+  )
+  select
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name
+  from deduped_suggestions
+  order by
+    case
+      when deduped_suggestions.normalized_title = (select query from normalized_input) then 0
+      when deduped_suggestions.normalized_title like (select query from normalized_input) || '%' then 1
+      else 2
+    end,
+    deduped_suggestions.source_rank,
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name nulls first
+  limit least(greatest(coalesce(p_limit, 10), 1), 20);
+$$;
+
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from public;
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from anon;
+grant execute on function public.search_repertoire_song_suggestions(text, integer) to authenticated;


### PR DESCRIPTION
## Summary
- expands comma-separated catalog voicings into one row per supported voicing during import
- keeps catalog/import dedupe by normalized title, single voicing, and normalized arranger
- adds a Supabase migration guard so autocomplete only returns supported single voicing values
- documents that the catalog import should be rerun after this change

Closes #238

## Tests
- npm run song-suggestions:import -- --dry-run
- npm run test:run
- npm run build

## Supabase / deployment notes
After this is merged and migrations are applied, rerun the catalog import so existing multi-voicing catalog rows are replaced with split single-voicing rows:

```bash
SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
```

The dry run now parses 20,949 catalog rows after expansion.