### PR TITLE
Add admin user deletion script

### DIFF
--- a/docs/admin-delete-user.md
+++ b/docs/admin-delete-user.md
@@ -1,0 +1,73 @@
+# Admin User Deletion
+
+Use `npm run admin:delete-user` when a user asks for account deletion or when
+an operator needs to remove a test account from Supabase. The script uses the
+Supabase service-role key from the local shell environment only. Never expose
+that key in browser code, checked-in files, or client-visible environment
+variables.
+
+## Required Environment
+
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_URL`
+
+Optional production guard:
+
+- `WCWS_ADMIN_ENV=production` or `VERCEL_ENV=production`
+
+When either production flag is present, confirmed deletion requires both
+`--confirm` and `--confirm-production`.
+
+## Dry Run First
+
+The script defaults to dry-run mode. It accepts only exact identifiers and
+does not support fuzzy matching or wildcards.
+
+```sh
+npm run admin:delete-user -- --email singer@example.com
+npm run admin:delete-user -- --user-id 00000000-0000-0000-0000-000000000000
+```
+
+The dry run prints counts only. It does not print repertoire titles, feedback
+message content, notes, or other private free text.
+
+## Confirm Deletion
+
+```sh
+npm run admin:delete-user -- --email singer@example.com --confirm
+```
+
+For production:
+
+```sh
+WCWS_ADMIN_ENV=production npm run admin:delete-user -- --email singer@example.com --confirm --confirm-production
+```
+
+## What It Deletes
+
+- Supabase auth user
+- `profiles` row, including display name and lightweight preferences such as
+  `has_seen_welcome`
+- `user_repertoire` rows
+- `session_participants` rows
+- `sung_song_events` rows
+
+The script deletes user-owned app rows before deleting the Supabase auth user,
+then deletes the auth user through `supabase.auth.admin.deleteUser`.
+
+## What It Preserves
+
+- Shared `sessions` rows
+- Shared/global `song_suggestion_catalog` rows
+- PostHog analytics events
+- Resend email delivery logs
+- Feedback email content already delivered outside Supabase
+
+The app does not store feedback submissions in a Supabase feedback table.
+
+## Verification
+
+After a confirmed deletion, run the same command without `--confirm`. It should
+report that no Supabase auth user matches the exact email or user ID. You can
+also verify in the Supabase dashboard that the auth user is gone and the
+user-owned table counts are zero.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -48,10 +48,15 @@ Code:
 - Mark quick-start orientation as seen: `lib/profileStore.ts#markWelcomeSeen`
 - Realtime profile display-name subscription:
   `lib/profileStore.ts#subscribeToProfileDisplayNames`
+- Admin deletion:
+  `scripts/delete-user.mjs` deletes the user's `profiles` row with the
+  Supabase service-role key during confirmed account deletion.
 
 Expected context:
 - Browser authenticated user for reads and own upsert.
 - Server route with user session for feedback profile read.
+- Local/server admin script with `SUPABASE_SERVICE_ROLE_KEY` for account
+  deletion only.
 
 Required database contract:
 - `id uuid primary key references auth.users(id) on delete cascade`
@@ -84,9 +89,12 @@ Code:
   `public.search_repertoire_song_suggestions`
 - Used by `lib/activeQuartetSnapshot.ts` to refresh the current user's
   `session_participants.repertoire` snapshot.
+- Deleted by `scripts/delete-user.mjs` during confirmed account deletion.
 
 Expected context:
 - Browser authenticated user.
+- Local/server admin script with `SUPABASE_SERVICE_ROLE_KEY` for account
+  deletion only.
 
 Required database contract:
 - `id uuid primary key`
@@ -134,6 +142,8 @@ Purpose: optional autocomplete reference data for song entry, imported from
 
 Code:
 - Imported by `scripts/import-song-suggestions.mjs`
+- Preserved by `scripts/delete-user.mjs`; catalog rows are global suggestions,
+  not user-owned data.
 - Read only through `public.search_repertoire_song_suggestions`
 - Parsed/deduplicated by `lib/__tests__/songSuggestionCatalogImport.test.ts`
 
@@ -175,6 +185,7 @@ Code:
   after participant snapshot upserts.
 - Start quartet flow: `app/session/page.tsx` creates the session before
   inserting the first participant snapshot.
+- Preserved by `scripts/delete-user.mjs`; sessions are shared join-code records.
 
 Expected context:
 - Browser authenticated user.
@@ -214,9 +225,12 @@ Code:
 - Match calculation source:
   `app/join/[code]/page.tsx` builds entries from current participants and calls
   `findMatches`.
+- Deleted by `scripts/delete-user.mjs` during confirmed account deletion.
 
 Expected context:
 - Browser authenticated user.
+- Local/server admin script with `SUPABASE_SERVICE_ROLE_KEY` for account
+  deletion only.
 
 Required database contract:
 - `id uuid primary key`
@@ -249,9 +263,12 @@ Code:
 - Read recent events: `lib/sungSongStore.ts#getRecentSungSongs`
 - Insert event as part of marking repertoire metadata:
   `public.mark_repertoire_sung`
+- Deleted by `scripts/delete-user.mjs` during confirmed account deletion.
 
 Expected context:
 - Browser authenticated user.
+- Local/server admin script with `SUPABASE_SERVICE_ROLE_KEY` for account
+  deletion only.
 
 Required database contract:
 - `id uuid primary key`
@@ -277,6 +294,8 @@ Supabase usage:
 - `app/api/feedback/route.ts` calls `supabase.auth.getUser()`.
 - If a user is authenticated, it reads `profiles.display_name`.
 - No feedback table, RPC, storage bucket, or Supabase function is used.
+- `scripts/delete-user.mjs` therefore has no Supabase feedback rows to delete;
+  delivered email and provider logs are outside the database.
 
 Expected context:
 - Server route with user cookies.
@@ -290,6 +309,11 @@ Expected context:
 - Most app pages require an authenticated user before reading or writing app
   tables.
 - RLS policies are written for the `authenticated` role and `auth.uid()`.
+- Account deletion uses `scripts/delete-user.mjs` from a trusted local/server
+  environment with `SUPABASE_SERVICE_ROLE_KEY`. The service-role key must never
+  be exposed to browser code. The script defaults to dry-run mode, requires an
+  exact email or auth user ID, and requires `--confirm-production` in addition
+  to `--confirm` when `WCWS_ADMIN_ENV=production` or `VERCEL_ENV=production`.
 
 ## Realtime Assumptions
 

--- a/lib/__tests__/adminDeleteUser.test.mjs
+++ b/lib/__tests__/adminDeleteUser.test.mjs
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  deletionOrder,
+  formatDeletionSummary,
+  parseDeleteUserArgs,
+  userOwnedTables,
+} from "../../scripts/admin/delete-user-core.mjs";
+
+describe("admin delete user helpers", () => {
+  it("defaults exact email deletion requests to dry-run mode", () => {
+    const options = parseDeleteUserArgs(["--email", "Singer@Example.com"], {});
+
+    expect(options.identifier).toEqual({
+      type: "email",
+      value: "singer@example.com",
+    });
+    expect(options.dryRun).toBe(true);
+    expect(options.confirm).toBe(false);
+  });
+
+  it("requires one exact identifier", () => {
+    expect(() => parseDeleteUserArgs([], {})).toThrow(
+      "Provide an exact --email or --user-id."
+    );
+    expect(() =>
+      parseDeleteUserArgs(
+        [
+          "--email",
+          "a@example.com",
+          "--user-id",
+          "46eed8b7-4a11-46e2-8c40-f22f3005ff77",
+        ],
+        {}
+      )
+    ).toThrow("Use either --email or --user-id, not both.");
+    expect(() => parseDeleteUserArgs(["--email", "*@example.com"], {})).toThrow(
+      "wildcards are not allowed"
+    );
+    expect(() =>
+      parseDeleteUserArgs(["--email", "a@example.com", "--force"], {})
+    ).toThrow("Unknown option: --force.");
+  });
+
+  it("validates user IDs as exact auth UUIDs", () => {
+    expect(() => parseDeleteUserArgs(["--user-id", "not-a-user"], {})).toThrow(
+      "User ID must be an exact Supabase auth UUID."
+    );
+
+    const options = parseDeleteUserArgs(
+      ["--user-id", "46eed8b7-4a11-46e2-8c40-f22f3005ff77"],
+      {}
+    );
+
+    expect(options.identifier).toEqual({
+      type: "user-id",
+      value: "46eed8b7-4a11-46e2-8c40-f22f3005ff77",
+    });
+  });
+
+  it("requires an extra confirmation flag for production deletes", () => {
+    expect(() =>
+      parseDeleteUserArgs(["--email", "singer@example.com", "--confirm"], {
+        WCWS_ADMIN_ENV: "production",
+      })
+    ).toThrow("Production deletion requires --confirm-production");
+
+    const options = parseDeleteUserArgs(
+      [
+        "--email",
+        "singer@example.com",
+        "--confirm",
+        "--confirm-production",
+      ],
+      { WCWS_ADMIN_ENV: "production" }
+    );
+
+    expect(options.dryRun).toBe(false);
+    expect(options.production).toBe(true);
+  });
+
+  it("targets only user-owned app tables before deleting auth", () => {
+    expect(deletionOrder()).toEqual([
+      "session_participants",
+      "sung_song_events",
+      "user_repertoire",
+      "profiles",
+    ]);
+    expect(userOwnedTables.map((item) => item.table)).not.toContain("sessions");
+    expect(userOwnedTables.map((item) => item.table)).not.toContain(
+      "song_suggestion_catalog"
+    );
+  });
+
+  it("summarizes counts without exposing repertoire or feedback content", () => {
+    const summary = formatDeletionSummary({
+      user: {
+        id: "46eed8b7-4a11-46e2-8c40-f22f3005ff77",
+        email: "singer@example.com",
+      },
+      counts: {
+        profiles: 1,
+        user_repertoire: 12,
+        session_participants: 2,
+        sung_song_events: 3,
+      },
+      dryRun: true,
+      production: false,
+    });
+
+    expect(summary).toContain("DRY RUN");
+    expect(summary).toContain("Repertoire entries: 12");
+    expect(summary).toContain("Preserved: sessions");
+    expect(summary).toContain("Preserved: song_suggestion_catalog");
+    expect(summary).not.toContain("song_title");
+    expect(summary).not.toContain("message");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "posthog:dashboards:inspect": "node scripts/posthog/sync-dashboards.mjs --inspect",
     "posthog:dashboards:compare": "node scripts/posthog/sync-dashboards.mjs --compare",
     "posthog:dashboards:sync": "node scripts/posthog/sync-dashboards.mjs",
+    "admin:delete-user": "node scripts/delete-user.mjs",
     "song-suggestions:import": "node scripts/import-song-suggestions.mjs",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/admin/delete-user-core.mjs
+++ b/scripts/admin/delete-user-core.mjs
@@ -1,0 +1,144 @@
+export const userOwnedTables = [
+  {
+    table: "session_participants",
+    column: "user_id",
+    label: "Session participant rows",
+  },
+  {
+    table: "sung_song_events",
+    column: "user_id",
+    label: "Sung song events",
+  },
+  {
+    table: "user_repertoire",
+    column: "user_id",
+    label: "Repertoire entries",
+  },
+  {
+    table: "profiles",
+    column: "id",
+    label: "Profile rows",
+  },
+];
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function readFlagValue(args, flag) {
+  const equalsPrefix = `${flag}=`;
+  const equalsValue = args.find((arg) => arg.startsWith(equalsPrefix));
+
+  if (equalsValue) return equalsValue.slice(equalsPrefix.length).trim();
+
+  const index = args.indexOf(flag);
+  if (index === -1) return null;
+
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}.`);
+  }
+
+  return value.trim();
+}
+
+function rejectUnknownFlags(args) {
+  const flagsWithValues = new Set(["--email", "--user-id"]);
+  const booleanFlags = new Set([
+    "--confirm",
+    "--confirm-production",
+    "--dry-run",
+  ]);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) continue;
+
+    const flag = arg.includes("=") ? arg.split("=")[0] : arg;
+
+    if (booleanFlags.has(flag)) continue;
+
+    if (flagsWithValues.has(flag)) {
+      if (!arg.includes("=")) index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${flag}.`);
+  }
+}
+
+export function isProductionEnvironment(env = process.env) {
+  return env.WCWS_ADMIN_ENV === "production" || env.VERCEL_ENV === "production";
+}
+
+export function parseDeleteUserArgs(argv, env = process.env) {
+  const args = [...argv];
+  rejectUnknownFlags(args);
+
+  const email = readFlagValue(args, "--email");
+  const userId = readFlagValue(args, "--user-id");
+  const confirm = args.includes("--confirm");
+  const dryRun = args.includes("--dry-run") || !confirm;
+  const confirmProduction = args.includes("--confirm-production");
+  const production = isProductionEnvironment(env);
+
+  if (email && userId) {
+    throw new Error("Use either --email or --user-id, not both.");
+  }
+
+  if (!email && !userId) {
+    throw new Error("Provide an exact --email or --user-id.");
+  }
+
+  if (email && /[*?]/.test(email)) {
+    throw new Error("Email matching must be exact; wildcards are not allowed.");
+  }
+
+  if (userId && !uuidPattern.test(userId)) {
+    throw new Error("User ID must be an exact Supabase auth UUID.");
+  }
+
+  if (production && confirm && !confirmProduction) {
+    throw new Error(
+      "Production deletion requires --confirm-production in addition to --confirm."
+    );
+  }
+
+  return {
+    identifier: email
+      ? { type: "email", value: email.toLowerCase() }
+      : { type: "user-id", value: userId },
+    confirm,
+    dryRun,
+    confirmProduction,
+    production,
+  };
+}
+
+export function formatDeletionSummary({
+  user,
+  counts,
+  dryRun,
+  production,
+}) {
+  const lines = [
+    `Mode: ${dryRun ? "DRY RUN (no changes)" : "CONFIRMED DELETE"}`,
+    `Environment: ${production ? "production" : "non-production/unspecified"}`,
+    `Auth user: ${user.id}`,
+  ];
+
+  if (user.email) lines.push(`Email: ${user.email}`);
+
+  for (const item of userOwnedTables) {
+    lines.push(`${item.label}: ${counts[item.table] ?? 0}`);
+  }
+
+  lines.push("Preserved: sessions");
+  lines.push("Preserved: song_suggestion_catalog");
+  lines.push("Feedback: no Supabase feedback table is used");
+
+  return lines.join("\n");
+}
+
+export function deletionOrder() {
+  return userOwnedTables.map((item) => item.table);
+}

--- a/scripts/delete-user.mjs
+++ b/scripts/delete-user.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { createClient } from "@supabase/supabase-js";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  deletionOrder,
+  formatDeletionSummary,
+  parseDeleteUserArgs,
+  userOwnedTables,
+} from "./admin/delete-user-core.mjs";
+
+function usage() {
+  return [
+    "Usage:",
+    "  npm run admin:delete-user -- --email singer@example.com [--dry-run]",
+    "  npm run admin:delete-user -- --user-id 00000000-0000-0000-0000-000000000000 [--dry-run]",
+    "  npm run admin:delete-user -- --email singer@example.com --confirm",
+    "",
+    "Production deletes also require --confirm-production when WCWS_ADMIN_ENV=production or VERCEL_ENV=production.",
+  ].join("\n");
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+function createAdminClient() {
+  const supabaseUrl =
+    process.env.SUPABASE_URL || requiredEnv("NEXT_PUBLIC_SUPABASE_URL");
+  const serviceRoleKey = requiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+async function findUserByEmail(supabase, email) {
+  const perPage = 1000;
+
+  for (let page = 1; page < 1000; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) throw error;
+
+    const users = data?.users ?? [];
+    const exactMatches = users.filter(
+      (user) => user.email?.toLowerCase() === email
+    );
+
+    if (exactMatches.length > 1) {
+      throw new Error(`Multiple auth users matched email ${email}.`);
+    }
+
+    if (exactMatches.length === 1) return exactMatches[0];
+
+    if (users.length < perPage) break;
+  }
+
+  throw new Error(`No Supabase auth user matched email ${email}.`);
+}
+
+async function findUser(supabase, identifier) {
+  if (identifier.type === "email") {
+    return findUserByEmail(supabase, identifier.value);
+  }
+
+  const { data, error } = await supabase.auth.admin.getUserById(
+    identifier.value
+  );
+
+  if (error) throw error;
+  if (!data?.user) {
+    throw new Error(`No Supabase auth user matched ID ${identifier.value}.`);
+  }
+
+  return data.user;
+}
+
+async function countRows(supabase, userId) {
+  const counts = {};
+
+  for (const item of userOwnedTables) {
+    const { count, error } = await supabase
+      .from(item.table)
+      .select(item.column, { count: "exact", head: true })
+      .eq(item.column, userId);
+
+    if (error) throw error;
+
+    counts[item.table] = count ?? 0;
+  }
+
+  return counts;
+}
+
+async function deleteRows(supabase, userId) {
+  const byTable = new Map(userOwnedTables.map((item) => [item.table, item]));
+
+  for (const table of deletionOrder()) {
+    const item = byTable.get(table);
+    const { error } = await supabase
+      .from(item.table)
+      .delete()
+      .eq(item.column, userId);
+
+    if (error) throw error;
+  }
+}
+
+function remainingRows(counts) {
+  return Object.entries(counts).filter(([, count]) => count > 0);
+}
+
+export async function deleteUserFromSupabase(argv = process.argv.slice(2)) {
+  const options = parseDeleteUserArgs(argv);
+  const supabase = createAdminClient();
+  const user = await findUser(supabase, options.identifier);
+  const counts = await countRows(supabase, user.id);
+
+  console.log(
+    formatDeletionSummary({
+      user,
+      counts,
+      dryRun: options.dryRun,
+      production: options.production,
+    })
+  );
+
+  if (options.dryRun) {
+    console.log("\nNo changes made. Re-run with --confirm to delete.");
+    return { deleted: false, userId: user.id, counts };
+  }
+
+  await deleteRows(supabase, user.id);
+
+  const verificationCounts = await countRows(supabase, user.id);
+  const remaining = remainingRows(verificationCounts);
+
+  if (remaining.length > 0) {
+    throw new Error(
+      `Deleted app rows, but some user-owned rows remain: ${remaining
+        .map(([table, count]) => `${table}=${count}`)
+        .join(", ")}. Auth user was not deleted.`
+    );
+  }
+
+  const { error } = await supabase.auth.admin.deleteUser(user.id);
+  if (error) throw error;
+
+  console.log("\nDeleted user-owned app rows and Supabase auth user.");
+  return { deleted: true, userId: user.id, counts };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  deleteUserFromSupabase().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    console.error("");
+    console.error(usage());
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
Closes #277

## Summary
- Added a service-role-only admin deletion script with dry-run-by-default behavior, exact email/user-id selection, production confirmation guardrails, and post-delete row verification before auth deletion.
- Added operator docs covering required env vars, dry-run/confirm commands, what is deleted, what is preserved, and verification steps.
- Updated the Supabase contract to document admin deletion expectations and preserved shared data.

## Tests
- Added unit coverage for argument parsing, production safeguards, deletion target scope, and summary privacy.
- npm run test:run
- npm run build

## Supabase / manual steps
- No migration is required for this change.
- To use the script, run it from a trusted environment with SUPABASE_SERVICE_ROLE_KEY and SUPABASE_URL or NEXT_PUBLIC_SUPABASE_URL configured. Production deletes require --confirm --confirm-production when WCWS_ADMIN_ENV=production or VERCEL_ENV=production.