### PR TITLE
Add first-login quick-start orientation

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -87,7 +87,10 @@ export default function LoginPage() {
         return;
       }
 
-      window.location.href = getPostLoginRedirectPath(window.location.search);
+      const postLoginPath = getPostLoginRedirectPath(window.location.search);
+      const welcomeUrl = new URL("/welcome", window.location.origin);
+      welcomeUrl.searchParams.set("redirect", postLoginPath);
+      window.location.href = `${welcomeUrl.pathname}${welcomeUrl.search}`;
     } catch (err) {
       console.error(err);
       setMessage("Network unavailable. Try again when you have a connection.");

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getCurrentUser, getMyProfile, markWelcomeSeen } from "@/lib/profileStore";
+import { getMyRepertoire } from "@/lib/repertoireStore";
+import { hasQuartetWorkflowHistory } from "@/lib/activeQuartet";
+import { isSafeAppRedirectPath } from "@/lib/authRedirect";
+
+function getRedirectPath() {
+  if (typeof window === "undefined") return "/repertoire";
+
+  const redirect = new URLSearchParams(window.location.search).get("redirect");
+  return isSafeAppRedirectPath(redirect) ? redirect : "/repertoire";
+}
+
+export default function WelcomePage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [hasDisplayName, setHasDisplayName] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const user = await getCurrentUser();
+
+        if (!user) {
+          window.location.href = "/login";
+          return;
+        }
+
+        const [profile, repertoire] = await Promise.all([
+          getMyProfile(),
+          getMyRepertoire().catch(() => []),
+        ]);
+        const displayNameIsSet = Boolean(profile?.display_name?.trim());
+        setHasDisplayName(displayNameIsSet);
+
+        if (
+          profile?.has_seen_welcome ||
+          repertoire.length > 0 ||
+          hasQuartetWorkflowHistory()
+        ) {
+          window.location.href = displayNameIsSet ? getRedirectPath() : "/settings";
+          return;
+        }
+      } catch (err) {
+        console.error(err);
+        setMessage("Could not load the quick start. Refresh and try again.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, []);
+
+  async function getStarted() {
+    if (saving) return;
+
+    try {
+      setSaving(true);
+      setMessage("");
+      await markWelcomeSeen();
+      window.location.href = hasDisplayName ? "/repertoire" : "/settings";
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not save your quick-start progress. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 text-white">
+        Loading quick start...
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
+      <div className="mx-auto flex min-h-[80vh] max-w-2xl items-center">
+        <section className="w-full rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-6 shadow-2xl shadow-cyan-950/30 sm:p-8">
+          <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
+            Quick start
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight">
+            Welcome to What Can We Sing
+          </h1>
+          <p className="mt-4 text-lg leading-8 text-slate-200">
+            What Can We Sing helps a pickup quartet figure out what everyone can
+            sing together right now.
+          </p>
+
+          <div className="mt-6 rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+            <p className="font-semibold text-white">To get useful matches:</p>
+            <ol className="mt-3 space-y-3 text-sm leading-6 text-slate-300">
+              <li>1. Set your display name.</li>
+              <li>2. Add a few songs you know, not your whole repertoire.</li>
+              <li>3. Start a quartet or join one with a code, QR code, or link.</li>
+              <li>4. Use the match list to pick something and sing.</li>
+            </ol>
+          </div>
+
+          <p className="mt-5 text-sm leading-6 text-slate-300">
+            You can always add more songs later.
+          </p>
+
+          <button
+            type="button"
+            onClick={getStarted}
+            disabled={saving}
+            className="mt-6 w-full rounded-xl bg-cyan-300 px-5 py-4 text-base font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40 sm:w-auto"
+          >
+            {saving ? "Starting..." : "Get started"}
+          </button>
+
+          {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -37,13 +37,15 @@ migrations in `supabase/migrations`, and tests or test documentation.
 
 ### `profiles`
 
-Purpose: source of truth for display names.
+Purpose: source of truth for display names and lightweight first-run user
+preferences.
 
 Code:
 - Read current profile: `lib/profileStore.ts#getMyProfile`
 - Read participant names by id: `lib/profileStore.ts#getProfilesByIds`
 - Read profile for feedback email context: `app/api/feedback/route.ts`
 - Insert/update own profile: `lib/profileStore.ts#upsertMyProfile`
+- Mark quick-start orientation as seen: `lib/profileStore.ts#markWelcomeSeen`
 - Realtime profile display-name subscription:
   `lib/profileStore.ts#subscribeToProfileDisplayNames`
 
@@ -54,6 +56,7 @@ Expected context:
 Required database contract:
 - `id uuid primary key references auth.users(id) on delete cascade`
 - `display_name text not null`
+- `has_seen_welcome boolean not null default false`
 - RLS enabled.
 - Authenticated users can read profiles.
 - Authenticated users can insert/update only their own profile where
@@ -62,6 +65,7 @@ Required database contract:
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
+- `20260501133000_add_profile_welcome_seen.sql`
 
 ### `user_repertoire`
 

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -54,6 +54,10 @@ describe("allowsMissingDisplayName", () => {
     expect(allowsMissingDisplayName("/settings")).toBe(true);
   });
 
+  it("allows welcome so new users can see quick start before display name setup", () => {
+    expect(allowsMissingDisplayName("/welcome")).toBe(true);
+  });
+
   it("does not allow protected app routes", () => {
     expect(allowsMissingDisplayName("/")).toBe(false);
     expect(allowsMissingDisplayName("/session")).toBe(false);

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -58,6 +58,13 @@ const songSuggestionSupportedVoicingMigration = readFileSync(
   ),
   "utf8"
 );
+const welcomeSeenMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260501133000_add_profile_welcome_seen.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -103,6 +110,13 @@ describe("Supabase contract guardrails", () => {
     expect(appFlows).toContain("Source Of Truth");
     expect(appFlows).toContain("Rejoin Quartet");
     expect(appFlows).toContain("Remove Singer");
+  });
+
+  it("documents and migrates the first-login welcome flag", () => {
+    expect(contract).toContain("has_seen_welcome");
+    expect(contract).toContain("markWelcomeSeen");
+    expect(welcomeSeenMigration).toContain("public.profiles");
+    expect(welcomeSeenMigration).toContain("has_seen_welcome boolean");
   });
 
   it("documents the analytics privacy contract", () => {

--- a/lib/__tests__/welcomePage.test.ts
+++ b/lib/__tests__/welcomePage.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const welcomePage = readFileSync(
+  join(process.cwd(), "app/welcome/page.tsx"),
+  "utf8"
+);
+const loginPage = readFileSync(join(process.cwd(), "app/login/page.tsx"), "utf8");
+
+describe("first-login welcome page", () => {
+  it("explains the quick-start app flow", () => {
+    expect(welcomePage).toContain("Welcome to What Can We Sing");
+    expect(welcomePage).toContain("Set your display name");
+    expect(welcomePage).toContain("Add a few songs you know");
+    expect(welcomePage).toContain("Start a quartet or join one");
+    expect(welcomePage).toContain("Use the match list");
+    expect(welcomePage).toContain("You can always add more songs later");
+  });
+
+  it("marks the welcome as seen and routes to the right setup step", () => {
+    expect(welcomePage).toContain("markWelcomeSeen");
+    expect(welcomePage).toContain('hasDisplayName ? "/repertoire" : "/settings"');
+  });
+
+  it("skips returning users with profile, repertoire, or quartet history", () => {
+    expect(welcomePage).toContain("profile?.has_seen_welcome");
+    expect(welcomePage).toContain("repertoire.length > 0");
+    expect(welcomePage).toContain("hasQuartetWorkflowHistory");
+  });
+
+  it("routes successful logins through welcome with the intended destination preserved", () => {
+    expect(loginPage).toContain('new URL("/welcome", window.location.origin)');
+    expect(loginPage).toContain('welcomeUrl.searchParams.set("redirect", postLoginPath)');
+  });
+});

--- a/lib/authRoute.ts
+++ b/lib/authRoute.ts
@@ -13,6 +13,8 @@ export function isPublicAuthPath(pathname: string): boolean {
 export function allowsMissingDisplayName(pathname: string): boolean {
   return (
     isPublicAuthPath(pathname) ||
+    pathname === "/welcome" ||
+    pathname.startsWith("/welcome/") ||
     pathname === "/settings" ||
     pathname.startsWith("/settings/")
   );

--- a/lib/profileStore.ts
+++ b/lib/profileStore.ts
@@ -4,6 +4,7 @@ import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 export type Profile = {
   id: string;
   display_name: string;
+  has_seen_welcome: boolean;
   created_at: string;
   updated_at: string;
 };
@@ -104,6 +105,42 @@ export async function upsertMyProfile(displayName: string) {
     .upsert({
       id: user.id,
       display_name: displayName,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Profile;
+}
+
+export async function markWelcomeSeen() {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const profile = await getMyProfile();
+
+  if (profile) {
+    const { data, error } = await supabase
+      .from("profiles")
+      .update({
+        has_seen_welcome: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", user.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as Profile;
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .insert({
+      id: user.id,
+      display_name: "",
+      has_seen_welcome: true,
       updated_at: new Date().toISOString(),
     })
     .select()

--- a/supabase/migrations/20260501133000_add_profile_welcome_seen.sql
+++ b/supabase/migrations/20260501133000_add_profile_welcome_seen.sql
@@ -1,0 +1,2 @@
+alter table public.profiles
+add column if not exists has_seen_welcome boolean not null default false;


### PR DESCRIPTION
## Summary
- route successful logins through a new authenticated /welcome quick-start screen
- add friendly one-page orientation copy for display name, repertoire, quartet, and match flow
- mark the welcome as seen in profiles and skip it for users with repertoire or quartet history
- send Get started to Settings when display name is missing, otherwise to Repertoire
- document and migrate the new profile welcome flag

Closes #276

## Docs and tests
- Docs: updated docs/supabase-contract.md for profiles.has_seen_welcome and markWelcomeSeen.
- Tests: added welcome-page coverage, auth-route coverage, and Supabase contract migration coverage.

## Supabase deployment/manual steps
- Migration added: supabase/migrations/20260501133000_add_profile_welcome_seen.sql
- Required production step: deploy through the existing Production Deploy workflow so Supabase migrations run before the Vercel production deploy. No dashboard-only change is required.

## Verification
- npm run test:run
- npm run build