### PR TITLE
Show arrangers with match title variants

### DIFF
--- a/components/MatchCard.test.tsx
+++ b/components/MatchCard.test.tsx
@@ -1,0 +1,115 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import type { MatchResult, Part, SingerEntry } from "@/lib/matching";
+import { MatchCard } from "./MatchCard";
+
+function singer(
+  patch: Partial<SingerEntry> & { displayName: string; part: Part }
+): SingerEntry {
+  return {
+    userId: patch.userId ?? patch.displayName,
+    displayName: patch.displayName,
+    songTitle: patch.songTitle ?? "Why Try to Change Me Now",
+    voicing: patch.voicing ?? "TTBB",
+    arrangerName: patch.arrangerName,
+    partsKnown: [patch.part],
+    confidence: patch.confidence ?? "Good to Go",
+  };
+}
+
+function renderMatch(match: MatchResult) {
+  return renderToStaticMarkup(
+    <MatchCard
+      match={match}
+      isExpanded
+      onToggle={() => undefined}
+    />
+  );
+}
+
+describe("MatchCard", () => {
+  it("shows arrangers with fuzzy title variant groups instead of a generic summary", () => {
+    const html = renderMatch({
+      songTitle: "Why Try to Change Me Now",
+      voicing: "TTBB",
+      arrangerNames: ["Cay Outerbridge"],
+      hasMissingArrangerInfo: true,
+      category: "possible",
+      missingParts: [],
+      assignments: {},
+      warnings: [],
+      score: 0,
+      titleMatchType: "fuzzy",
+      titleVariants: [
+        {
+          title: "Why Try To Change Me",
+          normalizedTitle: "whytrytochangeme",
+          singers: [
+            {
+              displayName: "Tenor Singer",
+              part: "Tenor",
+              confidence: "A Little Rusty",
+              arrangerName: "Cay Outerbridge",
+            },
+          ],
+        },
+        {
+          title: "Why Try To Change Me Now",
+          normalizedTitle: "whytrytochangemenow",
+          singers: [
+            {
+              displayName: "Lead Singer",
+              part: "Lead",
+              confidence: "Good to Go",
+              arrangerName: null,
+            },
+            {
+              displayName: "Bari Singer",
+              part: "Baritone",
+              confidence: "Good to Go",
+              arrangerName: null,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(html).toContain("Potential title match");
+    expect(html).toContain("Arranger: Cay Outerbridge");
+    expect(html).toContain("Arranger: No arranger entered");
+    expect(html).not.toContain("Cay Outerbridge, No arranger entered");
+  });
+
+  it("shows per-singer arrangers when the same displayed title has mixed arranger states", () => {
+    const lead = singer({
+      userId: "lead",
+      displayName: "Lead Singer",
+      part: "Lead",
+      arrangerName: "Unknown",
+    });
+    const bass = singer({
+      userId: "bass",
+      displayName: "Bass Singer",
+      part: "Bass",
+      arrangerName: null,
+    });
+
+    const html = renderMatch({
+      songTitle: "Shared Title",
+      voicing: "TTBB",
+      arrangerNames: ["Unknown"],
+      hasMissingArrangerInfo: true,
+      category: "ready",
+      missingParts: [],
+      assignments: {
+        Lead: [lead],
+        Bass: [bass],
+      },
+      warnings: [],
+      score: 0,
+    });
+
+    expect(html).toContain("Lead Singer (Arranger: Unknown)");
+    expect(html).toContain("Bass Singer (Arranger: No arranger entered)");
+  });
+});

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -1,9 +1,14 @@
 import {
   requiredPartsForVoicing,
+  type MatchTitleVariant,
+  type MatchTitleVariantSinger,
   type MatchResult,
 } from "@/lib/matching";
 import { partAbbreviation } from "@/lib/partAbbreviations";
-import { noArrangerEnteredLabel } from "@/lib/arrangerDisplay";
+import {
+  arrangerDisplayName,
+  noArrangerEnteredLabel,
+} from "@/lib/arrangerDisplay";
 
 type MatchCardProps = {
   match: MatchResult;
@@ -14,6 +19,21 @@ type MatchCardProps = {
   onToggle: () => void;
   onMarkAsSung?: () => void;
 };
+
+function uniqueArrangerLabels(singers: MatchTitleVariantSinger[]) {
+  return Array.from(
+    new Set(singers.map((singer) => arrangerDisplayName(singer.arrangerName)))
+  );
+}
+
+function variantKey(variant: MatchTitleVariant) {
+  return `${variant.title}-${variant.singers
+    .map(
+      (singer) =>
+        `${singer.displayName}-${singer.part}-${singer.arrangerName ?? ""}`
+    )
+    .join("|")}`;
+}
 
 const categoryStyles: Record<
   MatchResult["category"],
@@ -55,6 +75,9 @@ export function MatchCard({
     Boolean(match.arrangerVariantNote) ||
     personalNotes.length > 0 ||
     isRecentlySung;
+  const hasTitleVariantDetails = Boolean(match.titleVariants?.length);
+  const shouldShowEntryArrangers =
+    match.arrangerNames.length > 1 || match.hasMissingArrangerInfo;
 
   return (
     <details
@@ -129,20 +152,34 @@ export function MatchCard({
                 <span className="font-semibold text-white">{abbreviation}:</span>{" "}
                 {isMissing
                   ? "Missing"
-                  : singers.map((singer) => singer.displayName).join(", ")}
+                  : singers
+                      .map((singer) => {
+                        if (!shouldShowEntryArrangers) {
+                          return singer.displayName;
+                        }
+
+                        return `${singer.displayName} (Arranger: ${arrangerDisplayName(
+                          singer.arrangerName
+                        )})`;
+                      })
+                      .join(", ")}
               </p>
             );
           })}
         </div>
 
-        {(match.arrangerNames.length > 0 || match.hasMissingArrangerInfo) && (
-          <p className="mt-3">
-            <span className="font-semibold text-white">Arranger:</span>{" "}
-            {[...match.arrangerNames, match.hasMissingArrangerInfo ? noArrangerEnteredLabel : null]
-              .filter((name): name is string => Boolean(name))
-              .join(", ")}
-          </p>
-        )}
+        {!hasTitleVariantDetails &&
+          (match.arrangerNames.length > 0 || match.hasMissingArrangerInfo) && (
+            <p className="mt-3">
+              <span className="font-semibold text-white">Arranger:</span>{" "}
+              {[
+                ...match.arrangerNames,
+                match.hasMissingArrangerInfo ? noArrangerEnteredLabel : null,
+              ]
+                .filter((name): name is string => Boolean(name))
+                .join(", ")}
+            </p>
+          )}
 
         {match.arrangerVariantNote && (
           <p className="mt-2 text-sm text-slate-300">
@@ -165,23 +202,40 @@ export function MatchCard({
                 .join(" / ")}
             </p>
             <div className="mt-3 space-y-3">
-              {match.titleVariants.map((variant) => (
-                <div key={variant.title}>
-                  <p className="font-semibold text-white">"{variant.title}"</p>
-                  <ul className="mt-1 space-y-1">
-                    {variant.singers.map((singer) => (
-                      <li
-                        key={`${variant.title}-${singer.displayName}-${singer.part}`}
-                        className="text-xs text-amber-50/90"
-                      >
-                        {singer.displayName} -{" "}
-                        {partAbbreviation(match.voicing, singer.part)}
-                        {singer.confidence ? ` - ${singer.confidence}` : ""}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
+              {match.titleVariants.map((variant) => {
+                const arrangerLabels = uniqueArrangerLabels(variant.singers);
+                const showVariantArranger = arrangerLabels.length === 1;
+
+                return (
+                  <div key={variantKey(variant)}>
+                    <p className="font-semibold text-white">
+                      "{variant.title}"
+                    </p>
+                    {showVariantArranger && (
+                      <p className="mt-0.5 text-xs text-amber-50/80">
+                        Arranger: {arrangerLabels[0]}
+                      </p>
+                    )}
+                    <ul className="mt-1 space-y-1">
+                      {variant.singers.map((singer) => (
+                        <li
+                          key={`${variant.title}-${singer.displayName}-${singer.part}-${singer.arrangerName ?? ""}`}
+                          className="text-xs text-amber-50/90"
+                        >
+                          {singer.displayName} -{" "}
+                          {partAbbreviation(match.voicing, singer.part)}
+                          {singer.confidence ? ` - ${singer.confidence}` : ""}
+                          {!showVariantArranger
+                            ? ` - Arranger: ${arrangerDisplayName(
+                                singer.arrangerName
+                              )}`
+                            : ""}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
             </div>
             <p className="mt-3 text-xs text-amber-50/80">
               If these are the same song, consider updating repertoire titles

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -222,16 +222,122 @@ describe("findMatches", () => {
         title: "Why Try to Change Me",
         normalizedTitle: "whytrytochangeme",
         singers: [
-          { displayName: "T", part: "Tenor", confidence: null },
-          { displayName: "L", part: "Lead", confidence: null },
-          { displayName: "Bari", part: "Baritone", confidence: null },
+          {
+            displayName: "T",
+            part: "Tenor",
+            confidence: null,
+            arrangerName: null,
+          },
+          {
+            displayName: "L",
+            part: "Lead",
+            confidence: null,
+            arrangerName: null,
+          },
+          {
+            displayName: "Bari",
+            part: "Baritone",
+            confidence: null,
+            arrangerName: null,
+          },
         ],
       },
       {
         title: "Why Try To Change Me Now",
         normalizedTitle: "whytrytochangemenow",
         singers: [
-          { displayName: "Bass", part: "Bass", confidence: null },
+          {
+            displayName: "Bass",
+            part: "Bass",
+            confidence: null,
+            arrangerName: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps arranger values attached to fuzzy title variant singer rows", () => {
+    const entries: SingerEntry[] = [
+      {
+        userId: "1",
+        displayName: "Tenor",
+        songTitle: "Why Try To Change Me",
+        voicing: "TTBB",
+        arrangerName: "Cay Outerbridge",
+        partsKnown: ["Tenor"],
+      },
+      {
+        userId: "2",
+        displayName: "Lead",
+        songTitle: "Why Try To Change Me Now",
+        voicing: "TTBB",
+        arrangerName: null,
+        partsKnown: ["Lead"],
+      },
+      {
+        userId: "3",
+        displayName: "Bari",
+        songTitle: "Why Try To Change Me Now",
+        voicing: "TTBB",
+        arrangerName: "",
+        partsKnown: ["Baritone"],
+      },
+      {
+        userId: "4",
+        displayName: "Bass",
+        songTitle: "Why Try to Change Me Now",
+        voicing: "TTBB",
+        arrangerName: "Unknown",
+        partsKnown: ["Bass"],
+      },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].titleMatchType).toBe("fuzzy");
+    expect(matches[0].titleVariants).toEqual([
+      {
+        title: "Why Try To Change Me",
+        normalizedTitle: "whytrytochangeme",
+        singers: [
+          {
+            displayName: "Tenor",
+            part: "Tenor",
+            confidence: null,
+            arrangerName: "Cay Outerbridge",
+          },
+        ],
+      },
+      {
+        title: "Why Try To Change Me Now",
+        normalizedTitle: "whytrytochangemenow",
+        singers: [
+          {
+            displayName: "Lead",
+            part: "Lead",
+            confidence: null,
+            arrangerName: null,
+          },
+          {
+            displayName: "Bari",
+            part: "Baritone",
+            confidence: null,
+            arrangerName: null,
+          },
+        ],
+      },
+      {
+        title: "Why Try to Change Me Now",
+        normalizedTitle: "whytrytochangemenow",
+        singers: [
+          {
+            displayName: "Bass",
+            part: "Bass",
+            confidence: null,
+            arrangerName: "Unknown",
+          },
         ],
       },
     ]);

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -64,6 +64,7 @@ export type MatchTitleVariantSinger = {
   displayName: string;
   part: Part;
   confidence: Confidence | null;
+  arrangerName: string | null;
 };
 
 type InternalMatchResult = MatchResult & {
@@ -307,6 +308,7 @@ function buildTitleVariants(
       displayName: entry.displayName,
       part: assignedPart,
       confidence: confidenceForPart(entry, assignedPart),
+      arrangerName: entry.arrangerName?.trim() || null,
     };
 
     if (existing) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- carries arranger values on match title variant singer rows so the UI can associate arranger information with the relevant title/entry
- shows variant-level arranger labels when all rows under that title share the same arranger state
- shows per-singer arranger labels when the same displayed title has mixed arranger states
- suppresses the generic match-level arranger summary for fuzzy title variant details so the association is not obscured

Closes #231

## Verification
- npm run test:run
- npm run build

## Docs
No docs update: this is a focused display fix for existing match details behavior, covered by matching and component regression tests.