### PR TITLE
Fix PostHog dashboard breakdown queries

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -104,6 +104,9 @@ The sync script is idempotent by dashboard and insight name:
 - missing dashboards and insights are created
 - insights are created with PostHog query objects rather than legacy insight
   filters
+- event-property breakdowns are generated with PostHog query `breakdowns`
+  entries, for example the `Top routes` card groups `app_route_viewed` by the
+  `route` event property
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.
@@ -139,7 +142,9 @@ When dashboards are empty, check these in order:
    load should show `analytics_client_ready` and `app_route_viewed`.
 5. If Live Events shows app events but dashboard cards are empty, re-run
    `npm run posthog:dashboards:sync` with the correct
-   `POSTHOG_ENVIRONMENT_ID`.
+   `POSTHOG_ENVIRONMENT_ID`. The managed insights depend on the script's
+   current query-object format, including event-property `breakdowns` for cards
+   such as `Top routes`.
 6. If Live Events shows no events but `/api/analytics/status` is configured,
    check the browser network tab for blocked requests to the configured PostHog
    host. Ad blockers and privacy browsers can suppress analytics completely.

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { queryForInsight } from "../../scripts/posthog/sync-dashboards.mjs";
+
+describe("PostHog dashboard query generation", () => {
+  it("uses PostHog query breakdowns for event-property trend breakdowns", () => {
+    expect(
+      queryForInsight({
+        key: "top-routes",
+        name: "Top routes",
+        type: "trend",
+        dateFrom: "-30d",
+        breakdown: "route",
+        series: [{ event: "app_route_viewed" }],
+      })
+    ).toMatchObject({
+      kind: "TrendsQuery",
+      dateRange: {
+        date_from: "-30d",
+      },
+      series: [
+        {
+          kind: "EventsNode",
+          event: "app_route_viewed",
+          math: "total",
+        },
+      ],
+      breakdownFilter: {
+        breakdowns: [
+          {
+            property: "route",
+            type: "event",
+          },
+        ],
+      },
+    });
+  });
+
+  it("keeps browser and device breakdowns in the same query shape", () => {
+    expect(
+      queryForInsight({
+        key: "join-flow-by-device",
+        name: "Join flow by device",
+        type: "trend",
+        breakdown: "$device_type",
+        series: [{ event: "quartet_joined" }],
+      })
+    ).toMatchObject({
+      breakdownFilter: {
+        breakdowns: [
+          {
+            property: "$device_type",
+            type: "event",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -3,7 +3,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "../..");
@@ -81,6 +81,27 @@ function validateSpec(spec) {
         throw new Error(`Unsupported insight type for ${insight.key}.`);
       }
 
+      if (insight.breakdown && insight.breakdowns) {
+        throw new Error(
+          `Insight ${insight.key} must use either breakdown or breakdowns, not both.`
+        );
+      }
+
+      if (insight.breakdowns) {
+        const breakdowns = asArray(
+          insight.breakdowns,
+          `Insight ${insight.key} breakdowns must be an array.`
+        );
+
+        for (const breakdown of breakdowns) {
+          if (!breakdown.property) {
+            throw new Error(
+              `Insight ${insight.key} has a breakdown without property.`
+            );
+          }
+        }
+      }
+
       const series = asArray(
         insight.series,
         `Insight ${insight.key} must include event series.`
@@ -116,7 +137,27 @@ function eventToQueryNode(event) {
   return node;
 }
 
-function queryForInsight(insight) {
+function breakdownsForInsight(insight) {
+  if (insight.breakdowns) {
+    return insight.breakdowns.map((breakdown) => ({
+      property: breakdown.property,
+      type: breakdown.type || "event",
+    }));
+  }
+
+  if (!insight.breakdown) {
+    return [];
+  }
+
+  return [
+    {
+      property: insight.breakdown,
+      type: insight.breakdownType || "event",
+    },
+  ];
+}
+
+export function queryForInsight(insight) {
   const query = {
     kind: insight.type === "funnel" ? "FunnelsQuery" : "TrendsQuery",
     dateRange: {
@@ -129,10 +170,10 @@ function queryForInsight(insight) {
     query.interval = insight.interval;
   }
 
-  if (insight.breakdown) {
+  const breakdowns = breakdownsForInsight(insight);
+  if (breakdowns.length > 0) {
     query.breakdownFilter = {
-      breakdown: insight.breakdown,
-      breakdown_type: "event",
+      breakdowns,
     };
   }
 
@@ -264,7 +305,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- update the PostHog dashboard sync script to generate event-property breakdowns using PostHog query `breakdowns` entries
- cover `Top routes` / `app_route_viewed` route grouping and browser/device breakdowns with regression tests
- document the managed dashboard breakdown query shape and troubleshooting step

Closes #250

## Verification
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Post-merge step
After this merges, re-run:

```sh
npm run posthog:dashboards:sync
```

Then refresh the managed dashboards in PostHog. Existing `app_route_viewed` events with a `route` property should populate `Top routes` for the selected date range.