### PR TITLE
Refine Repertoire add-song controls

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -28,7 +28,11 @@ import {
   songSuggestionSubtitle,
   type SongSuggestion,
 } from "@/lib/songSuggestions";
-import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
+import {
+  dismissQuartetNudge,
+  getCurrentUser,
+  getMyProfile,
+} from "@/lib/profileStore";
 import { refreshActiveQuartetSnapshot } from "@/lib/activeQuartetSnapshot";
 import { arrangerDisplayName } from "@/lib/arrangerDisplay";
 import { hasQuartetWorkflowHistory } from "@/lib/activeQuartet";
@@ -114,6 +118,8 @@ export default function RepertoireManager() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [itemToDelete, setItemToDelete] = useState<RepertoireRow | null>(null);
   const [hasUsedQuartetWorkflow, setHasUsedQuartetWorkflow] = useState(false);
+  const [hasDismissedQuartetNudge, setHasDismissedQuartetNudge] =
+    useState(false);
 
   function completePartConfidences(
     rows: PartConfidenceFormRow[]
@@ -174,6 +180,9 @@ export default function RepertoireManager() {
           window.location.href = "/settings";
           return;
         }
+        setHasDismissedQuartetNudge(
+          Boolean(profile.has_dismissed_quartet_nudge)
+        );
 
         const data = await getMyRepertoire();
         setItems(data);
@@ -303,6 +312,16 @@ export default function RepertoireManager() {
   function selectSongSuggestionAndOpen(suggestion: SongSuggestion) {
     selectSongSuggestion(suggestion);
     setIsAddOpen(true);
+  }
+
+  async function dismissQuartetTeachingCard() {
+    setHasDismissedQuartetNudge(true);
+
+    try {
+      await dismissQuartetNudge();
+    } catch (err) {
+      console.error("Could not save quartet nudge dismissal", err);
+    }
   }
 
   function startEditing(item: RepertoireRow) {
@@ -662,7 +681,7 @@ export default function RepertoireManager() {
         ? "Add a few songs you are likely to sing. Search and filters become useful once you have more songs saved."
         : "Start typing a song title. Choose a suggestion if it matches your arrangement, or add your own title.";
   const showQuartetTeachingCard =
-    !hasUsedQuartetWorkflow && items.length > 0;
+    !hasDismissedQuartetNudge && !hasUsedQuartetWorkflow && items.length > 0;
   const quartetTeachingTitle =
     items.length <= 2
       ? "Good start - keep building or try a quartet"
@@ -674,14 +693,12 @@ export default function RepertoireManager() {
   const quartetTeachingActions =
     items.length <= 2
       ? ([
-          { label: "Add another song", kind: "add" },
           { label: "Start a quartet", href: "/session" },
           { label: "Join a quartet", href: "/join" },
         ] as const)
       : ([
           { label: "Start a quartet", href: "/session" },
           { label: "Join a quartet", href: "/join" },
-          { label: "Add another song", kind: "add" },
         ] as const);
   const returningUserActions = [
     { label: "Add another song", kind: "add" },
@@ -765,14 +782,6 @@ export default function RepertoireManager() {
                 {addSectionDescription}
               </p>
             </div>
-
-            <button
-              type="button"
-              onClick={openBlankAddModal}
-              className="w-full rounded-xl bg-white/10 px-5 py-3 font-semibold text-cyan-100 hover:bg-white/20 lg:w-auto"
-            >
-              Add song
-            </button>
           </div>
 
           <div className="relative mt-5">
@@ -845,7 +854,7 @@ export default function RepertoireManager() {
                     onClick={openAddModalWithCurrentTitle}
                     className="mt-2 w-full rounded-lg bg-cyan-300 px-3 py-2 text-left text-sm font-bold text-slate-950 hover:bg-cyan-200"
                   >
-                    Add &quot;{songTitle.trim()}&quot; as your own song
+                    Add &quot;{songTitle.trim()}&quot; manually
                   </button>
                   <p className="mt-2 text-xs leading-5 text-slate-300">
                     Choose the voicing, arranger, part, and confidence
@@ -869,34 +878,26 @@ export default function RepertoireManager() {
                 </p>
               </div>
               <div className="flex flex-col gap-2 sm:flex-row lg:shrink-0">
-                {quartetTeachingActions.map((action, index) =>
-                  "href" in action ? (
-                    <a
-                      key={action.label}
-                      href={action.href}
-                      className={`rounded-xl px-4 py-3 text-center text-sm font-bold ${
-                        index === 0
-                          ? "bg-cyan-300 text-slate-950 hover:bg-cyan-200"
-                          : "bg-white/10 text-cyan-100 hover:bg-white/20"
-                      }`}
-                    >
-                      {action.label}
-                    </a>
-                  ) : (
-                    <button
-                      key={action.label}
-                      type="button"
-                      onClick={openBlankAddModal}
-                      className={`rounded-xl px-4 py-3 text-sm font-bold ${
-                        index === 0
-                          ? "bg-cyan-300 text-slate-950 hover:bg-cyan-200"
-                          : "bg-white/10 text-cyan-100 hover:bg-white/20"
-                      }`}
-                    >
-                      {action.label}
-                    </button>
-                  )
-                )}
+                {quartetTeachingActions.map((action, index) => (
+                  <a
+                    key={action.label}
+                    href={action.href}
+                    className={`rounded-xl px-4 py-3 text-center text-sm font-bold ${
+                      index === 0
+                        ? "bg-cyan-300 text-slate-950 hover:bg-cyan-200"
+                        : "bg-white/10 text-cyan-100 hover:bg-white/20"
+                    }`}
+                  >
+                    {action.label}
+                  </a>
+                ))}
+                <button
+                  type="button"
+                  onClick={dismissQuartetTeachingCard}
+                  className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-300 hover:bg-white/20"
+                >
+                  Dismiss
+                </button>
               </div>
             </div>
           </section>
@@ -1423,7 +1424,7 @@ export default function RepertoireManager() {
                           onClick={openAddModalWithCurrentTitle}
                           className="mt-2 w-full rounded-lg bg-cyan-300 px-3 py-2 text-left text-sm font-bold text-slate-950 hover:bg-cyan-200"
                         >
-                          Add &quot;{songTitle.trim()}&quot; as your own song
+                          Add &quot;{songTitle.trim()}&quot; manually
                         </button>
                         <p className="mt-2 text-xs leading-5 text-slate-300">
                           Choose the voicing, arranger, part, and confidence

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -46,6 +46,8 @@ Code:
 - Read profile for feedback email context: `app/api/feedback/route.ts`
 - Insert/update own profile: `lib/profileStore.ts#upsertMyProfile`
 - Mark quick-start orientation as seen: `lib/profileStore.ts#markWelcomeSeen`
+- Dismiss repertoire quartet nudge:
+  `lib/profileStore.ts#dismissQuartetNudge`
 - Realtime profile display-name subscription:
   `lib/profileStore.ts#subscribeToProfileDisplayNames`
 - Admin deletion:
@@ -62,6 +64,7 @@ Required database contract:
 - `id uuid primary key references auth.users(id) on delete cascade`
 - `display_name text not null`
 - `has_seen_welcome boolean not null default false`
+- `has_dismissed_quartet_nudge boolean not null default false`
 - RLS enabled.
 - Authenticated users can read profiles.
 - Authenticated users can insert/update only their own profile where
@@ -71,6 +74,7 @@ Required database contract:
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
 - `20260501133000_add_profile_welcome_seen.sql`
+- `20260501154500_add_quartet_nudge_dismissal.sql`
 
 ### `user_repertoire`
 

--- a/lib/__tests__/repertoireEmptyState.test.ts
+++ b/lib/__tests__/repertoireEmptyState.test.ts
@@ -14,15 +14,17 @@ describe("repertoire empty state", () => {
     expect(repertoireManager).toContain("Add a song to your repertoire");
     expect(repertoireManager).toContain("Start typing a song title...");
     expect(repertoireManager).toContain("Add song");
-    expect(repertoireManager).not.toContain("Add manually");
+    expect(repertoireManager).not.toContain(
+      "w-full rounded-xl bg-white/10 px-5 py-3 font-semibold"
+    );
   });
 
-  it("uses the primary typeahead to open the add flow from suggestions or own-title text", () => {
+  it("uses the primary typeahead to open the add flow from suggestions or manual text", () => {
     expect(repertoireManager).toContain("searchRepertoireSongSuggestions");
     expect(repertoireManager).toContain("selectSongSuggestionAndOpen");
     expect(repertoireManager).toContain("openAddModalWithCurrentTitle");
     expect(repertoireManager).toContain(
-      'Add &quot;{songTitle.trim()}&quot; as your own song'
+      'Add &quot;{songTitle.trim()}&quot; manually'
     );
   });
 

--- a/lib/__tests__/repertoireSongSuggestions.test.ts
+++ b/lib/__tests__/repertoireSongSuggestions.test.ts
@@ -15,12 +15,12 @@ describe("repertoire song suggestion UI", () => {
     expect(repertoireManager).toContain("Song suggestions are optional");
     expect(repertoireManager).toContain("Don&apos;t see your version?");
     expect(repertoireManager).toContain(
-      "Add &quot;{songTitle.trim()}&quot; as your own song"
+      'Add &quot;{songTitle.trim()}&quot; manually'
     );
     expect(repertoireManager).toContain(
       "Choose the voicing, arranger, part, and confidence"
     );
-    expect(repertoireManager).not.toContain("Add manually");
+    expect(repertoireManager).not.toContain("as your own song");
     expect(repertoireManager).toContain("max-h-80 overflow-y-auto");
     expect(repertoireManager).toContain("setTimeout(async () =>");
     expect(repertoireManager).toContain("}, 250)");
@@ -46,5 +46,14 @@ describe("repertoire song suggestion UI", () => {
     expect(repertoireManager).toContain(
       "Next: choose the part you sing and your confidence."
     );
+  });
+
+  it("keeps the quartet nudge focused and dismissible", () => {
+    expect(repertoireManager).toContain("dismissQuartetTeachingCard");
+    expect(repertoireManager).toContain("dismissQuartetNudge");
+    expect(repertoireManager).toContain("Dismiss");
+    expect(repertoireManager).toContain("Start a quartet");
+    expect(repertoireManager).toContain("Join a quartet");
+    expect(repertoireManager).toContain("hasDismissedQuartetNudge");
   });
 });

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -65,6 +65,13 @@ const welcomeSeenMigration = readFileSync(
   ),
   "utf8"
 );
+const quartetNudgeDismissalMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260501154500_add_quartet_nudge_dismissal.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -117,6 +124,15 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("markWelcomeSeen");
     expect(welcomeSeenMigration).toContain("public.profiles");
     expect(welcomeSeenMigration).toContain("has_seen_welcome boolean");
+  });
+
+  it("documents and migrates the repertoire quartet nudge dismissal flag", () => {
+    expect(contract).toContain("has_dismissed_quartet_nudge");
+    expect(contract).toContain("dismissQuartetNudge");
+    expect(quartetNudgeDismissalMigration).toContain("public.profiles");
+    expect(quartetNudgeDismissalMigration).toContain(
+      "has_dismissed_quartet_nudge boolean"
+    );
   });
 
   it("documents the analytics privacy contract", () => {

--- a/lib/profileStore.ts
+++ b/lib/profileStore.ts
@@ -5,6 +5,7 @@ export type Profile = {
   id: string;
   display_name: string;
   has_seen_welcome: boolean;
+  has_dismissed_quartet_nudge: boolean;
   created_at: string;
   updated_at: string;
 };
@@ -141,6 +142,42 @@ export async function markWelcomeSeen() {
       id: user.id,
       display_name: "",
       has_seen_welcome: true,
+      updated_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Profile;
+}
+
+export async function dismissQuartetNudge() {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const profile = await getMyProfile();
+
+  if (profile) {
+    const { data, error } = await supabase
+      .from("profiles")
+      .update({
+        has_dismissed_quartet_nudge: true,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", user.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as Profile;
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .insert({
+      id: user.id,
+      display_name: "",
+      has_dismissed_quartet_nudge: true,
       updated_at: new Date().toISOString(),
     })
     .select()

--- a/supabase/migrations/20260501154500_add_quartet_nudge_dismissal.sql
+++ b/supabase/migrations/20260501154500_add_quartet_nudge_dismissal.sql
@@ -1,0 +1,2 @@
+alter table public.profiles
+add column if not exists has_dismissed_quartet_nudge boolean not null default false;


### PR DESCRIPTION
Closes #284

## Summary
- Removed the duplicate upper Add song button from the Repertoire add-song card so the input-associated action is the clear path.
- Restored suggestion footer wording to Add "[title]" manually while preserving the #280/#282 scroll, grouping, collapse, and selected-summary behavior.
- Removed Add another song from the quartet nudge and added a Dismiss action.
- Persisted quartet nudge dismissal on profiles with a new migration and Supabase contract update.

## Tests
- Updated Repertoire UI guardrails for duplicate-button removal, manual footer wording, and nudge dismissal.
- Updated Supabase contract tests for the new profile preference migration.
- npm run test:run
- npm run build

## Docs / Supabase
- Added migration: supabase/migrations/20260501154500_add_quartet_nudge_dismissal.sql
- Updated docs/supabase-contract.md for profiles.has_dismissed_quartet_nudge and dismissQuartetNudge.
- Required manual step: ensure the normal Supabase migration deployment workflow runs before/with production deployment.