### PR TITLE
Reorganize Help page guidance

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -7,7 +7,7 @@ import {
   maxFeedbackMessageLength,
   type FeedbackType,
 } from "@/lib/feedback";
-import { helpSections, quickStartSteps } from "@/lib/helpContent";
+import { feedbackHelpCopy, helpGuideSections } from "@/lib/helpContent";
 import { getCurrentUser } from "@/lib/profileStore";
 import { useEffect, useState } from "react";
 
@@ -103,14 +103,14 @@ export default function HelpPage() {
           <p className="text-sm font-semibold uppercase text-cyan-300">
             Help
           </p>
-          <h1 className="mt-3 text-4xl font-bold tracking-tight">
-            Get started quickly
+          <h1 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+            How to use What Can We Sing
           </h1>
-          <p className="mt-3 max-w-2xl text-slate-300">
+          <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">
             What Can We Sing helps a pickup quartet quickly answer the question:
             what can we sing together right now?
           </p>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
+          <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">
             Each singer adds the songs they know, the voicing, the parts they
             can sing, and how confident they feel. When singers join the same
             quartet, the app compares everyone&apos;s repertoire and shows songs
@@ -118,32 +118,44 @@ export default function HelpPage() {
           </p>
         </header>
 
-        <section className="mt-8 rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-5">
-          <h2 className="text-2xl font-semibold">Quick start</h2>
-          <ol className="mt-4 space-y-3">
-            {quickStartSteps.map((step, index) => (
-              <li key={step} className="flex gap-3 text-slate-100">
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-300 text-sm font-bold text-slate-950">
-                  {index + 1}
-                </span>
-                <span className="pt-1">{step}</span>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        <section className="mt-8 grid gap-4 sm:grid-cols-2">
-          {helpSections.map((section) => (
+        <section className="mt-8 space-y-6">
+          {helpGuideSections.map((section) => (
             <article
               key={section.title}
-              className="rounded-xl border border-white/10 bg-white/10 p-5"
+              className="rounded-2xl border border-white/10 bg-white/10 p-5 sm:p-6"
             >
-              <h2 className="text-lg font-semibold text-white">
+              <p className="text-sm font-semibold uppercase text-cyan-300">
+                {section.eyebrow}
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">
                 {section.title}
               </h2>
-              <div className="mt-2 space-y-3 text-sm leading-6 text-slate-300">
-                {section.body.map((paragraph) => (
-                  <p key={paragraph}>{paragraph}</p>
+              <p className="mt-3 text-base leading-7 text-slate-300">
+                {section.intro}
+              </p>
+
+              <div className="mt-5 space-y-5">
+                {section.topics.map((topic) => (
+                  <section
+                    key={topic.title}
+                    className="rounded-xl border border-white/10 bg-slate-950/40 p-4"
+                  >
+                    <h3 className="text-lg font-semibold text-slate-100">
+                      {topic.title}
+                    </h3>
+                    <div className="mt-2 space-y-3 text-base leading-7 text-slate-300">
+                      {topic.body.map((paragraph) => (
+                        <p key={paragraph}>{paragraph}</p>
+                      ))}
+                    </div>
+                    {topic.bullets && (
+                      <ul className="mt-3 list-disc space-y-2 pl-5 text-base leading-7 text-slate-300">
+                        {topic.bullets.map((bullet) => (
+                          <li key={bullet}>{bullet}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
                 ))}
               </div>
             </article>
@@ -154,9 +166,7 @@ export default function HelpPage() {
           <div>
             <h2 className="text-2xl font-semibold">Send feedback</h2>
             <p className="mt-2 text-sm leading-6 text-slate-300">
-              Report a bug, describe confusing behavior, or suggest an
-              improvement. A short note about what you were trying to do and
-              what happened is usually enough.
+              {feedbackHelpCopy}
             </p>
           </div>
 

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { helpSections, quickStartSteps } from "../helpContent";
+import {
+  helpGuideSections,
+  helpSections,
+  feedbackHelpCopy,
+  quickStartSteps,
+} from "../helpContent";
 
 describe("help content", () => {
+  const guideText = helpGuideSections
+    .map((section) =>
+      [
+        section.eyebrow,
+        section.title,
+        section.intro,
+        ...section.topics.flatMap((topic) => [
+          topic.title,
+          ...topic.body,
+          ...(topic.bullets ?? []),
+        ]),
+      ].join(" ")
+    )
+    .join(" ");
+
   it("covers the core new-user flow", () => {
     expect(quickStartSteps.join(" ")).toContain("display name");
     expect(quickStartSteps.join(" ")).toContain("repertoire");
@@ -13,10 +33,49 @@ describe("help content", () => {
 
     expect(sectionText).toContain("pickup quartet");
     expect(sectionText).toContain("Start");
-    expect(sectionText).toContain("Join");
-    expect(sectionText).toContain("Possible Matches");
+    expect(sectionText).toContain("join");
+    expect(sectionText).toContain("Possible matches");
     expect(sectionText).toContain("display name");
-    expect(sectionText).toContain("Leave quartet");
-    expect(sectionText).toContain("feedback");
+    expect(sectionText).toContain("Leaving removes you");
+    expect(feedbackHelpCopy).toContain("Report a bug");
+    expect(feedbackHelpCopy).toContain("confusing behavior");
+  });
+
+  it("is organized into onboarding, repertoire, and quartet guidance", () => {
+    expect(helpGuideSections.map((section) => section.title)).toEqual([
+      "Get Singing Quickly",
+      "Manage What You Know",
+      "Understand What The Group Can Sing",
+    ]);
+
+    expect(guideText).toContain("First Time Setup");
+    expect(guideText).toContain("you do not need to enter your entire repertoire");
+    expect(guideText).toContain("Song title autocomplete");
+    expect(guideText).toContain("Suggestions are optional");
+    expect(guideText).toContain("does not add it to anyone else’s repertoire");
+    expect(guideText).toContain("TTBB means Tenor, Lead, Baritone, Bass");
+    expect(guideText).toContain("add it more than once");
+    expect(guideText).toContain("A singer may know multiple parts");
+    expect(guideText).toContain("each singer can only cover one required part");
+    expect(guideText).toContain("No arranger entered");
+    expect(guideText).toContain("Unknown");
+    expect(guideText).toContain("Notes are for your own memory");
+    expect(guideText).toContain("Recently sung helps you remember");
+    expect(guideText).toContain("sort by title");
+    expect(guideText).toContain("Never sung");
+  });
+
+  it("explains quartet match details and management", () => {
+    expect(guideText).toContain("Ready to Sing");
+    expect(guideText).toContain("Possible matches");
+    expect(guideText).toContain("voicing, required part coverage");
+    expect(guideText).toContain("distinct singers");
+    expect(guideText).toContain("Title variants");
+    expect(guideText).toContain("arranger differences");
+    expect(guideText).toContain("Open a match to see who is covering which part");
+    expect(guideText).toContain("use Manage to see quartet members");
+    expect(guideText).toContain("edit repertoire");
+    expect(guideText).toContain("Leaving removes you from the active quartet");
+    expect(guideText).toContain("you can rejoin normally");
   });
 });

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -3,76 +3,175 @@ export type HelpSection = {
   body: string[];
 };
 
+export type HelpTopic = {
+  title: string;
+  body: string[];
+  bullets?: string[];
+};
+
+export type HelpGuideSection = {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  topics: HelpTopic[];
+};
+
 export const quickStartSteps = [
-  "Add your display name. This is the name other singers will see in the quartet.",
-  "Add your repertoire. Add the songs you know, choose the voicing, select the parts you can sing, and set your confidence.",
-  "Start or join a quartet. One singer can start a quartet and share the code, QR code, or link. Other singers can join from their phones.",
-  "Pick a match and sing. Use the match list to find songs the quartet can sing together right now.",
+  "Add your display name so other singers know who is in the quartet.",
+  "Add a few songs you are likely to sing. You do not need to enter your entire repertoire before starting.",
+  "For each song, choose the voicing and every part you can sing for that arrangement.",
+  "Start a quartet or join someone else with a code, QR code, or shared link.",
+  "Use Matches to pick something everyone can sing right now.",
 ] as const;
 
-export const helpSections: HelpSection[] = [
+export const helpGuideSections: HelpGuideSection[] = [
   {
-    title: "What Is This App For?",
-    body: [
-      "This app is built for informal barbershop singing: rehearsals, afterglows, conventions, hospitality rooms, and any other time a pickup quartet wants to find something to sing.",
-      "It is not trying to be a perfect music library. It is meant to be fast, forgiving, and useful in the moment.",
+    eyebrow: "First Time Setup",
+    title: "Get Singing Quickly",
+    intro:
+      "If you are using the app for the first time, you do not need to enter your entire repertoire. Add a few songs you are likely to sing, join a quartet, and add more as you go.",
+    topics: [
+      {
+        title: "The basic flow",
+        body: [
+          "What Can We Sing is built for informal barbershop singing: rehearsals, afterglows, conventions, hospitality rooms, and any time a pickup quartet wants to find something to sing.",
+          "Set your display name, add songs you know, then start or join a quartet. The match list answers the practical question: what can we sing together right now?",
+        ],
+        bullets: [...quickStartSteps],
+      },
+      {
+        title: "Keep setup lightweight",
+        body: [
+          "Start with songs you are likely to sing soon. You can add more repertoire later, and if you are already in a quartet, repertoire edits refresh your active quartet snapshot so matches can update.",
+        ],
+      },
     ],
   },
   {
-    title: "Add Your Repertoire",
-    body: [
-      "Use Repertoire to add songs you know. For each song, choose the voicing, select the part or parts you can sing, and set your confidence.",
-      "You can edit your repertoire later. If you are already in an active quartet, your updated repertoire can refresh your quartet snapshot so the match list stays current.",
+    eyebrow: "Repertoire",
+    title: "Manage What You Know",
+    intro:
+      "The Repertoire page stores your songs, voicings, parts, confidence, arranger information, notes, and recently sung history.",
+    topics: [
+      {
+        title: "Song title autocomplete",
+        body: [
+          "Start typing to see suggestions. Suggestions are optional — you can always enter your own song title if the song is not listed or if your title is different.",
+          "Selecting a suggestion can prefill title, voicing, and arranger. You can still edit the fields before saving.",
+        ],
+      },
+      {
+        title: "How suggestions are shared",
+        body: [
+          "When you add a song, its title, voicing, and arranger can help future singers find the same song faster. Adding a song does not add it to anyone else’s repertoire.",
+          "Suggestions do not expose private user details such as user IDs, singer names, notes, parts, confidence, timestamps, or your full personal repertoire.",
+        ],
+      },
+      {
+        title: "Voicing",
+        body: [
+          "Choose the voicing for the arrangement you know. TTBB means Tenor, Lead, Baritone, Bass. SSAA means Soprano 1, Soprano 2, Alto 1, Alto 2. SATB means Soprano, Alto, Tenor, Bass.",
+          "If you know the same song in more than one voicing, add it more than once — one entry for each voicing.",
+        ],
+      },
+      {
+        title: "Parts and confidence",
+        body: [
+          "Select every part you can sing for that arrangement and set your confidence for each part.",
+          "A singer may know multiple parts, but in a quartet match each singer can only cover one required part. The app looks for distinct singers covering the required parts.",
+        ],
+      },
+      {
+        title: "Arranger",
+        body: [
+          "Arranger is helpful when the same song exists in multiple arrangements. It gives the quartet context, but missing arranger information does not automatically prevent a match.",
+          "Leaving arranger blank means No arranger entered. Typing Unknown is treated as an entered value and stays visible as Unknown.",
+        ],
+      },
+      {
+        title: "Notes",
+        body: [
+          "Notes are for your own memory — for example, version reminders, tags, first words, key, or tricky spots. They help you manage your repertoire but are not used to decide whether the quartet can sing a song.",
+        ],
+      },
+      {
+        title: "Recently sung",
+        body: [
+          "Recently sung helps you remember what you have sung lately. It can help you sort or filter your repertoire, but it does not remove the song from your repertoire or from possible matches.",
+        ],
+      },
+      {
+        title: "Sorting and filtering",
+        body: [
+          "Use search to filter by title. You can sort by title, newest or oldest added, sung recently, or least recently sung.",
+          "You can filter by voicing, part, and Never sung. Active filters appear above the song list and can be cleared together.",
+        ],
+      },
     ],
   },
   {
-    title: "Start A Quartet",
-    body: [
-      "Use Start when you want to create a new quartet. The app will create a quartet code that other singers can use to join.",
-      "Other singers can join by entering the code, scanning the QR code, or opening the shared link.",
-    ],
-  },
-  {
-    title: "Join A Quartet",
-    body: [
-      "Use Join when another singer has already started a quartet. Enter the code they give you, or use the QR code or shared link.",
-      "When you join, your saved repertoire is loaded into that quartet so the app can look for matches.",
-    ],
-  },
-  {
-    title: "Reading The Match List",
-    body: [
-      "A match appears when the quartet has different singers covering the required parts for the same song and voicing.",
-      "For example, a TTBB song needs Tenor, Lead, Baritone, and Bass covered by four distinct singers. One singer may know multiple parts, but a valid quartet match only uses each singer once.",
-    ],
-  },
-  {
-    title: "Possible Matches",
-    body: [
-      "Sometimes the app may show a possible match instead of a clean match. This can happen when song titles are slightly different or the same song may exist in more than one arrangement.",
-      "Missing arranger information is shown as context, not as a problem. Similar arranger names such as a full name, first initial, or last name only may be shown so the quartet can quickly confirm they refer to the same arranger.",
-      "Use the match details to compare what each singer has entered. If the titles or arrangement details do not match, check with the quartet before singing.",
-    ],
-  },
-  {
-    title: "Update Your Songs Or Name",
-    body: [
-      "Use Repertoire to add, edit, or delete songs. Use Change my display name or Profile to update the name other singers see.",
-      "If something looks wrong in a match, the first thing to check is usually whether the song title, voicing, part, or arranger is entered consistently in everyone's repertoire.",
-    ],
-  },
-  {
-    title: "Leaving Or Being Removed",
-    body: [
-      "Use Leave quartet when you want to remove yourself from the active quartet.",
-      "If another singer removes you from a quartet, you will be returned to the join flow. You can rejoin with the code if that is what the group wants and there is still room.",
-    ],
-  },
-  {
-    title: "Feedback And Problems",
-    body: [
-      "If something is confusing, broken, or missing, please send feedback from this page.",
-      "A short note about what you were trying to do and what happened is usually enough.",
+    eyebrow: "Quartet Matches",
+    title: "Understand What The Group Can Sing",
+    intro:
+      "The quartet page compares the current participant snapshots and groups matches by how ready they are to sing.",
+    topics: [
+      {
+        title: "Ready to Sing",
+        body: [
+          "Ready to Sing matches are the cleanest matches. All required parts are covered, and the app assigns distinct singers to distinct required parts.",
+          "For example, TTBB needs Tenor, Lead, Baritone, and Bass covered by four different singers.",
+        ],
+      },
+      {
+        title: "Possible matches",
+        body: [
+          "Possible matches are not necessarily bad. They may involve slightly different titles, missing arranger information, or possible arrangement differences.",
+          "The quartet should quickly confirm the details before singing.",
+        ],
+      },
+      {
+        title: "What matters most",
+        body: [
+          "The strongest signals are voicing, required part coverage, and distinct singers for the required parts. Different voicings are not combined.",
+          "Title variants, arranger differences, missing arranger information, confidence, and notes are context to help the quartet decide quickly. They are not all automatic blockers.",
+        ],
+      },
+      {
+        title: "Match details",
+        body: [
+          "Open a match to see who is covering which part, what is missing if anything, which title variants are involved, and which arranger values singers entered.",
+          "Personal notes can appear in details to remind you about your own version or caveats.",
+        ],
+      },
+      {
+        title: "Managing the quartet",
+        body: [
+          "When the quartet is full, use Manage to see quartet members, edit repertoire, change your name, or leave the quartet.",
+          "If a song title, voicing, part, arranger, notes, or confidence looks wrong, update it from Repertoire. If the name shown to others is wrong, use Change name.",
+        ],
+      },
+      {
+        title: "Leaving and rejoining",
+        body: [
+          "Leaving removes you from the active quartet. If there is room and you still have the code or link, you can rejoin normally.",
+          "If another singer removes you, your screen should stop treating that quartet as active.",
+        ],
+      },
     ],
   },
 ];
+
+export const feedbackHelpCopy =
+  "Report a bug, describe confusing behavior, or suggest an improvement. A short note about what you were trying to do and what happened is usually enough.";
+
+export const helpSections: HelpSection[] = helpGuideSections.map((section) => ({
+  title: section.title,
+  body: [
+    section.intro,
+    ...section.topics.flatMap((topic) => [
+      topic.title,
+      ...topic.body,
+      ...(topic.bullets ?? []),
+    ]),
+  ],
+}));


### PR DESCRIPTION
## Summary
- reorganizes Help into larger onboarding, repertoire, and quartet match guidance sections
- expands Repertoire guidance for autocomplete, shared suggestion privacy, voicing, parts, arranger, notes, recently sung, and sorting/filtering
- expands quartet guidance for Ready to Sing, possible matches, match details, Manage panel, updating info, leaving, and rejoining
- keeps the feedback form and shared feedback copy connected to the redesigned page
- updates help content tests for the new structure and key guidance

Closes #244

## Verification
- npm run test:run
- npm run build

## Docs
No separate docs update: this issue updates the user-facing Help page itself, and the app-flow behavior referenced here already matches existing docs/app behavior.