### PR TITLE
Improve song suggestion picker

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -91,6 +91,9 @@ export default function RepertoireManager() {
   const [songSuggestions, setSongSuggestions] = useState<SongSuggestion[]>([]);
   const [songSuggestionsOpen, setSongSuggestionsOpen] = useState(false);
   const [songSuggestionsLoading, setSongSuggestionsLoading] = useState(false);
+  const [suggestedVoicings, setSuggestedVoicings] = useState<Voicing[] | null>(
+    null
+  );
   const [voicing, setVoicing] = useState<Voicing | "">("");
   const [arrangerName, setArrangerName] = useState("");
   const [notes, setNotes] = useState("");
@@ -236,6 +239,7 @@ export default function RepertoireManager() {
     setSongSuggestions([]);
     setSongSuggestionsLoading(false);
     setSongSuggestionsOpen(false);
+    setSuggestedVoicings(null);
     setVoicing("");
     setArrangerName("");
     setNotes("");
@@ -267,10 +271,21 @@ export default function RepertoireManager() {
     setMessage("");
   }
 
+  function updateSongTitle(value: string) {
+    setSongTitle(value);
+    setSuggestedVoicings(null);
+    setSongSuggestionsOpen(true);
+  }
+
   function selectSongSuggestion(suggestion: SongSuggestion) {
     setSongTitle(suggestion.songTitle);
     setSongSuggestionsOpen(false);
-    setVoicing(suggestion.voicing);
+    setSuggestedVoicings(
+      suggestion.voicings.length > 1 ? suggestion.voicings : null
+    );
+    setVoicing(
+      suggestion.voicings.length === 1 ? (suggestion.voicings[0] ?? "") : ""
+    );
     setArrangerName(suggestion.arrangerName);
     setShowArranger(Boolean(suggestion.arrangerName));
     setPartRows([emptyPartRow()]);
@@ -619,6 +634,7 @@ export default function RepertoireManager() {
     ? partsByVoicing[voicingFilter]
     : Array.from(new Set(voicings.flatMap((v) => partsByVoicing[v])));
   const hasSavedSongs = items.length > 0;
+  const voicingOptions = suggestedVoicings ?? voicings;
   const hasSmallRepertoire = items.length > 0 && items.length <= 3;
   const addSectionTitle =
     items.length === 0
@@ -754,10 +770,7 @@ export default function RepertoireManager() {
               <div className="mt-1 flex flex-col gap-3 sm:flex-row">
                 <input
                   value={songTitle}
-                  onChange={(e) => {
-                    setSongTitle(e.target.value);
-                    setSongSuggestionsOpen(true);
-                  }}
+                  onChange={(e) => updateSongTitle(e.target.value)}
                   onFocus={() => setSongSuggestionsOpen(true)}
                   placeholder="Start typing a song title..."
                   autoComplete="off"
@@ -777,44 +790,55 @@ export default function RepertoireManager() {
             {songSuggestionsOpen && !isAddOpen && songTitle.trim().length >= 2 && (
               <div className="mt-2 overflow-hidden rounded-xl border border-cyan-300/20 bg-slate-900 shadow-xl">
                 <p className="px-3 py-2 text-xs font-semibold uppercase tracking-normal text-slate-400">
-                  Song suggestions
+                  Song suggestions are optional
                 </p>
-                {songSuggestionsLoading ? (
-                  <p className="px-3 py-3 text-sm text-slate-300">
-                    Searching suggestions...
-                  </p>
-                ) : songSuggestions.length > 0 ? (
-                  <div className="divide-y divide-white/10">
-                    {songSuggestions.map((suggestion) => (
-                      <button
-                        key={`page:${suggestion.songTitle}:${suggestion.voicing}:${suggestion.arrangerName}`}
-                        type="button"
-                        onClick={() => selectSongSuggestionAndOpen(suggestion)}
-                        className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
-                      >
-                        <span className="block font-semibold text-white">
-                          {suggestion.songTitle}
-                        </span>
-                        <span className="mt-1 block text-xs text-slate-300">
-                          {songSuggestionSubtitle(suggestion)}
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="px-3 py-3">
-                    <p className="text-sm text-slate-300">
-                      No suggestion found.
+                <div className="max-h-80 overflow-y-auto sm:max-h-96">
+                  {songSuggestionsLoading ? (
+                    <p className="px-3 py-3 text-sm text-slate-300">
+                      Searching suggestions...
                     </p>
-                    <button
-                      type="button"
-                      onClick={openAddModalWithCurrentTitle}
-                      className="mt-2 rounded-lg bg-cyan-300 px-3 py-2 text-sm font-bold text-slate-950 hover:bg-cyan-200"
-                    >
-                      Add &quot;{songTitle.trim()}&quot; manually
-                    </button>
-                  </div>
-                )}
+                  ) : songSuggestions.length > 0 ? (
+                    <div className="divide-y divide-white/10">
+                      {songSuggestions.map((suggestion) => (
+                        <button
+                          key={`page:${suggestion.songTitle}:${suggestion.voicings.join(":")}:${suggestion.arrangerName}`}
+                          type="button"
+                          onClick={() => selectSongSuggestionAndOpen(suggestion)}
+                          className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
+                        >
+                          <span className="block font-semibold text-white">
+                            {suggestion.songTitle}
+                          </span>
+                          <span className="mt-1 block text-xs text-slate-300">
+                            {songSuggestionSubtitle(suggestion)}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="px-3 py-3">
+                      <p className="text-sm text-slate-300">
+                        No suggestion found.
+                      </p>
+                    </div>
+                  )}
+                </div>
+                <div className="border-t border-cyan-300/20 bg-cyan-300/5 p-3">
+                  <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
+                    Don&apos;t see your version?
+                  </p>
+                  <button
+                    type="button"
+                    onClick={openAddModalWithCurrentTitle}
+                    className="mt-2 w-full rounded-lg bg-cyan-300 px-3 py-2 text-left text-sm font-bold text-slate-950 hover:bg-cyan-200"
+                  >
+                    Add &quot;{songTitle.trim()}&quot; manually
+                  </button>
+                  <p className="mt-2 text-xs leading-5 text-slate-300">
+                    Choose your own title, voicing, arranger, part, and
+                    confidence.
+                  </p>
+                </div>
               </div>
             )}
           </div>
@@ -1331,10 +1355,7 @@ export default function RepertoireManager() {
                   <input
                     ref={songTitleInputRef}
                     value={songTitle}
-                    onChange={(e) => {
-                      setSongTitle(e.target.value);
-                      setSongSuggestionsOpen(true);
-                    }}
+                    onChange={(e) => updateSongTitle(e.target.value)}
                     onFocus={() => setSongSuggestionsOpen(true)}
                     autoComplete="off"
                     aria-invalid={!songTitle.trim()}
@@ -1349,36 +1370,53 @@ export default function RepertoireManager() {
                   {songSuggestionsOpen && songTitle.trim().length >= 2 && (
                     <div className="mt-2 overflow-hidden rounded-xl border border-cyan-300/20 bg-slate-900">
                       <p className="px-3 py-2 text-xs font-semibold uppercase tracking-normal text-slate-400">
-                        Song suggestions
+                        Song suggestions are optional
                       </p>
-                      {songSuggestionsLoading ? (
-                        <p className="px-3 py-3 text-sm text-slate-300">
-                          Searching suggestions...
+                      <div className="max-h-80 overflow-y-auto sm:max-h-96">
+                        {songSuggestionsLoading ? (
+                          <p className="px-3 py-3 text-sm text-slate-300">
+                            Searching suggestions...
+                          </p>
+                        ) : songSuggestions.length > 0 ? (
+                          <div className="divide-y divide-white/10">
+                            {songSuggestions.map((suggestion) => (
+                              <button
+                                key={`${suggestion.songTitle}:${suggestion.voicings.join(":")}:${suggestion.arrangerName}`}
+                                type="button"
+                                onClick={() => selectSongSuggestion(suggestion)}
+                                className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
+                              >
+                                <span className="block font-semibold text-white">
+                                  {suggestion.songTitle}
+                                </span>
+                                <span className="mt-1 block text-xs text-slate-300">
+                                  {songSuggestionSubtitle(suggestion)}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="px-3 py-3 text-sm text-slate-300">
+                            No suggestion found.
+                          </p>
+                        )}
+                      </div>
+                      <div className="border-t border-cyan-300/20 bg-cyan-300/5 p-3">
+                        <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
+                          Don&apos;t see your version?
                         </p>
-                      ) : songSuggestions.length > 0 ? (
-                        <div className="divide-y divide-white/10">
-                          {songSuggestions.map((suggestion) => (
-                            <button
-                              key={`${suggestion.songTitle}:${suggestion.voicing}:${suggestion.arrangerName}`}
-                              type="button"
-                              onClick={() => selectSongSuggestion(suggestion)}
-                              className="w-full px-3 py-3 text-left hover:bg-cyan-300/10 focus:bg-cyan-300/10 focus:outline-none"
-                            >
-                              <span className="block font-semibold text-white">
-                                {suggestion.songTitle}
-                              </span>
-                              <span className="mt-1 block text-xs text-slate-300">
-                                {songSuggestionSubtitle(suggestion)}
-                              </span>
-                            </button>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="px-3 py-3 text-sm text-slate-300">
-                          No suggestion found. You can still add this song
-                          manually.
+                        <button
+                          type="button"
+                          onClick={openAddModalWithCurrentTitle}
+                          className="mt-2 w-full rounded-lg bg-cyan-300 px-3 py-2 text-left text-sm font-bold text-slate-950 hover:bg-cyan-200"
+                        >
+                          Add &quot;{songTitle.trim()}&quot; manually
+                        </button>
+                        <p className="mt-2 text-xs leading-5 text-slate-300">
+                          Choose your own title, voicing, arranger, part, and
+                          confidence.
                         </p>
-                      )}
+                      </div>
                     </div>
                   )}
                 </label>
@@ -1386,11 +1424,12 @@ export default function RepertoireManager() {
                 <div>
                   <p className="text-sm font-medium text-slate-300">Voicing</p>
                   <p className="mt-1 text-xs text-slate-400">
-                    Suggestions are optional. You can always type your own title
-                    and choose the correct voicing.
+                    {suggestedVoicings
+                      ? "This suggestion has multiple voicings. Choose the version you know."
+                      : "Suggestions are optional. You can always type your own title and choose the correct voicing."}
                   </p>
                   <div className="mt-2 grid grid-cols-3 gap-2">
-                    {voicings.map((v) => (
+                    {voicingOptions.map((v) => (
                       <button
                         key={v}
                         type="button"

--- a/lib/__tests__/repertoireSongSuggestions.test.ts
+++ b/lib/__tests__/repertoireSongSuggestions.test.ts
@@ -12,11 +12,24 @@ describe("repertoire song suggestion UI", () => {
     expect(repertoireManager).toContain(
       "Start typing to see suggestions, or enter your own song"
     );
+    expect(repertoireManager).toContain("Song suggestions are optional");
+    expect(repertoireManager).toContain("Don&apos;t see your version?");
     expect(repertoireManager).toContain(
-      "No suggestion found. You can still add this song"
+      "Choose your own title, voicing, arranger, part, and"
     );
+    expect(repertoireManager).toContain("max-h-80 overflow-y-auto");
     expect(repertoireManager).toContain("setTimeout(async () =>");
     expect(repertoireManager).toContain("}, 250)");
     expect(repertoireManager).toContain("songSuggestionSubtitle");
+  });
+
+  it("requires choosing a voicing after selecting a grouped suggestion", () => {
+    expect(repertoireManager).toContain(
+      "const voicingOptions = suggestedVoicings ?? voicings"
+    );
+    expect(repertoireManager).toContain(
+      'suggestion.voicings.length === 1 ? (suggestion.voicings[0] ?? "") :'
+    );
+    expect(repertoireManager).toContain("voicingOptions.map((v) =>");
   });
 });

--- a/lib/__tests__/songSuggestions.test.ts
+++ b/lib/__tests__/songSuggestions.test.ts
@@ -47,17 +47,12 @@ describe("getSongSuggestions", () => {
     expect(getSongSuggestions(rows, "m")).toEqual([]);
   });
 
-  it("returns unique title, voicing, and arranger suggestions", () => {
+  it("groups matching title and arranger suggestions across voicings", () => {
     expect(getSongSuggestions(rows, "mam")).toEqual([
       {
         songTitle: "Mam'selle",
-        voicing: "SATB",
         arrangerName: "",
-      },
-      {
-        songTitle: "Mam'selle",
-        voicing: "TTBB",
-        arrangerName: "",
+        voicings: ["TTBB", "SATB"],
       },
     ]);
   });
@@ -66,8 +61,8 @@ describe("getSongSuggestions", () => {
     expect(getSongSuggestions(rows, "speb")).toEqual([
       {
         songTitle: "Why Try to Change Me Now",
-        voicing: "TTBB",
         arrangerName: "SPEBSQSA",
+        voicings: ["TTBB"],
       },
     ]);
   });
@@ -78,24 +73,60 @@ describe("getSongSuggestions", () => {
     expect(suggestions).toEqual([
       {
         songTitle: "Heart of My Heart",
-        voicing: "TTBB",
         arrangerName: "",
+        voicings: ["TTBB"],
       },
       {
         songTitle: "Heart of My Heart",
-        voicing: "TTBB",
         arrangerName: "Joe Arranger",
+        voicings: ["TTBB"],
       },
       {
         songTitle: "Heart of My Heart",
-        voicing: "TTBB",
         arrangerName: "Unknown",
+        voicings: ["TTBB"],
       },
     ]);
     expect(suggestions.map(songSuggestionSubtitle)).toEqual([
-      "TTBB · No arranger entered",
-      "TTBB · Joe Arranger",
-      "TTBB · Unknown",
+      "No arranger entered · TTBB",
+      "Joe Arranger · TTBB",
+      "Unknown · TTBB",
+    ]);
+  });
+
+  it("does not collapse different explicit arrangers together", () => {
+    const suggestions = getSongSuggestions(
+      [
+        {
+          song_title: "Hello, My Baby",
+          voicing: "TTBB",
+          arranger_name: "Joe Liles",
+        },
+        {
+          song_title: "Hello, My Baby",
+          voicing: "SSAA",
+          arranger_name: "Joe Liles",
+        },
+        {
+          song_title: "Hello, My Baby",
+          voicing: "TTBB",
+          arranger_name: "Clay Hine",
+        },
+      ],
+      "hello"
+    );
+
+    expect(suggestions).toEqual([
+      {
+        songTitle: "Hello, My Baby",
+        arrangerName: "Clay Hine",
+        voicings: ["TTBB"],
+      },
+      {
+        songTitle: "Hello, My Baby",
+        arrangerName: "Joe Liles",
+        voicings: ["TTBB", "SSAA"],
+      },
     ]);
   });
 });

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -65,7 +65,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "Song Title Autocomplete",
         body: [
           "Start typing to see suggestions. Suggestions are optional — you can always enter your own song title if the song is not listed or if your title is different.",
-          "Selecting a suggestion can prefill title, voicing, and arranger. You can still edit the fields before saving.",
+          "Selecting a suggestion can prefill title, voicing, and arranger. If one suggestion covers multiple voicings, choose the voicing you know before saving.",
         ],
       },
       {

--- a/lib/songSuggestions.ts
+++ b/lib/songSuggestions.ts
@@ -9,8 +9,8 @@ export type SongSuggestionSource = {
 
 export type SongSuggestion = {
   songTitle: string;
-  voicing: Voicing;
   arrangerName: string;
+  voicings: Voicing[];
 };
 
 export function songSuggestionArrangerLabel(suggestion: SongSuggestion) {
@@ -18,7 +18,9 @@ export function songSuggestionArrangerLabel(suggestion: SongSuggestion) {
 }
 
 export function songSuggestionSubtitle(suggestion: SongSuggestion) {
-  return `${suggestion.voicing} · ${songSuggestionArrangerLabel(suggestion)}`;
+  return `${songSuggestionArrangerLabel(suggestion)} · ${suggestion.voicings.join(
+    ", "
+  )}`;
 }
 
 const validVoicings: Voicing[] = ["TTBB", "SATB", "SSAA"];
@@ -31,12 +33,19 @@ function normalizeSearchText(value: string) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
-function suggestionKey(suggestion: SongSuggestion) {
+function suggestionKey(
+  suggestion: Pick<SongSuggestion, "songTitle" | "arrangerName">
+) {
   return [
     normalizeSearchText(suggestion.songTitle),
-    suggestion.voicing,
     normalizeSearchText(suggestion.arrangerName),
   ].join(":");
+}
+
+function preferredTitle(current: string, next: string) {
+  if (next.length > current.length) return next;
+  if (next.length < current.length) return current;
+  return current.localeCompare(next) <= 0 ? current : next;
 }
 
 export function getSongSuggestions(
@@ -71,18 +80,47 @@ export function getSongSuggestions(
       continue;
     }
 
-    suggestions.set(suggestionKey(suggestion), suggestion);
+    const key = suggestionKey(suggestion);
+    const existing = suggestions.get(key);
+
+    if (existing) {
+      existing.songTitle = preferredTitle(
+        existing.songTitle,
+        suggestion.songTitle
+      );
+      if (!existing.voicings.includes(suggestion.voicing)) {
+        existing.voicings.push(suggestion.voicing);
+      }
+      continue;
+    }
+
+    suggestions.set(key, {
+      songTitle: suggestion.songTitle,
+      arrangerName: suggestion.arrangerName,
+      voicings: [suggestion.voicing],
+    });
   }
 
   return Array.from(suggestions.values())
+    .map((suggestion) => ({
+      ...suggestion,
+      voicings: validVoicings.filter((voicing) =>
+        suggestion.voicings.includes(voicing)
+      ),
+    }))
     .sort((a, b) => {
       const titleComparison = a.songTitle.localeCompare(b.songTitle);
       if (titleComparison !== 0) return titleComparison;
 
-      const voicingComparison = a.voicing.localeCompare(b.voicing);
+      const arrangerComparison = a.arrangerName.localeCompare(b.arrangerName);
+      if (arrangerComparison !== 0) return arrangerComparison;
+
+      const voicingComparison = a.voicings
+        .join(",")
+        .localeCompare(b.voicings.join(","));
       if (voicingComparison !== 0) return voicingComparison;
 
-      return a.arrangerName.localeCompare(b.arrangerName);
+      return 0;
     })
     .slice(0, limit);
 }


### PR DESCRIPTION
Closes #280

## Summary
- Made the add-song suggestion panels scroll internally with a persistent manual-add footer explaining that suggestions are optional.
- Grouped suggestions by normalized title plus normalized arranger across multiple voicings while keeping different arrangers, blank arranger, and literal Unknown distinct.
- When a grouped suggestion has multiple voicings, the add-song form leaves voicing unselected and offers only the grouped voicing choices.
- Updated help copy to describe choosing a voicing for grouped suggestions.

## Tests
- Added/updated unit coverage for suggestion grouping, arranger semantics, manual-add UI copy, scrollable panel styling, and multi-voicing selection behavior.
- npm run test:run
- npm run build

## Docs / Supabase
- Updated in-app help content for the new grouped suggestion behavior.
- No Supabase schema, RLS, or manual deployment step required.