### PR TITLE
Add PostHog dashboard diagnostics tooling

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -93,6 +93,43 @@ POSTHOG_ENVIRONMENT_ID=... \
 npm run posthog:dashboards:sync
 ```
 
+For a narrow local test loop, sync only one or two sandbox cards instead of the
+full managed dashboard set:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:sync -- --sandbox --only top-routes,analytics-client-ready
+```
+
+This creates or updates `What Can We Sing - Dashboard Sync Sandbox` with
+`Sandbox - ...` insight names so production dashboard cards are not overwritten
+while testing query shape and display settings.
+
+Inspect a saved dashboard or insight directly from PostHog:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:inspect -- --dashboard "What Can We Sing - Product Health"
+
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:inspect -- --insight "Top routes"
+```
+
+Compare a repo-managed insight against a manually edited working insight:
+
+```sh
+POSTHOG_PERSONAL_API_KEY=phx_... \
+POSTHOG_HOST=https://us.posthog.com \
+POSTHOG_ENVIRONMENT_ID=400013 \
+npm run posthog:dashboards:compare -- --left "Top routes" --right "Manual working Top routes"
+```
+
 `POSTHOG_PROJECT_ID` is accepted as a fallback name for older PostHog docs, but
 `POSTHOG_ENVIRONMENT_ID` matches the current PostHog dashboard and insight API
 paths.
@@ -102,6 +139,9 @@ The sync script is idempotent by dashboard and insight name:
 - existing dashboards are patched by exact name
 - existing insights are patched by exact name
 - missing dashboards and insights are created
+- `--only insight-key-1,insight-key-2` limits sync to selected insight keys
+- `--sandbox` writes selected cards to the dashboard sync sandbox and prefixes
+  insight names with `Sandbox -`
 - insights are created with PostHog query objects rather than legacy insight
   filters
 - event-property breakdowns are generated with PostHog query `breakdowns`

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { queryForInsight } from "../../scripts/posthog/sync-dashboards.mjs";
+import {
+  queryForInsight,
+  sandboxDashboardFromSpec,
+  selectInsightEntries,
+} from "../../scripts/posthog/sync-dashboards.mjs";
 
 describe("PostHog dashboard query generation", () => {
   it("uses PostHog query breakdowns for event-property trend breakdowns", () => {
@@ -58,6 +62,66 @@ describe("PostHog dashboard query generation", () => {
           },
         ],
       },
+    });
+  });
+
+  it("selects managed insights by key for narrow syncs", () => {
+    const spec = {
+      dashboards: [
+        {
+          key: "product-health",
+          insights: [
+            { key: "analytics-client-ready" },
+            { key: "top-routes" },
+          ],
+        },
+        {
+          key: "reliability",
+          insights: [{ key: "join-errors" }],
+        },
+      ],
+    };
+
+    expect(selectInsightEntries(spec, ["top-routes"])).toEqual([
+      {
+        dashboard: spec.dashboards[0],
+        insight: { key: "top-routes" },
+      },
+    ]);
+  });
+
+  it("builds isolated sandbox insight names instead of overwriting production insights", () => {
+    const sandboxDashboard = sandboxDashboardFromSpec(
+      {
+        dashboards: [
+          {
+            key: "product-health",
+            name: "What Can We Sing - Product Health",
+            insights: [
+              {
+                key: "top-routes",
+                name: "Top routes",
+                description: "Routes by normalized path.",
+                type: "trend",
+                display: "ActionsBarValue",
+                breakdown: "route",
+                series: [{ event: "app_route_viewed" }],
+              },
+            ],
+          },
+        ],
+      },
+      ["top-routes"]
+    );
+
+    expect(sandboxDashboard.name).toBe(
+      "What Can We Sing - Dashboard Sync Sandbox"
+    );
+    expect(sandboxDashboard.insights).toHaveLength(1);
+    expect(sandboxDashboard.insights[0]).toMatchObject({
+      key: "sandbox-top-routes",
+      name: "Sandbox - Top routes",
+      breakdown: "route",
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "posthog:dashboards:check": "node scripts/posthog/sync-dashboards.mjs --check",
+    "posthog:dashboards:inspect": "node scripts/posthog/sync-dashboards.mjs --inspect",
+    "posthog:dashboards:compare": "node scripts/posthog/sync-dashboards.mjs --compare",
     "posthog:dashboards:sync": "node scripts/posthog/sync-dashboards.mjs",
     "song-suggestions:import": "node scripts/import-song-suggestions.mjs",
     "test": "vitest",

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -11,6 +11,9 @@ const specPath = path.join(repoRoot, "analytics/posthog/dashboards.json");
 
 const args = new Set(process.argv.slice(2));
 const checkOnly = args.has("--check");
+const inspectMode = args.has("--inspect");
+const compareMode = args.has("--compare");
+const sandboxMode = args.has("--sandbox");
 const trendDisplayTypes = new Set([
   "ActionsLineGraph",
   "ActionsTable",
@@ -20,6 +23,23 @@ const trendDisplayTypes = new Set([
   "WorldMap",
   "BoldNumber",
 ]);
+const defaultSandboxInsightKeys = ["analytics-client-ready", "top-routes"];
+
+function argValue(name) {
+  const argv = process.argv.slice(2);
+  const index = argv.indexOf(name);
+
+  if (index === -1) return "";
+
+  return argv[index + 1] || "";
+}
+
+function splitCsv(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -140,6 +160,42 @@ async function readSpec() {
   return spec;
 }
 
+function allInsights(spec) {
+  return spec.dashboards.flatMap((dashboard) =>
+    dashboard.insights.map((insight) => ({
+      dashboard,
+      insight,
+    }))
+  );
+}
+
+export function selectInsightEntries(spec, selectedKeys) {
+  const selected = new Set(selectedKeys);
+
+  if (selected.size === 0) {
+    return allInsights(spec);
+  }
+
+  return allInsights(spec).filter(({ insight }) => selected.has(insight.key));
+}
+
+export function sandboxDashboardFromSpec(spec, selectedKeys) {
+  const selectedEntries = selectInsightEntries(spec, selectedKeys);
+
+  return {
+    key: "dashboard-sync-sandbox",
+    name: "What Can We Sing - Dashboard Sync Sandbox",
+    description:
+      "Temporary dashboard for testing repo-managed PostHog insight queries before updating production dashboards.",
+    insights: selectedEntries.map(({ insight }) => ({
+      ...insight,
+      key: `sandbox-${insight.key}`,
+      name: `Sandbox - ${insight.name}`,
+      description: `${insight.description} Sandbox copy of ${insight.key}.`,
+    })),
+  };
+}
+
 function eventToQueryNode(event) {
   const node = {
     kind: "EventsNode",
@@ -240,6 +296,172 @@ async function listAll(endpoint) {
   return results;
 }
 
+function compactQuery(query) {
+  if (!query) return null;
+
+  return {
+    kind: query.kind,
+    dateRange: query.dateRange,
+    series: query.series?.map((series) => ({
+      kind: series.kind,
+      event: series.event,
+      name: series.name,
+      math: series.math,
+      math_property: series.math_property,
+    })),
+    breakdownFilter: query.breakdownFilter,
+    trendsFilter: query.trendsFilter,
+    funnelsFilter: query.funnelsFilter,
+    interval: query.interval,
+  };
+}
+
+function compactInsight(insight) {
+  return {
+    id: insight.id,
+    short_id: insight.short_id,
+    name: insight.name,
+    description: insight.description,
+    saved: insight.saved,
+    dashboards: insight.dashboards,
+    tags: insight.tags,
+    filters: insight.filters,
+    query: compactQuery(insight.query),
+    result:
+      insight.result === undefined
+        ? undefined
+        : {
+            type: Array.isArray(insight.result) ? "array" : typeof insight.result,
+            length: Array.isArray(insight.result) ? insight.result.length : undefined,
+            preview: Array.isArray(insight.result)
+              ? insight.result.slice(0, 3)
+              : insight.result,
+          },
+  };
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function getDashboardByNameOrId(environment, nameOrId) {
+  if (!nameOrId) {
+    throw new Error("Pass --dashboard \"Dashboard name\" or --dashboard 123.");
+  }
+
+  if (/^\d+$/.test(nameOrId)) {
+    return posthogFetch(`/api/environments/${environment}/dashboards/${nameOrId}/`);
+  }
+
+  const dashboards = await listAll(
+    `/api/environments/${environment}/dashboards/?limit=100`
+  );
+  const dashboard = dashboards.find((item) => item.name === nameOrId);
+
+  if (!dashboard) {
+    throw new Error(`Dashboard not found: ${nameOrId}`);
+  }
+
+  return posthogFetch(`/api/environments/${environment}/dashboards/${dashboard.id}/`);
+}
+
+async function getInsightByNameOrId(environment, nameOrId) {
+  if (!nameOrId) {
+    throw new Error("Pass --insight \"Insight name\" or --insight 123.");
+  }
+
+  if (/^\d+$/.test(nameOrId)) {
+    return posthogFetch(`/api/environments/${environment}/insights/${nameOrId}/`);
+  }
+
+  const insights = await listAll(
+    `/api/environments/${environment}/insights/?limit=100`
+  );
+  const insight = insights.find((item) => item.name === nameOrId);
+
+  if (!insight) {
+    throw new Error(`Insight not found: ${nameOrId}`);
+  }
+
+  return posthogFetch(`/api/environments/${environment}/insights/${insight.id}/`);
+}
+
+async function inspectPostHog(environment) {
+  const dashboardNameOrId = argValue("--dashboard");
+  const insightNameOrId = argValue("--insight");
+
+  if (dashboardNameOrId) {
+    const dashboard = await getDashboardByNameOrId(environment, dashboardNameOrId);
+    const tileInsights = (dashboard.tiles || [])
+      .map((tile) => tile.insight)
+      .filter((insight) => insight && typeof insight === "object");
+    const insights = await listAll(
+      `/api/environments/${environment}/insights/?limit=100`
+    );
+    const dashboardInsightIds = new Set(
+      [
+        ...(dashboard.tiles || []).map((tile) => tile.insight?.id || tile.insight),
+        ...(dashboard.insights || []).map((insight) =>
+          typeof insight === "object" ? insight.id : insight
+        ),
+      ].filter(Boolean)
+    );
+    const dashboardInsights =
+      tileInsights.length > 0
+        ? tileInsights
+        : insights.filter((insight) => dashboardInsightIds.has(insight.id));
+
+    printJson({
+      dashboard: {
+        id: dashboard.id,
+        name: dashboard.name,
+        description: dashboard.description,
+        pinned: dashboard.pinned,
+        tiles: dashboard.tiles?.map((tile) => ({
+          id: tile.id,
+          insight: tile.insight?.id || tile.insight,
+          layouts: tile.layouts,
+        })),
+      },
+      insights: dashboardInsights.map(compactInsight),
+    });
+    return;
+  }
+
+  if (insightNameOrId) {
+    printJson(compactInsight(await getInsightByNameOrId(environment, insightNameOrId)));
+    return;
+  }
+
+  throw new Error("Pass --dashboard or --insight with --inspect.");
+}
+
+async function comparePostHogInsights(environment) {
+  const left = argValue("--left");
+  const right = argValue("--right");
+
+  if (!left || !right) {
+    throw new Error("Pass --left and --right insight names or IDs with --compare.");
+  }
+
+  const leftInsight = compactInsight(await getInsightByNameOrId(environment, left));
+  const rightInsight = compactInsight(await getInsightByNameOrId(environment, right));
+
+  printJson({
+    left: leftInsight,
+    right: rightInsight,
+    same: {
+      query:
+        JSON.stringify(leftInsight.query) === JSON.stringify(rightInsight.query),
+      filters:
+        JSON.stringify(leftInsight.filters) === JSON.stringify(rightInsight.filters),
+      dashboards:
+        JSON.stringify(leftInsight.dashboards) ===
+        JSON.stringify(rightInsight.dashboards),
+    },
+  });
+}
+
 async function upsertDashboard(environment, dashboard, tags) {
   const dashboards = await listAll(
     `/api/environments/${environment}/dashboards/?limit=100`
@@ -316,9 +538,38 @@ async function main() {
     throw new Error("Missing POSTHOG_ENVIRONMENT_ID or POSTHOG_PROJECT_ID");
   }
 
-  const tags = spec.tags || [];
+  if (inspectMode) {
+    await inspectPostHog(environment);
+    return;
+  }
 
-  for (const dashboardSpec of spec.dashboards) {
+  if (compareMode) {
+    await comparePostHogInsights(environment);
+    return;
+  }
+
+  const selectedInsightKeys = splitCsv(argValue("--only"));
+  const tags = spec.tags || [];
+  const dashboardSpecs = sandboxMode
+    ? [
+        sandboxDashboardFromSpec(
+          spec,
+          selectedInsightKeys.length > 0
+            ? selectedInsightKeys
+            : defaultSandboxInsightKeys
+        ),
+      ]
+    : spec.dashboards.map((dashboard) => ({
+        ...dashboard,
+        insights: selectInsightEntries(
+          { dashboards: [dashboard] },
+          selectedInsightKeys
+        ).map(({ insight }) => insight),
+      }));
+
+  for (const dashboardSpec of dashboardSpecs) {
+    if (dashboardSpec.insights.length === 0) continue;
+
     const dashboard = await upsertDashboard(environment, dashboardSpec, tags);
     console.log(`Synced dashboard: ${dashboardSpec.name}`);
 


### PR DESCRIPTION
## Summary
- add local PostHog dashboard diagnostics for inspecting dashboards, inspecting insights, and comparing two saved insights
- add `--only` and `--sandbox` sync options so we can test one or two cards in `What Can We Sing - Dashboard Sync Sandbox` without touching production dashboard cards
- document the local diagnostic workflow and add tests for narrow sync selection and sandbox isolation

## Why
The dashboard/card issue needs a tight PostHog-only debug loop. This avoids Vercel deploys and avoids blindly changing the production managed dashboards before comparing the actual saved PostHog JSON.

## Useful commands after merge

Inspect the product dashboard:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_HOST=https://us.posthog.com \
POSTHOG_ENVIRONMENT_ID=400013 \
npm run posthog:dashboards:inspect -- --dashboard "What Can We Sing - Product Health"
```

Sync only sandbox Top routes/client-ready cards:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_HOST=https://us.posthog.com \
POSTHOG_ENVIRONMENT_ID=400013 \
npm run posthog:dashboards:sync -- --sandbox --only top-routes,analytics-client-ready
```

Compare a repo-managed insight to a manually edited working one:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_HOST=https://us.posthog.com \
POSTHOG_ENVIRONMENT_ID=400013 \
npm run posthog:dashboards:compare -- --left "Top routes" --right "Manual working Top routes"
```

## Verification
- `npm run posthog:dashboards:check`
- `npm run test:run`
- `npm run build`