### PR TITLE
Refine Harmony Brigade repertoire selection

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -47,7 +47,6 @@ import { arrangerDisplayName } from "@/lib/arrangerDisplay";
 import { hasQuartetWorkflowHistory } from "@/lib/activeQuartet";
 import {
   buildHarmonyBrigadeAddInputs,
-  dedupeHarmonyBrigadeSongs,
   filterHarmonyBrigadeSongs,
   getHarmonyBrigadeBrigadeOptions,
   getHarmonyBrigadeEvents,
@@ -56,11 +55,13 @@ import {
   HARMONY_BRIGADE_ALL_BRIGADES,
   HARMONY_BRIGADE_ALL_YEARS,
   HARMONY_BRIGADE_SOURCE,
+  harmonyBrigadeEventSongKey,
   harmonyBrigadeSelectionDescription,
   resolveHarmonyBrigadeCandidates,
   searchHarmonyBrigadeCandidates,
   type HarmonyBrigadeEvent,
   type HarmonyBrigadeEventSong,
+  type HarmonyBrigadePartSelections,
 } from "@/lib/harmonyBrigade";
 import {
   hasDuplicateParts,
@@ -176,11 +177,8 @@ export default function RepertoireManager() {
   );
   const [harmonyBrigadeSearchQuery, setHarmonyBrigadeSearchQuery] =
     useState("");
-  const [selectedHarmonyBrigadeSongIds, setSelectedHarmonyBrigadeSongIds] =
-    useState<Set<string>>(new Set());
-  const [harmonyBrigadePart, setHarmonyBrigadePart] = useState<Part | "">("");
-  const [harmonyBrigadeConfidence, setHarmonyBrigadeConfidence] =
-    useState<Confidence | "">("");
+  const [harmonyBrigadePartSelections, setHarmonyBrigadePartSelections] =
+    useState<HarmonyBrigadePartSelections>({});
   const [harmonyBrigadeMessage, setHarmonyBrigadeMessage] = useState("");
   const [isHarmonyBrigadeLoading, setIsHarmonyBrigadeLoading] = useState(false);
   const [isAddingHarmonyBrigadeSongs, setIsAddingHarmonyBrigadeSongs] =
@@ -368,7 +366,7 @@ export default function RepertoireManager() {
     setSecondaryRepertoireTool("harmony-brigade");
     setHarmonyBrigadeMessage("");
     setHarmonyBrigadeSearchQuery("");
-    setSelectedHarmonyBrigadeSongIds(new Set());
+    setHarmonyBrigadePartSelections({});
     setIsHarmonyBrigadeLoading(true);
 
     try {
@@ -850,28 +848,33 @@ export default function RepertoireManager() {
     }
   }
 
-  function toggleHarmonyBrigadeSong(songId: string) {
-    setSelectedHarmonyBrigadeSongIds((current) => {
-      const next = new Set(current);
-      if (next.has(songId)) {
-        next.delete(songId);
-      } else {
-        next.add(songId);
-      }
-      return next;
-    });
-  }
+  function updateHarmonyBrigadePartSelection(
+    eventSongKey: string,
+    part: Part,
+    confidence: Confidence | ""
+  ) {
+    setHarmonyBrigadePartSelections((current) => {
+      const next = { ...current };
+      const rowSelection = { ...(next[eventSongKey] ?? {}) };
 
-  function selectAllVisibleHarmonyBrigadeSongs(songIds: string[]) {
-    setSelectedHarmonyBrigadeSongIds((current) => {
-      const next = new Set(current);
-      for (const id of songIds) next.add(id);
+      if (confidence) {
+        rowSelection[part] = confidence;
+      } else {
+        delete rowSelection[part];
+      }
+
+      if (Object.keys(rowSelection).length === 0) {
+        delete next[eventSongKey];
+      } else {
+        next[eventSongKey] = rowSelection;
+      }
+
       return next;
     });
   }
 
   function clearHarmonyBrigadeSelection() {
-    setSelectedHarmonyBrigadeSongIds(new Set());
+    setHarmonyBrigadePartSelections({});
   }
 
   async function addHarmonyBrigadeSongs(
@@ -881,13 +884,6 @@ export default function RepertoireManager() {
 
     if (inputs.length === 0) {
       setHarmonyBrigadeMessage("Choose at least one song to add.");
-      return;
-    }
-
-    if (!harmonyBrigadePart || !harmonyBrigadeConfidence) {
-      setHarmonyBrigadeMessage(
-        "Choose your part and confidence before adding songs."
-      );
       return;
     }
 
@@ -913,7 +909,7 @@ export default function RepertoireManager() {
       }
 
       await loadRepertoire();
-      setSelectedHarmonyBrigadeSongIds(new Set());
+      setHarmonyBrigadePartSelections({});
       setHarmonyBrigadeMessage(
         `${addedCount} ${addedCount === 1 ? "song" : "songs"} added. You can edit parts, confidence, arranger, or delete songs anytime.`
       );
@@ -997,12 +993,10 @@ export default function RepertoireManager() {
   )
     ? harmonyBrigadeBrigade
     : HARMONY_BRIGADE_ALL_BRIGADES;
-  const harmonyBrigadeScopedRows = dedupeHarmonyBrigadeSongs(
-    filterHarmonyBrigadeSongs(
-      harmonyBrigadeRows,
-      harmonyBrigadeYear,
-      selectedHarmonyBrigadeBrigade
-    )
+  const harmonyBrigadeScopedRows = filterHarmonyBrigadeSongs(
+    harmonyBrigadeRows,
+    harmonyBrigadeYear,
+    selectedHarmonyBrigadeBrigade
   );
   const harmonyBrigadeCandidates = resolveHarmonyBrigadeCandidates(
     harmonyBrigadeScopedRows,
@@ -1017,23 +1011,17 @@ export default function RepertoireManager() {
   ).length;
   const harmonyBrigadeAlreadyCount =
     harmonyBrigadeCandidates.length - harmonyBrigadeEligibleCount;
-  const visibleHarmonyBrigadeEligibleIds = visibleHarmonyBrigadeCandidates
-    .filter((row) => row.duplicateStatus === "eligible")
-    .map((row) => row.song.id);
   const selectedHarmonyBrigadeEligibleCount = harmonyBrigadeCandidates.filter(
     (row) =>
       row.duplicateStatus === "eligible" &&
-      selectedHarmonyBrigadeSongIds.has(row.song.id)
+      Object.keys(
+        harmonyBrigadePartSelections[harmonyBrigadeEventSongKey(row)] ?? {}
+      ).length > 0
   ).length;
-  const selectedHarmonyBrigadeAddInputs =
-    harmonyBrigadePart && harmonyBrigadeConfidence
-      ? buildHarmonyBrigadeAddInputs(
-          harmonyBrigadeCandidates,
-          selectedHarmonyBrigadeSongIds,
-          harmonyBrigadePart,
-          harmonyBrigadeConfidence
-        )
-      : [];
+  const selectedHarmonyBrigadeAddInputs = buildHarmonyBrigadeAddInputs(
+    harmonyBrigadeCandidates,
+    harmonyBrigadePartSelections
+  );
   const harmonyBrigadePreviewDescription =
     harmonyBrigadeSelectionDescription(
       harmonyBrigadeYear,
@@ -1041,10 +1029,7 @@ export default function RepertoireManager() {
       harmonyBrigadeCandidates.length,
       harmonyBrigadeEvents
     );
-  const canAddHarmonyBrigadeSongs =
-    selectedHarmonyBrigadeEligibleCount > 0 &&
-    Boolean(harmonyBrigadePart) &&
-    Boolean(harmonyBrigadeConfidence);
+  const canAddHarmonyBrigadeSongs = selectedHarmonyBrigadeAddInputs.length > 0;
   const quartetTeachingTitle =
     items.length <= 2
       ? "Good start - keep building or try a quartet"
@@ -1349,7 +1334,7 @@ export default function RepertoireManager() {
                               ? harmonyBrigadeBrigade
                               : HARMONY_BRIGADE_ALL_BRIGADES
                           );
-                          setSelectedHarmonyBrigadeSongIds(new Set());
+                          setHarmonyBrigadePartSelections({});
                           setHarmonyBrigadeSearchQuery("");
                         }}
                         className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
@@ -1369,7 +1354,7 @@ export default function RepertoireManager() {
                         value={selectedHarmonyBrigadeBrigade}
                         onChange={(event) => {
                           setHarmonyBrigadeBrigade(event.target.value);
-                          setSelectedHarmonyBrigadeSongIds(new Set());
+                          setHarmonyBrigadePartSelections({});
                           setHarmonyBrigadeSearchQuery("");
                         }}
                         className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
@@ -1397,8 +1382,8 @@ export default function RepertoireManager() {
                       in your repertoire.
                     </p>
                     <p className="mt-1 text-sm leading-6 text-slate-300">
-                      Choose the songs you want to add. You can edit individual
-                      songs later.
+                      Choose one or more parts for each song you want to add.
+                      Blank parts will not be added.
                     </p>
 
                     <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
@@ -1415,62 +1400,40 @@ export default function RepertoireManager() {
                           className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                         />
                       </label>
-                      <div className="flex flex-col gap-2 sm:flex-row">
-                        <button
-                          type="button"
-                          onClick={() =>
-                            selectAllVisibleHarmonyBrigadeSongs(
-                              visibleHarmonyBrigadeEligibleIds
-                            )
-                          }
-                          className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-cyan-100 hover:bg-white/20"
-                        >
-                          Select visible
-                        </button>
-                        <button
-                          type="button"
-                          onClick={clearHarmonyBrigadeSelection}
-                          className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-white/20"
-                        >
-                          Clear
-                        </button>
-                      </div>
+                      <button
+                        type="button"
+                        onClick={clearHarmonyBrigadeSelection}
+                        className="rounded-xl bg-white/10 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-white/20"
+                      >
+                        Clear choices
+                      </button>
                     </div>
 
                     <div className="mt-4 max-h-80 divide-y divide-white/10 overflow-y-auto rounded-xl border border-white/10">
                       {visibleHarmonyBrigadeCandidates.map((row) => {
                         const isExactDuplicate =
                           row.duplicateStatus === "exact";
-                        const checked = selectedHarmonyBrigadeSongIds.has(
-                          row.song.id
-                        );
+                        const eventSongKey = harmonyBrigadeEventSongKey(row);
+                        const selectedParts =
+                          harmonyBrigadePartSelections[eventSongKey] ?? {};
 
                         return (
-                          <label
-                            key={row.song.id}
-                            className={`flex gap-3 p-3 ${
+                          <div
+                            key={eventSongKey}
+                            className={`grid gap-3 p-3 ${
                               isExactDuplicate
                                 ? "bg-slate-900/80 text-slate-500"
                                 : "bg-slate-900/40 text-slate-100"
                             }`}
                           >
-                            <input
-                              type="checkbox"
-                              checked={checked}
-                              disabled={isExactDuplicate}
-                              onChange={() =>
-                                toggleHarmonyBrigadeSong(row.song.id)
-                              }
-                              className="mt-1 h-4 w-4 rounded border-white/20 bg-slate-950"
-                            />
-                            <span className="min-w-0">
-                              <span className="block font-semibold">
+                            <div className="min-w-0">
+                              <p className="font-semibold">
                                 {isExactDuplicate
                                   ? "Already in your repertoire: "
                                   : ""}
                                 {row.song.songTitle}
-                              </span>
-                              <span className="mt-1 block text-xs leading-5 text-slate-400">
+                              </p>
+                              <p className="mt-1 text-xs leading-5 text-slate-400">
                                 TTBB -{" "}
                                 {row.song.arranger
                                   ? `Arr. ${arrangerDisplayName(row.song.arranger)}`
@@ -1481,64 +1444,51 @@ export default function RepertoireManager() {
                                 {row.song.startingWords
                                   ? ` - Starts "${row.song.startingWords}"`
                                   : ""}
-                              </span>
-                            </span>
-                          </label>
+                              </p>
+                              <p className="mt-1 text-xs leading-5 text-slate-500">
+                                {row.event.eventLabel}
+                                {row.trackNumber
+                                  ? ` - Track ${row.trackNumber}`
+                                  : ""}
+                              </p>
+                            </div>
+
+                            {!isExactDuplicate && (
+                              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                                {partsByVoicing.TTBB.map((part) => (
+                                  <label key={part} className="block">
+                                    <span className="text-xs font-semibold text-slate-300">
+                                      {partButtonLabel("TTBB", part)}
+                                    </span>
+                                    <select
+                                      value={selectedParts[part] ?? ""}
+                                      onChange={(event) =>
+                                        updateHarmonyBrigadePartSelection(
+                                          eventSongKey,
+                                          part,
+                                          event.target.value as Confidence | ""
+                                        )
+                                      }
+                                      className="mt-1 w-full rounded-lg border border-white/10 bg-slate-950 px-2 py-2 text-sm text-white outline-none ring-cyan-300 focus:ring-2"
+                                      aria-label={`${row.song.songTitle} ${partButtonLabel(
+                                        "TTBB",
+                                        part
+                                      )} confidence`}
+                                    >
+                                      <option value="">Not adding</option>
+                                      {confidenceLevels.map((level) => (
+                                        <option key={level} value={level}>
+                                          {level}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </label>
+                                ))}
+                              </div>
+                            )}
+                          </div>
                         );
                       })}
-                    </div>
-                  </div>
-
-                  <div className="mt-5 rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-4">
-                    <h3 className="text-xl font-bold">
-                      Apply your part and confidence
-                    </h3>
-                    <p className="mt-2 text-sm leading-6 text-slate-200">
-                      For these songs, choose the part you usually sing and your
-                      confidence. These settings will be applied to all selected
-                      songs. You can edit individual songs later.
-                    </p>
-                    <div className="mt-4 grid gap-4 md:grid-cols-2">
-                      <label className="block">
-                        <span className="text-sm font-medium text-slate-200">
-                          Part
-                        </span>
-                        <select
-                          value={harmonyBrigadePart}
-                          onChange={(event) =>
-                            setHarmonyBrigadePart(event.target.value as Part | "")
-                          }
-                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                        >
-                          <option value="">Choose part</option>
-                          {partsByVoicing.TTBB.map((part) => (
-                            <option key={part} value={part}>
-                              {partButtonLabel("TTBB", part)}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <label className="block">
-                        <span className="text-sm font-medium text-slate-200">
-                          Confidence
-                        </span>
-                        <select
-                          value={harmonyBrigadeConfidence}
-                          onChange={(event) =>
-                            setHarmonyBrigadeConfidence(
-                              event.target.value as Confidence | ""
-                            )
-                          }
-                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                        >
-                          <option value="">Choose confidence</option>
-                          {confidenceLevels.map((level) => (
-                            <option key={level} value={level}>
-                              {level}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
                     </div>
                   </div>
                 </>
@@ -1555,9 +1505,14 @@ export default function RepertoireManager() {
                   <p className="text-sm text-slate-300">
                     {selectedHarmonyBrigadeEligibleCount}{" "}
                     {selectedHarmonyBrigadeEligibleCount === 1
-                      ? "song"
-                      : "songs"}{" "}
-                    selected. {harmonyBrigadeAlreadyCount}{" "}
+                      ? "listing has"
+                      : "listings have"}{" "}
+                    part choices. {selectedHarmonyBrigadeAddInputs.length}{" "}
+                    unique{" "}
+                    {selectedHarmonyBrigadeAddInputs.length === 1
+                      ? "song is"
+                      : "songs are"}{" "}
+                    ready to add. {harmonyBrigadeAlreadyCount}{" "}
                     {harmonyBrigadeAlreadyCount === 1 ? "song was" : "songs were"}{" "}
                     already in your repertoire and will not be added again.
                   </p>
@@ -1573,9 +1528,9 @@ export default function RepertoireManager() {
                   >
                     {isAddingHarmonyBrigadeSongs
                       ? "Adding..."
-                      : selectedHarmonyBrigadeEligibleCount > 0
-                        ? `Add ${selectedHarmonyBrigadeEligibleCount} ${
-                            selectedHarmonyBrigadeEligibleCount === 1
+                      : selectedHarmonyBrigadeAddInputs.length > 0
+                        ? `Add ${selectedHarmonyBrigadeAddInputs.length} ${
+                            selectedHarmonyBrigadeAddInputs.length === 1
                               ? "song"
                               : "songs"
                           }`

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -181,8 +181,12 @@ The user-facing flow appears under **More ways to build your repertoire** as
 - `All years` or a real `YearHeld` value
 - `All brigades` or a real brigade abbreviation/name from `XQ_Brigades`
 
-Songs default to `TTBB`. Before adding, the user chooses the part they usually
-sing and a confidence value. Adding Harmony Brigade songs writes only to the
+The picker lists event-song appearances from `ViewHistory`, so the same song
+can appear under multiple years or brigades. Songs default to `TTBB`. Before
+adding, the user chooses any TTBB parts they know for each song and a confidence
+value for each selected part. If multiple appearances of the same normalized
+title + arranger are selected, they are saved as one repertoire row with the
+combined part confidences. Adding Harmony Brigade songs writes only to the
 current user's `user_repertoire`; it does not expose the user's Brigade
 selection publicly.
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -262,6 +262,10 @@ Expected context:
   reference rows.
 - Browser users never write to these reference tables. Adding songs writes only
   to the current user's `user_repertoire`.
+- The UI lists event-song appearances from `harmony_brigade_event_songs`, not
+  only unique songs. If a user selects parts from multiple appearances of the
+  same normalized song + arranger, the app writes one `user_repertoire` row with
+  combined TTBB part confidences.
 
 Required database contract:
 - `harmony_brigade_songs`

--- a/lib/__tests__/harmonyBrigade.test.ts
+++ b/lib/__tests__/harmonyBrigade.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { RepertoireRow } from "@/lib/repertoireStore";
 import {
   buildHarmonyBrigadeAddInputs,
-  dedupeHarmonyBrigadeSongs,
   filterHarmonyBrigadeSongs,
   getHarmonyBrigadeBrigadeOptions,
   getHarmonyBrigadeYearOptions,
   HARMONY_BRIGADE_ALL_BRIGADES,
   HARMONY_BRIGADE_ALL_YEARS,
+  harmonyBrigadeEventSongKey,
   harmonyBrigadeSelectionDescription,
   resolveHarmonyBrigadeCandidates,
   type HarmonyBrigadeEvent,
@@ -105,13 +105,15 @@ describe("Harmony Brigade source helpers", () => {
     expect(filterHarmonyBrigadeSongs(rows, 2024, "NCHB")).toEqual([rows[1]]);
   });
 
-  it("dedupes the same song across multiple event appearances", () => {
+  it("preserves the same song across multiple event appearances", () => {
     const rows = [
       eventSong("1", "A", "Arranger", atlantic2024),
       eventSong("1", "A", "Arranger", atlantic2023),
     ];
 
-    expect(dedupeHarmonyBrigadeSongs(rows)).toEqual([rows[0]]);
+    expect(
+      filterHarmonyBrigadeSongs(rows, HARMONY_BRIGADE_ALL_YEARS, "AHB")
+    ).toEqual(rows);
   });
 
   it("uses natural preview copy for selected scope", () => {
@@ -164,7 +166,7 @@ describe("Harmony Brigade source helpers", () => {
     ]);
   });
 
-  it("builds TTBB add inputs with the user's batch part and confidence", () => {
+  it("builds TTBB add inputs with per-song part confidence choices", () => {
     const candidates = resolveHarmonyBrigadeCandidates(
       [
         eventSong("1", "Hello, My Baby", "Joe Liles", atlantic2024),
@@ -176,9 +178,15 @@ describe("Harmony Brigade source helpers", () => {
     expect(
       buildHarmonyBrigadeAddInputs(
         candidates,
-        new Set(["1", "2"]),
-        "Lead",
-        "A Little Rusty"
+        {
+          [harmonyBrigadeEventSongKey(candidates[0])]: {
+            Lead: "A Little Rusty",
+            Baritone: "Good to Go",
+          },
+          [harmonyBrigadeEventSongKey(candidates[1])]: {
+            Bass: "Good to Go",
+          },
+        }
       )
     ).toEqual([
       {
@@ -189,6 +197,48 @@ describe("Harmony Brigade source helpers", () => {
           {
             part: "Lead",
             confidence: "A Little Rusty",
+          },
+          {
+            part: "Baritone",
+            confidence: "Good to Go",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("merges part confidence choices from duplicate event appearances", () => {
+    const candidates = resolveHarmonyBrigadeCandidates(
+      [
+        eventSong("1", "Hello, My Baby", "Joe Liles", atlantic2024),
+        eventSong("1", "Hello, My Baby", "Joe Liles", atlantic2023),
+      ],
+      []
+    );
+
+    expect(
+      buildHarmonyBrigadeAddInputs(candidates, {
+        [harmonyBrigadeEventSongKey(candidates[0])]: {
+          Lead: "A Little Rusty",
+        },
+        [harmonyBrigadeEventSongKey(candidates[1])]: {
+          Lead: "Good to Go",
+          Bass: "Music Required",
+        },
+      })
+    ).toEqual([
+      {
+        songTitle: "Hello, My Baby",
+        voicing: "TTBB",
+        arrangerName: "Joe Liles",
+        partConfidences: [
+          {
+            part: "Lead",
+            confidence: "Good to Go",
+          },
+          {
+            part: "Bass",
+            confidence: "Music Required",
           },
         ],
       },

--- a/lib/__tests__/harmonyBrigadeUi.test.ts
+++ b/lib/__tests__/harmonyBrigadeUi.test.ts
@@ -29,9 +29,13 @@ describe("Harmony Brigade repertoire UI", () => {
 
   it("uses singer-facing add language instead of import language", () => {
     expect(repertoireManager).toContain("Review songs before adding");
-    expect(repertoireManager).toContain("Apply your part and confidence");
-    expect(repertoireManager).toContain("Add selected songs");
+    expect(repertoireManager).toContain(
+      "Choose one or more parts for each song you want to add"
+    );
+    expect(repertoireManager).toContain("Not adding");
+    expect(repertoireManager).toContain("part choices");
     expect(repertoireManager).not.toContain("Import Harmony Brigade songs");
+    expect(repertoireManager).not.toContain("Apply your part and confidence");
   });
 
   it("keeps Brigade songs out of normal typeahead suggestions", () => {

--- a/lib/harmonyBrigade.ts
+++ b/lib/harmonyBrigade.ts
@@ -47,6 +47,11 @@ export type HarmonyBrigadeAddInput = {
   partConfidences: PartConfidence[];
 };
 
+export type HarmonyBrigadePartSelections = Record<
+  string,
+  Partial<Record<Part, Confidence>>
+>;
+
 type RawHarmonyBrigadeEvent = {
   id: string;
   year_held: number;
@@ -197,16 +202,10 @@ export function filterHarmonyBrigadeSongs(
   });
 }
 
-export function dedupeHarmonyBrigadeSongs(rows: HarmonyBrigadeEventSong[]) {
-  const uniqueRows = new Map<string, HarmonyBrigadeEventSong>();
-
-  for (const row of rows) {
-    if (!uniqueRows.has(row.song.id)) {
-      uniqueRows.set(row.song.id, row);
-    }
-  }
-
-  return Array.from(uniqueRows.values());
+export function harmonyBrigadeEventSongKey(
+  row: Pick<HarmonyBrigadeEventSong, "event" | "song">
+) {
+  return `${row.event.id}:${row.song.id}`;
 }
 
 export function harmonyBrigadeSelectionDescription(
@@ -289,28 +288,75 @@ export function searchHarmonyBrigadeCandidates(
   });
 }
 
+function confidenceRank(confidence: Confidence) {
+  if (confidence === "Good to Go") return 3;
+  if (confidence === "A Little Rusty") return 2;
+  return 1;
+}
+
+function mergePartConfidences(
+  current: PartConfidence[],
+  next: PartConfidence[]
+) {
+  const merged = new Map<Part, Confidence>();
+
+  for (const item of [...current, ...next]) {
+    const existing = merged.get(item.part);
+    if (!existing || confidenceRank(item.confidence) > confidenceRank(existing)) {
+      merged.set(item.part, item.confidence);
+    }
+  }
+
+  return Array.from(merged.entries()).map(([part, confidence]) => ({
+    part,
+    confidence,
+  }));
+}
+
 export function buildHarmonyBrigadeAddInputs(
   candidates: HarmonyBrigadeCandidate[],
-  selectedIds: Set<string>,
-  part: Part,
-  confidence: Confidence
+  selections: HarmonyBrigadePartSelections
 ): HarmonyBrigadeAddInput[] {
-  return candidates
+  const inputs = new Map<string, HarmonyBrigadeAddInput>();
+
+  for (const row of candidates
     .filter(
       (row) =>
-        selectedIds.has(row.song.id) && row.duplicateStatus === "eligible"
+        Object.keys(selections[harmonyBrigadeEventSongKey(row)] ?? {}).length >
+          0 &&
+        row.duplicateStatus === "eligible"
     )
-    .map((row) => ({
+  ) {
+    const rowSelections = selections[harmonyBrigadeEventSongKey(row)] ?? {};
+    const partConfidences = Object.entries(rowSelections)
+      .filter((entry): entry is [Part, Confidence] => Boolean(entry[1]))
+      .map(([part, confidence]) => ({ part, confidence }));
+
+    if (partConfidences.length === 0) continue;
+
+    const key = exactSongKey({
       songTitle: row.song.songTitle,
-      voicing: HARMONY_BRIGADE_DEFAULT_VOICING,
-      arrangerName: row.song.arranger ?? undefined,
-      partConfidences: [
-        {
-          part,
-          confidence,
-        },
-      ],
-    }));
+      arrangerName: row.song.arranger,
+    });
+
+    const existing = inputs.get(key);
+
+    if (existing) {
+      existing.partConfidences = mergePartConfidences(
+        existing.partConfidences,
+        partConfidences
+      );
+    } else {
+      inputs.set(key, {
+        songTitle: row.song.songTitle,
+        voicing: HARMONY_BRIGADE_DEFAULT_VOICING,
+        arrangerName: row.song.arranger ?? undefined,
+        partConfidences,
+      });
+    }
+  }
+
+  return Array.from(inputs.values());
 }
 
 export async function getHarmonyBrigadeEvents() {


### PR DESCRIPTION
## Summary
- Show Harmony Brigade event-song appearances instead of collapsing the list to unique songs.
- Let singers choose multiple TTBB parts per Brigade listing, with a separate confidence for each selected part.
- Merge duplicate event appearances into one repertoire row at save time with combined part confidences.
- Update Harmony Brigade docs and regression tests for the new selection model.

## Tests
- npm run test:run
- npm run build

## Supabase
- No migration required. Existing Harmony Brigade reference tables and user_repertoire writes are unchanged.