### PR TITLE
Add private repertoire sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Current source-of-truth model:
 - `user_repertoire` stores each singer's saved songs, voicing, parts,
   per-part confidence values, optional arranger, private notes, and personal
   sung metadata.
+- `repertoire_shares` stores opt-in private share codes for copying safe song
+  identity fields into another singer's own repertoire.
 - `sessions` stores quartet join codes and activity.
 - `session_participants` stores active quartet membership and each singer's
   repertoire snapshot.
@@ -71,6 +73,9 @@ The Supabase project should have the current production schema applied:
 - `profiles` stores each user's required `display_name`.
 - `user_repertoire` stores each user's songs, voicing, part/confidence pairs,
   optional arranger name, private notes, and personal sung-count metadata.
+- `repertoire_shares` stores private, revocable, six-character share codes for
+  copying song identity fields. Shared repertoire links expose song title,
+  voicing, and arranger only; recipients choose their own part and confidence.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by

--- a/app/shared-repertoire/[code]/page.tsx
+++ b/app/shared-repertoire/[code]/page.tsx
@@ -1,0 +1,10 @@
+import { SharedRepertoireManager } from "@/components/SharedRepertoireManager";
+
+export default async function SharedRepertoirePage({
+  params,
+}: {
+  params: Promise<{ code: string }>;
+}) {
+  const { code } = await params;
+  return <SharedRepertoireManager code={code} />;
+}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import QRCode from "qrcode";
 import { useEffect, useRef, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import { QuartetActionConfirmation } from "@/components/QuartetActionConfirmation";
@@ -24,6 +25,12 @@ import {
   updateRepertoireItem,
   type RepertoireRow,
 } from "@/lib/repertoireStore";
+import {
+  createRepertoireShare,
+  getMyActiveRepertoireShare,
+  revokeRepertoireShare,
+  type RepertoireShare,
+} from "@/lib/repertoireSharing";
 import {
   songSuggestionSubtitle,
   type SongSuggestion,
@@ -120,6 +127,12 @@ export default function RepertoireManager() {
   const [hasUsedQuartetWorkflow, setHasUsedQuartetWorkflow] = useState(false);
   const [hasDismissedQuartetNudge, setHasDismissedQuartetNudge] =
     useState(false);
+  const [repertoireShare, setRepertoireShare] =
+    useState<RepertoireShare | null>(null);
+  const [isCreatingShare, setIsCreatingShare] = useState(false);
+  const [isRevokingShare, setIsRevokingShare] = useState(false);
+  const [shareMessage, setShareMessage] = useState("");
+  const [shareQrUrl, setShareQrUrl] = useState("");
 
   function completePartConfidences(
     rows: PartConfidenceFormRow[]
@@ -186,6 +199,7 @@ export default function RepertoireManager() {
 
         const data = await getMyRepertoire();
         setItems(data);
+        setRepertoireShare(await getMyActiveRepertoireShare());
       } catch (err) {
         console.error(err);
         setLoadError(
@@ -212,6 +226,32 @@ export default function RepertoireManager() {
   useEffect(() => {
     setHasUsedQuartetWorkflow(hasQuartetWorkflowHistory());
   }, []);
+
+  useEffect(() => {
+    if (!repertoireShare || typeof window === "undefined") {
+      setShareQrUrl("");
+      return;
+    }
+
+    const shareUrl = `${window.location.origin}/shared-repertoire/${repertoireShare.code}`;
+    let cancelled = false;
+
+    QRCode.toDataURL(shareUrl)
+      .then((qr) => {
+        if (!cancelled) setShareQrUrl(qr);
+      })
+      .catch((err) => {
+        console.error(err);
+        if (!cancelled) {
+          setShareQrUrl("");
+          setShareMessage("QR code unavailable. Share the code or link instead.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repertoireShare]);
 
   useEffect(() => {
     if (addSongSource || !songSuggestionsOpen || songTitle.trim().length < 2) {
@@ -637,6 +677,52 @@ export default function RepertoireManager() {
     }
   }
 
+  async function createShareLink() {
+    if (isCreatingShare) return;
+
+    try {
+      setIsCreatingShare(true);
+      setShareMessage("");
+      const share = await createRepertoireShare();
+      setRepertoireShare(share);
+      setShareMessage("Repertoire share link created.");
+    } catch (err) {
+      console.error(err);
+      setShareMessage("Could not create share link. Please try again.");
+    } finally {
+      setIsCreatingShare(false);
+    }
+  }
+
+  async function copyShareLink() {
+    if (!shareLink) return;
+
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setShareMessage("Share link copied.");
+    } catch (err) {
+      console.error(err);
+      setShareMessage("Could not copy automatically. Select and copy the link.");
+    }
+  }
+
+  async function revokeShareLink() {
+    if (!repertoireShare || isRevokingShare) return;
+
+    try {
+      setIsRevokingShare(true);
+      setShareMessage("");
+      await revokeRepertoireShare(repertoireShare.id);
+      setRepertoireShare(null);
+      setShareMessage("Repertoire share link revoked.");
+    } catch (err) {
+      console.error(err);
+      setShareMessage("Could not revoke share link. Please try again.");
+    } finally {
+      setIsRevokingShare(false);
+    }
+  }
+
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
@@ -688,6 +774,10 @@ export default function RepertoireManager() {
         : "Start typing a song title. Choose a suggestion if it matches your arrangement, or add your own title.";
   const showQuartetTeachingCard =
     !hasDismissedQuartetNudge && !hasUsedQuartetWorkflow && items.length > 0;
+  const shareLink =
+    repertoireShare && typeof window !== "undefined"
+      ? `${window.location.origin}/shared-repertoire/${repertoireShare.code}`
+      : "";
   const quartetTeachingTitle =
     items.length <= 2
       ? "Good start - keep building or try a quartet"
@@ -866,6 +956,91 @@ export default function RepertoireManager() {
             )}
           </div>
         </section>
+
+        {hasSavedSongs && (
+          <section className="mt-5 rounded-2xl border border-cyan-300/20 bg-slate-900/70 p-5 shadow-lg sm:p-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-3xl">
+                <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
+                  Share repertoire
+                </p>
+                <h2 className="mt-2 text-2xl font-bold tracking-tight text-white">
+                  Help another singer copy songs
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  Let another singer view your song titles, voicings, and
+                  arrangers so they can copy songs into their own repertoire.
+                  Notes, parts, confidence, and sung history are not shared.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-2 lg:min-w-72 lg:shrink-0">
+                {repertoireShare ? (
+                  <>
+                    <p className="text-sm font-semibold text-cyan-100">
+                      Your repertoire share link is active
+                    </p>
+                    <div className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-center">
+                      <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
+                        Share code
+                      </p>
+                      <p className="mt-1 text-3xl font-black tracking-[0.2em] text-white">
+                        {repertoireShare.code}
+                      </p>
+                      {shareQrUrl && (
+                        <img
+                          src={shareQrUrl}
+                          alt="QR code for repertoire share link"
+                          className="mx-auto mt-3 h-36 w-36 rounded-xl bg-white p-2"
+                        />
+                      )}
+                    </div>
+                    <p className="text-xs leading-5 text-slate-400">
+                      Anyone with this link can view song titles, voicings, and
+                      arrangers from your repertoire. They cannot edit your
+                      songs.
+                    </p>
+                    <input
+                      value={shareLink}
+                      readOnly
+                      className="w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-200"
+                      aria-label="Repertoire share link"
+                    />
+                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+                      <button
+                        type="button"
+                        onClick={copyShareLink}
+                        className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200"
+                      >
+                        Copy link
+                      </button>
+                      <button
+                        type="button"
+                        onClick={revokeShareLink}
+                        disabled={isRevokingShare}
+                        className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-white/20 disabled:opacity-40"
+                      >
+                        {isRevokingShare ? "Revoking..." : "Revoke link"}
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={createShareLink}
+                    disabled={isCreatingShare}
+                    className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+                  >
+                    {isCreatingShare ? "Creating..." : "Create share link"}
+                  </button>
+                )}
+                {shareMessage && (
+                  <p className="text-sm text-slate-300">{shareMessage}</p>
+                )}
+              </div>
+            </div>
+          </section>
+        )}
 
         {showQuartetTeachingCard && (
           <section className="mt-5 rounded-2xl border border-cyan-300/20 bg-slate-900/80 p-5 shadow-lg sm:p-6">

--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AppNav } from "@/components/AppNav";
+import type { Confidence, Part, Voicing } from "@/lib/matching";
+import { arrangerDisplayName } from "@/lib/arrangerDisplay";
+import { partButtonLabel } from "@/lib/partAbbreviations";
+import { getCurrentUser } from "@/lib/profileStore";
+import { getMyRepertoire } from "@/lib/repertoireStore";
+import {
+  copySharedSongsToMyRepertoire,
+  getSharedRepertoire,
+  resolveSharedSongCopyability,
+  type CopyableSharedSong,
+  type SharedRepertoire,
+  type SharedRepertoireSong,
+} from "@/lib/repertoireSharing";
+
+const confidenceLevels: Confidence[] = [
+  "Good to Go",
+  "A Little Rusty",
+  "Music Required",
+];
+
+const partsByVoicing: Record<Voicing, Part[]> = {
+  TTBB: ["Tenor", "Lead", "Baritone", "Bass"],
+  SATB: ["Soprano", "Alto", "Tenor", "Bass"],
+  SSAA: ["Soprano 1", "Soprano 2", "Alto 1", "Alto 2"],
+};
+
+type SelectionByVoicing = Partial<
+  Record<Voicing, { part: Part | ""; confidence: Confidence | "" }>
+>;
+
+function duplicateLabel(status: CopyableSharedSong["duplicateStatus"]) {
+  if (status === "exact") return "Already in your repertoire";
+  if (status === "possible_arrangement") return "Possible different arrangement";
+  return null;
+}
+
+export function SharedRepertoireManager({ code }: { code: string }) {
+  const normalizedCode = code.toUpperCase();
+  const [loading, setLoading] = useState(true);
+  const [share, setShare] = useState<SharedRepertoire | null>(null);
+  const [songs, setSongs] = useState<CopyableSharedSong[]>([]);
+  const [selectedSongIds, setSelectedSongIds] = useState<Set<string>>(new Set());
+  const [selectionsByVoicing, setSelectionsByVoicing] =
+    useState<SelectionByVoicing>({});
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [message, setMessage] = useState("");
+  const [copying, setCopying] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true);
+        setMessage("");
+
+        const sharedRepertoire = await getSharedRepertoire(normalizedCode);
+        setShare(sharedRepertoire);
+
+        const user = await getCurrentUser();
+        setIsSignedIn(Boolean(user));
+
+        if (!sharedRepertoire) {
+          setSongs([]);
+          setSelectedSongIds(new Set());
+          return;
+        }
+
+        if (!user) {
+          const anonymousSongs = resolveSharedSongCopyability(
+            sharedRepertoire.songs,
+            []
+          );
+          setSongs(anonymousSongs);
+          setSelectedSongIds(new Set());
+          return;
+        }
+
+        const myRepertoire = await getMyRepertoire();
+        const resolvedSongs = resolveSharedSongCopyability(
+          sharedRepertoire.songs,
+          myRepertoire
+        );
+        setSongs(resolvedSongs);
+        setSelectedSongIds(
+          new Set(
+            resolvedSongs
+              .filter((song) => song.duplicateStatus !== "exact")
+              .map((song) => song.id)
+          )
+        );
+      } catch (err) {
+        console.error(err);
+        setMessage("Could not load shared repertoire. Check the link and try again.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, [normalizedCode]);
+
+  const selectedSongs = useMemo(
+    () => songs.filter((song) => selectedSongIds.has(song.id)),
+    [selectedSongIds, songs]
+  );
+  const selectedVoicings = useMemo(
+    () => Array.from(new Set(selectedSongs.map((song) => song.voicing))).sort(),
+    [selectedSongs]
+  );
+  const eligibleSongs = songs.filter((song) => song.duplicateStatus !== "exact");
+  const signInPath = `/login?redirect=${encodeURIComponent(
+    `/shared-repertoire/${normalizedCode}`
+  )}`;
+
+  function toggleSong(song: CopyableSharedSong) {
+    if (song.duplicateStatus === "exact") return;
+
+    setSelectedSongIds((current) => {
+      const next = new Set(current);
+      if (next.has(song.id)) {
+        next.delete(song.id);
+      } else {
+        next.add(song.id);
+      }
+      return next;
+    });
+  }
+
+  function selectAllEligible() {
+    setSelectedSongIds(new Set(eligibleSongs.map((song) => song.id)));
+  }
+
+  function clearSelection() {
+    setSelectedSongIds(new Set());
+  }
+
+  function updateVoicingSelection(
+    voicing: Voicing,
+    patch: Partial<{ part: Part | ""; confidence: Confidence | "" }>
+  ) {
+    setSelectionsByVoicing((current) => ({
+      ...current,
+      [voicing]: {
+        part: current[voicing]?.part ?? "",
+        confidence: current[voicing]?.confidence ?? "",
+        ...patch,
+      },
+    }));
+  }
+
+  async function copySelectedSongs() {
+    if (!isSignedIn) {
+      window.location.href = signInPath;
+      return;
+    }
+
+    if (selectedSongs.length === 0) {
+      setMessage("Select at least one song to copy.");
+      return;
+    }
+
+    const missingVoicing = selectedVoicings.find((voicing) => {
+      const selection = selectionsByVoicing[voicing];
+      return !selection?.part || !selection?.confidence;
+    });
+
+    if (missingVoicing) {
+      setMessage(`Choose a part and confidence for ${missingVoicing}.`);
+      return;
+    }
+
+    const completeSelections = Object.fromEntries(
+      selectedVoicings.map((voicing) => {
+        const selection = selectionsByVoicing[voicing];
+        return [
+          voicing,
+          {
+            part: selection?.part as Part,
+            confidence: selection?.confidence as Confidence,
+          },
+        ];
+      })
+    ) as Record<Voicing, { part: Part; confidence: Confidence }>;
+
+    try {
+      setCopying(true);
+      setMessage("");
+      const result = await copySharedSongsToMyRepertoire(
+        selectedSongs as SharedRepertoireSong[],
+        completeSelections
+      );
+      setMessage(
+        `${result.copiedCount} ${
+          result.copiedCount === 1 ? "song" : "songs"
+        } copied${
+          result.skippedExactCount > 0
+            ? `; ${result.skippedExactCount} already in your repertoire`
+            : ""
+        }.`
+      );
+
+      const myRepertoire = await getMyRepertoire();
+      const refreshedSongs = resolveSharedSongCopyability(
+        share?.songs ?? [],
+        myRepertoire
+      );
+      setSongs(refreshedSongs);
+      setSelectedSongIds(new Set());
+    } catch (err) {
+      console.error(err);
+      setMessage("Could not copy songs. Check your connection and try again.");
+    } finally {
+      setCopying(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
+        Loading shared repertoire...
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-10 text-white">
+      <div className="mx-auto max-w-5xl">
+        <AppNav />
+
+        {!share ? (
+          <section className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
+            <h1 className="text-3xl font-bold">Shared repertoire unavailable</h1>
+            <p className="mt-3 text-slate-200">
+              This repertoire link may have been revoked, expired, or typed
+              incorrectly.
+            </p>
+          </section>
+        ) : (
+          <>
+            <section className="mt-8 rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-6">
+              <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
+                Shared repertoire
+              </p>
+              <h1 className="mt-3 text-4xl font-bold tracking-tight">
+                {share.ownerDisplayName} shared repertoire with you
+              </h1>
+              <p className="mt-3 max-w-3xl text-slate-200">
+                {isSignedIn
+                  ? "You can copy songs into your own repertoire. You'll choose your own part and confidence before saving."
+                  : "Sign in to copy songs into your own repertoire."}
+              </p>
+              {!isSignedIn && (
+                <a
+                  href={signInPath}
+                  className="mt-5 inline-flex rounded-xl bg-cyan-300 px-5 py-3 font-bold text-slate-950 hover:bg-cyan-200"
+                >
+                  Sign in to copy songs
+                </a>
+              )}
+            </section>
+
+            {isSignedIn && songs.length > 0 && (
+              <section className="mt-5 rounded-2xl border border-white/10 bg-white/5 p-5">
+                <h2 className="text-2xl font-semibold">Copy songs</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  For copied songs, choose the part you usually sing and your
+                  confidence. You can edit individual songs later.
+                </p>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={selectAllEligible}
+                    className="rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-cyan-100 hover:bg-white/20"
+                  >
+                    Select all eligible
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearSelection}
+                    className="rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-slate-200 hover:bg-white/20"
+                  >
+                    Clear selection
+                  </button>
+                </div>
+
+                {selectedVoicings.length > 0 && (
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {selectedVoicings.map((voicing) => (
+                      <div
+                        key={voicing}
+                        className="rounded-xl border border-white/10 bg-slate-950/60 p-3"
+                      >
+                        <p className="text-sm font-semibold text-white">
+                          {voicing} copied songs
+                        </p>
+                        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                          <label className="block">
+                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                              Part
+                            </span>
+                            <select
+                              value={selectionsByVoicing[voicing]?.part ?? ""}
+                              onChange={(event) =>
+                                updateVoicingSelection(voicing, {
+                                  part: event.target.value as Part | "",
+                                })
+                              }
+                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                            >
+                              <option value="">Choose part</option>
+                              {partsByVoicing[voicing].map((part) => (
+                                <option key={part} value={part}>
+                                  {partButtonLabel(voicing, part)}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="block">
+                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                              Confidence
+                            </span>
+                            <select
+                              value={
+                                selectionsByVoicing[voicing]?.confidence ?? ""
+                              }
+                              onChange={(event) =>
+                                updateVoicingSelection(voicing, {
+                                  confidence: event.target
+                                    .value as Confidence | "",
+                                })
+                              }
+                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                            >
+                              <option value="">Choose confidence</option>
+                              {confidenceLevels.map((confidence) => (
+                                <option key={confidence} value={confidence}>
+                                  {confidence}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <button
+                  type="button"
+                  onClick={copySelectedSongs}
+                  disabled={copying || selectedSongs.length === 0}
+                  className="mt-4 rounded-xl bg-cyan-300 px-5 py-3 font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+                >
+                  {copying
+                    ? "Copying..."
+                    : `Copy ${selectedSongs.length} selected ${
+                        selectedSongs.length === 1 ? "song" : "songs"
+                      }`}
+                </button>
+              </section>
+            )}
+
+            {message && <p className="mt-4 text-sm text-slate-300">{message}</p>}
+
+            <section className="mt-5 rounded-2xl border border-white/10 bg-white/10">
+              <div className="border-b border-white/10 p-4">
+                <h2 className="text-2xl font-semibold">Shared songs</h2>
+                <p className="mt-1 text-sm text-slate-400">
+                  {songs.length} {songs.length === 1 ? "song" : "songs"} shared
+                </p>
+              </div>
+
+              {songs.length === 0 ? (
+                <p className="p-4 text-sm text-slate-300">
+                  This share link is active, but there are no songs to copy yet.
+                </p>
+              ) : (
+                <div className="divide-y divide-white/10">
+                  {songs.map((song) => {
+                    const label = duplicateLabel(song.duplicateStatus);
+                    const disabled = song.duplicateStatus === "exact";
+
+                    return (
+                      <label
+                        key={song.id}
+                        className={`flex gap-3 p-4 ${
+                          disabled ? "opacity-70" : "cursor-pointer"
+                        }`}
+                      >
+                        {isSignedIn && (
+                          <input
+                            type="checkbox"
+                            checked={selectedSongIds.has(song.id)}
+                            disabled={disabled}
+                            onChange={() => toggleSong(song)}
+                            className="mt-1 h-4 w-4 rounded border-white/20 bg-slate-900 text-cyan-300"
+                          />
+                        )}
+                        <span className="min-w-0 flex-1">
+                          <span className="block font-semibold text-white">
+                            {song.songTitle}
+                          </span>
+                          <span className="mt-1 block text-sm text-slate-300">
+                            {song.voicing} - Arr.{" "}
+                            {arrangerDisplayName(song.arrangerName)}
+                          </span>
+                          {label && (
+                            <span className="mt-2 inline-flex rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
+                              {label}
+                            </span>
+                          )}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -26,6 +26,10 @@ migrations in `supabase/migrations`, and tests or test documentation.
 - Repertoire add, edit, delete, and mark-as-sung actions update
   `user_repertoire`. Add/edit/delete actions refresh the active quartet
   `session_participants.repertoire` snapshot when the user is in a quartet.
+- Private repertoire sharing is opt-in. A singer creates a code in
+  `repertoire_shares`; recipients can view only safe song identity fields
+  through `get_shared_repertoire` and must sign in before copying songs into
+  their own `user_repertoire`.
 - Leaving a quartet deletes the current user's `session_participants` row.
 - Removing another singer uses `remove_session_participant_by_id` and deletes
   the selected participant row when the requester is also a current participant
@@ -138,6 +142,51 @@ Established by migrations:
 - `20260428142000_add_part_confidences_to_repertoire.sql`
 - `20260428145000_add_repertoire_sung_metadata.sql`
 - `20260428223000_add_global_song_suggestions.sql`
+
+### `repertoire_shares`
+
+Purpose: opt-in private repertoire share links. A share code lets another
+singer view only song identity fields from the owner's current repertoire so
+they can copy selected songs into their own repertoire.
+
+Code:
+- Create active share: `lib/repertoireSharing.ts#createRepertoireShare`
+- Read own active share: `lib/repertoireSharing.ts#getMyActiveRepertoireShare`
+- Revoke own share: `lib/repertoireSharing.ts#revokeRepertoireShare`
+- Read safe shared repertoire by code:
+  `lib/repertoireSharing.ts#getSharedRepertoire`, through
+  `public.get_shared_repertoire`
+- Recipient copy flow: `components/SharedRepertoireManager.tsx`
+- Sharer controls: `components/RepertoireManager.tsx`
+
+Expected context:
+- Browser authenticated owner for create/read/revoke of own share rows.
+- Anonymous or authenticated browser user for `get_shared_repertoire` by code.
+- Authenticated browser user for copying selected songs into their own
+  `user_repertoire`.
+
+Required database contract:
+- `id uuid primary key`
+- `owner_id uuid not null references auth.users(id) on delete cascade`
+- `code text not null` with six uppercase alphanumeric characters
+- `created_at timestamptz not null default now()`
+- `revoked_at timestamptz`
+- `expires_at timestamptz`
+- Unique index on `code`
+- RLS enabled.
+- Authenticated users can select/insert/update only their own share rows where
+  `owner_id = auth.uid()`.
+- `public.get_shared_repertoire(p_code text)` is a security-definer RPC
+  available to `anon` and `authenticated`. It returns only active,
+  non-expired shares and only these fields: `share_id`, `code`,
+  `owner_display_name`, `song_id`, `song_title`, `voicing`, and
+  `arranger_name`.
+- The shared view must not expose owner email, user IDs, notes, parts,
+  confidence, last-sung history, timestamps, or quartet/session history.
+- Revoked or expired links return no rows.
+
+Established by migrations:
+- `20260501190000_add_repertoire_shares.sql`
 
 ### `song_suggestion_catalog`
 

--- a/lib/__tests__/repertoireSharing.test.ts
+++ b/lib/__tests__/repertoireSharing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "http://localhost:54321";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+
+const {
+  normalizeSharedSongText,
+  resolveSharedSongCopyability,
+  sharedSongExactKey,
+} = await import("@/lib/repertoireSharing");
+
+import type { SharedRepertoireSong } from "@/lib/repertoireSharing";
+import type { RepertoireRow } from "@/lib/repertoireStore";
+
+function repertoireRow(
+  song_title: string,
+  voicing: RepertoireRow["voicing"],
+  arranger_name: string | null
+) {
+  return {
+    song_title,
+    voicing,
+    arranger_name,
+  } as RepertoireRow;
+}
+
+const sharedSong = (
+  songTitle: string,
+  voicing: SharedRepertoireSong["voicing"],
+  arrangerName: string | null
+): SharedRepertoireSong => ({
+  id: `${songTitle}-${voicing}-${arrangerName ?? "blank"}`,
+  songTitle,
+  voicing,
+  arrangerName,
+});
+
+describe("repertoire sharing", () => {
+  it("normalizes title and arranger text for duplicate detection", () => {
+    expect(normalizeSharedSongText(" Why Try To Change Me Now? ")).toBe(
+      "why try to change me now"
+    );
+    expect(sharedSongExactKey(sharedSong("Mam'selle", "TTBB", "Lou Perry"))).toBe(
+      "mam selle|TTBB|lou perry"
+    );
+  });
+
+  it("keeps blank arranger distinct from literal Unknown", () => {
+    const blankArranger = sharedSongExactKey(
+      sharedSong("Hello, My Baby", "TTBB", null)
+    );
+    const unknownArranger = sharedSongExactKey(
+      sharedSong("Hello, My Baby", "TTBB", "Unknown")
+    );
+
+    expect(blankArranger).not.toBe(unknownArranger);
+  });
+
+  it("marks exact duplicates as already in repertoire", () => {
+    const songs = [
+      sharedSong("Hello, My Baby", "TTBB", "Joe Liles"),
+      sharedSong("Over the Rainbow", "SATB", "Melody Hine"),
+    ];
+
+    const resolved = resolveSharedSongCopyability(songs, [
+      repertoireRow("Hello My Baby", "TTBB", "Joe Liles"),
+    ]);
+
+    expect(resolved.map((song) => song.duplicateStatus)).toEqual([
+      "exact",
+      "eligible",
+    ]);
+  });
+
+  it("allows same title and voicing with a different arranger but flags it", () => {
+    const resolved = resolveSharedSongCopyability(
+      [sharedSong("Coney Island Baby", "TTBB", null)],
+      [repertoireRow("Coney Island Baby", "TTBB", "Unknown")]
+    );
+
+    expect(resolved[0].duplicateStatus).toBe("possible_arrangement");
+  });
+
+  it("does not compare across different voicings", () => {
+    const resolved = resolveSharedSongCopyability(
+      [sharedSong("Amazing Grace", "SSAA", "Tom Gentry")],
+      [repertoireRow("Amazing Grace", "TTBB", "Tom Gentry")]
+    );
+
+    expect(resolved[0].duplicateStatus).toBe("eligible");
+  });
+});

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -72,6 +72,13 @@ const quartetNudgeDismissalMigration = readFileSync(
   ),
   "utf8"
 );
+const repertoireSharesMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260501190000_add_repertoire_shares.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -80,7 +87,11 @@ describe("Supabase contract guardrails", () => {
     "sessions",
     "session_participants",
     "sung_song_events",
+    "repertoire_shares",
   ];
+  const baseMigrationTables = tables.filter(
+    (table) => table !== "repertoire_shares"
+  );
 
   it("documents every app-owned Supabase table", () => {
     for (const table of tables) {
@@ -89,7 +100,7 @@ describe("Supabase contract guardrails", () => {
   });
 
   it("keeps schema and RLS policies in migrations for browser-written tables", () => {
-    for (const table of tables) {
+    for (const table of baseMigrationTables) {
       expect(migration).toContain(`public.${table}`);
       expect(migration).toContain(
         `alter table public.${table} enable row level security`
@@ -171,6 +182,28 @@ describe("Supabase contract guardrails", () => {
     expect(sungMetadataMigration).toContain("times_sung_count + 1");
     expect(sungMetadataMigration).toContain("user_id = auth.uid()");
     expect(sungMetadataMigration).toContain("sung_song_events");
+  });
+
+  it("documents and migrates private repertoire share links", () => {
+    expect(contract).toContain("repertoire_shares");
+    expect(contract).toContain("get_shared_repertoire");
+    expect(contract).toContain("six uppercase alphanumeric characters");
+    expect(contract).toContain("must not expose owner email");
+    expect(repertoireSharesMigration).toContain(
+      "create table if not exists public.repertoire_shares"
+    );
+    expect(repertoireSharesMigration).toContain("owner_id = auth.uid()");
+    expect(repertoireSharesMigration).toContain("enable row level security");
+    expect(repertoireSharesMigration).toContain("security definer");
+    expect(repertoireSharesMigration).toContain("grant execute");
+    expect(repertoireSharesMigration).toContain("to anon");
+    expect(repertoireSharesMigration).toContain("song_title");
+    expect(repertoireSharesMigration).toContain("voicing");
+    expect(repertoireSharesMigration).toContain("arranger_name");
+    expect(repertoireSharesMigration).not.toContain("email");
+    expect(repertoireSharesMigration).not.toContain("notes");
+    expect(repertoireSharesMigration).not.toContain("part_confidences");
+    expect(repertoireSharesMigration).not.toContain("last_sung_at");
   });
 
   it("documents and migrates global song identity suggestions", () => {

--- a/lib/repertoireSharing.ts
+++ b/lib/repertoireSharing.ts
@@ -1,0 +1,258 @@
+import { supabase } from "@/lib/supabase";
+import type { Confidence, Part, Voicing } from "@/lib/matching";
+import {
+  addRepertoireItem,
+  getMyRepertoire,
+  type RepertoireRow,
+} from "@/lib/repertoireStore";
+import { getCurrentUser } from "@/lib/profileStore";
+
+export type RepertoireShare = {
+  id: string;
+  owner_id: string;
+  code: string;
+  created_at: string;
+  revoked_at: string | null;
+  expires_at: string | null;
+};
+
+type SharedRepertoireRpcRow = {
+  share_id: string;
+  code: string;
+  owner_display_name: string;
+  song_id: string | null;
+  song_title: string | null;
+  voicing: Voicing | null;
+  arranger_name: string | null;
+};
+
+export type SharedRepertoireSong = {
+  id: string;
+  songTitle: string;
+  voicing: Voicing;
+  arrangerName: string | null;
+};
+
+export type SharedRepertoire = {
+  shareId: string;
+  code: string;
+  ownerDisplayName: string;
+  songs: SharedRepertoireSong[];
+};
+
+export type CopyableSharedSong = SharedRepertoireSong & {
+  duplicateStatus: "eligible" | "exact" | "possible_arrangement";
+};
+
+export function normalizeSharedSongText(value?: string | null) {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\u2019']/g, "'")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function sharedSongExactKey(input: {
+  songTitle: string;
+  voicing: Voicing;
+  arrangerName?: string | null;
+}) {
+  return [
+    normalizeSharedSongText(input.songTitle),
+    input.voicing,
+    input.arrangerName?.trim()
+      ? normalizeSharedSongText(input.arrangerName)
+      : "__blank_arranger__",
+  ].join("|");
+}
+
+function sharedSongTitleVoicingKey(input: {
+  songTitle: string;
+  voicing: Voicing;
+}) {
+  return [normalizeSharedSongText(input.songTitle), input.voicing].join("|");
+}
+
+export function resolveSharedSongCopyability(
+  songs: SharedRepertoireSong[],
+  myRepertoire: Pick<RepertoireRow, "song_title" | "voicing" | "arranger_name">[]
+): CopyableSharedSong[] {
+  const exactKeys = new Set(
+    myRepertoire.map((item) =>
+      sharedSongExactKey({
+        songTitle: item.song_title,
+        voicing: item.voicing,
+        arrangerName: item.arranger_name,
+      })
+    )
+  );
+  const titleVoicingKeys = new Set(
+    myRepertoire.map((item) =>
+      sharedSongTitleVoicingKey({
+        songTitle: item.song_title,
+        voicing: item.voicing,
+      })
+    )
+  );
+
+  return songs.map((song) => {
+    const exactKey = sharedSongExactKey(song);
+    const titleVoicingKey = sharedSongTitleVoicingKey(song);
+
+    return {
+      ...song,
+      duplicateStatus: exactKeys.has(exactKey)
+        ? "exact"
+        : titleVoicingKeys.has(titleVoicingKey)
+          ? "possible_arrangement"
+          : "eligible",
+    };
+  });
+}
+
+function generateShareCode() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+function defaultExpirationDate() {
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + 30);
+  return expiresAt.toISOString();
+}
+
+export async function getMyActiveRepertoireShare() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from("repertoire_shares")
+    .select("*")
+    .eq("owner_id", user.id)
+    .is("revoked_at", null)
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (error) throw error;
+  const now = Date.now();
+  const activeShare = ((data ?? []) as RepertoireShare[]).find(
+    (share) => !share.expires_at || Date.parse(share.expires_at) > now
+  );
+  return activeShare ?? null;
+}
+
+export async function createRepertoireShare() {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const existingShare = await getMyActiveRepertoireShare();
+  if (existingShare) return existingShare;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const { data, error } = await supabase
+      .from("repertoire_shares")
+      .insert({
+        owner_id: user.id,
+        code: generateShareCode(),
+        expires_at: defaultExpirationDate(),
+      })
+      .select()
+      .single();
+
+    if (!error) return data as RepertoireShare;
+    lastError = error;
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Could not create repertoire share link.");
+}
+
+export async function revokeRepertoireShare(shareId: string) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in.");
+
+  const { data, error } = await supabase
+    .from("repertoire_shares")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", shareId)
+    .eq("owner_id", user.id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as RepertoireShare;
+}
+
+export async function getSharedRepertoire(code: string) {
+  const { data, error } = await supabase.rpc("get_shared_repertoire", {
+    p_code: code,
+  });
+
+  if (error) throw error;
+
+  const rows = (data ?? []) as SharedRepertoireRpcRow[];
+  const firstRow = rows[0];
+  if (!firstRow) return null;
+
+  return {
+    shareId: firstRow.share_id,
+    code: firstRow.code,
+    ownerDisplayName: firstRow.owner_display_name,
+    songs: rows
+      .filter(
+        (row): row is SharedRepertoireRpcRow & {
+          song_id: string;
+          song_title: string;
+          voicing: Voicing;
+        } => Boolean(row.song_id && row.song_title && row.voicing)
+      )
+      .map((row) => ({
+        id: row.song_id,
+        songTitle: row.song_title,
+        voicing: row.voicing,
+        arrangerName: row.arranger_name,
+      })),
+  } satisfies SharedRepertoire;
+}
+
+export async function copySharedSongsToMyRepertoire(
+  songs: SharedRepertoireSong[],
+  selectionsByVoicing: Record<Voicing, { part: Part; confidence: Confidence }>
+) {
+  const myRepertoire = await getMyRepertoire();
+  const copyableSongs = resolveSharedSongCopyability(
+    songs,
+    myRepertoire
+  ).filter((song) => song.duplicateStatus !== "exact");
+  let copiedCount = 0;
+  const skippedExactCount = songs.length - copyableSongs.length;
+
+  for (const song of copyableSongs) {
+    const selection = selectionsByVoicing[song.voicing];
+    if (!selection) {
+      throw new Error(`Choose a part and confidence for ${song.voicing}.`);
+    }
+
+    await addRepertoireItem({
+      songTitle: song.songTitle,
+      voicing: song.voicing,
+      arrangerName: song.arrangerName ?? undefined,
+      partConfidences: [
+        {
+          part: selection.part,
+          confidence: selection.confidence,
+        },
+      ],
+    });
+    copiedCount += 1;
+  }
+
+  return {
+    copiedCount,
+    skippedExactCount,
+  };
+}

--- a/supabase/migrations/20260501190000_add_repertoire_shares.sql
+++ b/supabase/migrations/20260501190000_add_repertoire_shares.sql
@@ -1,0 +1,91 @@
+create table if not exists public.repertoire_shares (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  code text not null check (code ~ '^[A-Z0-9]{6}$'),
+  created_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  expires_at timestamptz
+);
+
+create unique index if not exists repertoire_shares_code_key
+on public.repertoire_shares (code);
+
+create index if not exists repertoire_shares_owner_active_idx
+on public.repertoire_shares (owner_id, created_at desc)
+where revoked_at is null;
+
+alter table public.repertoire_shares enable row level security;
+
+grant select, insert, update on public.repertoire_shares to authenticated;
+
+drop policy if exists "Users can read their own repertoire shares"
+on public.repertoire_shares;
+drop policy if exists "Users can create their own repertoire shares"
+on public.repertoire_shares;
+drop policy if exists "Users can update their own repertoire shares"
+on public.repertoire_shares;
+
+create policy "Users can read their own repertoire shares"
+on public.repertoire_shares
+for select
+to authenticated
+using (owner_id = auth.uid());
+
+create policy "Users can create their own repertoire shares"
+on public.repertoire_shares
+for insert
+to authenticated
+with check (owner_id = auth.uid());
+
+create policy "Users can update their own repertoire shares"
+on public.repertoire_shares
+for update
+to authenticated
+using (owner_id = auth.uid())
+with check (owner_id = auth.uid());
+
+create or replace function public.get_shared_repertoire(p_code text)
+returns table (
+  share_id uuid,
+  code text,
+  owner_display_name text,
+  song_id uuid,
+  song_title text,
+  voicing text,
+  arranger_name text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  return query
+  select
+    repertoire_shares.id as share_id,
+    repertoire_shares.code,
+    profiles.display_name as owner_display_name,
+    user_repertoire.id as song_id,
+    user_repertoire.song_title,
+    user_repertoire.voicing,
+    user_repertoire.arranger_name
+  from public.repertoire_shares
+  join public.profiles
+    on profiles.id = repertoire_shares.owner_id
+  left join public.user_repertoire
+    on user_repertoire.user_id = repertoire_shares.owner_id
+  where repertoire_shares.code = upper(btrim(p_code))
+    and repertoire_shares.revoked_at is null
+    and (
+      repertoire_shares.expires_at is null
+      or repertoire_shares.expires_at > now()
+    )
+  order by
+    user_repertoire.song_title asc nulls last,
+    user_repertoire.voicing asc nulls last,
+    user_repertoire.arranger_name asc nulls first;
+end;
+$$;
+
+revoke all on function public.get_shared_repertoire(text) from public;
+grant execute on function public.get_shared_repertoire(text) to anon;
+grant execute on function public.get_shared_repertoire(text) to authenticated;


### PR DESCRIPTION
## Summary
- add private, revocable repertoire share codes with QR/link display on the Repertoire page
- add `/shared-repertoire/[code]` so recipients can view safe song identity fields and copy selected songs after signing in
- require recipients to choose their own part and confidence per selected voicing before copying
- detect exact duplicates, preserve blank arranger vs literal `Unknown`, and flag possible different arrangements
- add Supabase migration/RLS/RPC contract docs and regression tests

## Privacy / data model
- `repertoire_shares` stores owner-owned share codes only
- shared repertoire lookup uses `get_shared_repertoire(code)` security-definer RPC
- shared view returns only owner display name plus song title, voicing, and arranger
- shared view does not return owner email, user IDs, notes, parts/confidence, last-sung metadata, timestamps, or quartet/session history
- revoked or expired links return no rows

## Docs and tests
- Docs updated: README.md, docs/supabase-contract.md
- Tests added/updated: repertoire sharing duplicate/copyability tests and Supabase contract guardrails

## Verification
- npm run test:run
- npm run build

## Supabase / manual step
This PR adds a migration:

```text
supabase/migrations/20260501190000_add_repertoire_shares.sql
```

After merge, production needs the normal migration deployment path to run before the feature is used. The Production Deploy workflow should apply it automatically. If running manually, use:

```bash
supabase db push
```

Closes #290
