### PR TITLE
Add start and join help navigation

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -7,7 +7,11 @@ import {
   maxFeedbackMessageLength,
   type FeedbackType,
 } from "@/lib/feedback";
-import { feedbackHelpCopy, helpGuideSections } from "@/lib/helpContent";
+import {
+  feedbackHelpCopy,
+  helpGuideSections,
+  helpNavItems,
+} from "@/lib/helpContent";
 import { getCurrentUser } from "@/lib/profileStore";
 import { useEffect, useState } from "react";
 
@@ -118,11 +122,32 @@ export default function HelpPage() {
           </p>
         </header>
 
+        <nav
+          aria-label="Help page sections"
+          className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-4"
+        >
+          <h2 className="text-sm font-semibold uppercase text-slate-300">
+            On this page
+          </h2>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {helpNavItems.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="rounded-full border border-cyan-300/30 bg-cyan-300/10 px-3 py-2 text-sm font-medium text-cyan-100 hover:border-cyan-200 hover:bg-cyan-300/20"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+
         <section className="mt-8 space-y-6">
           {helpGuideSections.map((section) => (
             <article
               key={section.title}
-              className="rounded-2xl border border-white/10 bg-white/10 p-5 sm:p-6"
+              id={section.id}
+              className="scroll-mt-6 rounded-2xl border border-white/10 bg-white/10 p-5 sm:p-6"
             >
               <p className="text-sm font-semibold uppercase text-cyan-300">
                 {section.eyebrow}
@@ -162,7 +187,10 @@ export default function HelpPage() {
           ))}
         </section>
 
-        <section className="mt-10 rounded-2xl border border-white/10 bg-white/10 p-5">
+        <section
+          id="feedback"
+          className="mt-10 scroll-mt-6 rounded-2xl border border-white/10 bg-white/10 p-5"
+        >
           <div>
             <h2 className="text-2xl font-semibold">Send feedback</h2>
             <p className="mt-2 text-sm leading-6 text-slate-300">

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -3,6 +3,7 @@ import {
   helpGuideSections,
   helpSections,
   feedbackHelpCopy,
+  helpNavItems,
   quickStartSteps,
 } from "../helpContent";
 
@@ -45,7 +46,19 @@ describe("help content", () => {
     expect(helpGuideSections.map((section) => section.title)).toEqual([
       "Get Singing Quickly",
       "Manage The Songs You Know",
+      "Start A Quartet For The Group",
+      "Join A Quartet Someone Else Started",
       "Understand What Your Pick-Up Quartet Can Sing",
+      "Update, Leave, Or Rejoin A Quartet",
+    ]);
+
+    expect(helpGuideSections.map((section) => section.id)).toEqual([
+      "first-time-setup",
+      "repertoire",
+      "starting-a-quartet",
+      "joining-a-quartet",
+      "quartet-matches",
+      "managing-a-quartet",
     ]);
 
     expect(guideText).toContain("First Time Setup");
@@ -66,6 +79,13 @@ describe("help content", () => {
   });
 
   it("explains quartet match details and management", () => {
+    expect(guideText).toContain("Start creates a quartet session");
+    expect(guideText).toContain("code, QR code, and shareable link");
+    expect(guideText).toContain("You are part of the quartet you start");
+    expect(guideText).toContain("Starting a quartet does not permanently change");
+    expect(guideText).toContain("Use Join when another singer");
+    expect(guideText).toContain("Joining does not add songs");
+    expect(guideText).toContain("If the quartet is full");
     expect(guideText).toContain("Ready to Sing");
     expect(guideText).toContain("Possible matches");
     expect(guideText).toContain("voicing, required part coverage");
@@ -77,5 +97,26 @@ describe("help content", () => {
     expect(guideText).toContain("edit repertoire");
     expect(guideText).toContain("Leaving removes you from the active quartet");
     expect(guideText).toContain("you can rejoin normally");
+  });
+
+  it("provides compact table of contents links for every major help section", () => {
+    expect(helpNavItems).toEqual([
+      { id: "first-time-setup", label: "First time setup" },
+      { id: "repertoire", label: "Repertoire" },
+      { id: "starting-a-quartet", label: "Starting a quartet" },
+      { id: "joining-a-quartet", label: "Joining a quartet" },
+      { id: "quartet-matches", label: "Quartet matches" },
+      { id: "managing-a-quartet", label: "Managing a quartet" },
+      { id: "feedback", label: "Feedback" },
+    ]);
+
+    const sectionIds = new Set([
+      ...helpGuideSections.map((section) => section.id),
+      "feedback",
+    ]);
+
+    for (const item of helpNavItems) {
+      expect(sectionIds.has(item.id)).toBe(true);
+    }
   });
 });

--- a/lib/__tests__/helpPageNavigation.test.ts
+++ b/lib/__tests__/helpPageNavigation.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const helpPage = readFileSync(join(repoRoot, "app/help/page.tsx"), "utf8");
+
+describe("help page navigation", () => {
+  it("renders a compact on-page navigation from shared help nav items", () => {
+    expect(helpPage).toContain("helpNavItems");
+    expect(helpPage).toContain("On this page");
+    expect(helpPage).toContain('href={`#${item.id}`}');
+    expect(helpPage).toContain("Help page sections");
+  });
+
+  it("adds stable scroll targets for guide sections and feedback", () => {
+    expect(helpPage).toContain("id={section.id}");
+    expect(helpPage).toContain('id="feedback"');
+    expect(helpPage).toContain("scroll-mt-6");
+  });
+});

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -10,10 +10,16 @@ export type HelpTopic = {
 };
 
 export type HelpGuideSection = {
+  id: string;
   eyebrow: string;
   title: string;
   intro: string;
   topics: HelpTopic[];
+};
+
+export type HelpNavItem = {
+  id: string;
+  label: string;
 };
 
 export const quickStartSteps = [
@@ -26,6 +32,7 @@ export const quickStartSteps = [
 
 export const helpGuideSections: HelpGuideSection[] = [
   {
+    id: "first-time-setup",
     eyebrow: "First Time Setup",
     title: "Get Singing Quickly",
     intro:
@@ -48,6 +55,7 @@ export const helpGuideSections: HelpGuideSection[] = [
     ],
   },
   {
+    id: "repertoire",
     eyebrow: "Repertoire",
     title: "Manage The Songs You Know",
     intro:
@@ -110,6 +118,65 @@ export const helpGuideSections: HelpGuideSection[] = [
     ],
   },
   {
+    id: "starting-a-quartet",
+    eyebrow: "Starting A Quartet",
+    title: "Start A Quartet For The Group",
+    intro:
+      "Use Start when you want to create the quartet for the group. The app gives you a code, QR code, and shareable link so the other singers can join from their phones.",
+    topics: [
+      {
+        title: "What Start Does",
+        body: [
+          "Start creates a quartet session and gives it a short code. Other singers can enter the code, scan the QR code, or open the shared link to join.",
+          "You are part of the quartet you start. Your saved repertoire is used along with the other singers’ repertoire to find matches, so add at least a few songs first.",
+        ],
+      },
+      {
+        title: "After Singers Join",
+        body: [
+          "Once singers join, the app compares the current quartet members’ saved repertoire snapshots. A quartet is full when four singers have joined.",
+          "Starting a quartet does not permanently change anyone else’s repertoire. It only creates a shared place where the group can compare what each singer already has saved.",
+        ],
+      },
+      {
+        title: "Fixing Something After Starting",
+        body: [
+          "If you notice a missing song, wrong part, confidence issue, arranger detail, or display name problem, you can still edit your repertoire or name after starting and return to the quartet.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "joining-a-quartet",
+    eyebrow: "Joining A Quartet",
+    title: "Join A Quartet Someone Else Started",
+    intro:
+      "Use Join when another singer has already started a quartet. Enter the code they give you, scan the QR code, or open the shared link.",
+    topics: [
+      {
+        title: "What Join Uses",
+        body: [
+          "When you join, the app uses your saved repertoire to look for songs the group can sing together. Joining does not add songs to your repertoire or change the songs you already saved.",
+          "If your repertoire is empty or missing common songs, the group may see fewer matches until you add or update entries.",
+        ],
+      },
+      {
+        title: "Signing In and Rejoining",
+        body: [
+          "If the app asks you to sign in or set a display name, do that first so the quartet can identify you and use your saved songs.",
+          "If you leave and later rejoin with the same code or link while there is room, rejoining behaves like joining normally.",
+        ],
+      },
+      {
+        title: "When The Quartet Is Full",
+        body: [
+          "A quartet is full at four singers. If the quartet is full, the app will keep you from joining until someone leaves or is removed.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "quartet-matches",
     eyebrow: "Quartet Matches",
     title: "Understand What Your Pick-Up Quartet Can Sing",
     intro:
@@ -143,6 +210,15 @@ export const helpGuideSections: HelpGuideSection[] = [
           "Personal notes can appear in details to remind you about your own version or caveats.",
         ],
       },
+    ],
+  },
+  {
+    id: "managing-a-quartet",
+    eyebrow: "Managing A Quartet",
+    title: "Update, Leave, Or Rejoin A Quartet",
+    intro:
+      "Quartet membership and match results come from the current quartet data. Use the quartet controls when someone updates repertoire, changes names, leaves, rejoins, or needs to be removed.",
+    topics: [
       {
         title: "Managing The Quartet",
         body: [
@@ -159,6 +235,16 @@ export const helpGuideSections: HelpGuideSection[] = [
       },
     ],
   },
+];
+
+export const helpNavItems: HelpNavItem[] = [
+  { id: "first-time-setup", label: "First time setup" },
+  { id: "repertoire", label: "Repertoire" },
+  { id: "starting-a-quartet", label: "Starting a quartet" },
+  { id: "joining-a-quartet", label: "Joining a quartet" },
+  { id: "quartet-matches", label: "Quartet matches" },
+  { id: "managing-a-quartet", label: "Managing a quartet" },
+  { id: "feedback", label: "Feedback" },
 ];
 
 export const feedbackHelpCopy =


### PR DESCRIPTION
## Summary
- add explicit Help sections for starting a quartet and joining a quartet
- add shared stable section IDs and a compact `On this page` anchor nav
- split match guidance from quartet management guidance for clearer scanning
- add tests for the help content and rendered page navigation hooks

Closes #259

## Validation
- npm run test:run
- npm run build

## Docs and tests
- Docs: not separate; this change updates the in-app Help content directly.
- Tests: updated help content coverage and added page navigation guardrails.