### PR TITLE
Fix Harmony Brigade scoped song loading

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -50,10 +50,9 @@ import { arrangerDisplayName } from "@/lib/arrangerDisplay";
 import { hasQuartetWorkflowHistory } from "@/lib/activeQuartet";
 import {
   buildHarmonyBrigadeAddInputs,
-  filterHarmonyBrigadeSongs,
   getHarmonyBrigadeBrigadeOptions,
   getHarmonyBrigadeEvents,
-  getHarmonyBrigadeEventSongs,
+  getHarmonyBrigadeEventSongsForScope,
   getHarmonyBrigadeYearOptions,
   HARMONY_BRIGADE_ALL_BRIGADES,
   HARMONY_BRIGADE_ALL_YEARS,
@@ -375,14 +374,44 @@ export default function RepertoireManager() {
     setIsHarmonyBrigadeLoading(true);
 
     try {
-      const [events, rows] = await Promise.all([
-        getHarmonyBrigadeEvents(),
-        getHarmonyBrigadeEventSongs(),
-      ]);
+      const events = await getHarmonyBrigadeEvents();
+      const rows = await getHarmonyBrigadeEventSongsForScope(
+        events,
+        HARMONY_BRIGADE_ALL_YEARS,
+        HARMONY_BRIGADE_ALL_BRIGADES
+      );
       setHarmonyBrigadeEvents(events);
       setHarmonyBrigadeRows(rows);
       setHarmonyBrigadeYear(HARMONY_BRIGADE_ALL_YEARS);
       setHarmonyBrigadeBrigade(HARMONY_BRIGADE_ALL_BRIGADES);
+    } catch (err) {
+      console.error(err);
+      setHarmonyBrigadeMessage(
+        "Could not load Harmony Brigade songs. Please try again."
+      );
+    } finally {
+      setIsHarmonyBrigadeLoading(false);
+    }
+  }
+
+  async function loadHarmonyBrigadeSongsForScope(
+    events: HarmonyBrigadeEvent[],
+    selectedYear: string | number,
+    selectedBrigade: string
+  ) {
+    setHarmonyBrigadeRows([]);
+    setHarmonyBrigadePartSelections({});
+    setHarmonyBrigadeSearchQuery("");
+    setHarmonyBrigadeMessage("");
+    setIsHarmonyBrigadeLoading(true);
+
+    try {
+      const rows = await getHarmonyBrigadeEventSongsForScope(
+        events,
+        selectedYear,
+        selectedBrigade
+      );
+      setHarmonyBrigadeRows(rows);
     } catch (err) {
       console.error(err);
       setHarmonyBrigadeMessage(
@@ -1020,13 +1049,8 @@ export default function RepertoireManager() {
   )
     ? harmonyBrigadeBrigade
     : HARMONY_BRIGADE_ALL_BRIGADES;
-  const harmonyBrigadeScopedRows = filterHarmonyBrigadeSongs(
-    harmonyBrigadeRows,
-    harmonyBrigadeYear,
-    selectedHarmonyBrigadeBrigade
-  );
   const harmonyBrigadeCandidates = resolveHarmonyBrigadeCandidates(
-    harmonyBrigadeScopedRows,
+    harmonyBrigadeRows,
     items
   );
   const visibleHarmonyBrigadeCandidates = searchHarmonyBrigadeCandidates(
@@ -1357,15 +1381,17 @@ export default function RepertoireManager() {
                               harmonyBrigadeEvents
                             );
                           setHarmonyBrigadeYear(nextYear);
-                          setHarmonyBrigadeBrigade(
-                            nextBrigadeOptions.some(
-                              (option) => option.value === harmonyBrigadeBrigade
-                            )
-                              ? harmonyBrigadeBrigade
-                              : HARMONY_BRIGADE_ALL_BRIGADES
+                          const nextBrigade = nextBrigadeOptions.some(
+                            (option) => option.value === harmonyBrigadeBrigade
+                          )
+                            ? harmonyBrigadeBrigade
+                            : HARMONY_BRIGADE_ALL_BRIGADES;
+                          setHarmonyBrigadeBrigade(nextBrigade);
+                          void loadHarmonyBrigadeSongsForScope(
+                            harmonyBrigadeEvents,
+                            nextYear,
+                            nextBrigade
                           );
-                          setHarmonyBrigadePartSelections({});
-                          setHarmonyBrigadeSearchQuery("");
                         }}
                         className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                       >
@@ -1383,9 +1409,13 @@ export default function RepertoireManager() {
                       <select
                         value={selectedHarmonyBrigadeBrigade}
                         onChange={(event) => {
-                          setHarmonyBrigadeBrigade(event.target.value);
-                          setHarmonyBrigadePartSelections({});
-                          setHarmonyBrigadeSearchQuery("");
+                          const nextBrigade = event.target.value;
+                          setHarmonyBrigadeBrigade(nextBrigade);
+                          void loadHarmonyBrigadeSongsForScope(
+                            harmonyBrigadeEvents,
+                            harmonyBrigadeYear,
+                            nextBrigade
+                          );
                         }}
                         className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                       >

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -169,6 +169,11 @@ Use a dry run to parse and summarize without writing:
 npm run harmony-brigade:import -- --dry-run
 ```
 
+Both dry runs and imports print per-event song counts. Counts below 10 are
+flagged as suspicious so missing or truncated event-song data is visible before
+using the picker, while still allowing historical/special events that may
+legitimately have fewer than a standard 12-song list.
+
 The import creates or updates:
 
 - `harmony_brigade_songs`
@@ -188,7 +193,9 @@ value for each selected part. If multiple appearances of the same normalized
 title + arranger are selected, they are saved as one My Songs row with the
 combined part confidences. Adding Harmony Brigade songs writes only to the
 current user's `user_repertoire`; it does not expose the user's Brigade
-selection publicly.
+selection publicly. The picker fetches event-song rows for the selected
+year/brigade scope and paginates Supabase reads so complete event lists are not
+truncated by PostgREST response caps.
 
 Duplicate detection uses normalized title + `TTBB` + normalized arranger,
 preserving the distinction between a blank arranger and literal `Unknown`.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -267,6 +267,14 @@ Expected context:
   only unique songs. If a user selects parts from multiple appearances of the
   same normalized song + arranger, the app writes one `user_repertoire` row with
   combined TTBB part confidences.
+- The UI scopes event-song reads by the selected year/brigade event ids and
+  paginates Supabase reads. It must not depend on one unbounded
+  `harmony_brigade_event_songs` select and then filter a potentially capped
+  result set in the browser.
+- The import script prints per-event song counts before writing, and after
+  writing when not in dry-run mode. Counts below 10 are flagged as suspicious
+  data-quality warnings, not hard failures, because some historical/special
+  events may legitimately have shorter lists.
 
 Required database contract:
 - `harmony_brigade_songs`

--- a/lib/__tests__/harmonyBrigade.test.ts
+++ b/lib/__tests__/harmonyBrigade.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { RepertoireRow } from "@/lib/repertoireStore";
 import {
   buildHarmonyBrigadeAddInputs,
+  fetchHarmonyBrigadeEventSongPages,
   filterHarmonyBrigadeSongs,
   getHarmonyBrigadeBrigadeOptions,
   getHarmonyBrigadeYearOptions,
@@ -114,6 +115,30 @@ describe("Harmony Brigade source helpers", () => {
     expect(
       filterHarmonyBrigadeSongs(rows, HARMONY_BRIGADE_ALL_YEARS, "AHB")
     ).toEqual(rows);
+  });
+
+  it("paginates event-song queries instead of relying on one capped response", async () => {
+    const calls: Array<[number, number]> = [];
+    const pages = [
+      [{ id: "1" }, { id: "2" }],
+      [{ id: "3" }, { id: "4" }],
+      [{ id: "5" }],
+    ];
+
+    const rows = await fetchHarmonyBrigadeEventSongPages((from, to) => {
+      calls.push([from, to]);
+      return Promise.resolve({
+        data: pages[calls.length - 1] as never,
+        error: null,
+      });
+    }, 2);
+
+    expect(calls).toEqual([
+      [0, 1],
+      [2, 3],
+      [4, 5],
+    ]);
+    expect(rows).toHaveLength(5);
   });
 
   it("uses natural preview copy for selected scope", () => {

--- a/lib/__tests__/harmonyBrigadeImport.test.mjs
+++ b/lib/__tests__/harmonyBrigadeImport.test.mjs
@@ -75,6 +75,14 @@ describe("Harmony Brigade import parsing", () => {
         track_number: 7,
       },
     ]);
+    expect(parsed.eventSongCountSummary).toEqual([
+      {
+        year_held: 2024,
+        brigade_abbr: "AHB",
+        song_count: 1,
+        suspicious: true,
+      },
+    ]);
     expect(parsed.missingSongCount).toBe(0);
   });
 });

--- a/lib/harmonyBrigade.ts
+++ b/lib/harmonyBrigade.ts
@@ -6,6 +6,7 @@ export const HARMONY_BRIGADE_SOURCE =
 export const HARMONY_BRIGADE_DEFAULT_VOICING = "TTBB" as const;
 export const HARMONY_BRIGADE_ALL_YEARS = "All years";
 export const HARMONY_BRIGADE_ALL_BRIGADES = "All brigades";
+export const HARMONY_BRIGADE_EVENT_SONG_PAGE_SIZE = 500;
 
 export type HarmonyBrigadeEvent = {
   id: string;
@@ -75,11 +76,23 @@ type RawHarmonyBrigadeSong = {
 };
 
 type RawHarmonyBrigadeEventSong = {
+  id?: string;
+  event_id?: string;
   track_number: number | null;
   sort_order: number | null;
   event: RawHarmonyBrigadeEvent | RawHarmonyBrigadeEvent[];
   song: RawHarmonyBrigadeSong | RawHarmonyBrigadeSong[];
 };
+
+type HarmonyBrigadeEventSongQueryResult = {
+  data: RawHarmonyBrigadeEventSong[] | null;
+  error: unknown;
+};
+
+type HarmonyBrigadeEventSongQueryRunner = (
+  from: number,
+  to: number
+) => PromiseLike<HarmonyBrigadeEventSongQueryResult>;
 
 function normalizeSongText(value?: string | null) {
   return (value ?? "")
@@ -190,14 +203,29 @@ export function filterHarmonyBrigadeSongs(
   selectedYear: string | number,
   selectedBrigade: string
 ) {
+  const events = rows.map((row) => row.event);
+  const eventIds = new Set(
+    filterHarmonyBrigadeEvents(events, selectedYear, selectedBrigade).map(
+      (event) => event.id
+    )
+  );
+
+  return rows.filter((row) => eventIds.has(row.event.id));
+}
+
+export function filterHarmonyBrigadeEvents(
+  events: HarmonyBrigadeEvent[],
+  selectedYear: string | number,
+  selectedBrigade: string
+) {
   const year =
     selectedYear === HARMONY_BRIGADE_ALL_YEARS ? null : Number(selectedYear);
   const brigade =
     selectedBrigade === HARMONY_BRIGADE_ALL_BRIGADES ? null : selectedBrigade;
 
-  return rows.filter((row) => {
-    if (year && row.event.yearHeld !== year) return false;
-    if (brigade && row.event.brigadeAbbr !== brigade) return false;
+  return events.filter((event) => {
+    if (year && event.yearHeld !== year) return false;
+    if (brigade && event.brigadeAbbr !== brigade) return false;
     return true;
   });
 }
@@ -359,6 +387,46 @@ export function buildHarmonyBrigadeAddInputs(
   return Array.from(inputs.values());
 }
 
+function mapEventSongRows(rows: RawHarmonyBrigadeEventSong[]) {
+  return rows
+    .map((row) => ({
+      event: mapEvent(firstRelated(row.event)),
+      song: mapSong(firstRelated(row.song)),
+      trackNumber: row.track_number,
+      sortOrder: row.sort_order,
+    }))
+    .sort((a, b) => {
+      return (
+        b.event.yearHeld - a.event.yearHeld ||
+        a.event.brigadeAbbr.localeCompare(b.event.brigadeAbbr) ||
+        (a.sortOrder ?? 9999) - (b.sortOrder ?? 9999) ||
+        (a.trackNumber ?? 9999) - (b.trackNumber ?? 9999) ||
+        a.song.songTitle.localeCompare(b.song.songTitle)
+      );
+    });
+}
+
+export async function fetchHarmonyBrigadeEventSongPages(
+  runQuery: HarmonyBrigadeEventSongQueryRunner,
+  pageSize = HARMONY_BRIGADE_EVENT_SONG_PAGE_SIZE
+) {
+  const rows: RawHarmonyBrigadeEventSong[] = [];
+
+  for (let from = 0; ; from += pageSize) {
+    const to = from + pageSize - 1;
+    const { data, error } = await runQuery(from, to);
+
+    if (error) throw error;
+
+    const page = data ?? [];
+    rows.push(...page);
+
+    if (page.length < pageSize) break;
+  }
+
+  return rows;
+}
+
 export async function getHarmonyBrigadeEvents() {
   const { supabase } = await import("@/lib/supabase");
   const { data, error } = await supabase
@@ -372,29 +440,51 @@ export async function getHarmonyBrigadeEvents() {
 }
 
 export async function getHarmonyBrigadeEventSongs() {
+  return getHarmonyBrigadeEventSongsByEventIds();
+}
+
+export async function getHarmonyBrigadeEventSongsForScope(
+  events: HarmonyBrigadeEvent[],
+  selectedYear: string | number,
+  selectedBrigade: string
+) {
+  const isAllEventsScope =
+    selectedYear === HARMONY_BRIGADE_ALL_YEARS &&
+    selectedBrigade === HARMONY_BRIGADE_ALL_BRIGADES;
+  const scopedEventIds = filterHarmonyBrigadeEvents(
+    events,
+    selectedYear,
+    selectedBrigade
+  ).map((event) => event.id);
+
+  return getHarmonyBrigadeEventSongsByEventIds(
+    isAllEventsScope ? undefined : scopedEventIds
+  );
+}
+
+async function getHarmonyBrigadeEventSongsByEventIds(eventIds?: string[]) {
+  if (eventIds && eventIds.length === 0) return [];
+
   const { supabase } = await import("@/lib/supabase");
-  const { data, error } = await supabase
-    .from("harmony_brigade_event_songs")
-    .select(
-      "track_number,sort_order,event:harmony_brigade_events(id,year_held,brigade_abbr,brigade_name,event_label),song:harmony_brigade_songs(id,source_song_id,song_title,arranger,default_voicing,song_key,starting_words,as_sung_by,learning_track_provider,song_style,song_length)"
-    )
-    .order("sort_order", { ascending: true });
 
-  if (error) throw error;
+  const rows = await fetchHarmonyBrigadeEventSongPages((from, to) => {
+    let query = supabase
+      .from("harmony_brigade_event_songs")
+      .select(
+        "id,event_id,track_number,sort_order,event:harmony_brigade_events(id,year_held,brigade_abbr,brigade_name,event_label),song:harmony_brigade_songs(id,source_song_id,song_title,arranger,default_voicing,song_key,starting_words,as_sung_by,learning_track_provider,song_style,song_length)"
+      )
+      .order("event_id", { ascending: true })
+      .order("sort_order", { ascending: true })
+      .order("track_number", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, to);
 
-  return ((data ?? []) as RawHarmonyBrigadeEventSong[])
-    .map((row) => ({
-      event: mapEvent(firstRelated(row.event)),
-      song: mapSong(firstRelated(row.song)),
-      trackNumber: row.track_number,
-      sortOrder: row.sort_order,
-    }))
-    .sort((a, b) => {
-      return (
-        b.event.yearHeld - a.event.yearHeld ||
-        a.event.brigadeAbbr.localeCompare(b.event.brigadeAbbr) ||
-        (a.sortOrder ?? 9999) - (b.sortOrder ?? 9999) ||
-        a.song.songTitle.localeCompare(b.song.songTitle)
-      );
-    });
+    if (eventIds) {
+      query = query.in("event_id", eventIds);
+    }
+
+    return query as PromiseLike<HarmonyBrigadeEventSongQueryResult>;
+  });
+
+  return mapEventSongRows(rows);
 }

--- a/scripts/import-harmony-brigade-songs.mjs
+++ b/scripts/import-harmony-brigade-songs.mjs
@@ -15,6 +15,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const defaultSourceDir = path.join(repoRoot, "data/harmony-brigade");
 const batchSize = 500;
+const suspiciousEventSongCountThreshold = 10;
 
 function requiredEnv(name) {
   const value = process.env[name];
@@ -40,6 +41,47 @@ async function readCsv(filePath) {
 function numberOrNull(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function eventSongCountSummary(events, eventSongs) {
+  const counts = new Map(events.map((event) => [
+    `${event.year_held}|${event.brigade_abbr}`,
+    0,
+  ]));
+
+  for (const eventSong of eventSongs) {
+    counts.set(
+      eventSong.eventKey,
+      (counts.get(eventSong.eventKey) ?? 0) + 1
+    );
+  }
+
+  return events
+    .map((event) => {
+      const eventKey = `${event.year_held}|${event.brigade_abbr}`;
+      const song_count = counts.get(eventKey) ?? 0;
+
+      return {
+        year_held: event.year_held,
+        brigade_abbr: event.brigade_abbr,
+        song_count,
+        suspicious: song_count < suspiciousEventSongCountThreshold,
+      };
+    })
+    .sort((a, b) => {
+      return b.year_held - a.year_held || a.brigade_abbr.localeCompare(b.brigade_abbr);
+    });
+}
+
+function printEventSongCountSummary(label, summary) {
+  console.log(`${label}:`);
+
+  for (const row of summary) {
+    const warning = row.suspicious ? " - fewer than 10" : "";
+    console.log(
+      `- ${row.year_held} ${row.brigade_abbr}: ${row.song_count} songs${warning}`
+    );
+  }
 }
 
 export function parseHarmonyBrigadeSnapshots({
@@ -138,7 +180,7 @@ export function parseHarmonyBrigadeSnapshots({
     });
   }
 
-  return {
+  const parsed = {
     songs: Array.from(songsById.values()).sort((a, b) => a.source_song_id - b.source_song_id),
     events: Array.from(events.values()).sort((a, b) => {
       return b.year_held - a.year_held || a.brigade_abbr.localeCompare(b.brigade_abbr);
@@ -146,6 +188,14 @@ export function parseHarmonyBrigadeSnapshots({
     eventSongs: Array.from(eventSongs.values()),
     missingSongCount,
     missingArrangerCount: Array.from(songsById.values()).filter((song) => !song.arranger).length,
+  };
+
+  return {
+    ...parsed,
+    eventSongCountSummary: eventSongCountSummary(
+      parsed.events,
+      parsed.eventSongs
+    ),
   };
 }
 
@@ -180,9 +230,13 @@ export async function importHarmonyBrigadeSongs({
     historyRows,
     brigadeRows,
   });
+  const sourceEventSongCountSummary = eventSongCountSummary(
+    parsed.events,
+    parsed.eventSongs
+  );
 
   if (dryRun) {
-    return { ...parsed, dryRun: true };
+    return { ...parsed, sourceEventSongCountSummary, dryRun: true };
   }
 
   const supabaseUrl =
@@ -215,14 +269,20 @@ export async function importHarmonyBrigadeSongs({
     eventRows.map((row) => [`${row.year_held}|${row.brigade_abbr}`, row.id])
   );
 
-  const joinRows = parsed.eventSongs
+  const joinRowsWithEventKeys = parsed.eventSongs
     .map((row, index) => ({
+      eventKey: row.eventKey,
       event_id: eventIds.get(row.eventKey),
       song_id: songIds.get(row.source_song_id),
       track_number: row.track_number,
       sort_order: row.track_number ?? index + 1,
     }))
     .filter((row) => row.event_id && row.song_id);
+  const joinRows = joinRowsWithEventKeys.map(({ eventKey: _eventKey, ...row }) => row);
+  const importedEventSongCountSummary = eventSongCountSummary(
+    parsed.events,
+    joinRowsWithEventKeys.map((row) => ({ eventKey: row.eventKey }))
+  );
 
   await deleteAllRows(supabase, "harmony_brigade_event_songs");
   await upsertInBatches(supabase, "harmony_brigade_event_songs", joinRows, {
@@ -231,6 +291,8 @@ export async function importHarmonyBrigadeSongs({
 
   return {
     ...parsed,
+    sourceEventSongCountSummary,
+    importedEventSongCountSummary,
     eventSongsImported: joinRows.length,
     dryRun: false,
   };
@@ -247,6 +309,10 @@ async function main() {
   console.log(`Event-song rows: ${result.eventSongsImported ?? result.eventSongs.length}`);
   console.log(`Missing arrangers: ${result.missingArrangerCount}`);
   console.log(`History rows missing SongData match: ${result.missingSongCount}`);
+  printEventSongCountSummary("Source event-song counts", result.sourceEventSongCountSummary);
+  if (result.importedEventSongCountSummary) {
+    printEventSongCountSummary("Imported event-song counts", result.importedEventSongCountSummary);
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary
- Replace the broad Harmony Brigade event-song load with scoped, paginated Supabase reads so selected year/brigade lists are complete.
- Reload event-song rows when the user changes year or brigade instead of filtering a potentially capped all-row response in the browser.
- Add import/dry-run per-event song count summaries and warnings for suspiciously small event lists.

## Docs and tests
- Added a pagination regression test for Harmony Brigade event-song reads.
- Added import parser coverage for per-event count summaries.
- Updated `docs/imports.md` and `docs/supabase-contract.md` with the scoped/paginated read contract and import validation behavior.

## Verification
- npm run test:run
- npm run build

## Supabase / manual steps
- No migration required. Existing indexes/RLS cover the scoped read pattern.
- No dashboard changes required.

Closes #323