### PR TITLE
Refresh PostHog dashboard results during sync

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -153,6 +153,9 @@ The sync script is idempotent by dashboard and insight name:
   the intended presentation: line graphs for time-series trends, bold numbers
   for single health counters, and bar charts for route/category/browser
   breakdowns
+- after every create or update, the sync script force-refreshes the saved
+  insight in the dashboard context so dashboard tiles have rendered results
+  without needing each card to be opened manually
 - API keys are read from environment variables only
 
 The personal API key needs PostHog dashboard and insight read/write scopes.

--- a/lib/__tests__/posthogDashboardQueries.test.ts
+++ b/lib/__tests__/posthogDashboardQueries.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  insightRefreshEndpoint,
   queryForInsight,
   sandboxDashboardFromSpec,
   selectInsightEntries,
@@ -129,5 +130,11 @@ describe("PostHog dashboard query generation", () => {
       name: "Sandbox - Top routes",
       breakdown: "route",
     });
+  });
+
+  it("refreshes saved insight results in dashboard context after sync", () => {
+    expect(insightRefreshEndpoint("400013", 1521699, 12345)).toBe(
+      "/api/environments/400013/insights/12345/?refresh=true&refresh_method=force_blocking&dashboard_id_context=1521699"
+    );
   });
 });

--- a/scripts/posthog/sync-dashboards.mjs
+++ b/scripts/posthog/sync-dashboards.mjs
@@ -14,6 +14,7 @@ const checkOnly = args.has("--check");
 const inspectMode = args.has("--inspect");
 const compareMode = args.has("--compare");
 const sandboxMode = args.has("--sandbox");
+const skipRefresh = args.has("--skip-refresh");
 const trendDisplayTypes = new Set([
   "ActionsLineGraph",
   "ActionsTable",
@@ -527,6 +528,28 @@ async function upsertInsight(environment, dashboardId, insight, tags) {
   });
 }
 
+export function insightRefreshEndpoint(environment, dashboardId, insightId) {
+  const params = new URLSearchParams({
+    refresh: "true",
+    refresh_method: "force_blocking",
+    dashboard_id_context: String(dashboardId),
+  });
+
+  return `/api/environments/${environment}/insights/${insightId}/?${params.toString()}`;
+}
+
+async function refreshInsightResult(environment, dashboardId, insight) {
+  const refreshed = await posthogFetch(
+    insightRefreshEndpoint(environment, dashboardId, insight.id)
+  );
+
+  if (!refreshed) {
+    throw new Error(`Insight ${insight.name} did not return refresh metadata.`);
+  }
+
+  return refreshed;
+}
+
 async function main() {
   const spec = await readSpec();
 
@@ -581,8 +604,18 @@ async function main() {
     console.log(`Synced dashboard: ${dashboardSpec.name}`);
 
     for (const insight of dashboardSpec.insights) {
-      await upsertInsight(environment, dashboard.id, insight, tags);
+      const savedInsight = await upsertInsight(
+        environment,
+        dashboard.id,
+        insight,
+        tags
+      );
       console.log(`  Synced insight: ${insight.name}`);
+
+      if (!skipRefresh) {
+        await refreshInsightResult(environment, dashboard.id, savedInsight);
+        console.log(`  Refreshed insight result: ${insight.name}`);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- force-refresh each saved insight after create/update in the dashboard context
- add a regression test for the PostHog refresh endpoint and parameters
- document that sync now renders/prewarms dashboard tile results instead of requiring cards to be opened manually

## Why

The prior sync changes saved insight metadata and query/display settings, but dashboard tiles can remain blank until each insight is opened. This makes the sync look successful while dashboard cards still show empty shells. The script now refreshes each saved insight with `refresh=true`, `refresh_method=force_blocking`, and `dashboard_id_context` immediately after syncing.

This replacement PR is based on current `main` so it preserves the newer sandbox/inspect/compare dashboard tooling while adding the refresh behavior from #254.

## Verification

CI should run:

- `npm run test:run`
- `npm run build`

## Post-merge step

After this merges, run the sync again:

```sh
POSTHOG_PERSONAL_API_KEY=phx_... \
POSTHOG_ENVIRONMENT_ID=400013 \
POSTHOG_HOST=https://us.posthog.com \
npm run posthog:dashboards:sync
```

The output should include `Refreshed insight result: ...` after each synced insight. If PostHog rejects the refresh endpoint, the command should fail instead of silently leaving blank dashboard tiles.

Replaces #254.