### PR TITLE
Show public nav on Help and Privacy when signed out

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AppNav } from "@/components/AppNav";
+import { PublicAwareAppNav } from "@/components/PublicAwareAppNav";
 import { trackEvent } from "@/lib/analytics";
 import {
   feedbackTypes,
@@ -97,7 +97,7 @@ export default function HelpPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
       <div className="mx-auto max-w-4xl">
-        <AppNav />
+        <PublicAwareAppNav />
 
         <header className="mt-8">
           <p className="text-sm font-semibold uppercase text-cyan-300">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,10 +1,10 @@
-import { AppNav } from "@/components/AppNav";
+import { PublicAwareAppNav } from "@/components/PublicAwareAppNav";
 
 export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
       <div className="mx-auto max-w-3xl">
-        <AppNav />
+        <PublicAwareAppNav />
 
         <h1 className="mt-8 text-4xl font-bold tracking-tight">Privacy</h1>
         <p className="mt-3 text-lg text-slate-300">

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -36,8 +36,33 @@ const secondaryNavItems = [
   },
 ];
 
-export function AppNav() {
+type AppNavProps = {
+  variant?: "app" | "public";
+};
+
+export function AppNav({ variant = "app" }: AppNavProps) {
   const pathname = usePathname();
+
+  if (variant === "public") {
+    return (
+      <nav
+        aria-label="Main navigation"
+        className="rounded-2xl border border-white/10 bg-white/10 p-3"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <a href="/" className="text-sm font-bold uppercase text-cyan-300">
+            What Can We Sing
+          </a>
+          <a
+            href="/login"
+            className="rounded-xl bg-cyan-300 px-4 py-2 text-center text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+          >
+            Log in or sign up
+          </a>
+        </div>
+      </nav>
+    );
+  }
 
   return (
     <nav

--- a/components/PublicAwareAppNav.tsx
+++ b/components/PublicAwareAppNav.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AppNav } from "@/components/AppNav";
+import { getCurrentUser } from "@/lib/profileStore";
+
+export function PublicAwareAppNav() {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadAuthState() {
+      try {
+        const user = await getCurrentUser();
+
+        if (isMounted) {
+          setIsSignedIn(Boolean(user));
+        }
+      } catch (err) {
+        console.error("Could not load navigation auth state", err);
+
+        if (isMounted) {
+          setIsSignedIn(false);
+        }
+      }
+    }
+
+    loadAuthState();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return <AppNav variant={isSignedIn ? "app" : "public"} />;
+}

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -8,9 +8,9 @@ const privacyPage = readFileSync(
 );
 
 describe("privacy page copy", () => {
-  it("uses the shared app navigation", () => {
-    expect(privacyPage).toContain('import { AppNav }');
-    expect(privacyPage).toContain("<AppNav />");
+  it("uses auth-aware public navigation", () => {
+    expect(privacyPage).toContain('import { PublicAwareAppNav }');
+    expect(privacyPage).toContain("<PublicAwareAppNav />");
   });
 
   it("discloses account, repertoire, quartet, feedback, analytics, and providers", () => {

--- a/lib/__tests__/publicNavigation.test.ts
+++ b/lib/__tests__/publicNavigation.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const appNav = readFileSync(join(repoRoot, "components/AppNav.tsx"), "utf8");
+const publicAwareAppNav = readFileSync(
+  join(repoRoot, "components/PublicAwareAppNav.tsx"),
+  "utf8"
+);
+const helpPage = readFileSync(join(repoRoot, "app/help/page.tsx"), "utf8");
+const privacyPage = readFileSync(
+  join(repoRoot, "app/privacy/page.tsx"),
+  "utf8"
+);
+
+describe("public page navigation", () => {
+  it("has a public AppNav variant with a login action and no quartet widget", () => {
+    const publicVariant = appNav.slice(
+      appNav.indexOf('if (variant === "public")'),
+      appNav.indexOf("\n\n  return (", appNav.indexOf('if (variant === "public")'))
+    );
+
+    expect(appNav).toContain('variant?: "app" | "public"');
+    expect(publicVariant).toContain('href="/login"');
+    expect(publicVariant).toContain("Log in or sign up");
+    expect(publicVariant).not.toContain("ActiveQuartetIndicator");
+  });
+
+  it("defaults public pages to public navigation until a signed-in user is confirmed", () => {
+    expect(publicAwareAppNav).toContain("getCurrentUser");
+    expect(publicAwareAppNav).toContain(
+      '<AppNav variant={isSignedIn ? "app" : "public"} />'
+    );
+    expect(helpPage).toContain("<PublicAwareAppNav />");
+    expect(privacyPage).toContain("<PublicAwareAppNav />");
+  });
+});


### PR DESCRIPTION
## Summary
- add a public AppNav variant with a `Log in or sign up` action
- use an auth-aware nav wrapper on Help and Privacy so signed-out users do not see active-quartet controls
- add tests covering the public navigation wiring and privacy page nav behavior

Closes #246

## Verification
- `npm run test:run`
- `npm run build`