### PR TITLE
Refine My Songs onboarding and last-sung filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,37 @@ business logic, data flow, matching, Supabase helpers, auth/session behavior,
 UI state transitions, or regression-prone bugs. If docs or tests are not
 updated, explain why in the PR.
 
+## Issue and PR completeness standard
+
+For every product, UX, feature, data, or workflow change, consider downstream
+impact across:
+
+- navigation
+- home/dashboard
+- onboarding and first-run prompts
+- empty states and new-user guidance
+- Help and Privacy pages
+- README, docs, AGENTS.md, and Supabase contract
+- analytics events and analytics privacy
+- mobile layout
+- accessibility
+- auth, permissions, and RLS
+- data model, migrations, seed/import scripts, and cleanup scripts
+- tests
+- deployment and environment variables
+- admin/support/runbook behavior
+- existing terminology decisions
+
+If an area is affected, update it in the same PR unless the issue explicitly
+says otherwise. If an area is not affected, note that briefly in the PR summary.
+Do not leave obvious rollout items as implicit follow-ups.
+
+When creating or refining issues, include an impact audit section when the
+change is more than a tiny bug fix. The issue should tell the implementer what
+needs to be inspected across nav, onboarding, Help, Privacy, docs, analytics,
+mobile, accessibility, tests, data/RLS, deployment, and admin/support
+implications.
+
 Supabase changes must be captured in repo migrations and docs rather than
 dashboard-only changes. If a change requires schema, RLS, or data-model updates,
 add a proper migration and update `docs/supabase-contract.md` as needed.

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -121,7 +121,7 @@ export default function HelpPage() {
           <p className={helpIntroParagraphClass}>
             Each singer adds the songs they know, the voicing, the parts they
             can sing, and how confident they feel. When singers join the same
-            quartet, the app compares everyone&apos;s repertoire and shows songs
+            quartet, the app compares everyone&apos;s saved songs and shows songs
             where the required parts are covered by different people.
           </p>
           <p className={helpIntroParagraphClass}>

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -330,7 +330,7 @@ export default function JoinSessionPage() {
         });
         showStatusMessage(
           options.successMessage ??
-            `Updated ${name}'s repertoire with ${entries.length} songs.`,
+            `Updated ${name}'s saved songs with ${entries.length} songs.`,
           "transient"
         );
         return;
@@ -667,7 +667,7 @@ export default function JoinSessionPage() {
 
       if (resolution.status === "ambiguous") {
         showStatusMessage(
-          "This match includes more than one of your repertoire entries. Update the exact song from your repertoire.",
+          "This match includes more than one of your saved song entries. Update the exact song from My Songs.",
           "error"
         );
         return;
@@ -1379,7 +1379,7 @@ export default function JoinSessionPage() {
                         href="/repertoire"
                         className="rounded-xl border border-white/10 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/10"
                       >
-                        Edit Repertoire
+                        Edit My Songs
                       </a>
                       <a
                         href="/settings"
@@ -1454,7 +1454,7 @@ export default function JoinSessionPage() {
                             href="/repertoire"
                             className="text-sm font-semibold text-cyan-300 hover:text-cyan-200"
                           >
-                            Edit repertoire
+                            Edit My Songs
                           </a>
                         </div>
                       </div>
@@ -1495,7 +1495,7 @@ export default function JoinSessionPage() {
               <div className="mt-4 space-y-5">
                 {matches.length === 0 && (
                   <p className="rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-300">
-                    No matches yet. Add more singers or repertoire.
+                    No matches yet. Add more singers or saved songs.
                   </p>
                 )}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: siteTitle,
     description:
-      "What Can We Sing helps barbershop singers compare repertoire, form pickup quartets, and find songs with the right parts covered by different singers.",
+      "What Can We Sing helps barbershop singers compare saved songs, form pickup quartets, and find songs with the right parts covered by different singers.",
     siteName: siteTitle,
     type: "website",
   },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ const actions = [
   },
   {
     href: "/repertoire",
-    title: "My repertoire",
+    title: "My Songs",
     description: "Add or update songs you know.",
   },
 ];
@@ -47,7 +47,7 @@ const setupPrompts: Record<
   missing_repertoire: {
     message: "Add a few songs before starting or joining a quartet.",
     helper:
-      "You can still use Start or Join from the navigation if you are helping set up a quartet.",
+      "You can type songs in, copy songs from another singer, or add Harmony Brigade songs from My Songs.",
     href: "/repertoire",
     action: "Add songs",
   },
@@ -157,7 +157,7 @@ export default function Home() {
             <div className="mt-6 rounded-xl bg-white/10 px-4 py-3">
               <p className="text-sm font-semibold text-slate-100">
                 {repertoireCount} {repertoireCount === 1 ? "song" : "songs"} in
-                your repertoire
+                My Songs
               </p>
               <p className="mt-1 text-sm text-slate-300">
                 Start a quartet, join with a code, or update your song list.

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -8,7 +8,7 @@ export default function PrivacyPage() {
 
         <h1 className="mt-8 text-4xl font-bold tracking-tight">Privacy</h1>
         <p className="mt-3 text-lg text-slate-300">
-          What Can We Sing is built to help singers compare repertoire in the
+          What Can We Sing is built to help singers compare saved songs in the
           room. This page explains what information the app uses, what other
           quartet members can see, and which services help run the app.
         </p>
@@ -18,19 +18,20 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">Information we collect</h2>
             <p className="mt-2 text-slate-300">
               We store your email address so you can sign in and access your
-              saved repertoire. We do not show your email address to other
+              saved songs. We do not show your email address to other
               singers in a quartet.
             </p>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
               <li>Your display name for profile and quartet screens.</li>
               <li>
-                Your repertoire entries, including song title, voicing, parts
+                Your My Songs entries, including song title, voicing, parts
                 known, confidence, arranger if entered, notes if entered, date
-                added or updated, and recently sung information.
+                added or updated, and last-sung information when you mark a song
+                as sung in the app.
               </li>
               <li>
                 Quartet/session data, including join codes, active membership,
-                and participant repertoire snapshots used to calculate matches.
+                and participant saved-song snapshots used to calculate matches.
               </li>
               <li>
                 Feedback messages you send, including the contact email shown in
@@ -43,7 +44,7 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">How we use it</h2>
             <p className="mt-2 text-slate-300">
               The app uses your information to sign you in, save your profile,
-              manage your repertoire, let you join or leave quartets, refresh
+              manage My Songs, let you join or leave quartets, refresh
               quartet snapshots, and show songs the group may be able to sing.
               Song title suggestions are generated from distinct song title,
               voicing, and arranger values that singers have entered before.
@@ -53,21 +54,69 @@ export default function PrivacyPage() {
           </div>
 
           <div>
+            <h2 className="text-xl font-semibold">Song suggestions</h2>
+            <p className="mt-2 text-slate-300">
+              Suggestions help singers enter songs faster. They may use safe song
+              identity fields such as title, voicing, and arranger from catalog
+              imports or previously saved song identities. Suggestions are not
+              authoritative, and adding a song to My Songs does not add it to
+              anyone else&apos;s My Songs. Personal details such as notes,
+              confidence, last-sung history, user identity, and email address are
+              not exposed as suggestions.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Private copy links</h2>
+            <p className="mt-2 text-slate-300">
+              If you choose Let another singer copy songs from My Songs, the app
+              creates a private code/link. Anyone with an active code/link can
+              view safe song identity fields: title, voicing, and arranger. They
+              must sign in before copying songs, and copied songs become their
+              own My Songs entries with their chosen part and confidence. The
+              shared view does not expose notes, confidence, last-sung history,
+              email address, or account details, and you can revoke the link.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Harmony Brigade songs</h2>
+            <p className="mt-2 text-slate-300">
+              Adding Harmony Brigade songs uses reference data to help you add
+              songs to My Songs. It does not publicly indicate that you attended
+              a Brigade event. Your selected year, brigade, song choices, parts,
+              and confidence are not shown to other users by default, except
+              through normal quartet matching if you join a quartet.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Last-sung data</h2>
+            <p className="mt-2 text-slate-300">
+              Last-sung data is stored when you mark a song as sung from a
+              quartet page or from My Songs. It is used for sorting, filtering,
+              and personal guidance. It is not meant to be a public performance
+              history, and Not marked yet does not make any claim about your
+              real-life singing history.
+            </p>
+          </div>
+
+          <div>
             <h2 className="text-xl font-semibold">
               What quartet members can see
             </h2>
             <p className="mt-2 text-slate-300">
               When you join a quartet, other singers in that quartet may see
-              your display name and repertoire-derived information needed for
+              your display name and saved-song information needed for
               matching, such as songs, voicing, parts, confidence, and possible
               arrangement details or warnings. This sharing is the core purpose
               of the app: helping the quartet answer what can we sing together
               right now.
             </p>
             <p className="mt-2 text-slate-300">
-              Personal repertoire notes are stored for you and are not included
+              Personal notes are stored for you and are not included
               in participant snapshots. Notes may appear to you in your own
-              repertoire and match details.
+              My Songs and match details.
             </p>
           </div>
 
@@ -87,7 +136,7 @@ export default function PrivacyPage() {
               If analytics are enabled, we use PostHog to understand product
               usage and reliability. Analytics events may include routes,
               counts, categories, browser/device information, and coarse action
-              details. We do not intentionally send feedback text, repertoire
+              details. We do not intentionally send feedback text, My Songs
               notes, song titles, arranger names, singer names, email addresses,
               or quartet join codes to analytics.
             </p>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -162,7 +162,7 @@ export default function SettingsPage() {
               href="/repertoire"
               className="mt-4 inline-block rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/20"
             >
-              Add songs
+              Add songs to My Songs
             </a>
           )}
         </section>

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -98,7 +98,11 @@ export default function WelcomePage() {
             <p className="font-semibold text-white">To get useful matches:</p>
             <ol className="mt-3 space-y-3 text-sm leading-6 text-slate-300">
               <li>1. Set your display name.</li>
-              <li>2. Add a few songs you know, not your whole repertoire.</li>
+              <li>
+                2. Add a few songs you know, not every song. You can type songs
+                in, copy songs from another singer, or add Harmony Brigade songs
+                if that applies to you.
+              </li>
               <li>3. Start a quartet or join one with a code, QR code, or link.</li>
               <li>4. Use the match list to pick something and sing.</li>
             </ol>

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -17,7 +17,7 @@ const primaryNavItems = [
   },
   {
     href: "/repertoire",
-    label: "Repertoire",
+    label: "My Songs",
     isActive: (pathname: string) => pathname === "/repertoire",
   },
 ];

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -193,7 +193,7 @@ export function MatchCard({
               Potential title match
             </p>
             <p className="mt-1 text-xs text-amber-50/80">
-              These repertoire entries may refer to the same song.
+              These saved song entries may refer to the same song.
             </p>
             <p className="mt-2 text-xs text-amber-50/70">
               Comparison key:{" "}
@@ -238,8 +238,8 @@ export function MatchCard({
               })}
             </div>
             <p className="mt-3 text-xs text-amber-50/80">
-              If these are the same song, consider updating repertoire titles
-              so future matches are clearer.
+              If these are the same song, consider updating song titles in My
+              Songs so future matches are clearer.
             </p>
           </div>
         ) : null}

--- a/components/QuartetActionConfirmation.test.tsx
+++ b/components/QuartetActionConfirmation.test.tsx
@@ -42,13 +42,13 @@ describe("QuartetActionConfirmation", () => {
     expect(html).toContain("Leaving...");
   });
 
-  it("supports destructive repertoire delete confirmation copy", () => {
+  it("supports destructive My Songs delete confirmation copy", () => {
     const html = renderToStaticMarkup(
       <QuartetActionConfirmation
         open
         busy={false}
         title="Delete song?"
-        description='This will remove "Mamselle" from your repertoire. This cannot be undone.'
+        description='This will remove "Mamselle" from My Songs. This cannot be undone.'
         confirmLabel="Delete song"
         busyLabel="Deleting..."
         onCancel={() => undefined}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -15,12 +15,15 @@ import {
   filterAndSortRepertoire,
   hasActiveRepertoireFilters,
   type RepertoireSortOption,
+  type SungStatusFilter,
 } from "@/lib/repertoireView";
+import { formatLastSungStatus } from "@/lib/lastSung";
 import { trackEvent } from "@/lib/analytics";
 import {
   addRepertoireItem,
   deleteRepertoireItem,
   getMyRepertoire,
+  markRepertoireItemAsSung,
   searchRepertoireSongSuggestions,
   updateRepertoireItem,
   type RepertoireRow,
@@ -124,7 +127,8 @@ export default function RepertoireManager() {
     useState<RepertoireSortOption>("title_asc");
   const [voicingFilter, setVoicingFilter] = useState<Voicing | "">("");
   const [partFilter, setPartFilter] = useState<Part | "">("");
-  const [neverSungOnly, setNeverSungOnly] = useState(false);
+  const [sungStatusFilter, setSungStatusFilter] =
+    useState<SungStatusFilter>("all");
   const [songTitle, setSongTitle] = useState("");
   const [songSuggestions, setSongSuggestions] = useState<SongSuggestion[]>([]);
   const [songSuggestionsOpen, setSongSuggestionsOpen] = useState(false);
@@ -148,6 +152,7 @@ export default function RepertoireManager() {
   const [isAdding, setIsAdding] = useState(false);
   const [savingEditId, setSavingEditId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [markingSungId, setMarkingSungId] = useState<string | null>(null);
   const [itemToDelete, setItemToDelete] = useState<RepertoireRow | null>(null);
   const [hasUsedQuartetWorkflow, setHasUsedQuartetWorkflow] = useState(false);
   const [hasDismissedQuartetNudge, setHasDismissedQuartetNudge] =
@@ -214,7 +219,7 @@ export default function RepertoireManager() {
     } catch (err) {
       console.error(err);
       setLoadError(
-        "Could not load your repertoire. Check your connection and try again."
+        "Could not load your songs. Check your connection and try again."
       );
       throw err;
     }
@@ -253,7 +258,7 @@ export default function RepertoireManager() {
       } catch (err) {
         console.error(err);
         setLoadError(
-          "Could not load your repertoire. Check your connection and try again."
+          "Could not load your songs. Check your connection and try again."
         );
       } finally {
         setLoading(false);
@@ -487,7 +492,7 @@ export default function RepertoireManager() {
     setSearchQuery("");
     setVoicingFilter("");
     setPartFilter("");
-    setNeverSungOnly(false);
+    setSungStatusFilter("all");
   }
 
   function updateEditForm(patch: Partial<RepertoireForm>) {
@@ -591,7 +596,7 @@ export default function RepertoireManager() {
       const nextSongCount = items.length + 1;
       setMessage(
         !hasUsedQuartetWorkflow && nextSongCount <= 3
-          ? "Song added. Add a few more songs for better matches, or start/join a quartet when you're ready."
+          ? "Song added. Add a few more songs for better matches, use More ways to build My Songs, or start/join a quartet when you're ready."
           : "Song added."
       );
       trackEvent("repertoire_song_added", {
@@ -766,6 +771,28 @@ export default function RepertoireManager() {
     }
   }
 
+  async function markSongSungToday(id: string) {
+    if (markingSungId) return;
+
+    try {
+      setMarkingSungId(id);
+      await markRepertoireItemAsSung(id);
+      setMessage("Marked sung today.");
+      trackEvent("song_marked_sung", {
+        source: "my_songs",
+      });
+      await loadRepertoire();
+    } catch (err) {
+      console.error(err);
+      trackEvent("song_mark_sung_failed", {
+        source: "my_songs",
+      });
+      setMessage("Could not mark song sung. Please try again.");
+    } finally {
+      setMarkingSungId(null);
+    }
+  }
+
   async function createShareLink() {
     if (isCreatingShare) return;
 
@@ -811,7 +838,7 @@ export default function RepertoireManager() {
     const path = sharedRepertoirePathFromInput(copySourceInput);
     if (!path) {
       setCopySourceMessage(
-        "Paste a six-character code or a shared repertoire link."
+        "Paste a six-character code or a shared My Songs link."
       );
       return;
     }
@@ -930,7 +957,7 @@ export default function RepertoireManager() {
   if (loading) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-950 text-white">
-        Loading repertoire...
+        Loading My Songs...
       </main>
     );
   }
@@ -947,7 +974,7 @@ export default function RepertoireManager() {
     searchQuery,
     voicing: voicingFilter,
     part: partFilter,
-    neverSungOnly,
+    sungStatus: sungStatusFilter,
     sort: sortOption,
   };
   const visibleItems = filterAndSortRepertoire(items, repertoireFilters);
@@ -968,13 +995,13 @@ export default function RepertoireManager() {
     items.length === 0
       ? "Add your first song"
       : hasSmallRepertoire
-        ? "Keep building your repertoire"
+        ? "Keep building My Songs"
         : "Add a song";
   const addSectionDescription =
     items.length === 0
-      ? "Start typing a song title. Choose a suggestion if it matches your arrangement, or add your own title."
+      ? "Start typing a song title, or use More ways to build My Songs to copy songs from another singer or add Harmony Brigade songs."
       : hasSmallRepertoire
-        ? "Add a few songs you are likely to sing. Search and filters become useful once you have more songs saved."
+        ? "Add a few more songs for better matches, or use More ways to build My Songs if another singer or Harmony Brigade can help you get started faster."
         : "Start typing a song title. Choose a suggestion if it matches your arrangement, or add your own title.";
   const showQuartetTeachingCard =
     !hasDismissedQuartetNudge && !hasUsedQuartetWorkflow && items.length > 0;
@@ -1055,7 +1082,11 @@ export default function RepertoireManager() {
         ? partButtonLabel(voicingFilter, partFilter)
         : partFilter
       : "",
-    neverSungOnly ? "never sung" : "",
+    sungStatusFilter === "marked"
+      ? "marked sung"
+      : sungStatusFilter === "not_marked"
+        ? "not marked yet"
+        : "",
   ]
     .filter(Boolean)
     .join(" ");
@@ -1069,7 +1100,7 @@ export default function RepertoireManager() {
           title="Delete song?"
           description={`This will remove "${
             itemToDelete?.song_title ?? "this song"
-          }" from your repertoire. This cannot be undone.`}
+          }" from My Songs. This cannot be undone.`}
           confirmLabel="Delete song"
           busyLabel="Deleting..."
           onCancel={() => setItemToDelete(null)}
@@ -1081,13 +1112,13 @@ export default function RepertoireManager() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div>
                   <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
-                    More ways to build your repertoire
+                    More ways to build My Songs
                   </p>
                   <h2 className="mt-2 text-3xl font-bold tracking-tight">
                     Copy songs from another singer
                   </h2>
                   <p className="mt-2 max-w-xl text-sm leading-6 text-slate-300">
-                    Ask another singer for a private repertoire link or code.
+                    Ask another singer for a private My Songs link or code.
                     Once you have it, paste it here.
                   </p>
                 </div>
@@ -1102,7 +1133,7 @@ export default function RepertoireManager() {
 
               <div className="mt-5 flex flex-col gap-2 sm:flex-row">
                 <label className="sr-only" htmlFor="shared-repertoire-code-modal">
-                  Shared repertoire link or code
+                  Shared My Songs link or code
                 </label>
                 <input
                   id="shared-repertoire-code-modal"
@@ -1119,15 +1150,14 @@ export default function RepertoireManager() {
                   onClick={openSharedRepertoire}
                   className="min-h-12 rounded-xl bg-cyan-300 px-4 py-3 text-sm font-bold text-slate-950 hover:bg-cyan-200"
                 >
-                  Open shared repertoire
+                  Open shared songs
                 </button>
               </div>
 
               <div className="mt-5 rounded-xl border border-white/10 bg-white/5 p-4 text-sm leading-6 text-slate-300">
                 <p>
-                  Standing together? Ask the other singer to open Repertoire,
-                  choose &quot;Let another singer copy songs from my
-                  repertoire,&quot; and show you the code or QR code.
+                  Standing together? Ask the other singer to open My Songs,
+                  choose &quot;Let another singer copy songs from My Songs,&quot; and show you the code or QR code.
                 </p>
                 <p className="mt-3">
                   Not together? Copy this request and send it by text or email.
@@ -1158,14 +1188,14 @@ export default function RepertoireManager() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div>
                   <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
-                    More ways to build your repertoire
+                    More ways to build My Songs
                   </p>
                   <h2 className="mt-2 text-3xl font-bold tracking-tight">
-                    Let another singer copy songs from my repertoire
+                    Let another singer copy songs from My Songs
                   </h2>
                   <p className="mt-2 max-w-xl text-sm leading-6 text-slate-300">
                     Create a private link or code another singer can use to copy
-                    song titles, voicings, and arrangers from your repertoire.
+                    song titles, voicings, and arrangers from My Songs.
                   </p>
                 </div>
                 <button
@@ -1194,7 +1224,7 @@ export default function RepertoireManager() {
                   ) : repertoireShare ? (
                     <>
                       <p className="text-sm font-semibold text-cyan-100">
-                        Your repertoire copy link is ready
+                        Your My Songs copy link is ready
                       </p>
                       <div className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-center">
                         <p className="text-xs font-semibold uppercase tracking-normal text-cyan-200">
@@ -1206,7 +1236,7 @@ export default function RepertoireManager() {
                         {shareQrUrl && (
                           <img
                             src={shareQrUrl}
-                            alt="QR code for repertoire copy link"
+                            alt="QR code for My Songs copy link"
                             className="mx-auto mt-3 h-36 w-36 rounded-xl bg-white p-2"
                           />
                         )}
@@ -1220,7 +1250,7 @@ export default function RepertoireManager() {
                         value={shareLink}
                         readOnly
                         className="w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-2 text-sm text-slate-200"
-                        aria-label="Repertoire copy link"
+                        aria-label="My Songs copy link"
                       />
                       <div className="grid gap-2 sm:grid-cols-3">
                         <button
@@ -1277,14 +1307,14 @@ export default function RepertoireManager() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <div>
                   <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
-                    More ways to build your repertoire
+                    More ways to build My Songs
                   </p>
                   <h2 className="mt-2 text-3xl font-bold tracking-tight">
                     Add Harmony Brigade songs
                   </h2>
                   <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
                     Choose a Harmony Brigade year and brigade, then add selected
-                    songs to your repertoire.
+                    songs to My Songs.
                   </p>
                   <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
                     These songs default to TTBB. You&apos;ll choose the part you
@@ -1379,7 +1409,7 @@ export default function RepertoireManager() {
                       {harmonyBrigadeEligibleCount} can be added.{" "}
                       {harmonyBrigadeAlreadyCount}{" "}
                       {harmonyBrigadeAlreadyCount === 1 ? "is" : "are"} already
-                      in your repertoire.
+                      in My Songs.
                     </p>
                     <p className="mt-1 text-sm leading-6 text-slate-300">
                       Choose one or more parts for each song you want to add.
@@ -1429,7 +1459,7 @@ export default function RepertoireManager() {
                             <div className="min-w-0">
                               <p className="font-semibold">
                                 {isExactDuplicate
-                                  ? "Already in your repertoire: "
+                                  ? "Already in My Songs: "
                                   : ""}
                                 {row.song.songTitle}
                               </p>
@@ -1514,7 +1544,7 @@ export default function RepertoireManager() {
                       : "songs are"}{" "}
                     ready to add. {harmonyBrigadeAlreadyCount}{" "}
                     {harmonyBrigadeAlreadyCount === 1 ? "song was" : "songs were"}{" "}
-                    already in your repertoire and will not be added again.
+                    already in My Songs and will not be added again.
                   </p>
                   <button
                     type="button"
@@ -1541,7 +1571,7 @@ export default function RepertoireManager() {
             </div>
           </div>
         )}
-        <h1 className="mt-4 text-4xl font-bold tracking-tight">My Repertoire</h1>
+        <h1 className="mt-4 text-4xl font-bold tracking-tight">My Songs</h1>
         <p className="mt-2 text-slate-300">
           Add songs you know, the parts you can sing, and how confident you are.
         </p>
@@ -1595,7 +1625,7 @@ export default function RepertoireManager() {
           <div className="relative mt-5">
             <label className="block">
               <span className="text-sm font-medium text-slate-200">
-                Add a song to your repertoire
+                Add a song to My Songs
               </span>
               <div className="mt-1 flex flex-col gap-3 sm:flex-row">
                 <input
@@ -1684,7 +1714,7 @@ export default function RepertoireManager() {
           >
             <span>
               <span className="block text-base font-bold text-white">
-                More ways to build your repertoire
+                More ways to build My Songs
               </span>
               <span className="mt-1 block text-sm leading-6 text-slate-300">
                 Copy songs with another singer or add Harmony Brigade songs.
@@ -1718,7 +1748,7 @@ export default function RepertoireManager() {
 
               <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
                 <h3 className="text-base font-bold text-white">
-                  Let another singer copy songs from my repertoire
+                  Let another singer copy songs from My Songs
                 </h3>
                 <p className="mt-1 text-sm leading-5 text-slate-300">
                   Create a private link or code for another singer.
@@ -1794,25 +1824,28 @@ export default function RepertoireManager() {
           <section className="mt-8">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <h2 className="text-2xl font-semibold">Songs I know</h2>
+                <h2 className="text-2xl font-semibold">My saved songs</h2>
                 <p className="mt-1 text-sm text-slate-400">
                   {visibleItems.length === items.length
                     ? `${items.length} ${items.length === 1 ? "song" : "songs"} saved`
                     : `${visibleItems.length} of ${items.length} songs shown`}
                 </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Last sung is based on songs you have marked as sung in the app.
+                </p>
               </div>
 
               <div
-                className={`grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(12rem,18rem)_11rem_11rem_11rem] ${
+                className={`grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(12rem,18rem)_11rem_11rem_11rem_11rem] ${
                   hasSmallRepertoire ? "opacity-75" : ""
                 }`}
               >
-                <p className="text-sm font-semibold text-slate-300 sm:col-span-2 lg:col-span-4">
+                <p className="text-sm font-semibold text-slate-300 sm:col-span-2 lg:col-span-5">
                   Filter saved songs
                 </p>
                 <label className="block">
                   <span className="text-sm font-medium text-slate-300">
-                    Search my repertoire
+                    Search My Songs
                   </span>
                   <input
                     value={searchQuery}
@@ -1877,19 +1910,30 @@ export default function RepertoireManager() {
                     ))}
                   </select>
                 </label>
+                <label className="block">
+                  <span className="text-sm font-medium text-slate-300">
+                    Sung status
+                  </span>
+                  <select
+                    value={sungStatusFilter}
+                    onChange={(e) =>
+                      setSungStatusFilter(e.target.value as SungStatusFilter)
+                    }
+                    className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                  >
+                    <option value="all">All songs</option>
+                    <option value="marked">Marked sung</option>
+                    <option value="not_marked">Not marked yet</option>
+                  </select>
+                </label>
               </div>
             </div>
 
             <div className="mt-3 flex flex-col gap-3 rounded-xl border border-white/10 bg-white/5 p-3 sm:flex-row sm:items-center sm:justify-between">
-              <label className="flex items-center gap-3 text-sm font-semibold text-slate-200">
-                <input
-                  type="checkbox"
-                  checked={neverSungOnly}
-                  onChange={(e) => setNeverSungOnly(e.target.checked)}
-                  className="h-4 w-4 rounded border-white/20 bg-slate-900 text-cyan-300"
-                />
-                Never sung
-              </label>
+              <p className="text-sm text-slate-400">
+                Use Sung status to find songs you have or have not marked in the
+                app.
+              </p>
 
               {hasActiveFilters ? (
                 <div className="flex flex-wrap items-center gap-2">
@@ -1910,9 +1954,11 @@ export default function RepertoireManager() {
                         : partFilter}
                     </span>
                   )}
-                  {neverSungOnly && (
+                  {sungStatusFilter !== "all" && (
                     <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
-                      Never sung
+                      {sungStatusFilter === "marked"
+                        ? "Marked sung"
+                        : "Not marked yet"}
                     </span>
                   )}
                   <button
@@ -2127,7 +2173,7 @@ export default function RepertoireManager() {
                     </div>
                   </div>
                 ) : (
-                  <div className="flex items-center gap-2 p-3">
+                  <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center">
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <h3 className="truncate text-base font-semibold text-white">
@@ -2151,6 +2197,9 @@ export default function RepertoireManager() {
                           Arr. {arrangerDisplayName(item.arranger_name)}
                         </span>
                       </div>
+                      <p className="mt-1 text-xs text-slate-400">
+                        Last sung: {formatLastSungStatus(item.last_sung_at)}
+                      </p>
                       {item.notes && (
                         <p className="mt-1 line-clamp-2 text-xs text-slate-400">
                           Notes: {item.notes}
@@ -2158,8 +2207,19 @@ export default function RepertoireManager() {
                       )}
                     </div>
 
-                    <div className="flex shrink-0 gap-1">
+                    <div className="flex shrink-0 flex-wrap gap-1 sm:justify-end">
                       <button
+                        type="button"
+                        onClick={() => markSongSungToday(item.id)}
+                        disabled={markingSungId === item.id || Boolean(deletingId)}
+                        className="rounded-lg bg-white/10 px-3 py-2 text-sm font-semibold text-slate-200 hover:bg-white/20 disabled:opacity-40"
+                      >
+                        {markingSungId === item.id
+                          ? "Marking..."
+                          : "Mark sung today"}
+                      </button>
+                      <button
+                        type="button"
                         onClick={() => startEditing(item)}
                         disabled={Boolean(deletingId)}
                         className="rounded-lg bg-cyan-300/10 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-cyan-300/20"
@@ -2167,6 +2227,7 @@ export default function RepertoireManager() {
                         Edit
                       </button>
                       <button
+                        type="button"
                         onClick={() => requestDeleteItem(item)}
                         disabled={deletingId === item.id}
                         className="rounded-lg bg-rose-400/10 px-3 py-2 text-sm font-semibold text-rose-200 hover:bg-rose-400/20 disabled:opacity-40"
@@ -2492,7 +2553,7 @@ export default function RepertoireManager() {
                   disabled={!canAddSong || isAdding}
                   className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                 >
-                  {isAdding ? "Adding..." : "Add to repertoire"}
+                  {isAdding ? "Adding..." : "Add to My Songs"}
                 </button>
                 <button
                   type="button"

--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -33,7 +33,7 @@ type SelectionByVoicing = Partial<
 >;
 
 function duplicateLabel(status: CopyableSharedSong["duplicateStatus"]) {
-  if (status === "exact") return "Already in your repertoire";
+  if (status === "exact") return "Already in My Songs";
   if (status === "possible_arrangement") return "Possible different arrangement";
   return null;
 }
@@ -197,7 +197,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
           result.copiedCount === 1 ? "song" : "songs"
         } copied${
           result.skippedExactCount > 0
-            ? `; ${result.skippedExactCount} already in your repertoire`
+            ? `; ${result.skippedExactCount} already in My Songs`
             : ""
         }.`
       );
@@ -249,8 +249,8 @@ export function SharedRepertoireManager({ code }: { code: string }) {
               </h1>
               <p className="mt-3 max-w-3xl text-slate-200">
                 {isSignedIn
-                  ? "You can copy songs into your own repertoire. You'll choose your own part and confidence before saving."
-                  : "Sign in to copy songs into your own repertoire."}
+                  ? "You can copy songs into My Songs. You'll choose your own part and confidence before saving."
+                  : "Sign in to copy songs into My Songs."}
               </p>
               {!isSignedIn && (
                 <a

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -62,8 +62,8 @@ The app currently tracks these events through `lib/analytics.ts`:
 | `repertoire_song_deleted` | `components/RepertoireManager.tsx` after deleting a song | `song_count` | No free text | Legacy compatibility |
 | `repertoire_updated` | `components/RepertoireManager.tsx` after add/edit/delete succeeds | `action`, `song_count`, `parts_known_count` | No free text | Quartet Funnel, Repertoire & Matching |
 | `repertoire_update_failed` | `components/RepertoireManager.tsx` when add/edit/delete fails | `action` | No free text | Reliability / Errors |
-| `song_marked_sung` | `app/join/[code]/page.tsx` after marking a match as sung | `session_id`, `match_category`, `voicing` | No free text | Future recently sung dashboard |
-| `song_mark_sung_failed` | `app/join/[code]/page.tsx` when marking a match as sung fails | `session_id`, `match_category`, `voicing` | No free text | Reliability / Errors |
+| `song_marked_sung` | `app/join/[code]/page.tsx` after marking a match as sung, or `components/RepertoireManager.tsx` after marking a My Songs row as sung | `session_id`, `match_category`, `voicing`, `source` | No free text | Future recently sung dashboard |
+| `song_mark_sung_failed` | `app/join/[code]/page.tsx` or `components/RepertoireManager.tsx` when marking a song as sung fails | `session_id`, `match_category`, `voicing`, `source` | No free text | Reliability / Errors |
 | `help_viewed` | `app/help/page.tsx` when the help page loads | none | No | Product Health context |
 | `feedback_submitted` | `app/help/page.tsx` after feedback API succeeds | `category`, `length` | No message text | Product Health |
 | `feedback_failed` | `app/help/page.tsx` when feedback API fails | `category`, `status_code` or `reason` | No message text | Reliability / Errors |

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -7,10 +7,10 @@ sync with `README.md`, `AGENTS.md`, and `docs/supabase-contract.md`.
 
 - `profiles.display_name` is the source of truth for singer names.
 - `user_repertoire` is the source of truth for a user's saved songs, parts,
-  confidence values, private notes, and recently sung metadata.
+  confidence values, private notes, and last-sung metadata.
 - `sessions` is the source of truth for quartet join codes and session activity.
 - `session_participants` is the source of truth for active quartet membership
-  and each singer's repertoire snapshot.
+  and each singer's saved-song snapshot.
 - Local active-quartet state is only a navigation shortcut. The quartet screen
   must reconcile it against `session_participants`.
 
@@ -19,7 +19,7 @@ sync with `README.md`, `AGENTS.md`, and `docs/supabase-contract.md`.
 ### Start Quartet
 
 Starting a quartet creates a `sessions` row, reads the current user's profile
-and repertoire, writes that user's `session_participants` snapshot, stores the
+and My Songs entries, writes that user's `session_participants` snapshot, stores the
 active quartet shortcut locally, and then sends the user to `/join/[code]`.
 
 The first singer should appear in the quartet without needing to manually join
@@ -55,14 +55,14 @@ A current participant may remove another singer through
 `session_participants` row is deleted, and their client should stop treating the
 quartet as active after it observes that database state.
 
-### Repertoire Updates While In A Quartet
+### My Songs Updates While In A Quartet
 
-Adding, editing, or deleting repertoire updates `user_repertoire`. If the user
+Adding, editing, or deleting My Songs entries updates `user_repertoire`. If the user
 has an active quartet, the app refreshes that user's
 `session_participants.repertoire` snapshot so quartet results derive from the
 database snapshot instead of stale local component state.
 
-When adding repertoire, song-title autocomplete suggestions come from distinct
+When adding My Songs entries, song-title autocomplete suggestions come from distinct
 song identities already entered in `user_repertoire` plus optional reference
 rows in `song_suggestion_catalog`. These suggestions only prefill the form.
 Users can ignore them, edit all fields, or enter a song that is not in the
@@ -87,7 +87,7 @@ should not be collapsed with blank data.
 ## Navigation
 
 The home page is an action hub. It offers Start Quartet, Join Quartet, Return to
-Quartet when local state exists, and Repertoire. Manual code entry belongs on
+Quartet when local state exists, and My Songs. Manual code entry belongs on
 `/join`, while QR and shared links use `/join/[code]`. Help and feedback live at
 `/help`; `/feedback` redirects there for older links. Help is public so new or
 logged-out users can read it before signing in.
@@ -102,7 +102,7 @@ not rely on magic-link callback redirects.
 
 PostHog is optional and controlled by `NEXT_PUBLIC_POSTHOG_KEY` and
 `NEXT_PUBLIC_POSTHOG_HOST`. Events must not include free-text user content such
-as feedback text, repertoire notes, song titles, arranger names, singer names,
+as feedback text, My Songs notes, song titles, arranger names, singer names,
 or email addresses.
 
 See `docs/analytics.md` for the current event contract.

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -1,9 +1,9 @@
 # Data Imports
 
 What Can We Sing uses controlled source-data transforms for optional song-entry
-suggestions and repertoire-building helpers. Catalog imports must not add songs
-to any user's repertoire. Singer-facing add flows may add songs only to the
-current authenticated user's repertoire after the user previews the songs and
+suggestions and My Songs-building helpers. Catalog imports must not add songs
+to any user's My Songs. Singer-facing add flows may add songs only to the
+current authenticated user's My Songs after the user previews the songs and
 chooses required personal fields. Source data must not store lyrics, sheet
 music contents, preview images, pricing, cart data, or full product
 descriptions in user-facing suggestion data.
@@ -175,7 +175,7 @@ The import creates or updates:
 - `harmony_brigade_events`
 - `harmony_brigade_event_songs`
 
-The user-facing flow appears under **More ways to build your repertoire** as
+The user-facing flow appears under **More ways to build My Songs** as
 **Add Harmony Brigade songs**. Users can choose:
 
 - `All years` or a real `YearHeld` value
@@ -185,7 +185,7 @@ The picker lists event-song appearances from `ViewHistory`, so the same song
 can appear under multiple years or brigades. Songs default to `TTBB`. Before
 adding, the user chooses any TTBB parts they know for each song and a confidence
 value for each selected part. If multiple appearances of the same normalized
-title + arranger are selected, they are saved as one repertoire row with the
+title + arranger are selected, they are saved as one My Songs row with the
 combined part confidences. Adding Harmony Brigade songs writes only to the
 current user's `user_repertoire`; it does not expose the user's Brigade
 selection publicly.

--- a/docs/recently-sung-events.md
+++ b/docs/recently-sung-events.md
@@ -2,15 +2,19 @@
 
 Issue #88 added a private event log for songs a user marks as sung from quartet
 results. Issue #179 also stores personal sung metadata on `user_repertoire`.
+Users can also mark a saved song as sung directly from My Songs; those events
+do not have a quartet session id.
 
 The event schema and RLS requirement is captured in
 `supabase/migrations/20260428060000_supabase_contract_alignment.sql`. The
 repertoire metadata and `mark_repertoire_sung` database function are captured in
-`supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql`.
+`supabase/migrations/20260428145000_add_repertoire_sung_metadata.sql` and
+`supabase/migrations/20260501210000_allow_repertoire_mark_sung_without_session.sql`.
 Production migrations are deployed by GitHub Actions after merge. For local
 development or emergency fallback, see `docs/deployment-automation.md`.
 
 Events are private to the user who marked the song. They are not copied into
 quartet participant snapshots and do not affect matching rank yet. The database
 function updates only the authenticated user's selected repertoire row and then
-records the private event.
+records the private event. When marked from a quartet, the event includes the
+quartet session id; when marked from My Songs, `session_id` is null.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -23,10 +23,10 @@ migrations in `supabase/migrations`, and tests or test documentation.
   Existing participants are recognized by `user_id`, not by display name.
 - Local active-quartet state is a shortcut for navigation only. It must not be
   treated as proof that the user still has a current `session_participants` row.
-- Repertoire add, edit, delete, and mark-as-sung actions update
+- My Songs add, edit, delete, and mark-as-sung actions update
   `user_repertoire`. Add/edit/delete actions refresh the active quartet
   `session_participants.repertoire` snapshot when the user is in a quartet.
-- Private repertoire sharing is opt-in. A singer creates a code in
+- Private My Songs sharing is opt-in. A singer creates a code in
   `repertoire_shares`; recipients can view only safe song identity fields
   through `get_shared_repertoire` and must sign in before copying songs into
   their own `user_repertoire`.
@@ -123,10 +123,11 @@ Required database contract:
   `user_id = auth.uid()`.
 - Index on `(user_id, song_title)` for repertoire listing.
 - Index on `(user_id, last_sung_at desc)` for future sung-history sorting.
-- `public.mark_repertoire_sung(p_repertoire_id uuid, p_session_id uuid)`
+- `public.mark_repertoire_sung(p_repertoire_id uuid, p_session_id uuid default null)`
   updates only the authenticated user's matching `user_repertoire` row,
   increments `times_sung_count`, sets `last_sung_at`, and records the matching
-  private `sung_song_events` row in one database operation.
+  private `sung_song_events` row in one database operation. Quartet-page marks
+  pass a session id; My Songs marks pass `null`.
 - `public.search_repertoire_song_suggestions(p_query text, p_limit integer)`
   is a security-definer RPC available only to authenticated users. It returns
   distinct global song identity suggestions from all repertoire rows and
@@ -145,9 +146,9 @@ Established by migrations:
 
 ### `repertoire_shares`
 
-Purpose: opt-in private repertoire copy links. A copy code lets another
-singer view only song identity fields from the owner's current repertoire so
-they can copy selected songs into their own repertoire.
+Purpose: opt-in private My Songs copy links. A copy code lets another
+singer view only song identity fields from the owner's current My Songs entries
+so they can copy selected songs into their own My Songs.
 
 Code:
 - Create active copy link/code: `lib/repertoireSharing.ts#createRepertoireShare`
@@ -158,7 +159,7 @@ Code:
   `lib/repertoireSharing.ts#getSharedRepertoire`, through
   `public.get_shared_repertoire`
 - Recipient copy flow: `components/SharedRepertoireManager.tsx`
-- "Let another singer copy songs from my repertoire" controls:
+- "Let another singer copy songs from My Songs" controls:
   `components/RepertoireManager.tsx`
 
 Expected context:
@@ -361,7 +362,8 @@ Expected context:
 
 Required database contract:
 - `id uuid primary key`
-- `session_id uuid not null references public.sessions(id) on delete cascade`
+- `session_id uuid references public.sessions(id) on delete cascade`; nullable
+  for songs marked from My Songs outside a quartet.
 - `user_id uuid not null references auth.users(id) on delete cascade`
 - `display_name text not null`
 - `repertoire jsonb not null default '[]'::jsonb`; snapshot entries include
@@ -412,6 +414,7 @@ Required database contract:
 
 Established by migrations:
 - `20260428060000_supabase_contract_alignment.sql`
+- `20260501210000_allow_repertoire_mark_sung_without_session.sql`
 
 ### Feedback Email
 

--- a/docs/test-coverage-notes.md
+++ b/docs/test-coverage-notes.md
@@ -15,7 +15,7 @@ This file tracks high-risk behavior that should stay covered as the app changes.
 - Detecting when the current participant has been removed from a quartet.
 - Building participant snapshot entries from profile display names and
   repertoire rows without leaking private notes.
-- Refreshing an active quartet snapshot from current repertoire, clearing stale
+- Refreshing an active quartet snapshot from current My Songs entries, clearing stale
   local active-quartet state when the user is no longer a participant, and
   refusing to write a snapshot without a display name.
 - `sessionStore` write helpers for participant upsert, leave/delete, and
@@ -28,7 +28,7 @@ This file tracks high-risk behavior that should stay covered as the app changes.
 ## Remaining Gaps
 
 - The suite still does not run a browser-level test for the full start -> join
-  -> edit repertoire -> refresh matches -> leave/remove flow. The current tests
+  -> edit My Songs -> refresh matches -> leave/remove flow. The current tests
   cover the pure helpers and store calls underneath those flows.
 - The suite does not execute RLS policies against a real Supabase instance.
   `docs/supabase-contract.md` describes the smallest follow-up: add
@@ -40,11 +40,11 @@ This file tracks high-risk behavior that should stay covered as the app changes.
 
 ## Future Checklist
 
-When changing quartet or repertoire data flow, add or update tests that prove:
+When changing quartet or My Songs data flow, add or update tests that prove:
 
 - database helpers read/write the expected Supabase table or RPC
 - stale local active-quartet state is reconciled against database state
-- repertoire edits refresh `session_participants.repertoire` when applicable
+- My Songs edits refresh `session_participants.repertoire` when applicable
 - matching derives from participant snapshots, not local-only component state
 - UI copy does not imply a user joined, left, or refreshed before the database
   operation has been verified

--- a/lib/__tests__/harmonyBrigadeUi.test.ts
+++ b/lib/__tests__/harmonyBrigadeUi.test.ts
@@ -9,10 +9,10 @@ const repertoireManager = readFileSync(
 
 describe("Harmony Brigade repertoire UI", () => {
   it("uses Add Harmony Brigade songs as a compact secondary action", () => {
-    expect(repertoireManager).toContain("More ways to build your repertoire");
+    expect(repertoireManager).toContain("More ways to build My Songs");
     expect(repertoireManager).toContain("Copy songs from another singer");
     expect(repertoireManager).toContain(
-      "Let another singer copy songs from my repertoire"
+      "Let another singer copy songs from My Songs"
     );
     expect(repertoireManager).toContain("Add Harmony Brigade songs");
     expect(repertoireManager).toContain("Choose Brigade songs");

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -27,7 +27,8 @@ describe("help content", () => {
 
   it("covers the core new-user flow", () => {
     expect(quickStartSteps.join(" ")).toContain("display name");
-    expect(quickStartSteps.join(" ")).toContain("repertoire");
+    expect(quickStartSteps.join(" ")).toContain("songs");
+    expect(quickStartSteps.join(" ")).toContain("Harmony Brigade");
     expect(quickStartSteps.join(" ")).toContain("code");
 
     const sectionText = helpSections
@@ -45,7 +46,7 @@ describe("help content", () => {
     expect(feedbackHelpCopy).toContain("General feedback");
   });
 
-  it("is organized into onboarding, repertoire, and quartet guidance", () => {
+  it("is organized into onboarding, My Songs, and quartet guidance", () => {
     expect(helpGuideSections.map((section) => section.title)).toEqual([
       "Get Singing Quickly",
       "Manage The Songs You Know",
@@ -65,10 +66,12 @@ describe("help content", () => {
     ]);
 
     expect(guideText).toContain("First Time Setup");
-    expect(guideText).toContain("you do not need to enter your entire repertoire");
+    expect(guideText).toContain("copy songs from another singer");
+    expect(guideText).toContain("Harmony Brigade songs");
     expect(guideText).toContain("Song Title Autocomplete");
     expect(guideText).toContain("Suggestions are optional");
-    expect(guideText).toContain("does not add it to anyone else’s repertoire");
+    expect(guideText).toContain("does not add it to anyone else’s My Songs");
+    expect(guideText).toContain("More Ways To Build My Songs");
     expect(guideText).toContain("TTBB means Tenor, Lead, Baritone, Bass");
     expect(guideText).toContain("add it more than once");
     expect(guideText).toContain("A singer may know multiple parts");
@@ -76,9 +79,10 @@ describe("help content", () => {
     expect(guideText).toContain("no arranger entered");
     expect(guideText).toContain("Unknown");
     expect(guideText).toContain("Notes are for your own memory");
-    expect(guideText).toContain("Recently sung helps you remember");
+    expect(guideText).toContain("Last sung is based on songs");
     expect(guideText).toContain("sort by title");
-    expect(guideText).toContain("Never Sung");
+    expect(guideText).toContain("Sung status");
+    expect(guideText).toContain("Not marked yet");
   });
 
   it("explains quartet match details and management", () => {
@@ -97,7 +101,7 @@ describe("help content", () => {
     expect(guideText).toContain("arranger differences");
     expect(guideText).toContain("Open a match to see who is covering which part");
     expect(guideText).toContain("use Manage to see quartet members");
-    expect(guideText).toContain("edit repertoire");
+    expect(guideText).toContain("edit My Songs");
     expect(guideText).toContain("Leaving removes you from the active quartet");
     expect(guideText).toContain("you can rejoin normally");
   });
@@ -105,7 +109,7 @@ describe("help content", () => {
   it("provides compact table of contents links for every major help section", () => {
     expect(helpNavItems).toEqual([
       { id: "first-time-setup", label: "First time setup" },
-      { id: "repertoire", label: "Repertoire" },
+      { id: "repertoire", label: "My Songs" },
       { id: "starting-a-quartet", label: "Starting a quartet" },
       { id: "joining-a-quartet", label: "Joining a quartet" },
       { id: "quartet-matches", label: "Quartet matches" },

--- a/lib/__tests__/lastSung.test.ts
+++ b/lib/__tests__/lastSung.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatLastSungStatus } from "../lastSung";
+
+describe("formatLastSungStatus", () => {
+  it("uses not-marked language for missing or invalid dates", () => {
+    expect(formatLastSungStatus(null)).toBe("Not marked yet");
+    expect(formatLastSungStatus("not-a-date")).toBe("Not marked yet");
+  });
+
+  it("shows today for songs marked on the current local day", () => {
+    expect(
+      formatLastSungStatus(
+        "2026-05-01T18:00:00.000Z",
+        new Date("2026-05-01T20:00:00.000Z")
+      )
+    ).toBe("Today");
+  });
+
+  it("shows recent day counts for songs marked within two weeks", () => {
+    expect(
+      formatLastSungStatus(
+        "2026-04-29T18:00:00.000Z",
+        new Date("2026-05-01T20:00:00.000Z")
+      )
+    ).toBe("2 days ago");
+  });
+
+  it("uses a compact date for older marks", () => {
+    const label = formatLastSungStatus(
+      "2026-04-01T18:00:00.000Z",
+      new Date("2026-05-01T20:00:00.000Z")
+    );
+
+    expect(label).toContain("Apr");
+    expect(label).toContain("1");
+  });
+});

--- a/lib/__tests__/loginContent.test.ts
+++ b/lib/__tests__/loginContent.test.ts
@@ -13,7 +13,7 @@ describe("login intro content", () => {
     expect(copy).toContain("what can we sing together right now");
     expect(copy).toContain("songs they know");
     expect(copy).toContain("parts they can sing");
-    expect(copy).toContain("Sign in to save your repertoire");
+    expect(copy).toContain("Sign in to save My Songs");
   });
 
   it("links new users to help before they sign in", () => {

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -13,14 +13,16 @@ describe("privacy page copy", () => {
     expect(privacyPage).toContain("<PublicAwareAppNav />");
   });
 
-  it("discloses account, repertoire, quartet, feedback, analytics, and providers", () => {
+  it("discloses account, My Songs, quartet, feedback, analytics, and providers", () => {
     expect(privacyPage).toContain("email address");
     expect(privacyPage).toContain("We do not show your email address");
     expect(privacyPage).toContain("song title");
     expect(privacyPage).toContain("parts");
     expect(privacyPage).toContain("confidence");
-    expect(privacyPage).toContain("recently sung");
-    expect(privacyPage).toContain("participant repertoire snapshots");
+    expect(privacyPage).toContain("Last-sung data");
+    expect(privacyPage).toContain("participant saved-song snapshots");
+    expect(privacyPage).toContain("Private copy links");
+    expect(privacyPage).toContain("Harmony Brigade songs");
     expect(privacyPage).toContain("other singers in that quartet may see");
     expect(privacyPage).toContain("Feedback forms");
     expect(privacyPage).toContain("PostHog");

--- a/lib/__tests__/quartetManagePanel.test.ts
+++ b/lib/__tests__/quartetManagePanel.test.ts
@@ -12,7 +12,7 @@ describe("quartet manage panel markup", () => {
     expect(joinPage).toContain("Singing as");
     expect(joinPage).toContain("Manage");
     expect(joinPage).toContain("Members");
-    expect(joinPage).toContain("Edit Repertoire");
+    expect(joinPage).toContain("Edit My Songs");
     expect(joinPage).toContain("Leave Quartet");
     expect(joinPage).toContain("showCurrentParticipantActions: false");
     expect(joinPage).not.toContain("Quartet full");

--- a/lib/__tests__/repertoireEmptyState.test.ts
+++ b/lib/__tests__/repertoireEmptyState.test.ts
@@ -11,7 +11,7 @@ describe("repertoire empty state", () => {
   it("makes the song-title input the primary first-run action", () => {
     expect(repertoireManager).toContain("Add your first song");
     expect(repertoireManager).toContain("Add songs here");
-    expect(repertoireManager).toContain("Add a song to your repertoire");
+    expect(repertoireManager).toContain("Add a song to My Songs");
     expect(repertoireManager).toContain("Start typing a song title...");
     expect(repertoireManager).toContain("Add song");
     expect(repertoireManager).not.toContain(
@@ -31,8 +31,11 @@ describe("repertoire empty state", () => {
   it("keeps saved-song filters separate from adding songs", () => {
     expect(repertoireManager).toContain("hasSavedSongs &&");
     expect(repertoireManager).toContain("Filter saved songs");
-    expect(repertoireManager).toContain("Search my repertoire");
+    expect(repertoireManager).toContain("Search My Songs");
     expect(repertoireManager).toContain("Filter songs you've already added");
+    expect(repertoireManager).toContain("Sung status");
+    expect(repertoireManager).toContain("Not marked yet");
+    expect(repertoireManager).toContain("Mark sung today");
     expect(repertoireManager).toContain('hasSmallRepertoire ? "opacity-75"');
     expect(repertoireManager).not.toContain("Search by title");
   });

--- a/lib/__tests__/repertoireQuartetGuidance.test.ts
+++ b/lib/__tests__/repertoireQuartetGuidance.test.ts
@@ -40,7 +40,7 @@ describe("repertoire quartet guidance", () => {
 
   it("uses more helpful post-save copy for early users", () => {
     expect(repertoireManager).toContain(
-      "Song added. Add a few more songs for better matches, or start/join a quartet when you're ready."
+      "Song added. Add a few more songs for better matches, use More ways to build My Songs, or start/join a quartet when you're ready."
     );
   });
 });

--- a/lib/__tests__/repertoireSharing.test.ts
+++ b/lib/__tests__/repertoireSharing.test.ts
@@ -111,11 +111,11 @@ describe("repertoire sharing", () => {
 
   it("uses a clear remote request message for copy links and codes", () => {
     expect(repertoireCopyRequestMessage).toContain(
-      "Let another singer copy songs from my repertoire"
+      "Let another singer copy songs from My Songs"
     );
     expect(repertoireCopyRequestMessage).toContain("link or code");
     expect(repertoireCopyRequestMessage).toContain(
-      "copy a few songs into my repertoire"
+      "copy a few songs into My Songs"
     );
   });
 });

--- a/lib/__tests__/repertoireSharingUi.test.ts
+++ b/lib/__tests__/repertoireSharingUi.test.ts
@@ -9,15 +9,15 @@ const repertoireManager = readFileSync(
 
 describe("repertoire sharing UI language", () => {
   it("offers separate copy-requester and copy-provider actions", () => {
-    expect(repertoireManager).toContain("More ways to build your repertoire");
+    expect(repertoireManager).toContain("More ways to build My Songs");
     expect(repertoireManager).toContain("aria-expanded={isMoreWaysOpen}");
     expect(repertoireManager).toContain("Show options");
     expect(repertoireManager).toContain("Hide options");
     expect(repertoireManager).toContain("Copy songs from another singer");
     expect(repertoireManager).toContain(
-      "Let another singer copy songs from my repertoire"
+      "Let another singer copy songs from My Songs"
     );
-    expect(repertoireManager).toContain("Open shared repertoire");
+    expect(repertoireManager).toContain("Open shared songs");
     expect(repertoireManager).toContain("Copy request message");
     expect(repertoireManager).toContain("Create link/code");
     expect(repertoireManager).toContain("Copy code");
@@ -39,5 +39,6 @@ describe("repertoire sharing UI language", () => {
     expect(repertoireManager).not.toContain("Share repertoire");
     expect(repertoireManager).not.toContain("Create share link");
     expect(repertoireManager).not.toContain("Your repertoire share link");
+    expect(repertoireManager).not.toContain("Share My Songs");
   });
 });

--- a/lib/__tests__/repertoireView.test.ts
+++ b/lib/__tests__/repertoireView.test.ts
@@ -29,7 +29,7 @@ const defaultFilters: RepertoireFilters = {
   searchQuery: "",
   voicing: "",
   part: "",
-  neverSungOnly: false,
+  sungStatus: "all",
   sort: "title_asc",
 };
 
@@ -63,7 +63,7 @@ describe("filterAndSortRepertoire", () => {
     ).toEqual(["old", "new"]);
   });
 
-  it("sorts by last sung with never-sung placement", () => {
+  it("sorts by last sung with not-marked placement", () => {
     const items = [
       row({ id: "never", song_title: "Never", last_sung_at: null }),
       row({ id: "old", song_title: "Old", last_sung_at: "2026-01-01T00:00:00.000Z" }),
@@ -84,7 +84,7 @@ describe("filterAndSortRepertoire", () => {
     ).toEqual(["never", "old", "recent"]);
   });
 
-  it("filters by search, voicing, part, and never sung", () => {
+  it("filters by search, voicing, part, and not-marked sung status", () => {
     const result = filterAndSortRepertoire(
       [
         row({
@@ -127,12 +127,44 @@ describe("filterAndSortRepertoire", () => {
         searchQuery: "bright",
         voicing: "TTBB",
         part: "Baritone",
-        neverSungOnly: true,
+        sungStatus: "not_marked",
         sort: "title_asc",
       }
     );
 
     expect(result.map((item) => item.id)).toEqual(["match"]);
+  });
+
+  it("filters by marked sung status", () => {
+    const result = filterAndSortRepertoire(
+      [
+        row({ id: "not-marked", song_title: "Mamselle", last_sung_at: null }),
+        row({
+          id: "marked",
+          song_title: "Bright Was The Night",
+          last_sung_at: "2026-04-01T00:00:00.000Z",
+        }),
+      ],
+      { ...defaultFilters, sungStatus: "marked" }
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["marked"]);
+  });
+
+  it("filters by not-marked sung status", () => {
+    const result = filterAndSortRepertoire(
+      [
+        row({ id: "not-marked", song_title: "Mamselle", last_sung_at: null }),
+        row({
+          id: "marked",
+          song_title: "Bright Was The Night",
+          last_sung_at: "2026-04-01T00:00:00.000Z",
+        }),
+      ],
+      { ...defaultFilters, sungStatus: "not_marked" }
+    );
+
+    expect(result.map((item) => item.id)).toEqual(["not-marked"]);
   });
 });
 

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -30,6 +30,13 @@ const sungMetadataMigration = readFileSync(
   ),
   "utf8"
 );
+const nullableSungSessionMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260501210000_allow_repertoire_mark_sung_without_session.sql"
+  ),
+  "utf8"
+);
 const participantRemovalMigration = readFileSync(
   join(
     repoRoot,
@@ -193,11 +200,19 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("last_sung_at");
     expect(contract).toContain("times_sung_count");
     expect(contract).toContain("mark_repertoire_sung");
+    expect(contract).toContain("p_session_id uuid default null");
+    expect(contract).toContain("My Songs marks pass `null`");
     expect(sungMetadataMigration).toContain("last_sung_at timestamptz");
     expect(sungMetadataMigration).toContain("times_sung_count integer");
     expect(sungMetadataMigration).toContain("times_sung_count + 1");
     expect(sungMetadataMigration).toContain("user_id = auth.uid()");
     expect(sungMetadataMigration).toContain("sung_song_events");
+    expect(nullableSungSessionMigration).toContain(
+      "alter column session_id drop not null"
+    );
+    expect(nullableSungSessionMigration).toContain(
+      "p_session_id uuid default null"
+    );
   });
 
   it("documents and migrates private repertoire share links", () => {

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -24,7 +24,7 @@ export type HelpNavItem = {
 
 export const quickStartSteps = [
   "Add your display name so other singers know who is in the quartet.",
-  "Add a few songs you are likely to sing. You do not need to enter your entire repertoire before starting.",
+  "Add a few songs you are likely to sing. You can type songs in, copy songs from another singer, or add Harmony Brigade songs.",
   "For each song, choose the voicing and every part you can sing for that arrangement.",
   "Start a quartet or join someone else with a code, QR code, or shared link.",
   "Use Matches to pick something everyone can sing right now.",
@@ -36,7 +36,7 @@ export const helpGuideSections: HelpGuideSection[] = [
     eyebrow: "First Time Setup",
     title: "Get Singing Quickly",
     intro:
-      "If you are using the app for the first time, you do not need to enter your entire repertoire. Add a few songs you are likely to sing, join a quartet, and add more as you go.",
+      "If you are using the app for the first time, you do not need to enter every song. Add a few songs you are likely to sing, join a quartet, and add more as you go.",
     topics: [
       {
         title: "The basic flow",
@@ -49,17 +49,17 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "Don't overthink entering all of your songs",
         body: [
-          "Start with songs you are likely to sing soon. You can add more repertoire later, and if you are already in a quartet, repertoire edits refresh your active quartet snapshot so matches can update.",
+          "Start with songs you are likely to sing soon. You can add more later, copy songs from another singer, or add Harmony Brigade songs if that helps you get started faster. If you are already in a quartet, edits to My Songs refresh your active quartet snapshot so matches can update.",
         ],
       },
     ],
   },
   {
     id: "repertoire",
-    eyebrow: "Repertoire",
+    eyebrow: "My Songs",
     title: "Manage The Songs You Know",
     intro:
-      "The Repertoire page stores your songs, voicings, parts, confidence, arranger information, notes, and recently sung history.",
+      "My Songs stores your songs, voicings, parts, confidence, arranger information, notes, and last-sung tracking.",
     topics: [
       {
         title: "Song Title Autocomplete",
@@ -71,8 +71,16 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "How Suggestions Are Shared",
         body: [
-          "When you add a song, the title, voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s repertoire.",
-          "Suggestions do not expose private user details such as user IDs, singer names, notes, parts, confidence, timestamps, or your full personal repertoire.",
+          "When you add a song, the title, voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s My Songs.",
+          "Suggestions do not expose private user details such as user IDs, singer names, notes, parts, confidence, timestamps, or your full personal song list.",
+        ],
+      },
+      {
+        title: "More Ways To Build My Songs",
+        body: [
+          "Use Copy songs from another singer when someone gives you a private link or code. You can copy song titles, voicings, and arrangers, then choose your own part and confidence before saving.",
+          "Use Let another singer copy songs from My Songs to create a private link/code. The other singer cannot see your notes, confidence, last-sung history, email address, or account details.",
+          "Use Add Harmony Brigade songs to choose a year and brigade, review TTBB songs from the reference data, and choose your own parts and confidence before adding anything.",
         ],
       },
       {
@@ -99,20 +107,22 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "Notes",
         body: [
-          "Notes are for your own memory — for example, version reminders, tags, first words, key, or tricky spots. They help you manage your repertoire but are not used to decide whether the quartet can sing a song.",
+          "Notes are for your own memory — for example, version reminders, tags, first words, key, or tricky spots. They help you manage My Songs but are not used to decide whether the quartet can sing a song.",
         ],
       },
       {
-        title: "Recently Sung",
+        title: "Last Sung",
         body: [
-          "Recently sung helps you remember what you have sung lately. It can help you sort or filter your repertoire, but it does not remove the song from your repertoire or from possible matches.",
+          "Last sung is based on songs you have marked as sung in the app, either from a quartet page or from My Songs. Not marked yet does not make any claim about your real-life singing history.",
+          "You can use Sung status to show all songs, marked-sung songs, or songs that are not marked yet.",
         ],
       },
       {
         title: "Sorting and Filtering",
         body: [
           "Use search to filter by title. You can sort by title, newest or oldest added, sung recently, or least recently sung.",
-          "You can filter by voicing, part, and Never Sung. Active filters appear above the song list and can be cleared together.",
+          "Recently sung puts marked-sung songs first, newest to oldest. Least recently sung puts Not marked yet songs first, then marked-sung songs from oldest to newest.",
+          "You can filter by voicing, part, and Sung status. Active filters appear above the song list and can be cleared together.",
         ],
       },
     ],
@@ -128,20 +138,20 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "What Start Does",
         body: [
           "Start creates a quartet session and gives it a short code. Other singers can enter the code, scan the QR code, or open the shared link to join.",
-          "You are part of the quartet you start. Your saved repertoire is used along with the other singers’ repertoire to find matches, so add at least a few songs first.",
+          "You are part of the quartet you start. My Songs is used along with the other singers’ saved songs to find matches, so add at least a few songs first.",
         ],
       },
       {
         title: "After Singers Join",
         body: [
-          "Once singers join, the app compares the current quartet members’ saved repertoire snapshots. A quartet is full when four singers have joined.",
-          "Starting a quartet does not permanently change anyone else’s repertoire. It only creates a shared place where the group can compare what each singer already has saved.",
+          "Once singers join, the app compares the current quartet members’ saved song snapshots. A quartet is full when four singers have joined.",
+          "Starting a quartet does not permanently change anyone else’s My Songs. It only creates a shared place where the group can compare what each singer already has saved.",
         ],
       },
       {
         title: "Fixing Something After Starting",
         body: [
-          "If you notice a missing song, wrong part, confidence issue, arranger detail, or display name problem, you can still edit your repertoire or name after starting and return to the quartet.",
+          "If you notice a missing song, wrong part, confidence issue, arranger detail, or display name problem, you can still edit My Songs or your name after starting and return to the quartet.",
         ],
       },
     ],
@@ -156,8 +166,8 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "What Join Uses",
         body: [
-          "When you join, the app uses your saved repertoire to look for songs the group can sing together. Joining does not add songs to your repertoire or change the songs you already saved.",
-          "If your repertoire is empty or missing common songs, the group may see fewer matches until you add or update entries.",
+          "When you join, the app uses My Songs to look for songs the group can sing together. Joining does not add songs to My Songs or change the songs you already saved.",
+          "If My Songs is empty or missing common songs, the group may see fewer matches until you add or update entries.",
         ],
       },
       {
@@ -217,13 +227,13 @@ export const helpGuideSections: HelpGuideSection[] = [
     eyebrow: "Managing A Quartet",
     title: "Update, Leave, Or Rejoin A Quartet",
     intro:
-      "Quartet membership and match results come from the current quartet data. Use the quartet controls when someone updates repertoire, changes names, leaves, rejoins, or needs to be removed.",
+      "Quartet membership and match results come from the current quartet data. Use the quartet controls when someone updates My Songs, changes names, leaves, rejoins, or needs to be removed.",
     topics: [
       {
         title: "Managing The Quartet",
         body: [
-          "When the quartet is full, use Manage to see quartet members, edit repertoire, change your name, or leave the quartet.",
-          "If a song title, voicing, part, arranger, notes, or confidence looks wrong, update it from Repertoire. If the name shown to others is wrong, use Change name.",
+          "When the quartet is full, use Manage to see quartet members, edit My Songs, change your name, or leave the quartet.",
+          "If a song title, voicing, part, arranger, notes, or confidence looks wrong, update it from My Songs. If the name shown to others is wrong, use Change name.",
         ],
       },
       {
@@ -239,7 +249,7 @@ export const helpGuideSections: HelpGuideSection[] = [
 
 export const helpNavItems: HelpNavItem[] = [
   { id: "first-time-setup", label: "First time setup" },
-  { id: "repertoire", label: "Repertoire" },
+  { id: "repertoire", label: "My Songs" },
   { id: "starting-a-quartet", label: "Starting a quartet" },
   { id: "joining-a-quartet", label: "Joining a quartet" },
   { id: "quartet-matches", label: "Quartet matches" },

--- a/lib/lastSung.ts
+++ b/lib/lastSung.ts
@@ -1,0 +1,29 @@
+const dayMs = 24 * 60 * 60 * 1000;
+
+function startOfLocalDay(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function formatLastSungStatus(
+  value: string | null | undefined,
+  now = new Date()
+) {
+  if (!value) return "Not marked yet";
+
+  const sungAt = new Date(value);
+  if (Number.isNaN(sungAt.getTime())) return "Not marked yet";
+
+  const today = startOfLocalDay(now);
+  const sungDay = startOfLocalDay(sungAt);
+  const dayDiff = Math.round((today.getTime() - sungDay.getTime()) / dayMs);
+
+  if (dayDiff === 0) return "Today";
+  if (dayDiff > 0 && dayDiff < 14) {
+    return `${dayDiff} ${dayDiff === 1 ? "day" : "days"} ago`;
+  }
+
+  return sungAt.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/lib/loginContent.ts
+++ b/lib/loginContent.ts
@@ -3,6 +3,6 @@ export const loginIntro = {
   description:
     "What Can We Sing helps a pickup quartet quickly answer the question: what can we sing together right now?",
   details:
-    "Each singer adds the songs they know, the voicing, the parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's repertoire and shows songs where the required parts are covered by different people.",
-  signInReason: "Sign in to save your repertoire and join or start a quartet.",
+    "Each singer adds the songs they know, the voicing, the parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's saved songs and shows songs where the required parts are covered by different people.",
+  signInReason: "Sign in to save My Songs and join or start a quartet.",
 } as const;

--- a/lib/repertoireSharing.ts
+++ b/lib/repertoireSharing.ts
@@ -45,7 +45,7 @@ export type CopyableSharedSong = SharedRepertoireSong & {
 };
 
 export const repertoireCopyRequestMessage =
-  "Can you open What Can We Sing, go to Repertoire, choose 'Let another singer copy songs from my repertoire,' and send me the link or code? I'd like to copy a few songs into my repertoire.";
+  "Can you open What Can We Sing, go to My Songs, choose 'Let another singer copy songs from My Songs,' and send me the link or code? I'd like to copy a few songs into My Songs.";
 
 export function sharedRepertoirePathFromInput(input: string) {
   const trimmed = input.trim();
@@ -188,7 +188,7 @@ export async function createRepertoireShare() {
 
   throw lastError instanceof Error
     ? lastError
-    : new Error("Could not create repertoire share link.");
+      : new Error("Could not create My Songs copy link.");
 }
 
 export async function revokeRepertoireShare(shareId: string) {

--- a/lib/repertoireStore.ts
+++ b/lib/repertoireStore.ts
@@ -129,7 +129,10 @@ export async function searchRepertoireSongSuggestions(
   );
 }
 
-export async function markRepertoireItemAsSung(id: string, sessionId: string) {
+export async function markRepertoireItemAsSung(
+  id: string,
+  sessionId: string | null = null
+) {
   const user = await getCurrentUser();
   if (!user) throw new Error("You must be logged in.");
 
@@ -142,7 +145,7 @@ export async function markRepertoireItemAsSung(id: string, sessionId: string) {
 
   const row = Array.isArray(data) ? data[0] : data;
   if (!row || row.user_id !== user.id || row.id !== id) {
-    throw new Error("Could not verify that your repertoire row was marked as sung.");
+    throw new Error("Could not verify that your song was marked as sung.");
   }
 
   return normalizeRepertoireRow(row as RawRepertoireRow);

--- a/lib/repertoireView.ts
+++ b/lib/repertoireView.ts
@@ -8,11 +8,13 @@ export type RepertoireSortOption =
   | "last_sung_desc"
   | "last_sung_asc";
 
+export type SungStatusFilter = "all" | "marked" | "not_marked";
+
 export type RepertoireFilters = {
   searchQuery: string;
   voicing: Voicing | "";
   part: Part | "";
-  neverSungOnly: boolean;
+  sungStatus: SungStatusFilter;
   sort: RepertoireSortOption;
 };
 
@@ -69,7 +71,11 @@ export function filterAndSortRepertoire(
         return false;
       }
 
-      if (filters.neverSungOnly && item.last_sung_at) {
+      if (filters.sungStatus === "marked" && !item.last_sung_at) {
+        return false;
+      }
+
+      if (filters.sungStatus === "not_marked" && item.last_sung_at) {
         return false;
       }
 
@@ -113,6 +119,6 @@ export function hasActiveRepertoireFilters(filters: RepertoireFilters) {
     filters.searchQuery.trim() ||
       filters.voicing ||
       filters.part ||
-      filters.neverSungOnly
+      filters.sungStatus !== "all"
   );
 }

--- a/supabase/migrations/20260501210000_allow_repertoire_mark_sung_without_session.sql
+++ b/supabase/migrations/20260501210000_allow_repertoire_mark_sung_without_session.sql
@@ -1,0 +1,49 @@
+alter table public.sung_song_events
+  alter column session_id drop not null;
+
+create or replace function public.mark_repertoire_sung(
+  p_repertoire_id uuid,
+  p_session_id uuid default null
+)
+returns public.user_repertoire
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  updated_repertoire public.user_repertoire;
+begin
+  update public.user_repertoire
+  set
+    last_sung_at = now(),
+    times_sung_count = times_sung_count + 1,
+    updated_at = now()
+  where id = p_repertoire_id
+    and user_id = auth.uid()
+  returning * into updated_repertoire;
+
+  if updated_repertoire.id is null then
+    raise exception 'Could not mark repertoire song as sung'
+      using errcode = 'P0002';
+  end if;
+
+  insert into public.sung_song_events (
+    user_id,
+    session_id,
+    song_title,
+    voicing,
+    arranger_name
+  )
+  values (
+    updated_repertoire.user_id,
+    p_session_id,
+    updated_repertoire.song_title,
+    updated_repertoire.voicing,
+    updated_repertoire.arranger_name
+  );
+
+  return updated_repertoire;
+end;
+$$;
+
+grant execute on function public.mark_repertoire_sung(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- Standardizes visible user-facing language around My Songs across nav, home, onboarding, help, privacy, quartet copy, sharing, and related tests.
- Adds Sung status filtering, Not marked yet wording, compact last-sung labels, and a Mark sung today row action on My Songs.
- Updates Help/Privacy/docs for song suggestions, private copy links, Harmony Brigade, last-sung behavior, and adds an AGENTS.md completeness standard.
- Adds a Supabase migration so mark_repertoire_sung can record My Songs marks without a quartet session id.

## Issues
Closes #296
Closes #302
Closes #307
Closes #309
Closes #317

## Docs and Tests
- Docs updated: AGENTS.md, Help/Privacy content, analytics docs, app flows, imports, recently sung events, Supabase contract, test coverage notes.
- Tests added/updated for last-sung display labels, sung status filtering, My Songs terminology, Help/Privacy copy, sharing copy, and Supabase contract migration coverage.

## Supabase / Deployment
- Added migration `20260501210000_allow_repertoire_mark_sung_without_session.sql`.
- No dashboard-only change required. Production Deploy should apply the migration before Vercel production deploy. If deploying manually, run `supabase db push`.

## Verification
- `npm run test:run`
- `npm run build`