### PR TITLE
Fix repertoire save validation after voicing changes

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -31,6 +31,12 @@ import {
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
 import { arrangerDisplayName } from "@/lib/arrangerDisplay";
+import {
+  hasDuplicateParts,
+  isRepertoireSongFormValid,
+  rowHasMissingPartOrConfidence,
+  type PartConfidenceFormRow,
+} from "@/lib/repertoireForm";
 
 const voicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
 
@@ -51,17 +57,23 @@ const emptyPartRow = (): PartConfidenceFormRow => ({
   confidence: "",
 });
 
+const requiredFieldClass =
+  "mt-1 w-full rounded-xl border px-4 py-3 text-white outline-none focus:ring-2";
+const requiredCompactFieldClass =
+  "mt-1 w-full rounded-xl border px-3 py-3 text-white outline-none focus:ring-2";
+
+function requiredFieldStateClass(isIncomplete: boolean) {
+  return isIncomplete
+    ? "border-rose-300/70 bg-rose-950/30 ring-rose-300"
+    : "border-white/10 bg-slate-900 ring-cyan-300";
+}
+
 type RepertoireForm = {
   songTitle: string;
   voicing: Voicing;
   arrangerName: string;
   partRows: PartConfidenceFormRow[];
   notes: string;
-};
-
-type PartConfidenceFormRow = {
-  part: Part | "";
-  confidence: Confidence | "";
 };
 
 export default function RepertoireManager() {
@@ -107,17 +119,6 @@ export default function RepertoireManager() {
         part: row.part,
         confidence: row.confidence,
       }));
-  }
-
-  function hasDuplicateParts(rows: PartConfidenceFormRow[]) {
-    const selectedParts = rows
-      .map((row) => row.part)
-      .filter((part): part is Part => Boolean(part));
-    return new Set(selectedParts).size !== selectedParts.length;
-  }
-
-  function rowHasMissingPartOrConfidence(rows: PartConfidenceFormRow[]) {
-    return rows.some((row) => !row.part || !row.confidence);
   }
 
   async function loadRepertoire() {
@@ -568,11 +569,14 @@ export default function RepertoireManager() {
     );
   }
 
-  const canAddSong =
-    Boolean(songTitle.trim()) &&
-    Boolean(voicing) &&
-    !rowHasMissingPartOrConfidence(partRows) &&
-    !hasDuplicateParts(partRows);
+  const canAddSong = isRepertoireSongFormValid(songTitle, voicing, partRows);
+  const canSaveEdit = editForm
+    ? isRepertoireSongFormValid(
+        editForm.songTitle,
+        editForm.voicing,
+        editForm.partRows
+      )
+    : false;
   const repertoireFilters = {
     searchQuery,
     voicing: voicingFilter,
@@ -823,7 +827,10 @@ export default function RepertoireManager() {
                           onChange={(e) =>
                             updateEditForm({ songTitle: e.target.value })
                           }
-                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                          aria-invalid={!editForm.songTitle.trim()}
+                          className={`${requiredFieldClass} ${requiredFieldStateClass(
+                            !editForm.songTitle.trim()
+                          )}`}
                         />
                       </label>
 
@@ -896,7 +903,10 @@ export default function RepertoireManager() {
                                     part: e.target.value as Part | "",
                                   })
                                 }
-                                className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                aria-invalid={!row.part}
+                                className={`${requiredCompactFieldClass} ${requiredFieldStateClass(
+                                  !row.part
+                                )}`}
                               >
                                 <option value="">Choose part</option>
                                 {partsByVoicing[editForm.voicing].map((part) => (
@@ -925,7 +935,10 @@ export default function RepertoireManager() {
                                     confidence: e.target.value as Confidence | "",
                                   })
                                 }
-                                className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                aria-invalid={!row.confidence}
+                                className={`${requiredCompactFieldClass} ${requiredFieldStateClass(
+                                  !row.confidence
+                                )}`}
                               >
                                 <option value="">Choose confidence</option>
                                 {confidenceLevels.map((level) => (
@@ -962,7 +975,11 @@ export default function RepertoireManager() {
                     <div className="mt-6 flex flex-col gap-3 sm:flex-row">
                       <button
                         onClick={() => saveEdit(item.id)}
-                        disabled={savingEditId === item.id || deletingId === item.id}
+                        disabled={
+                          !canSaveEdit ||
+                          savingEditId === item.id ||
+                          deletingId === item.id
+                        }
                         className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                       >
                         {savingEditId === item.id ? "Saving..." : "Save changes"}
@@ -1088,7 +1105,10 @@ export default function RepertoireManager() {
                     }}
                     onFocus={() => setSongSuggestionsOpen(true)}
                     autoComplete="off"
-                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                    aria-invalid={!songTitle.trim()}
+                    className={`${requiredFieldClass} ${requiredFieldStateClass(
+                      !songTitle.trim()
+                    )}`}
                   />
                   <p className="mt-1 text-xs text-slate-400">
                     Start typing to see suggestions, or enter your own song
@@ -1156,6 +1176,11 @@ export default function RepertoireManager() {
                       </button>
                     ))}
                   </div>
+                  {!voicing && (
+                    <p className="mt-2 text-sm text-rose-200">
+                      Choose a voicing to continue.
+                    </p>
+                  )}
                 </div>
 
                 <div>
@@ -1180,7 +1205,10 @@ export default function RepertoireManager() {
                                   part: e.target.value as Part | "",
                                 })
                               }
-                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                              aria-invalid={!row.part}
+                              className={`${requiredCompactFieldClass} ${requiredFieldStateClass(
+                                !row.part
+                              )}`}
                             >
                               <option value="">Choose part</option>
                               {partsByVoicing[voicing].map((part) => (
@@ -1209,7 +1237,10 @@ export default function RepertoireManager() {
                                   confidence: e.target.value as Confidence | "",
                                 })
                               }
-                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                              aria-invalid={!row.confidence}
+                              className={`${requiredCompactFieldClass} ${requiredFieldStateClass(
+                                !row.confidence
+                              )}`}
                             >
                               <option value="">Choose confidence</option>
                               {confidenceLevels.map((level) => (

--- a/lib/__tests__/repertoireForm.test.ts
+++ b/lib/__tests__/repertoireForm.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasDuplicateParts,
+  isRepertoireSongFormValid,
+  rowHasMissingPartOrConfidence,
+  type PartConfidenceFormRow,
+} from "../repertoireForm";
+
+const completeRows: PartConfidenceFormRow[] = [
+  { part: "Lead", confidence: "Good to Go" },
+];
+
+describe("repertoire song form validation", () => {
+  it("requires title, voicing, part, and confidence", () => {
+    expect(isRepertoireSongFormValid("Hello Mary Lou", "TTBB", completeRows)).toBe(
+      true
+    );
+    expect(isRepertoireSongFormValid("", "TTBB", completeRows)).toBe(false);
+    expect(isRepertoireSongFormValid("Hello Mary Lou", "", completeRows)).toBe(
+      false
+    );
+    expect(
+      isRepertoireSongFormValid("Hello Mary Lou", "TTBB", [
+        { part: "", confidence: "" },
+      ])
+    ).toBe(false);
+  });
+
+  it("keeps the form invalid after changing voicing clears required part fields", () => {
+    const clearedByVoicingChange: PartConfidenceFormRow[] = [
+      { part: "", confidence: "" },
+    ];
+
+    expect(
+      rowHasMissingPartOrConfidence(clearedByVoicingChange)
+    ).toBe(true);
+    expect(
+      isRepertoireSongFormValid(
+        "Hello Mary Lou",
+        "SATB",
+        clearedByVoicingChange
+      )
+    ).toBe(false);
+  });
+
+  it("treats duplicate selected parts as invalid", () => {
+    const duplicateRows: PartConfidenceFormRow[] = [
+      { part: "Lead", confidence: "Good to Go" },
+      { part: "Lead", confidence: "A Little Rusty" },
+    ];
+
+    expect(hasDuplicateParts(duplicateRows)).toBe(true);
+    expect(isRepertoireSongFormValid("Hello Mary Lou", "TTBB", duplicateRows)).toBe(
+      false
+    );
+  });
+});

--- a/lib/__tests__/repertoireFormUi.test.ts
+++ b/lib/__tests__/repertoireFormUi.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repertoireManager = readFileSync(
+  join(process.cwd(), "components/RepertoireManager.tsx"),
+  "utf8"
+);
+
+describe("repertoire form UI validation", () => {
+  it("uses shared form validity for add and edit save buttons", () => {
+    expect(repertoireManager).toContain(
+      "const canAddSong = isRepertoireSongFormValid(songTitle, voicing, partRows)"
+    );
+    expect(repertoireManager).toContain("const canSaveEdit = editForm");
+    expect(repertoireManager).toContain("!canSaveEdit");
+    expect(repertoireManager).toContain("disabled={!canAddSong || isAdding}");
+  });
+
+  it("marks incomplete required controls as invalid", () => {
+    expect(repertoireManager).toContain("aria-invalid={!row.part}");
+    expect(repertoireManager).toContain("aria-invalid={!row.confidence}");
+    expect(repertoireManager).toContain("border-rose-300/70");
+  });
+});

--- a/lib/repertoireForm.ts
+++ b/lib/repertoireForm.ts
@@ -1,0 +1,31 @@
+import type { Confidence, Part, Voicing } from "@/lib/matching";
+
+export type PartConfidenceFormRow = {
+  part: Part | "";
+  confidence: Confidence | "";
+};
+
+export function hasDuplicateParts(rows: PartConfidenceFormRow[]) {
+  const selectedParts = rows
+    .map((row) => row.part)
+    .filter((part): part is Part => Boolean(part));
+  return new Set(selectedParts).size !== selectedParts.length;
+}
+
+export function rowHasMissingPartOrConfidence(rows: PartConfidenceFormRow[]) {
+  return rows.some((row) => !row.part || !row.confidence);
+}
+
+export function isRepertoireSongFormValid(
+  songTitle: string,
+  voicing: Voicing | "",
+  rows: PartConfidenceFormRow[]
+) {
+  return (
+    Boolean(songTitle.trim()) &&
+    Boolean(voicing) &&
+    rows.length > 0 &&
+    !rowHasMissingPartOrConfidence(rows) &&
+    !hasDuplicateParts(rows)
+  );
+}


### PR DESCRIPTION
## Summary
- share repertoire form validity between add and edit flows
- disable edit Save when changing voicing clears required part/confidence fields
- mark incomplete required fields visually and with aria-invalid
- add regression tests for form validity and UI wiring

Closes #268

## Verification
- npm run test:run
- npm run build