### PR TITLE
Add login help link and compact quartet status copy

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1356,8 +1356,6 @@ export default function JoinSessionPage() {
               <details className="group mt-4 rounded-2xl border border-white/10 bg-white/10 p-3 open:p-4">
                 <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
                   <p className="min-w-0 truncate text-sm font-semibold text-slate-200">
-                    Quartet full
-                    <span className="px-1 text-slate-500">·</span>
                     {isCurrentUserParticipant ? (
                       <>
                         Singing as{" "}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -182,8 +182,15 @@ export default function LoginPage() {
           {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
         </div>
 
-        <p className="mt-5 text-sm text-slate-400">
-          See what data is stored and why on the{" "}
+        <p className="mt-5 text-sm leading-6 text-slate-400">
+          New here?{" "}
+          <a
+            href="/help"
+            className="font-semibold text-cyan-300 hover:text-cyan-200"
+          >
+            Read how the app works
+          </a>
+          . See what data is stored and why on the{" "}
           <a
             href="/privacy"
             className="font-semibold text-cyan-300 hover:text-cyan-200"

--- a/lib/__tests__/loginContent.test.ts
+++ b/lib/__tests__/loginContent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { loginIntro } from "../loginContent";
+
+const loginPage = readFileSync(join(process.cwd(), "app/login/page.tsx"), "utf8");
 
 describe("login intro content", () => {
   it("explains the product before asking new users to sign in", () => {
@@ -10,5 +14,10 @@ describe("login intro content", () => {
     expect(copy).toContain("songs they know");
     expect(copy).toContain("parts they can sing");
     expect(copy).toContain("Sign in to save your repertoire");
+  });
+
+  it("links new users to help before they sign in", () => {
+    expect(loginPage).toContain('href="/help"');
+    expect(loginPage).toContain("Read how the app works");
   });
 });

--- a/lib/__tests__/quartetManagePanel.test.ts
+++ b/lib/__tests__/quartetManagePanel.test.ts
@@ -9,13 +9,13 @@ const joinPage = readFileSync(
 
 describe("quartet manage panel markup", () => {
   it("keeps the full-quartet status compact with manage actions and members", () => {
-    expect(joinPage).toContain("Quartet full");
     expect(joinPage).toContain("Singing as");
     expect(joinPage).toContain("Manage");
     expect(joinPage).toContain("Members");
     expect(joinPage).toContain("Edit Repertoire");
     expect(joinPage).toContain("Leave Quartet");
     expect(joinPage).toContain("showCurrentParticipantActions: false");
+    expect(joinPage).not.toContain("Quartet full");
     expect(joinPage).not.toContain("Quartet is full");
     expect(joinPage).not.toContain("Quartet members");
     expect(joinPage).not.toContain("Change my display name");


### PR DESCRIPTION
## Summary
- add a Help link on the login page for new users who want to read how the app works
- remove redundant `Quartet full` text from the compact full-quartet status bar so `Singing as [name]` has more room
- update tests for the login Help link and compact status copy

Closes #247

## Verification
- `npm run test:run`
- `npm run build`