### PR TITLE
Set intentional PostHog dashboard displays

### DIFF
--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -12,6 +12,7 @@
           "name": "Daily active users",
           "description": "Distinct signed-in users seen each day.",
           "type": "trend",
+          "display": "ActionsLineGraph",
           "dateFrom": "-30d",
           "series": [{ "event": "user_logged_in", "math": "dau" }]
         },
@@ -20,6 +21,7 @@
           "name": "Analytics client ready",
           "description": "Browser sessions where the configured PostHog client accepted its first app event.",
           "type": "trend",
+          "display": "BoldNumber",
           "dateFrom": "-30d",
           "series": [{ "event": "analytics_client_ready" }]
         },
@@ -28,6 +30,7 @@
           "name": "Weekly active users",
           "description": "Distinct signed-in users seen each week.",
           "type": "trend",
+          "display": "ActionsLineGraph",
           "dateFrom": "-12w",
           "interval": "week",
           "series": [{ "event": "user_logged_in", "math": "weekly_active" }]
@@ -37,6 +40,7 @@
           "name": "Quartet activity",
           "description": "Quartets created, joined, left, and rejoined.",
           "type": "trend",
+          "display": "ActionsLineGraph",
           "dateFrom": "-30d",
           "series": [
             { "event": "quartet_created" },
@@ -50,6 +54,7 @@
           "name": "Quartets reaching full state",
           "description": "Quartets with four participants.",
           "type": "trend",
+          "display": "BoldNumber",
           "dateFrom": "-30d",
           "series": [{ "event": "quartet_full" }]
         },
@@ -58,6 +63,7 @@
           "name": "Feedback submissions",
           "description": "Feedback sent successfully by category.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "category",
           "series": [{ "event": "feedback_submitted" }]
@@ -67,6 +73,7 @@
           "name": "Top routes",
           "description": "Route visits with join codes normalized to /join/[code].",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "route",
           "series": [{ "event": "app_route_viewed" }]
@@ -128,6 +135,7 @@
           "name": "Create vs join route",
           "description": "Quartet joins by route context.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "route",
           "series": [{ "event": "quartet_joined" }]
@@ -144,6 +152,7 @@
           "name": "Repertoire updates",
           "description": "Add, edit, and delete activity.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "action",
           "series": [{ "event": "repertoire_updated" }]
@@ -153,6 +162,7 @@
           "name": "Average songs per participant snapshot",
           "description": "Average song count reported when singers join or refresh a quartet snapshot.",
           "type": "trend",
+          "display": "ActionsLineGraph",
           "dateFrom": "-30d",
           "series": [
             { "event": "quartet_joined", "math": "avg", "mathProperty": "song_count" },
@@ -164,6 +174,7 @@
           "name": "Matches generated",
           "description": "Total and ready/possible/missing-part match counts.",
           "type": "trend",
+          "display": "ActionsLineGraph",
           "dateFrom": "-30d",
           "series": [
             { "event": "matches_generated", "math": "avg", "mathProperty": "match_count" },
@@ -177,6 +188,7 @@
           "name": "Full quartets with zero matches",
           "description": "Quartets that reached four singers but generated no matches.",
           "type": "trend",
+          "display": "BoldNumber",
           "dateFrom": "-30d",
           "series": [{ "event": "zero_matches_found" }]
         }
@@ -192,6 +204,7 @@
           "name": "Join errors",
           "description": "Quartet join failures by reason.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "reason",
           "series": [{ "event": "quartet_join_failed" }]
@@ -201,6 +214,7 @@
           "name": "Leave errors",
           "description": "Quartet leave failures by source.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "source",
           "series": [{ "event": "quartet_leave_failed" }]
@@ -210,6 +224,7 @@
           "name": "Repertoire update errors",
           "description": "Repertoire update failures by action.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "action",
           "series": [{ "event": "repertoire_update_failed" }]
@@ -219,6 +234,7 @@
           "name": "Feedback errors",
           "description": "Feedback send failures.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "category",
           "series": [{ "event": "feedback_failed" }]
@@ -228,6 +244,7 @@
           "name": "Mark sung errors",
           "description": "Failures when marking a match as recently sung.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "voicing",
           "series": [{ "event": "song_mark_sung_failed" }]
@@ -244,6 +261,7 @@
           "name": "Leave flow by browser",
           "description": "Leave clicks, confirmations, successes, and failures by browser.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "$browser",
           "series": [
@@ -258,6 +276,7 @@
           "name": "Join flow by device",
           "description": "Join attempts, successes, and failures by device type.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "$device_type",
           "series": [
@@ -271,6 +290,7 @@
           "name": "Key actions on browser/OS combinations",
           "description": "Useful for Brave on iOS and Chrome on Mac compatibility checks.",
           "type": "trend",
+          "display": "ActionsBarValue",
           "dateFrom": "-30d",
           "breakdown": "$browser",
           "series": [

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -107,6 +107,10 @@ The sync script is idempotent by dashboard and insight name:
 - event-property breakdowns are generated with PostHog query `breakdowns`
   entries, for example the `Top routes` card groups `app_route_viewed` by the
   `route` event property
+- trend insights include explicit display types so dashboard cards sync into
+  the intended presentation: line graphs for time-series trends, bold numbers
+  for single health counters, and bar-value charts for route/category/browser
+  breakdowns
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -8,6 +8,7 @@ describe("PostHog dashboard query generation", () => {
         key: "top-routes",
         name: "Top routes",
         type: "trend",
+        display: "ActionsBarValue",
         dateFrom: "-30d",
         breakdown: "route",
         series: [{ event: "app_route_viewed" }],
@@ -32,6 +33,9 @@ describe("PostHog dashboard query generation", () => {
           },
         ],
       },
+      trendsFilter: {
+        display: "ActionsBarValue",
+      },
     });
   });
 
@@ -41,6 +45,7 @@ describe("PostHog dashboard query generation", () => {
         key: "join-flow-by-device",
         name: "Join flow by device",
         type: "trend",
+        display: "ActionsBarValue",
         breakdown: "$device_type",
         series: [{ event: "quartet_joined" }],
       })

--- a/lib/__tests__/posthogDashboardSpec.test.ts
+++ b/lib/__tests__/posthogDashboardSpec.test.ts
@@ -15,6 +15,7 @@ const dashboardSpec = JSON.parse(
       key: string;
       name: string;
       type: string;
+      display?: string;
       series: Array<{ event: string }>;
     }>;
   }>;
@@ -72,5 +73,29 @@ describe("PostHog dashboard spec", () => {
     for (const event of dashboardEvents) {
       expect(emittedEvents.has(event)).toBe(true);
     }
+  });
+
+  it("sets an intentional display for every managed trend insight", () => {
+    const trendInsights = dashboardSpec.dashboards.flatMap((dashboard) =>
+      dashboard.insights.filter((insight) => insight.type === "trend")
+    );
+
+    expect(trendInsights.every((insight) => Boolean(insight.display))).toBe(
+      true
+    );
+
+    expect(
+      Object.fromEntries(
+        trendInsights.map((insight) => [insight.key, insight.display])
+      )
+    ).toMatchObject({
+      "analytics-client-ready": "BoldNumber",
+      "feedback-submissions": "ActionsBarValue",
+      "top-routes": "ActionsBarValue",
+      "join-by-route": "ActionsBarValue",
+      "repertoire-updates": "ActionsBarValue",
+      "join-errors": "ActionsBarValue",
+      "leave-flow-by-browser": "ActionsBarValue",
+    });
   });
 });

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -11,6 +11,15 @@ const specPath = path.join(repoRoot, "analytics/posthog/dashboards.json");
 
 const args = new Set(process.argv.slice(2));
 const checkOnly = args.has("--check");
+const trendDisplayTypes = new Set([
+  "ActionsLineGraph",
+  "ActionsTable",
+  "ActionsPie",
+  "ActionsBar",
+  "ActionsBarValue",
+  "WorldMap",
+  "BoldNumber",
+]);
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -79,6 +88,15 @@ function validateSpec(spec) {
 
       if (!["trend", "funnel"].includes(insight.type)) {
         throw new Error(`Unsupported insight type for ${insight.key}.`);
+      }
+
+      if (
+        insight.type === "trend" &&
+        (!insight.display || !trendDisplayTypes.has(insight.display))
+      ) {
+        throw new Error(
+          `Trend insight ${insight.key} must include a supported display.`
+        );
       }
 
       if (insight.breakdown && insight.breakdowns) {
@@ -168,6 +186,12 @@ export function queryForInsight(insight) {
 
   if (insight.interval) {
     query.interval = insight.interval;
+  }
+
+  if (insight.type === "trend" && insight.display) {
+    query.trendsFilter = {
+      display: insight.display,
+    };
   }
 
   const breakdowns = breakdownsForInsight(insight);


### PR DESCRIPTION
## Summary
- assign explicit display types to every managed PostHog trend insight
- sync time-series cards as line graphs, single health counters as bold numbers, and route/category/action/browser breakdowns as bar-value charts
- make the dashboard spec check fail if a future trend insight is added without an intentional display
- document the dashboard display strategy

## Dashboard display audit
- Product Health: active-user and quartet-activity trends stay line graphs; client-ready/full-quartet counters are bold numbers; feedback and top-route breakdowns are bar-value charts.
- Quartet Funnel: funnel cards remain native funnel insights; create-vs-join route breakdown is a bar-value chart.
- Repertoire & Matching: repertoire actions are bar-value, snapshot and match-count trends stay line graphs, zero-match count is a bold number.
- Reliability / Errors: all error breakdowns are bar-value charts for quick scanning by reason/source/action/category/voicing.
- Browser / Mobile Compatibility: browser/device breakdowns are bar-value charts rather than default line charts.

## Verification
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Post-merge step
After this merges, re-run:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_ENVIRONMENT_ID=400013 \
POSTHOG_HOST=https://us.posthog.com \
npm run posthog:dashboards:sync
```

Then refresh the managed dashboards in PostHog.