### PR TITLE
Inset Help page intro copy

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -17,6 +17,7 @@ import { getCurrentUser } from "@/lib/profileStore";
 import { useEffect, useState } from "react";
 
 const helpIntroParagraphClass = "mt-3 text-base leading-7 text-slate-300";
+const helpIntroInsetClass = "mx-auto max-w-[calc(100%-2rem)] sm:max-w-[calc(100%-3rem)]";
 
 export default function HelpPage() {
   const [type, setType] = useState<FeedbackType>("General feedback");
@@ -106,7 +107,7 @@ export default function HelpPage() {
       <div className="mx-auto max-w-4xl">
         <PublicAwareAppNav />
 
-        <header className="mt-8">
+        <header className={`mt-8 ${helpIntroInsetClass}`}>
           <p className="text-sm font-semibold uppercase text-cyan-300">
             Help
           </p>

--- a/lib/__tests__/helpPageNavigation.test.ts
+++ b/lib/__tests__/helpPageNavigation.test.ts
@@ -6,8 +6,9 @@ const repoRoot = process.cwd();
 const helpPage = readFileSync(join(repoRoot, "app/help/page.tsx"), "utf8");
 
 describe("help page navigation", () => {
-  it("keeps the intro aligned to the same help container as the nav and sections", () => {
+  it("keeps the intro visually tucked inside the shared help container", () => {
     expect(helpPage).toContain('className="mx-auto max-w-4xl"');
+    expect(helpPage).toContain("helpIntroInsetClass");
     expect(helpPage).toContain("helpIntroParagraphClass");
     expect(helpPage).not.toContain("max-w-3xl text-base leading-7");
   });


### PR DESCRIPTION
## Summary
- add a subtle responsive inset to the Help page header/intro block
- keep the TOC and main Help cards at their existing width
- update the Help page layout guardrail test

Follow-up to #265.

## Validation
- npm run test:run
- npm run build