### PR TITLE
Fix PostHog dashboard visualization sync

### DIFF
--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -63,7 +63,7 @@
           "name": "Feedback submissions",
           "description": "Feedback sent successfully by category.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "category",
           "series": [{ "event": "feedback_submitted" }]
@@ -73,7 +73,7 @@
           "name": "Top routes",
           "description": "Route visits with join codes normalized to /join/[code].",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "route",
           "series": [{ "event": "app_route_viewed" }]
@@ -135,7 +135,7 @@
           "name": "Create vs join route",
           "description": "Quartet joins by route context.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "route",
           "series": [{ "event": "quartet_joined" }]
@@ -152,7 +152,7 @@
           "name": "Repertoire updates",
           "description": "Add, edit, and delete activity.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "action",
           "series": [{ "event": "repertoire_updated" }]
@@ -204,7 +204,7 @@
           "name": "Join errors",
           "description": "Quartet join failures by reason.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "reason",
           "series": [{ "event": "quartet_join_failed" }]
@@ -214,7 +214,7 @@
           "name": "Leave errors",
           "description": "Quartet leave failures by source.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "source",
           "series": [{ "event": "quartet_leave_failed" }]
@@ -224,7 +224,7 @@
           "name": "Repertoire update errors",
           "description": "Repertoire update failures by action.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "action",
           "series": [{ "event": "repertoire_update_failed" }]
@@ -234,7 +234,7 @@
           "name": "Feedback errors",
           "description": "Feedback send failures.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "category",
           "series": [{ "event": "feedback_failed" }]
@@ -244,7 +244,7 @@
           "name": "Mark sung errors",
           "description": "Failures when marking a match as recently sung.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "voicing",
           "series": [{ "event": "song_mark_sung_failed" }]
@@ -261,7 +261,7 @@
           "name": "Leave flow by browser",
           "description": "Leave clicks, confirmations, successes, and failures by browser.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "$browser",
           "series": [
@@ -276,7 +276,7 @@
           "name": "Join flow by device",
           "description": "Join attempts, successes, and failures by device type.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "$device_type",
           "series": [
@@ -290,7 +290,7 @@
           "name": "Key actions on browser/OS combinations",
           "description": "Useful for Brave on iOS and Chrome on Mac compatibility checks.",
           "type": "trend",
-          "display": "ActionsBarValue",
+          "display": "ActionsBar",
           "dateFrom": "-30d",
           "breakdown": "$browser",
           "series": [

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -147,9 +147,11 @@ The sync script is idempotent by dashboard and insight name:
 - event-property breakdowns are generated with PostHog query `breakdowns`
   entries, for example the `Top routes` card groups `app_route_viewed` by the
   `route` event property
+- trend insights are saved as PostHog visualization nodes that wrap their
+  source trend/funnel query, matching the shape created by the PostHog UI
 - trend insights include explicit display types so dashboard cards sync into
   the intended presentation: line graphs for time-series trends, bold numbers
-  for single health counters, and bar-value charts for route/category/browser
+  for single health counters, and bar charts for route/category/browser
   breakdowns
 - API keys are read from environment variables only
 

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -6,39 +6,42 @@ import {
 } from "../../scripts/posthog/sync-dashboards.mjs";
 
 describe("PostHog dashboard query generation", () => {
-  it("uses PostHog query breakdowns for event-property trend breakdowns", () => {
+  it("wraps trend query sources in a dashboard-renderable visualization node", () => {
     expect(
       queryForInsight({
         key: "top-routes",
         name: "Top routes",
         type: "trend",
-        display: "ActionsBarValue",
+        display: "ActionsBar",
         dateFrom: "-30d",
         breakdown: "route",
         series: [{ event: "app_route_viewed" }],
       })
     ).toMatchObject({
-      kind: "TrendsQuery",
-      dateRange: {
-        date_from: "-30d",
-      },
-      series: [
-        {
-          kind: "EventsNode",
-          event: "app_route_viewed",
-          math: "total",
+      kind: "InsightVizNode",
+      source: {
+        kind: "TrendsQuery",
+        dateRange: {
+          date_from: "-30d",
         },
-      ],
-      breakdownFilter: {
-        breakdowns: [
+        series: [
           {
-            property: "route",
-            type: "event",
+            kind: "EventsNode",
+            event: "app_route_viewed",
+            math: "total",
           },
         ],
-      },
-      trendsFilter: {
-        display: "ActionsBarValue",
+        breakdownFilter: {
+          breakdowns: [
+            {
+              property: "route",
+              type: "event",
+            },
+          ],
+        },
+        trendsFilter: {
+          display: "ActionsBar",
+        },
       },
     });
   });
@@ -49,18 +52,21 @@ describe("PostHog dashboard query generation", () => {
         key: "join-flow-by-device",
         name: "Join flow by device",
         type: "trend",
-        display: "ActionsBarValue",
+        display: "ActionsBar",
         breakdown: "$device_type",
         series: [{ event: "quartet_joined" }],
       })
     ).toMatchObject({
-      breakdownFilter: {
-        breakdowns: [
-          {
-            property: "$device_type",
-            type: "event",
-          },
-        ],
+      kind: "InsightVizNode",
+      source: {
+        breakdownFilter: {
+          breakdowns: [
+            {
+              property: "$device_type",
+              type: "event",
+            },
+          ],
+        },
       },
     });
   });
@@ -103,7 +109,7 @@ describe("PostHog dashboard query generation", () => {
                 name: "Top routes",
                 description: "Routes by normalized path.",
                 type: "trend",
-                display: "ActionsBarValue",
+                display: "ActionsBar",
                 breakdown: "route",
                 series: [{ event: "app_route_viewed" }],
               },

--- a/lib/__tests__/posthogDashboardSpec.test.ts
+++ b/lib/__tests__/posthogDashboardSpec.test.ts
@@ -90,12 +90,12 @@ describe("PostHog dashboard spec", () => {
       )
     ).toMatchObject({
       "analytics-client-ready": "BoldNumber",
-      "feedback-submissions": "ActionsBarValue",
-      "top-routes": "ActionsBarValue",
-      "join-by-route": "ActionsBarValue",
-      "repertoire-updates": "ActionsBarValue",
-      "join-errors": "ActionsBarValue",
-      "leave-flow-by-browser": "ActionsBarValue",
+      "feedback-submissions": "ActionsBar",
+      "top-routes": "ActionsBar",
+      "join-by-route": "ActionsBar",
+      "repertoire-updates": "ActionsBar",
+      "join-errors": "ActionsBar",
+      "leave-flow-by-browser": "ActionsBar",
     });
   });
 });

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -19,7 +19,6 @@ const trendDisplayTypes = new Set([
   "ActionsTable",
   "ActionsPie",
   "ActionsBar",
-  "ActionsBarValue",
   "WorldMap",
   "BoldNumber",
 ]);
@@ -231,7 +230,7 @@ function breakdownsForInsight(insight) {
   ];
 }
 
-export function queryForInsight(insight) {
+function sourceQueryForInsight(insight) {
   const query = {
     kind: insight.type === "funnel" ? "FunnelsQuery" : "TrendsQuery",
     dateRange: {
@@ -258,6 +257,13 @@ export function queryForInsight(insight) {
   }
 
   return query;
+}
+
+export function queryForInsight(insight) {
+  return {
+    kind: "InsightVizNode",
+    source: sourceQueryForInsight(insight),
+  };
 }
 
 async function posthogFetch(endpoint, options = {}) {
@@ -313,6 +319,7 @@ function compactQuery(query) {
     trendsFilter: query.trendsFilter,
     funnelsFilter: query.funnelsFilter,
     interval: query.interval,
+    source: query.source ? compactQuery(query.source) : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- save managed PostHog insights as `InsightVizNode` visualization wrappers around the generated trend/funnel source query
- use normal bar charts for route/category/browser/device breakdown cards instead of the bar-value display that rendered blank dashboard tiles
- update dashboard sync docs and tests so this shape is preserved

## Validation
- npm run posthog:dashboards:check
- npm run test:run
- npm run build

## PostHog follow-up
After this merges, run the sandbox sync first with your PostHog env vars:

```sh
npm run posthog:dashboards:sync -- --sandbox --only top-routes,analytics-client-ready
```

If the sandbox cards render, run the full dashboard sync. This change does not require a Vercel deploy to test the dashboard sync script itself.