### PR TITLE
Add safer repertoire copy entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ The Supabase project should have the current production schema applied:
 - `profiles` stores each user's required `display_name`.
 - `user_repertoire` stores each user's songs, voicing, part/confidence pairs,
   optional arranger name, private notes, and personal sung-count metadata.
-- `repertoire_shares` stores private, revocable, six-character share codes for
-  copying song identity fields. Shared repertoire links expose song title,
-  voicing, and arranger only; recipients choose their own part and confidence.
+- `repertoire_shares` stores private, revocable, six-character copy codes for
+  copying song identity fields from another singer. Copy links expose song
+  title, voicing, and arranger only; recipients choose their own part and
+  confidence.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -28,7 +28,9 @@ import {
 import {
   createRepertoireShare,
   getMyActiveRepertoireShare,
+  repertoireCopyRequestMessage,
   revokeRepertoireShare,
+  sharedRepertoirePathFromInput,
   type RepertoireShare,
 } from "@/lib/repertoireSharing";
 import {
@@ -133,6 +135,8 @@ export default function RepertoireManager() {
   const [isRevokingShare, setIsRevokingShare] = useState(false);
   const [shareMessage, setShareMessage] = useState("");
   const [shareQrUrl, setShareQrUrl] = useState("");
+  const [copySourceInput, setCopySourceInput] = useState("");
+  const [copySourceMessage, setCopySourceMessage] = useState("");
 
   function completePartConfidences(
     rows: PartConfidenceFormRow[]
@@ -244,7 +248,7 @@ export default function RepertoireManager() {
         console.error(err);
         if (!cancelled) {
           setShareQrUrl("");
-          setShareMessage("QR code unavailable. Share the code or link instead.");
+          setShareMessage("QR code unavailable. Use the code or link instead.");
         }
       });
 
@@ -685,10 +689,10 @@ export default function RepertoireManager() {
       setShareMessage("");
       const share = await createRepertoireShare();
       setRepertoireShare(share);
-      setShareMessage("Repertoire share link created.");
+      setShareMessage("Copy link/code created.");
     } catch (err) {
       console.error(err);
-      setShareMessage("Could not create share link. Please try again.");
+      setShareMessage("Could not create copy link/code. Please try again.");
     } finally {
       setIsCreatingShare(false);
     }
@@ -699,10 +703,46 @@ export default function RepertoireManager() {
 
     try {
       await navigator.clipboard.writeText(shareLink);
-      setShareMessage("Share link copied.");
+      setShareMessage("Copy link copied.");
     } catch (err) {
       console.error(err);
       setShareMessage("Could not copy automatically. Select and copy the link.");
+    }
+  }
+
+  async function copyShareCode() {
+    if (!repertoireShare) return;
+
+    try {
+      await navigator.clipboard.writeText(repertoireShare.code);
+      setShareMessage("Copy code copied.");
+    } catch (err) {
+      console.error(err);
+      setShareMessage("Could not copy automatically. Select and copy the code.");
+    }
+  }
+
+  function openSharedRepertoire() {
+    const path = sharedRepertoirePathFromInput(copySourceInput);
+    if (!path) {
+      setCopySourceMessage(
+        "Paste a six-character code or a shared repertoire link."
+      );
+      return;
+    }
+
+    window.location.href = path;
+  }
+
+  async function copyRemoteRequestMessage() {
+    try {
+      await navigator.clipboard.writeText(repertoireCopyRequestMessage);
+      setCopySourceMessage("Request message copied.");
+    } catch (err) {
+      console.error(err);
+      setCopySourceMessage(
+        "Could not copy automatically. Select and copy the message."
+      );
     }
   }
 
@@ -714,10 +754,10 @@ export default function RepertoireManager() {
       setShareMessage("");
       await revokeRepertoireShare(repertoireShare.id);
       setRepertoireShare(null);
-      setShareMessage("Repertoire share link revoked.");
+      setShareMessage("Copy link/code revoked.");
     } catch (err) {
       console.error(err);
-      setShareMessage("Could not revoke share link. Please try again.");
+      setShareMessage("Could not revoke copy link/code. Please try again.");
     } finally {
       setIsRevokingShare(false);
     }
@@ -959,84 +999,172 @@ export default function RepertoireManager() {
 
         {hasSavedSongs && (
           <section className="mt-5 rounded-2xl border border-cyan-300/20 bg-slate-900/70 p-5 shadow-lg sm:p-6">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              <div className="max-w-3xl">
-                <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
-                  Share repertoire
-                </p>
-                <h2 className="mt-2 text-2xl font-bold tracking-tight text-white">
-                  Help another singer copy songs
-                </h2>
-                <p className="mt-2 text-sm leading-6 text-slate-300">
-                  Let another singer view your song titles, voicings, and
-                  arrangers so they can copy songs into their own repertoire.
-                  Notes, parts, confidence, and sung history are not shared.
-                </p>
-              </div>
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
+                More ways to build your repertoire
+              </p>
+              <h2 className="mt-2 text-2xl font-bold tracking-tight text-white">
+                Copy songs with another singer
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Use a private link or code when one singer already has songs
+                entered and another singer wants to copy a few of them.
+              </p>
+            </div>
 
-              <div className="flex flex-col gap-2 lg:min-w-72 lg:shrink-0">
-                {repertoireShare ? (
-                  <>
-                    <p className="text-sm font-semibold text-cyan-100">
-                      Your repertoire share link is active
-                    </p>
-                    <div className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-center">
-                      <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
-                        Share code
-                      </p>
-                      <p className="mt-1 text-3xl font-black tracking-[0.2em] text-white">
-                        {repertoireShare.code}
-                      </p>
-                      {shareQrUrl && (
-                        <img
-                          src={shareQrUrl}
-                          alt="QR code for repertoire share link"
-                          className="mx-auto mt-3 h-36 w-36 rounded-xl bg-white p-2"
-                        />
-                      )}
-                    </div>
-                    <p className="text-xs leading-5 text-slate-400">
-                      Anyone with this link can view song titles, voicings, and
-                      arrangers from your repertoire. They cannot edit your
-                      songs.
-                    </p>
-                    <input
-                      value={shareLink}
-                      readOnly
-                      className="w-full rounded-xl border border-white/10 bg-slate-950 px-3 py-2 text-sm text-slate-200"
-                      aria-label="Repertoire share link"
-                    />
-                    <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-                      <button
-                        type="button"
-                        onClick={copyShareLink}
-                        className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200"
-                      >
-                        Copy link
-                      </button>
-                      <button
-                        type="button"
-                        onClick={revokeShareLink}
-                        disabled={isRevokingShare}
-                        className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-white/20 disabled:opacity-40"
-                      >
-                        {isRevokingShare ? "Revoking..." : "Revoke link"}
-                      </button>
-                    </div>
-                  </>
-                ) : (
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+              <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
+                <h3 className="text-xl font-bold text-white">
+                  Copy songs from another singer
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  Paste a shared repertoire link or six-character code, then
+                  choose which songs to copy into your repertoire.
+                </p>
+                <div className="mt-4 flex flex-col gap-2 sm:flex-row lg:flex-col xl:flex-row">
+                  <label className="sr-only" htmlFor="shared-repertoire-code">
+                    Shared repertoire link or code
+                  </label>
+                  <input
+                    id="shared-repertoire-code"
+                    value={copySourceInput}
+                    onChange={(event) => {
+                      setCopySourceInput(event.target.value);
+                      setCopySourceMessage("");
+                    }}
+                    placeholder="Paste link or code"
+                    className="min-h-12 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                  />
                   <button
                     type="button"
-                    onClick={createShareLink}
-                    disabled={isCreatingShare}
-                    className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+                    onClick={openSharedRepertoire}
+                    className="min-h-12 rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200"
                   >
-                    {isCreatingShare ? "Creating..." : "Create share link"}
+                    Open shared repertoire
                   </button>
+                </div>
+                <div className="mt-4 space-y-3 text-sm leading-6 text-slate-300">
+                  <p>
+                    Standing together? Ask the other singer to open Repertoire,
+                    choose &quot;Let another singer copy songs from my
+                    repertoire,&quot; and show you the code or QR code.
+                  </p>
+                  <p>
+                    Not together? Copy this request and send it by text or
+                    email.
+                  </p>
+                </div>
+                <div className="mt-3 rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-3">
+                  <p className="text-sm leading-6 text-slate-100">
+                    {repertoireCopyRequestMessage}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={copyRemoteRequestMessage}
+                    className="mt-3 rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-cyan-100 hover:bg-white/20"
+                  >
+                    Copy request message
+                  </button>
+                </div>
+                {copySourceMessage && (
+                  <p className="mt-3 text-sm text-slate-300">
+                    {copySourceMessage}
+                  </p>
                 )}
-                {shareMessage && (
-                  <p className="text-sm text-slate-300">{shareMessage}</p>
-                )}
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
+                <h3 className="text-xl font-bold text-white">
+                  Let another singer copy songs from my repertoire
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  Create a private link and code another singer can use to copy
+                  selected song titles, voicings, and arrangers from your
+                  repertoire.
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  They cannot see your notes, confidence, last-sung history, or
+                  email address. They will choose their own part and confidence
+                  before saving anything.
+                </p>
+
+                <div className="mt-4 flex flex-col gap-3">
+                  {repertoireShare ? (
+                    <>
+                      <p className="text-sm font-semibold text-cyan-100">
+                        Your repertoire copy link is ready
+                      </p>
+                      <div className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-center">
+                        <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
+                          Copy code
+                        </p>
+                        <p className="mt-1 text-3xl font-black tracking-[0.2em] text-white">
+                          {repertoireShare.code}
+                        </p>
+                        {shareQrUrl && (
+                          <img
+                            src={shareQrUrl}
+                            alt="QR code for repertoire copy link"
+                            className="mx-auto mt-3 h-36 w-36 rounded-xl bg-white p-2"
+                          />
+                        )}
+                      </div>
+                      <p className="text-xs leading-5 text-slate-400">
+                        If you are standing together, show the QR code or code.
+                        If not, send the link or code by text or email. Revoke
+                        the link whenever you are done.
+                      </p>
+                      <input
+                        value={shareLink}
+                        readOnly
+                        className="w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-200"
+                        aria-label="Repertoire copy link"
+                      />
+                      <div className="grid gap-2 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+                        <button
+                          type="button"
+                          onClick={copyShareLink}
+                          className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200"
+                        >
+                          Copy link
+                        </button>
+                        <button
+                          type="button"
+                          onClick={copyShareCode}
+                          className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-cyan-100 hover:bg-white/20"
+                        >
+                          Copy code
+                        </button>
+                        <button
+                          type="button"
+                          onClick={revokeShareLink}
+                          disabled={isRevokingShare}
+                          className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-white/20 disabled:opacity-40"
+                        >
+                          {isRevokingShare ? "Revoking..." : "Revoke link"}
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-sm leading-6 text-slate-300">
+                        Standing together? Create the link/code and show the QR
+                        code. Remote? Create it and send the link or code.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={createShareLink}
+                        disabled={isCreatingShare}
+                        className="rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
+                      >
+                        {isCreatingShare ? "Creating..." : "Create link/code"}
+                      </button>
+                    </>
+                  )}
+                  {shareMessage && (
+                    <p className="text-sm text-slate-300">{shareMessage}</p>
+                  )}
+                </div>
               </div>
             </div>
           </section>

--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -93,7 +93,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
         );
       } catch (err) {
         console.error(err);
-        setMessage("Could not load shared repertoire. Check the link and try again.");
+        setMessage("Could not load songs to copy. Check the link and try again.");
       } finally {
         setLoading(false);
       }
@@ -220,7 +220,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
-        Loading shared repertoire...
+        Loading songs to copy...
       </main>
     );
   }
@@ -232,9 +232,9 @@ export function SharedRepertoireManager({ code }: { code: string }) {
 
         {!share ? (
           <section className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
-            <h1 className="text-3xl font-bold">Shared repertoire unavailable</h1>
+            <h1 className="text-3xl font-bold">Copy link unavailable</h1>
             <p className="mt-3 text-slate-200">
-              This repertoire link may have been revoked, expired, or typed
+              This copy link may have been revoked, expired, or typed
               incorrectly.
             </p>
           </section>
@@ -242,10 +242,10 @@ export function SharedRepertoireManager({ code }: { code: string }) {
           <>
             <section className="mt-8 rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-6">
               <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
-                Shared repertoire
+                Copy songs from another singer
               </p>
               <h1 className="mt-3 text-4xl font-bold tracking-tight">
-                {share.ownerDisplayName} shared repertoire with you
+                {share.ownerDisplayName} shared songs with you
               </h1>
               <p className="mt-3 max-w-3xl text-slate-200">
                 {isSignedIn

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -145,19 +145,21 @@ Established by migrations:
 
 ### `repertoire_shares`
 
-Purpose: opt-in private repertoire share links. A share code lets another
+Purpose: opt-in private repertoire copy links. A copy code lets another
 singer view only song identity fields from the owner's current repertoire so
 they can copy selected songs into their own repertoire.
 
 Code:
-- Create active share: `lib/repertoireSharing.ts#createRepertoireShare`
-- Read own active share: `lib/repertoireSharing.ts#getMyActiveRepertoireShare`
-- Revoke own share: `lib/repertoireSharing.ts#revokeRepertoireShare`
+- Create active copy link/code: `lib/repertoireSharing.ts#createRepertoireShare`
+- Read own active copy link/code:
+  `lib/repertoireSharing.ts#getMyActiveRepertoireShare`
+- Revoke own copy link/code: `lib/repertoireSharing.ts#revokeRepertoireShare`
 - Read safe shared repertoire by code:
   `lib/repertoireSharing.ts#getSharedRepertoire`, through
   `public.get_shared_repertoire`
 - Recipient copy flow: `components/SharedRepertoireManager.tsx`
-- Sharer controls: `components/RepertoireManager.tsx`
+- "Let another singer copy songs from my repertoire" controls:
+  `components/RepertoireManager.tsx`
 
 Expected context:
 - Browser authenticated owner for create/read/revoke of own share rows.

--- a/lib/__tests__/repertoireSharing.test.ts
+++ b/lib/__tests__/repertoireSharing.test.ts
@@ -5,7 +5,9 @@ process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
 
 const {
   normalizeSharedSongText,
+  repertoireCopyRequestMessage,
   resolveSharedSongCopyability,
+  sharedRepertoirePathFromInput,
   sharedSongExactKey,
 } = await import("@/lib/repertoireSharing");
 
@@ -88,5 +90,32 @@ describe("repertoire sharing", () => {
     );
 
     expect(resolved[0].duplicateStatus).toBe("eligible");
+  });
+
+  it("opens shared repertoire links from pasted codes or URLs", () => {
+    expect(sharedRepertoirePathFromInput("abc123")).toBe(
+      "/shared-repertoire/ABC123"
+    );
+    expect(
+      sharedRepertoirePathFromInput(
+        "https://www.whatcanwesing.com/shared-repertoire/def456"
+      )
+    ).toBe("/shared-repertoire/DEF456");
+    expect(
+      sharedRepertoirePathFromInput(
+        "https://www.whatcanwesing.com/shared-repertoire/GHI789?from=text"
+      )
+    ).toBe("/shared-repertoire/GHI789");
+    expect(sharedRepertoirePathFromInput("not a code")).toBeNull();
+  });
+
+  it("uses a clear remote request message for copy links and codes", () => {
+    expect(repertoireCopyRequestMessage).toContain(
+      "Let another singer copy songs from my repertoire"
+    );
+    expect(repertoireCopyRequestMessage).toContain("link or code");
+    expect(repertoireCopyRequestMessage).toContain(
+      "copy a few songs into my repertoire"
+    );
   });
 });

--- a/lib/__tests__/repertoireSharingUi.test.ts
+++ b/lib/__tests__/repertoireSharingUi.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repertoireManager = readFileSync(
+  join(process.cwd(), "components/RepertoireManager.tsx"),
+  "utf8"
+);
+
+describe("repertoire sharing UI language", () => {
+  it("offers separate copy-requester and copy-provider actions", () => {
+    expect(repertoireManager).toContain("More ways to build your repertoire");
+    expect(repertoireManager).toContain("Copy songs from another singer");
+    expect(repertoireManager).toContain(
+      "Let another singer copy songs from my repertoire"
+    );
+    expect(repertoireManager).toContain("Open shared repertoire");
+    expect(repertoireManager).toContain("Copy request message");
+    expect(repertoireManager).toContain("Create link/code");
+    expect(repertoireManager).toContain("Copy code");
+  });
+
+  it("does not use share-my-repertoire language as the primary action", () => {
+    expect(repertoireManager).not.toContain("Share repertoire");
+    expect(repertoireManager).not.toContain("Create share link");
+    expect(repertoireManager).not.toContain("Your repertoire share link");
+  });
+});

--- a/lib/repertoireSharing.ts
+++ b/lib/repertoireSharing.ts
@@ -44,6 +44,26 @@ export type CopyableSharedSong = SharedRepertoireSong & {
   duplicateStatus: "eligible" | "exact" | "possible_arrangement";
 };
 
+export const repertoireCopyRequestMessage =
+  "Can you open What Can We Sing, go to Repertoire, choose 'Let another singer copy songs from my repertoire,' and send me the link or code? I'd like to copy a few songs into my repertoire.";
+
+export function sharedRepertoirePathFromInput(input: string) {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const directCode = trimmed.toUpperCase();
+  if (/^[A-Z0-9]{6}$/.test(directCode)) {
+    return `/shared-repertoire/${directCode}`;
+  }
+
+  const pathMatch = trimmed.match(
+    /\/shared-repertoire\/([A-Za-z0-9]{6})(?:[/?#]|$)/
+  );
+  if (!pathMatch?.[1]) return null;
+
+  return `/shared-repertoire/${pathMatch[1].toUpperCase()}`;
+}
+
 export function normalizeSharedSongText(value?: string | null) {
   return (value ?? "")
     .trim()


### PR DESCRIPTION
## Summary
- add a requester-side Repertoire entry point for pasting a copy link or six-character code
- replace primary sharing language with safer copy-focused labels and instructions
- add copy-code support, a copyable remote request message, and clearer recipient route copy

## Docs and tests
- updated README and Supabase contract wording for repertoire copy links/codes
- added helper tests for link/code parsing and the request message
- added UI language guardrail tests for the Repertoire copy actions

## Supabase
- no schema, RLS, migration, or dashboard changes required

## Verification
- npm run test:run
- npm run build

Closes #294