### PR TITLE
Refresh PostHog dashboard results during sync

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -111,6 +111,9 @@ The sync script is idempotent by dashboard and insight name:
   the intended presentation: line graphs for time-series trends, bold numbers
   for single health counters, and bar-value charts for route/category/browser
   breakdowns
+- after every create or update, the sync script force-refreshes the saved
+  insight in the dashboard context so dashboard tiles have rendered results
+  without needing each card to be opened manually
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -93,6 +93,43 @@ POSTHOG_ENVIRONMENT_ID=... \
 npm run posthog:dashboards:sync
 ```
 
+For a narrow local test loop, sync only one or two sandbox cards instead of the
+full managed dashboard set:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:sync -- --sandbox --only top-routes,analytics-client-ready
+```
+
+This creates or updates `What Can We Sing - Dashboard Sync Sandbox` with
+`Sandbox - ...` insight names so production dashboard cards are not overwritten
+while testing query shape and display settings.
+
+Inspect a saved dashboard or insight directly from PostHog:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:inspect -- --dashboard "What Can We Sing - Product Health"
+
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:inspect -- --insight "Top routes"
+```
+
+Compare a repo-managed insight against a manually edited working insight:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:compare -- --left "Top routes" --right "Manual working Top routes"
+```
+
 `POSTHOG_PROJECT_ID` is accepted as a fallback name for older PostHog docs, but
 `POSTHOG_ENVIRONMENT_ID` matches the current PostHog dashboard and insight API
 paths.
@@ -102,14 +139,19 @@ The sync script is idempotent by dashboard and insight name:
 - existing dashboards are patched by exact name
 - existing insights are patched by exact name
 - missing dashboards and insights are created
+- `--only insight-key-1,insight-key-2` limits sync to selected insight keys
+- `--sandbox` writes selected cards to the dashboard sync sandbox and prefixes
+  insight names with `Sandbox -`
 - insights are created with PostHog query objects rather than legacy insight
   filters
 - event-property breakdowns are generated with PostHog query `breakdowns`
   entries, for example the `Top routes` card groups `app_route_viewed` by the
   `route` event property
+- trend insights are saved as PostHog visualization nodes that wrap their
+  source trend/funnel query, matching the shape created by the PostHog UI
 - trend insights include explicit display types so dashboard cards sync into
   the intended presentation: line graphs for time-series trends, bold numbers
-  for single health counters, and bar-value charts for route/category/browser
+  for single health counters, and bar charts for route/category/browser
   breakdowns
 - after every create or update, the sync script force-refreshes the saved
   insight in the dashboard context so dashboard tiles have rendered results

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -2,42 +2,47 @@ import { describe, expect, it } from "vitest";
 import {
   insightRefreshEndpoint,
   queryForInsight,
+  sandboxDashboardFromSpec,
+  selectInsightEntries,
 } from "../../scripts/posthog/sync-dashboards.mjs";
 
 describe("PostHog dashboard query generation", () => {
-  it("uses PostHog query breakdowns for event-property trend breakdowns", () => {
+  it("wraps trend query sources in a dashboard-renderable visualization node", () => {
     expect(
       queryForInsight({
         key: "top-routes",
         name: "Top routes",
         type: "trend",
-        display: "ActionsBarValue",
+        display: "ActionsBar",
         dateFrom: "-30d",
         breakdown: "route",
         series: [{ event: "app_route_viewed" }],
       })
     ).toMatchObject({
-      kind: "TrendsQuery",
-      dateRange: {
-        date_from: "-30d",
-      },
-      series: [
-        {
-          kind: "EventsNode",
-          event: "app_route_viewed",
-          math: "total",
+      kind: "InsightVizNode",
+      source: {
+        kind: "TrendsQuery",
+        dateRange: {
+          date_from: "-30d",
         },
-      ],
-      breakdownFilter: {
-        breakdowns: [
+        series: [
           {
-            property: "route",
-            type: "event",
+            kind: "EventsNode",
+            event: "app_route_viewed",
+            math: "total",
           },
         ],
-      },
-      trendsFilter: {
-        display: "ActionsBarValue",
+        breakdownFilter: {
+          breakdowns: [
+            {
+              property: "route",
+              type: "event",
+            },
+          ],
+        },
+        trendsFilter: {
+          display: "ActionsBar",
+        },
       },
     });
   });
@@ -48,19 +53,82 @@ describe("PostHog dashboard query generation", () => {
         key: "join-flow-by-device",
         name: "Join flow by device",
         type: "trend",
-        display: "ActionsBarValue",
+        display: "ActionsBar",
         breakdown: "$device_type",
         series: [{ event: "quartet_joined" }],
       })
     ).toMatchObject({
-      breakdownFilter: {
-        breakdowns: [
+      kind: "InsightVizNode",
+      source: {
+        breakdownFilter: {
+          breakdowns: [
+            {
+              property: "$device_type",
+              type: "event",
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("selects managed insights by key for narrow syncs", () => {
+    const spec = {
+      dashboards: [
+        {
+          key: "product-health",
+          insights: [
+            { key: "analytics-client-ready" },
+            { key: "top-routes" },
+          ],
+        },
+        {
+          key: "reliability",
+          insights: [{ key: "join-errors" }],
+        },
+      ],
+    };
+
+    expect(selectInsightEntries(spec, ["top-routes"])).toEqual([
+      {
+        dashboard: spec.dashboards[0],
+        insight: { key: "top-routes" },
+      },
+    ]);
+  });
+
+  it("builds isolated sandbox insight names instead of overwriting production insights", () => {
+    const sandboxDashboard = sandboxDashboardFromSpec(
+      {
+        dashboards: [
           {
-            property: "$device_type",
-            type: "event",
+            key: "product-health",
+            name: "What Can We Sing - Product Health",
+            insights: [
+              {
+                key: "top-routes",
+                name: "Top routes",
+                description: "Routes by normalized path.",
+                type: "trend",
+                display: "ActionsBar",
+                breakdown: "route",
+                series: [{ event: "app_route_viewed" }],
+              },
+            ],
           },
         ],
       },
+      ["top-routes"]
+    );
+
+    expect(sandboxDashboard.name).toBe(
+      "What Can We Sing - Dashboard Sync Sandbox"
+    );
+    expect(sandboxDashboard.insights).toHaveLength(1);
+    expect(sandboxDashboard.insights[0]).toMatchObject({
+      key: "sandbox-top-routes",
+      name: "Sandbox - Top routes",
+      breakdown: "route",
     });
   });
 

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { queryForInsight } from "../../scripts/posthog/sync-dashboards.mjs";
+import {
+  insightRefreshEndpoint,
+  queryForInsight,
+} from "../../scripts/posthog/sync-dashboards.mjs";
 
 describe("PostHog dashboard query generation", () => {
   it("uses PostHog query breakdowns for event-property trend breakdowns", () => {
@@ -59,5 +62,11 @@ describe("PostHog dashboard query generation", () => {
         ],
       },
     });
+  });
+
+  it("refreshes saved insight results in dashboard context after sync", () => {
+    expect(insightRefreshEndpoint("400013", 1521699, 12345)).toBe(
+      "/api/environments/400013/insights/12345/?refresh=true&refresh_method=force_blocking&dashboard_id_context=1521699"
+    );
   });
 });

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -11,6 +11,7 @@ const specPath = path.join(repoRoot, "analytics/posthog/dashboards.json");
 
 const args = new Set(process.argv.slice(2));
 const checkOnly = args.has("--check");
+const skipRefresh = args.has("--skip-refresh");
 const trendDisplayTypes = new Set([
   "ActionsLineGraph",
   "ActionsTable",
@@ -298,6 +299,28 @@ async function upsertInsight(environment, dashboardId, insight, tags) {
   });
 }
 
+export function insightRefreshEndpoint(environment, dashboardId, insightId) {
+  const params = new URLSearchParams({
+    refresh: "true",
+    refresh_method: "force_blocking",
+    dashboard_id_context: String(dashboardId),
+  });
+
+  return `/api/environments/${environment}/insights/${insightId}/?${params.toString()}`;
+}
+
+async function refreshInsightResult(environment, dashboardId, insight) {
+  const refreshed = await posthogFetch(
+    insightRefreshEndpoint(environment, dashboardId, insight.id)
+  );
+
+  if (!refreshed) {
+    throw new Error(`Insight ${insight.name} did not return refresh metadata.`);
+  }
+
+  return refreshed;
+}
+
 async function main() {
   const spec = await readSpec();
 
@@ -323,8 +346,18 @@ async function main() {
     console.log(`Synced dashboard: ${dashboardSpec.name}`);
 
     for (const insight of dashboardSpec.insights) {
-      await upsertInsight(environment, dashboard.id, insight, tags);
+      const savedInsight = await upsertInsight(
+        environment,
+        dashboard.id,
+        insight,
+        tags
+      );
       console.log(`  Synced insight: ${insight.name}`);
+
+      if (!skipRefresh) {
+        await refreshInsightResult(environment, dashboard.id, savedInsight);
+        console.log(`  Refreshed insight result: ${insight.name}`);
+      }
     }
   }
 }

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -11,16 +11,35 @@ const specPath = path.join(repoRoot, "analytics/posthog/dashboards.json");
 
 const args = new Set(process.argv.slice(2));
 const checkOnly = args.has("--check");
+const inspectMode = args.has("--inspect");
+const compareMode = args.has("--compare");
+const sandboxMode = args.has("--sandbox");
 const skipRefresh = args.has("--skip-refresh");
 const trendDisplayTypes = new Set([
   "ActionsLineGraph",
   "ActionsTable",
   "ActionsPie",
   "ActionsBar",
-  "ActionsBarValue",
   "WorldMap",
   "BoldNumber",
 ]);
+const defaultSandboxInsightKeys = ["analytics-client-ready", "top-routes"];
+
+function argValue(name) {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+
+  if (index === -1) return "";
+
+  return argv[index + 1] || "";
+}
+
+function splitCsv(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -141,6 +160,42 @@ async function readSpec() {
   return spec;
 }
 
+function allInsights(spec) {
+  return spec.dashboards.flatMap((dashboard) =>
+    dashboard.insights.map((insight) => ({
+      dashboard,
+      insight,
+    }))
+  );
+}
+
+export function selectInsightEntries(spec, selectedKeys) {
+  const selected = new Set(selectedKeys);
+
+  if (selected.size === 0) {
+    return allInsights(spec);
+  }
+
+  return allInsights(spec).filter(({ insight }) => selected.has(insight.key));
+}
+
+export function sandboxDashboardFromSpec(spec, selectedKeys) {
+  const selectedEntries = selectInsightEntries(spec, selectedKeys);
+
+  return {
+    key: "dashboard-sync-sandbox",
+    name: "What Can We Sing - Dashboard Sync Sandbox",
+    description:
+      "Temporary dashboard for testing repo-managed PostHog insight queries before updating production dashboards.",
+    insights: selectedEntries.map(({ insight }) => ({
+      ...insight,
+      key: `sandbox-${insight.key}`,
+      name: `Sandbox - ${insight.name}`,
+      description: `${insight.description} Sandbox copy of ${insight.key}.`,
+    })),
+  };
+}
+
 function eventToQueryNode(event) {
   const node = {
     kind: "EventsNode",
@@ -176,7 +231,7 @@ function breakdownsForInsight(insight) {
   ];
 }
 
-export function queryForInsight(insight) {
+function sourceQueryForInsight(insight) {
   const query = {
     kind: insight.type === "funnel" ? "FunnelsQuery" : "TrendsQuery",
     dateRange: {
@@ -203,6 +258,13 @@ export function queryForInsight(insight) {
   }
 
   return query;
+}
+
+export function queryForInsight(insight) {
+  return {
+    kind: "InsightVizNode",
+    source: sourceQueryForInsight(insight),
+  };
 }
 
 async function posthogFetch(endpoint, options = {}) {
@@ -239,6 +301,173 @@ async function listAll(endpoint) {
   }
 
   return results;
+}
+
+function compactQuery(query) {
+  if (!query) return null;
+
+  return {
+    kind: query.kind,
+    dateRange: query.dateRange,
+    series: query.series?.map((series) => ({
+      kind: series.kind,
+      event: series.event,
+      name: series.name,
+      math: series.math,
+      math_property: series.math_property,
+    })),
+    breakdownFilter: query.breakdownFilter,
+    trendsFilter: query.trendsFilter,
+    funnelsFilter: query.funnelsFilter,
+    interval: query.interval,
+    source: query.source ? compactQuery(query.source) : undefined,
+  };
+}
+
+function compactInsight(insight) {
+  return {
+    id: insight.id,
+    short_id: insight.short_id,
+    name: insight.name,
+    description: insight.description,
+    saved: insight.saved,
+    dashboards: insight.dashboards,
+    tags: insight.tags,
+    filters: insight.filters,
+    query: compactQuery(insight.query),
+    result:
+      insight.result === undefined
+        ? undefined
+        : {
+            type: Array.isArray(insight.result) ? "array" : typeof insight.result,
+            length: Array.isArray(insight.result) ? insight.result.length : undefined,
+            preview: Array.isArray(insight.result)
+              ? insight.result.slice(0, 3)
+              : insight.result,
+          },
+  };
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function getDashboardByNameOrId(environment, nameOrId) {
+  if (!nameOrId) {
+    throw new Error("Pass --dashboard \"Dashboard name\" or --dashboard 123.");
+  }
+
+  if (/^\d+$/.test(nameOrId)) {
+    return posthogFetch(`/api/environments/${environment}/dashboards/${nameOrId}/`);
+  }
+
+  const dashboards = await listAll(
+    `/api/environments/${environment}/dashboards/?limit=100`
+  );
+  const dashboard = dashboards.find((item) => item.name === nameOrId);
+
+  if (!dashboard) {
+    throw new Error(`Dashboard not found: ${nameOrId}`);
+  }
+
+  return posthogFetch(`/api/environments/${environment}/dashboards/${dashboard.id}/`);
+}
+
+async function getInsightByNameOrId(environment, nameOrId) {
+  if (!nameOrId) {
+    throw new Error("Pass --insight \"Insight name\" or --insight 123.");
+  }
+
+  if (/^\d+$/.test(nameOrId)) {
+    return posthogFetch(`/api/environments/${environment}/insights/${nameOrId}/`);
+  }
+
+  const insights = await listAll(
+    `/api/environments/${environment}/insights/?limit=100`
+  );
+  const insight = insights.find((item) => item.name === nameOrId);
+
+  if (!insight) {
+    throw new Error(`Insight not found: ${nameOrId}`);
+  }
+
+  return posthogFetch(`/api/environments/${environment}/insights/${insight.id}/`);
+}
+
+async function inspectPostHog(environment) {
+  const dashboardNameOrId = argValue("--dashboard");
+  const insightNameOrId = argValue("--insight");
+
+  if (dashboardNameOrId) {
+    const dashboard = await getDashboardByNameOrId(environment, dashboardNameOrId);
+    const tileInsights = (dashboard.tiles || [])
+      .map((tile) => tile.insight)
+      .filter((insight) => insight && typeof insight === "object");
+    const insights = await listAll(
+      `/api/environments/${environment}/insights/?limit=100`
+    );
+    const dashboardInsightIds = new Set(
+      [
+        ...(dashboard.tiles || []).map((tile) => tile.insight?.id || tile.insight),
+        ...(dashboard.insights || []).map((insight) =>
+          typeof insight === "object" ? insight.id : insight
+        ),
+      ].filter(Boolean)
+    );
+    const dashboardInsights =
+      tileInsights.length > 0
+        ? tileInsights
+        : insights.filter((insight) => dashboardInsightIds.has(insight.id));
+
+    printJson({
+      dashboard: {
+        id: dashboard.id,
+        name: dashboard.name,
+        description: dashboard.description,
+        pinned: dashboard.pinned,
+        tiles: dashboard.tiles?.map((tile) => ({
+          id: tile.id,
+          insight: tile.insight?.id || tile.insight,
+          layouts: tile.layouts,
+        })),
+      },
+      insights: dashboardInsights.map(compactInsight),
+    });
+    return;
+  }
+
+  if (insightNameOrId) {
+    printJson(compactInsight(await getInsightByNameOrId(environment, insightNameOrId)));
+    return;
+  }
+
+  throw new Error("Pass --dashboard or --insight with --inspect.");
+}
+
+async function comparePostHogInsights(environment) {
+  const left = argValue("--left");
+  const right = argValue("--right");
+
+  if (!left || !right) {
+    throw new Error("Pass --left and --right insight names or IDs with --compare.");
+  }
+
+  const leftInsight = compactInsight(await getInsightByNameOrId(environment, left));
+  const rightInsight = compactInsight(await getInsightByNameOrId(environment, right));
+
+  printJson({
+    left: leftInsight,
+    right: rightInsight,
+    same: {
+      query:
+        JSON.stringify(leftInsight.query) === JSON.stringify(rightInsight.query),
+      filters:
+        JSON.stringify(leftInsight.filters) === JSON.stringify(rightInsight.filters),
+      dashboards:
+        JSON.stringify(leftInsight.dashboards) ===
+        JSON.stringify(rightInsight.dashboards),
+    },
+  });
 }
 
 async function upsertDashboard(environment, dashboard, tags) {
@@ -339,9 +568,38 @@ async function main() {
     throw new Error("Missing POSTHOG_ENVIRONMENT_ID or POSTHOG_PROJECT_ID");
   }
 
-  const tags = spec.tags || [];
+  if (inspectMode) {
+    await inspectPostHog(environment);
+    return;
+  }
 
-  for (const dashboardSpec of spec.dashboards) {
+  if (compareMode) {
+    await comparePostHogInsights(environment);
+    return;
+  }
+
+  const selectedInsightKeys = splitCsv(argValue("--only"));
+  const tags = spec.tags || [];
+  const dashboardSpecs = sandboxMode
+    ? [
+        sandboxDashboardFromSpec(
+          spec,
+          selectedInsightKeys.length > 0
+            ? selectedInsightKeys
+            : defaultSandboxInsightKeys
+        ),
+      ]
+    : spec.dashboards.map((dashboard) => ({
+        ...dashboard,
+        insights: selectInsightEntries(
+          { dashboards: [dashboard] },
+          selectedInsightKeys
+        ).map(({ insight }) => insight),
+      }));
+
+  for (const dashboardSpec of dashboardSpecs) {
+    if (dashboardSpec.insights.length === 0) continue;
+
     const dashboard = await upsertDashboard(environment, dashboardSpec, tags);
     console.log(`Synced dashboard: ${dashboardSpec.name}`);
 


### PR DESCRIPTION
## Summary
- force-refresh each saved insight after create/update in the dashboard context
- add a regression test for the PostHog refresh endpoint and parameters
- document that sync now renders/prewarms dashboard tile results instead of requiring cards to be opened manually

## Why
The prior sync changes saved insight metadata and query/display settings, but dashboard tiles can remain blank until each insight is opened. This makes the sync look successful while dashboard cards still show empty shells. The script now refreshes each saved insight with `refresh=true`, `refresh_method=force_blocking`, and `dashboard_id_context` immediately after syncing.

## Verification
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`

## Post-merge step
After this merges, run the sync again:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_ENVIRONMENT_ID=400013 \
POSTHOG_HOST=https://us.posthog.com \
npm run posthog:dashboards:sync
```

The output should include `Refreshed insight result: ...` after each synced insight. If PostHog rejects the refresh endpoint, the command should fail instead of silently leaving blank dashboard tiles.