### PR TITLE
Clean up home links and feedback copy

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -11,12 +11,13 @@ import {
   feedbackHelpCopy,
   helpGuideSections,
   helpNavItems,
+  helpWelcomeCopy,
 } from "@/lib/helpContent";
 import { getCurrentUser } from "@/lib/profileStore";
 import { useEffect, useState } from "react";
 
 export default function HelpPage() {
-  const [type, setType] = useState<FeedbackType>("Bug report");
+  const [type, setType] = useState<FeedbackType>("General feedback");
   const [message, setMessage] = useState("");
   const [contactEmail, setContactEmail] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
@@ -119,6 +120,20 @@ export default function HelpPage() {
             can sing, and how confident they feel. When singers join the same
             quartet, the app compares everyone&apos;s repertoire and shows songs
             where the required parts are covered by different people.
+          </p>
+          <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">
+            {helpWelcomeCopy}
+          </p>
+          <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">
+            If the app helps you, confuses you, or gives you an idea for
+            something better, please send a note using the{" "}
+            <a
+              href="#feedback"
+              className="font-semibold text-cyan-200 hover:text-cyan-100"
+            >
+              feedback form
+            </a>{" "}
+            at the bottom of this page.
           </p>
         </header>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -149,12 +149,6 @@ export default function Home() {
             >
               {setupPrompt.action}
             </a>
-            <a
-              href="/help"
-              className="ml-3 mt-4 inline-block px-1 py-3 text-sm font-semibold text-cyan-100 hover:text-white"
-            >
-              Help
-            </a>
           </div>
         )}
 
@@ -201,20 +195,6 @@ export default function Home() {
               ))}
             </div>
 
-            <div className="mt-5 flex flex-wrap gap-x-4 gap-y-2 text-sm">
-              <a
-                href="/settings"
-                className="font-semibold text-slate-300 hover:text-cyan-200"
-              >
-                Profile
-              </a>
-              <a
-                href="/help"
-                className="font-semibold text-slate-300 hover:text-cyan-200"
-              >
-                Help
-              </a>
-            </div>
           </>
         )}
       </div>

--- a/lib/__tests__/feedback.test.ts
+++ b/lib/__tests__/feedback.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  feedbackTypes,
   formatFeedbackEmailText,
   validateFeedbackSubmission,
 } from "../feedback";
 
 describe("feedback helpers", () => {
+  it("defaults the feedback form toward general feedback", () => {
+    expect(feedbackTypes[0]).toBe("General feedback");
+  });
+
   it("validates and trims feedback submissions", () => {
     expect(
       validateFeedbackSubmission({

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -3,7 +3,9 @@ import {
   helpGuideSections,
   helpSections,
   feedbackHelpCopy,
+  helpFeedbackInvitationCopy,
   helpNavItems,
+  helpWelcomeCopy,
   quickStartSteps,
 } from "../helpContent";
 
@@ -40,6 +42,7 @@ describe("help content", () => {
     expect(sectionText).toContain("Leaving removes you");
     expect(feedbackHelpCopy).toContain("Report a bug");
     expect(feedbackHelpCopy).toContain("confusing behavior");
+    expect(feedbackHelpCopy).toContain("General feedback");
   });
 
   it("is organized into onboarding, repertoire, and quartet guidance", () => {
@@ -118,5 +121,16 @@ describe("help content", () => {
     for (const item of helpNavItems) {
       expect(sectionIds.has(item.id)).toBe(true);
     }
+  });
+
+  it("welcomes general and positive feedback from real singing contexts", () => {
+    expect(helpWelcomeCopy).toContain("great time using What Can We Sing");
+    expect(helpWelcomeCopy).toContain("convention");
+    expect(helpWelcomeCopy).toContain("afterglow");
+    expect(helpWelcomeCopy).toContain("Brigade");
+    expect(helpFeedbackInvitationCopy).toContain("feedback form");
+    expect(feedbackHelpCopy).toContain("just let us know how you are using the app");
+    expect(feedbackHelpCopy).toContain("if it helped at a convention");
+    expect(feedbackHelpCopy).toContain("General feedback");
   });
 });

--- a/lib/__tests__/helpPageNavigation.test.ts
+++ b/lib/__tests__/helpPageNavigation.test.ts
@@ -18,4 +18,16 @@ describe("help page navigation", () => {
     expect(helpPage).toContain('id="feedback"');
     expect(helpPage).toContain("scroll-mt-6");
   });
+
+  it("links the friendly intro copy to the feedback form", () => {
+    expect(helpPage).toContain("helpWelcomeCopy");
+    expect(helpPage).toContain('href="#feedback"');
+    expect(helpPage).toContain("feedback form");
+  });
+
+  it("auto-selects general feedback for the feedback form", () => {
+    expect(helpPage).toContain(
+      'useState<FeedbackType>("General feedback")'
+    );
+  });
 });

--- a/lib/__tests__/homePageLinks.test.ts
+++ b/lib/__tests__/homePageLinks.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const homePage = readFileSync(join(repoRoot, "app/page.tsx"), "utf8");
+const appNav = readFileSync(join(repoRoot, "components/AppNav.tsx"), "utf8");
+const siteFooter = readFileSync(join(repoRoot, "components/SiteFooter.tsx"), "utf8");
+
+describe("home page links", () => {
+  it("does not render duplicate profile or help links in the home page body", () => {
+    expect(homePage).not.toContain('href="/settings"');
+    expect(homePage).not.toContain('href="/help"');
+  });
+
+  it("keeps normal navigation and footer help links available", () => {
+    expect(appNav).toContain('href: "/settings"');
+    expect(appNav).toContain('href: "/help"');
+    expect(siteFooter).toContain('href: "/help"');
+    expect(siteFooter).toContain("Help & Feedback");
+  });
+});

--- a/lib/feedback.ts
+++ b/lib/feedback.ts
@@ -1,7 +1,7 @@
 export const feedbackTypes = [
+  "General feedback",
   "Bug report",
   "Feature idea",
-  "General feedback",
 ] as const;
 
 export type FeedbackType = (typeof feedbackTypes)[number];

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -247,8 +247,14 @@ export const helpNavItems: HelpNavItem[] = [
   { id: "feedback", label: "Feedback" },
 ];
 
+export const helpWelcomeCopy =
+  "We really hope you have a great time using What Can We Sing, and that it makes your convention, afterglow, or Brigade experience that much more fun and worthwhile.";
+
+export const helpFeedbackInvitationCopy =
+  "If the app helps you, confuses you, or gives you an idea for something better, please send a note using the feedback form at the bottom of this page.";
+
 export const feedbackHelpCopy =
-  "Report a bug, describe confusing behavior, or suggest an improvement. A short note about what you were trying to do and what happened is usually enough.";
+  "Report a bug, describe confusing behavior, suggest an improvement, or just let us know how you are using the app. If you like it, if it helped at a convention, afterglow, or Brigade, or if you have general feedback, choose General feedback and send a quick note. A short note about what you were trying to do and what happened is usually enough.";
 
 export const helpSections: HelpSection[] = helpGuideSections.map((section) => ({
   title: section.title,


### PR DESCRIPTION
## Summary
- remove duplicate Profile and Help links from the home page body
- keep AppNav and footer Profile/Help/Feedback navigation intact
- add friendlier Help page intro copy with an anchor link to the feedback form
- expand feedback copy to welcome general and positive/use-case notes
- make General feedback the first and default-selected feedback type

Closes #262
Closes #263

## Validation
- npm run test:run
- npm run build

## Docs and tests
- Docs: in-app Help copy updated directly.
- Tests: added home page link guardrail and updated help/feedback copy coverage.