### PR TITLE
Sequence production deploys after migrations

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,105 @@
+name: Production Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Test, migrate, and deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment: production
+
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:run
+
+      - run: npm run build
+
+      - name: Detect migration changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "migrations_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_sha="${{ github.event.before }}"
+          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            base_sha="$(git rev-parse HEAD^)"
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha" "${{ github.sha }}")"
+          if echo "$changed_files" | grep -Eq '^(supabase/migrations/|\.github/workflows/(production-deploy|supabase-migrations)\.yml$)'; then
+            echo "migrations_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "migrations_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: supabase/setup-cli@v2
+        if: steps.changes.outputs.migrations_changed == 'true'
+        with:
+          version: latest
+
+      - name: Verify Supabase migration secrets
+        if: steps.changes.outputs.migrations_changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SUPABASE_ACCESS_TOKEN"
+          test -n "$SUPABASE_DB_URL"
+
+      - name: Apply Supabase migrations
+        if: steps.changes.outputs.migrations_changed == 'true'
+        run: supabase --yes db push --db-url "$SUPABASE_DB_URL"
+
+      - name: Verify Vercel deployment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$VERCEL_TOKEN"
+          test -n "$VERCEL_ORG_ID"
+          test -n "$VERCEL_PROJECT_ID"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel production environment
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build Vercel production output
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy Vercel production output
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,18 +1,13 @@
 name: Supabase Migrations
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "supabase/migrations/**"
-      - ".github/workflows/supabase-migrations.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: supabase-migrations-production
+  group: production-deploy
   cancel-in-progress: false
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,10 @@ updated, explain why in the PR.
 Supabase changes must be captured in repo migrations and docs rather than
 dashboard-only changes. If a change requires schema, RLS, or data-model updates,
 add a proper migration and update `docs/supabase-contract.md` as needed.
-Production Supabase migrations should be deployed by the automated GitHub
-Actions workflow after merge to `main`. If automation is unavailable or a
-manual step remains, document that clearly in the PR.
+Production deploys should run through the `Production Deploy` GitHub Actions
+workflow, which applies Supabase migrations before the Vercel production deploy.
+If automation is unavailable or a manual step remains, document that clearly in
+the PR.
 
 For normal repo work, ask early for any needed access: repo file writes, Git
 metadata writes, network access for Git/package/build/font resources, pushing

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes
 Supabase usage must update that contract, migrations, and tests or test notes.
 
-Database migrations live in `supabase/migrations`. In production, migrations are
-deployed by GitHub Actions after a migration PR is merged to `main`; see
+Database migrations live in `supabase/migrations`. In production, the
+`Production Deploy` GitHub Actions workflow applies migrations before deploying
+the Vercel app; see
 [docs/deployment-automation.md](docs/deployment-automation.md). For local
 development or emergency fallback, apply unapplied migrations to the linked
 Supabase project with:

--- a/docs/deployment-automation.md
+++ b/docs/deployment-automation.md
@@ -1,7 +1,8 @@
 # Deployment Automation
 
-This repo uses GitHub Actions to keep Codex-authored PRs reviewable while
-removing the easy-to-forget manual Supabase migration step.
+This repo uses GitHub Actions to keep Codex-authored PRs reviewable, apply
+Supabase migrations before production app deployment, and avoid production
+deploys that race ahead of the database.
 
 ## PR Lifecycle
 
@@ -10,12 +11,17 @@ removing the easy-to-forget manual Supabase migration step.
 3. The maintainer reviews the PR.
 4. GitHub auto-merge may merge the PR after required checks and any required
    approvals pass.
-5. Vercel deploys the app from `main`.
-6. If the merge includes files under `supabase/migrations`, the
-   `Supabase Migrations` workflow applies them to the production Supabase
-   project after the code is on `main`.
+5. The `Production Deploy` workflow runs from `main`.
+6. `Production Deploy` runs tests and build again on the merge commit.
+7. If the merge includes files under `supabase/migrations`, `Production Deploy`
+   applies them to the production Supabase project.
+8. Only after the migration step is skipped or succeeds, `Production Deploy`
+   builds and deploys the Vercel production app.
 
 Supabase migrations are not deployed from unmerged PR branches.
+
+Vercel preview deployments may still be created automatically for PR branches.
+That is useful for review and is separate from production readiness.
 
 ## CI Checks
 
@@ -27,11 +33,56 @@ Required checks:
 - `npm run test:run`.
 - `npm run build`.
 
-## Supabase Migration Deployment
+## Production Deployment
 
-The `Supabase Migrations` workflow runs only on `main` pushes that touch
-`supabase/migrations/**` or the migration workflow itself. It can also be rerun
-manually with `workflow_dispatch`.
+The `Production Deploy` workflow is the intended production deployment path. It
+runs on pushes to `main` and can also be run manually with `workflow_dispatch`.
+
+The workflow:
+- installs dependencies
+- runs `npm run test:run`
+- runs `npm run build`
+- checks whether the merge included migration workflow or
+  `supabase/migrations/**` changes
+- applies Supabase migrations first when needed
+- verifies Vercel deployment secrets are present
+- runs `vercel pull --environment=production`
+- runs `vercel build --prod`
+- runs `vercel deploy --prebuilt --prod`
+
+If the Supabase migration step fails, the Vercel deployment steps do not run.
+That makes the failure visible in GitHub Actions and prevents the GitHub Actions
+production deploy from presenting app code as healthy while the database is
+behind.
+
+## Vercel Git Integration
+
+`vercel.json` disables automatic Git deployments for the `main` branch:
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}
+```
+
+This keeps production deploys sequenced through GitHub Actions. Leave Vercel's
+Git integration connected for PR preview deployments, but do not rely on Vercel
+automatic production deployment from `main`.
+
+If production deployments still start immediately after a merge, check the
+Vercel project settings and confirm the project is reading this repository's
+`vercel.json`. The intended setting is: automatic Git deployments for `main`
+disabled; GitHub Actions `Production Deploy` owns production.
+
+## Manual Supabase Migration Recovery
+
+The `Supabase Migrations` workflow is now a manual recovery workflow. It runs
+only with `workflow_dispatch` on `main`. It shares the production deployment
+concurrency group so it cannot run at the same time as `Production Deploy`.
 
 The workflow:
 - installs the Supabase CLI
@@ -44,6 +95,9 @@ Required GitHub Actions secrets:
 - `SUPABASE_DB_URL`: production Supabase session-pooler database URI used by `supabase db push`
 - `NEXT_PUBLIC_SUPABASE_URL`: used by the app build in CI
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`: used by the app build in CI
+- `VERCEL_TOKEN`: Vercel token used by GitHub Actions production deploys
+- `VERCEL_ORG_ID`: Vercel team/user id for the linked project
+- `VERCEL_PROJECT_ID`: Vercel project id for the linked project
 
 Do not commit these values. Do not use a service-role key in frontend code.
 
@@ -59,8 +113,9 @@ Configure GitHub branch protection for `main` in repository settings:
 - Prevent direct pushes to `main` where practical.
 - Allow auto-merge only after required checks and approvals pass.
 
-Do not require the `Supabase Migrations` workflow as a pre-merge PR check. It
-runs after migration changes merge to `main`.
+Do not require the `Supabase Migrations` workflow as a pre-merge PR check. It is
+a manual recovery workflow. The post-merge production readiness signal is
+`Production Deploy / Test, migrate, and deploy`.
 
 These settings are repository settings and are not stored in the codebase.
 
@@ -72,14 +127,41 @@ merge or auto-merge PRs with failing tests, failing builds, or failed guardrails
 
 ## Failure Recovery
 
-If the `Supabase Migrations` workflow fails after a merge:
+If the `Production Deploy` workflow fails during the Supabase migration step:
 
-1. Treat production app code as potentially ahead of the database.
+1. Treat production deployment as failed.
 2. Open the failed GitHub Actions run and read the failed step.
 3. Fix the migration or missing secret in a new PR.
-4. Merge the fix to `main`, or rerun the failed workflow after correcting only
+4. Merge the fix to `main`, or rerun `Production Deploy` after correcting only
    repository secrets/configuration.
-5. Confirm the migration workflow passes before relying on the affected app
-   behavior.
+5. Confirm `Production Deploy` passes before relying on the affected behavior.
+
+If you need to apply migrations without deploying the app, run the manual
+`Supabase Migrations` workflow from `main` after fixing secrets/configuration.
 
 Manual `supabase db push` is now a fallback only, not the primary workflow.
+
+## Vercel Free-Tier Limits
+
+Vercel free-tier build or deployment limits can still block production deploys.
+When that happens, GitHub Actions will show the failed Vercel step. The code on
+`main` remains up to date, but production may still be serving an older
+deployment until the limit resets and `Production Deploy` is rerun.
+
+After limits reset, rerun the failed `Production Deploy` workflow from GitHub
+Actions. You do not need to create a no-op code change just to redeploy.
+
+## Verifying Production
+
+To verify what is live:
+
+1. Open GitHub Actions and confirm the latest `Production Deploy` run for
+   `main` passed.
+2. If that run included migrations, confirm the `Apply Supabase migrations` step
+   passed before the Vercel deploy steps.
+3. In Vercel, inspect the latest production deployment and compare its Git
+   commit SHA to the `main` commit from the successful `Production Deploy` run.
+   The Vercel CLI equivalent is `vercel list --prod` followed by
+   `vercel inspect <deployment-url>`.
+4. If analytics are configured, `/api/analytics/status` can help confirm the
+   deployed Vercel environment and commit metadata exposed to the app runtime.

--- a/lib/__tests__/deploymentAutomation.test.ts
+++ b/lib/__tests__/deploymentAutomation.test.ts
@@ -11,6 +11,11 @@ const migrationWorkflow = readFileSync(
   join(repoRoot, ".github/workflows/supabase-migrations.yml"),
   "utf8"
 );
+const productionDeployWorkflow = readFileSync(
+  join(repoRoot, ".github/workflows/production-deploy.yml"),
+  "utf8"
+);
+const vercelConfig = readFileSync(join(repoRoot, "vercel.json"), "utf8");
 const deploymentDocs = readFileSync(
   join(repoRoot, "docs/deployment-automation.md"),
   "utf8"
@@ -25,19 +30,54 @@ describe("deployment automation guardrails", () => {
     expect(ciWorkflow).toContain("npm run build");
   });
 
-  it("deploys Supabase migrations only from main", () => {
-    expect(migrationWorkflow).toContain("branches: [main]");
+  it("deploys production only after tests and migrations succeed", () => {
+    expect(productionDeployWorkflow).toContain("branches: [main]");
+    expect(productionDeployWorkflow).toContain("npm run test:run");
+    expect(productionDeployWorkflow).toContain("npm run build");
+    expect(productionDeployWorkflow).toContain("Detect migration changes");
+    expect(productionDeployWorkflow).toContain("supabase --yes db push");
+    expect(productionDeployWorkflow).toContain("vercel build --prod");
+    expect(productionDeployWorkflow).toContain(
+      "vercel deploy --prebuilt --prod"
+    );
+    expect(
+      productionDeployWorkflow.indexOf("Apply Supabase migrations")
+    ).toBeLessThan(
+      productionDeployWorkflow.indexOf("Deploy Vercel production output")
+    );
+  });
+
+  it("keeps Supabase migration workflow as manual recovery only", () => {
     expect(migrationWorkflow).toContain("if: github.ref == 'refs/heads/main'");
     expect(migrationWorkflow).not.toContain("pull_request:");
-    expect(migrationWorkflow).toContain("supabase/migrations/**");
+    expect(migrationWorkflow).not.toContain("push:");
+    expect(migrationWorkflow).toContain("group: production-deploy");
     expect(migrationWorkflow).toContain("supabase --yes db push");
   });
 
   it("keeps production Supabase credentials in GitHub Actions secrets", () => {
     for (const secretName of ["SUPABASE_ACCESS_TOKEN", "SUPABASE_DB_URL"]) {
       expect(migrationWorkflow).toContain(`secrets.${secretName}`);
+      expect(productionDeployWorkflow).toContain(`secrets.${secretName}`);
       expect(deploymentDocs).toContain(secretName);
     }
+  });
+
+  it("keeps production Vercel deployment controlled by GitHub Actions", () => {
+    expect(vercelConfig).toContain('"main": false');
+    for (const secretName of [
+      "VERCEL_TOKEN",
+      "VERCEL_ORG_ID",
+      "VERCEL_PROJECT_ID",
+    ]) {
+      expect(productionDeployWorkflow).toContain(`secrets.${secretName}`);
+      expect(deploymentDocs).toContain(secretName);
+    }
+    expect(deploymentDocs).toContain(
+      "automatic Git deployments for `main`"
+    );
+    expect(deploymentDocs).toContain("Production Deploy");
+    expect(deploymentDocs).toContain("vercel inspect <deployment-url>");
   });
 
   it("documents merge, branch protection, auto-merge, and failure recovery", () => {
@@ -53,5 +93,7 @@ describe("deployment automation guardrails", () => {
     expect(deploymentDocs).toContain(
       "Supabase migrations are not deployed from unmerged PR branches"
     );
+    expect(deploymentDocs).toContain("Vercel free-tier build or deployment limits");
+    expect(deploymentDocs).toContain("Production Deploy` passes");
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- adds a `Production Deploy` GitHub Actions workflow that runs tests/build, applies Supabase migrations when needed, then deploys Vercel production with `vercel deploy --prebuilt --prod`
- changes `Supabase Migrations` into a manual recovery workflow and shares the production concurrency queue
- adds `vercel.json` to disable automatic Git deployments for `main` so production deploys are controlled by GitHub Actions
- updates deployment docs, README, and AGENTS guidance with the intended flow, failure recovery, free-tier Vercel behavior, and production verification steps

Closes #229

## Verification
- npm run test:run
- npm run build

## Required settings / secrets
Production deploys now require these GitHub Actions secrets:
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_DB_URL`
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

`vercel.json` disables automatic Git deployments for `main`. PR preview deployments can remain enabled. After merge, verify production readiness through the `Production Deploy / Test, migrate, and deploy` workflow; if that workflow fails, production should not be treated as successfully deployed.