### PR TITLE
Deduplicate Harmony Brigade picker cards

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -54,13 +54,15 @@ import {
   getHarmonyBrigadeEvents,
   getHarmonyBrigadeEventSongsForScope,
   getHarmonyBrigadeYearOptions,
+  groupHarmonyBrigadeCandidates,
   HARMONY_BRIGADE_ALL_BRIGADES,
   HARMONY_BRIGADE_ALL_YEARS,
   HARMONY_BRIGADE_SOURCE,
-  harmonyBrigadeEventSongKey,
+  harmonyBrigadeAppearanceSummary,
+  harmonyBrigadeGroupedCandidateKey,
   harmonyBrigadeSelectionDescription,
   resolveHarmonyBrigadeCandidates,
-  searchHarmonyBrigadeCandidates,
+  searchHarmonyBrigadeGroupedCandidates,
   type HarmonyBrigadeEvent,
   type HarmonyBrigadeEventSong,
   type HarmonyBrigadePartSelections,
@@ -1053,22 +1055,27 @@ export default function RepertoireManager() {
     harmonyBrigadeRows,
     items
   );
-  const visibleHarmonyBrigadeCandidates = searchHarmonyBrigadeCandidates(
-    harmonyBrigadeCandidates,
+  const harmonyBrigadeGroupedCandidates = groupHarmonyBrigadeCandidates(
+    harmonyBrigadeCandidates
+  );
+  const visibleHarmonyBrigadeCandidates = searchHarmonyBrigadeGroupedCandidates(
+    harmonyBrigadeGroupedCandidates,
     harmonyBrigadeSearchQuery
   );
-  const harmonyBrigadeEligibleCount = harmonyBrigadeCandidates.filter(
+  const harmonyBrigadeEligibleCount = harmonyBrigadeGroupedCandidates.filter(
     (row) => row.duplicateStatus === "eligible"
   ).length;
   const harmonyBrigadeAlreadyCount =
-    harmonyBrigadeCandidates.length - harmonyBrigadeEligibleCount;
-  const selectedHarmonyBrigadeEligibleCount = harmonyBrigadeCandidates.filter(
-    (row) =>
-      row.duplicateStatus === "eligible" &&
-      Object.keys(
-        harmonyBrigadePartSelections[harmonyBrigadeEventSongKey(row)] ?? {}
-      ).length > 0
-  ).length;
+    harmonyBrigadeGroupedCandidates.length - harmonyBrigadeEligibleCount;
+  const selectedHarmonyBrigadeEligibleCount =
+    harmonyBrigadeGroupedCandidates.filter(
+      (row) =>
+        row.duplicateStatus === "eligible" &&
+        Object.keys(
+          harmonyBrigadePartSelections[harmonyBrigadeGroupedCandidateKey(row)] ??
+            {}
+        ).length > 0
+    ).length;
   const selectedHarmonyBrigadeAddInputs = buildHarmonyBrigadeAddInputs(
     harmonyBrigadeCandidates,
     harmonyBrigadePartSelections
@@ -1077,7 +1084,7 @@ export default function RepertoireManager() {
     harmonyBrigadeSelectionDescription(
       harmonyBrigadeYear,
       selectedHarmonyBrigadeBrigade,
-      harmonyBrigadeCandidates.length,
+      harmonyBrigadeGroupedCandidates.length,
       harmonyBrigadeEvents
     );
   const canAddHarmonyBrigadeSongs = selectedHarmonyBrigadeAddInputs.length > 0;
@@ -1473,13 +1480,14 @@ export default function RepertoireManager() {
                       {visibleHarmonyBrigadeCandidates.map((row) => {
                         const isExactDuplicate =
                           row.duplicateStatus === "exact";
-                        const eventSongKey = harmonyBrigadeEventSongKey(row);
+                        const selectionKey =
+                          harmonyBrigadeGroupedCandidateKey(row);
                         const selectedParts =
-                          harmonyBrigadePartSelections[eventSongKey] ?? {};
+                          harmonyBrigadePartSelections[selectionKey] ?? {};
 
                         return (
                           <div
-                            key={eventSongKey}
+                            key={selectionKey}
                             className={`grid gap-3 p-3 ${
                               isExactDuplicate
                                 ? "bg-slate-900/80 text-slate-500"
@@ -1498,18 +1506,9 @@ export default function RepertoireManager() {
                                 {row.song.arranger
                                   ? `Arr. ${arrangerDisplayName(row.song.arranger)}`
                                   : "No arranger entered"}
-                                {row.song.asSungBy
-                                  ? ` - As sung by ${row.song.asSungBy}`
-                                  : ""}
-                                {row.song.startingWords
-                                  ? ` - Starts "${row.song.startingWords}"`
-                                  : ""}
                               </p>
                               <p className="mt-1 text-xs leading-5 text-slate-500">
-                                {row.event.eventLabel}
-                                {row.trackNumber
-                                  ? ` - Track ${row.trackNumber}`
-                                  : ""}
+                                {harmonyBrigadeAppearanceSummary(row)}
                               </p>
                             </div>
 
@@ -1524,7 +1523,7 @@ export default function RepertoireManager() {
                                       value={selectedParts[part] ?? ""}
                                       onChange={(event) =>
                                         updateHarmonyBrigadePartSelection(
-                                          eventSongKey,
+                                          selectionKey,
                                           part,
                                           event.target.value as Confidence | ""
                                         )
@@ -1565,8 +1564,8 @@ export default function RepertoireManager() {
                   <p className="text-sm text-slate-300">
                     {selectedHarmonyBrigadeEligibleCount}{" "}
                     {selectedHarmonyBrigadeEligibleCount === 1
-                      ? "listing has"
-                      : "listings have"}{" "}
+                      ? "song has"
+                      : "songs have"}{" "}
                     part choices. {selectedHarmonyBrigadeAddInputs.length}{" "}
                     unique{" "}
                     {selectedHarmonyBrigadeAddInputs.length === 1

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -186,16 +186,18 @@ The user-facing flow appears under **More ways to build My Songs** as
 - `All years` or a real `YearHeld` value
 - `All brigades` or a real brigade abbreviation/name from `XQ_Brigades`
 
-The picker lists event-song appearances from `ViewHistory`, so the same song
-can appear under multiple years or brigades. Songs default to `TTBB`. Before
-adding, the user chooses any TTBB parts they know for each song and a confidence
-value for each selected part. If multiple appearances of the same normalized
-title + arranger are selected, they are saved as one My Songs row with the
-combined part confidences. Adding Harmony Brigade songs writes only to the
-current user's `user_repertoire`; it does not expose the user's Brigade
-selection publicly. The picker fetches event-song rows for the selected
-year/brigade scope and paginates Supabase reads so complete event lists are not
-truncated by PostgREST response caps.
+The picker reads event-song appearances from `ViewHistory`, then groups visible
+cards by normalized title + `TTBB` + normalized arranger. If the same song
+appears in multiple brigades for the selected scope, users see one card with the
+event/track appearances listed on it. Songs default to `TTBB`. Before adding,
+the user chooses any TTBB parts they know for each song and a confidence value
+for each selected part. If multiple appearances of the same normalized title +
+arranger are selected, they are saved as one My Songs row with the combined part
+confidences. Adding Harmony Brigade songs writes only to the current user's
+`user_repertoire`; it does not expose the user's Brigade selection publicly. The
+picker fetches event-song rows for the selected year/brigade scope and paginates
+Supabase reads so complete event lists are not truncated by PostgREST response
+caps.
 
 Duplicate detection uses normalized title + `TTBB` + normalized arranger,
 preserving the distinction between a blank arranger and literal `Unknown`.

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -267,6 +267,9 @@ Expected context:
   only unique songs. If a user selects parts from multiple appearances of the
   same normalized song + arranger, the app writes one `user_repertoire` row with
   combined TTBB part confidences.
+- The picker groups visible cards by normalized title + `TTBB` + normalized
+  arranger while preserving an appearances list for year/brigade/track context.
+  Blank arranger and literal `Unknown` remain different identities.
 - The UI scopes event-song reads by the selected year/brigade event ids and
   paginates Supabase reads. It must not depend on one unbounded
   `harmony_brigade_event_songs` select and then filter a potentially capped

--- a/lib/__tests__/harmonyBrigade.test.ts
+++ b/lib/__tests__/harmonyBrigade.test.ts
@@ -6,9 +6,12 @@ import {
   filterHarmonyBrigadeSongs,
   getHarmonyBrigadeBrigadeOptions,
   getHarmonyBrigadeYearOptions,
+  groupHarmonyBrigadeCandidates,
   HARMONY_BRIGADE_ALL_BRIGADES,
   HARMONY_BRIGADE_ALL_YEARS,
+  harmonyBrigadeAppearanceSummary,
   harmonyBrigadeEventSongKey,
+  harmonyBrigadeGroupedCandidateKey,
   harmonyBrigadeSelectionDescription,
   resolveHarmonyBrigadeCandidates,
   type HarmonyBrigadeEvent,
@@ -69,6 +72,7 @@ const eventSong = (
 const atlantic2024 = event("event-1", 2024, "AHB", "Atlantic HB");
 const carolina2024 = event("event-2", 2024, "NCHB", "North Carolina HB");
 const atlantic2023 = event("event-3", 2023, "AHB", "Atlantic HB");
+const greatLakes2024 = event("event-4", 2024, "GLHB", "Great Lakes HB");
 
 describe("Harmony Brigade source helpers", () => {
   it("builds real year and brigade filter options from event rows", () => {
@@ -188,6 +192,79 @@ describe("Harmony Brigade source helpers", () => {
     expect(resolved.map((row) => row.duplicateStatus)).toEqual([
       "exact",
       "eligible",
+    ]);
+  });
+
+  it("groups shared all-brigades picker rows by title, voicing, and arranger", () => {
+    const candidates = resolveHarmonyBrigadeCandidates(
+      [
+        {
+          ...eventSong("1", "Fun and Fancy Free", "Dan Wessler", atlantic2024),
+          trackNumber: 4,
+          sortOrder: 4,
+        },
+        {
+          ...eventSong("1", "Fun and Fancy Free", "Dan Wessler", greatLakes2024),
+          trackNumber: 11,
+          sortOrder: 11,
+        },
+      ],
+      []
+    );
+
+    const grouped = groupHarmonyBrigadeCandidates(candidates);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].song.songTitle).toBe("Fun and Fancy Free");
+    expect(grouped[0].appearances).toHaveLength(2);
+    expect(harmonyBrigadeAppearanceSummary(grouped[0])).toBe(
+      "Appears in 2024: AHB track 4, GLHB track 11"
+    );
+  });
+
+  it("keeps blank arranger and literal Unknown arranger as separate picker groups", () => {
+    const candidates = resolveHarmonyBrigadeCandidates(
+      [
+        eventSong("1", "Mystery Song", null, atlantic2024),
+        eventSong("2", "Mystery Song", "Unknown", greatLakes2024),
+      ],
+      []
+    );
+
+    const grouped = groupHarmonyBrigadeCandidates(candidates);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped.map((group) => group.song.arranger)).toEqual([null, "Unknown"]);
+  });
+
+  it("adds one repertoire row when part choices are made on a grouped picker card", () => {
+    const candidates = resolveHarmonyBrigadeCandidates(
+      [
+        eventSong("1", "Fun and Fancy Free", "Dan Wessler", atlantic2024),
+        eventSong("1", "Fun and Fancy Free", "Dan Wessler", greatLakes2024),
+      ],
+      []
+    );
+    const [grouped] = groupHarmonyBrigadeCandidates(candidates);
+
+    expect(
+      buildHarmonyBrigadeAddInputs(candidates, {
+        [harmonyBrigadeGroupedCandidateKey(grouped)]: {
+          Lead: "Good to Go",
+        },
+      })
+    ).toEqual([
+      {
+        songTitle: "Fun and Fancy Free",
+        voicing: "TTBB",
+        arrangerName: "Dan Wessler",
+        partConfidences: [
+          {
+            part: "Lead",
+            confidence: "Good to Go",
+          },
+        ],
+      },
     ]);
   });
 

--- a/lib/__tests__/harmonyBrigadeUi.test.ts
+++ b/lib/__tests__/harmonyBrigadeUi.test.ts
@@ -38,6 +38,14 @@ describe("Harmony Brigade repertoire UI", () => {
     expect(repertoireManager).not.toContain("Apply your part and confidence");
   });
 
+  it("renders grouped Brigade picker cards with clean primary metadata", () => {
+    expect(repertoireManager).toContain("groupHarmonyBrigadeCandidates");
+    expect(repertoireManager).toContain("harmonyBrigadeAppearanceSummary");
+    expect(repertoireManager).toContain("harmonyBrigadeGroupedCandidateKey");
+    expect(repertoireManager).not.toContain("As sung by");
+    expect(repertoireManager).not.toContain("Starts &quot;");
+  });
+
   it("keeps Brigade songs out of normal typeahead suggestions", () => {
     expect(repertoireManager).toContain("searchRepertoireSongSuggestions");
     expect(repertoireManager).toContain("harmonyBrigadeSearchQuery");

--- a/lib/harmonyBrigade.ts
+++ b/lib/harmonyBrigade.ts
@@ -41,6 +41,13 @@ export type HarmonyBrigadeCandidate = HarmonyBrigadeEventSong & {
   duplicateStatus: "eligible" | "exact";
 };
 
+export type HarmonyBrigadeGroupedCandidate = {
+  key: string;
+  song: HarmonyBrigadeSong;
+  duplicateStatus: "eligible" | "exact";
+  appearances: HarmonyBrigadeEventSong[];
+};
+
 export type HarmonyBrigadeAddInput = {
   songTitle: string;
   voicing: typeof HARMONY_BRIGADE_DEFAULT_VOICING;
@@ -236,6 +243,65 @@ export function harmonyBrigadeEventSongKey(
   return `${row.event.id}:${row.song.id}`;
 }
 
+export function harmonyBrigadeSongIdentityKey(
+  row: Pick<HarmonyBrigadeEventSong, "song">
+) {
+  return exactSongKey({
+    songTitle: row.song.songTitle,
+    arrangerName: row.song.arranger,
+  });
+}
+
+export function harmonyBrigadeGroupedCandidateKey(
+  row: Pick<HarmonyBrigadeGroupedCandidate, "key">
+) {
+  return row.key;
+}
+
+function harmonyBrigadeTrackLabel(row: Pick<HarmonyBrigadeEventSong, "trackNumber">) {
+  return row.trackNumber ? ` track ${row.trackNumber}` : "";
+}
+
+export function harmonyBrigadeAppearanceSummary(
+  group: Pick<HarmonyBrigadeGroupedCandidate, "appearances">,
+  maxVisible = 4
+) {
+  const appearances = [...group.appearances].sort((a, b) => {
+    return (
+      b.event.yearHeld - a.event.yearHeld ||
+      a.event.brigadeAbbr.localeCompare(b.event.brigadeAbbr) ||
+      (a.sortOrder ?? 9999) - (b.sortOrder ?? 9999) ||
+      (a.trackNumber ?? 9999) - (b.trackNumber ?? 9999)
+    );
+  });
+
+  if (appearances.length === 0) return "";
+
+  if (appearances.length === 1) {
+    const [appearance] = appearances;
+    return `${appearance.event.eventLabel}${harmonyBrigadeTrackLabel(appearance)}`;
+  }
+
+  const years = new Set(appearances.map((appearance) => appearance.event.yearHeld));
+  const prefix = years.size === 1
+    ? `Appears in ${appearances[0].event.yearHeld}: `
+    : "Appears in: ";
+  const visible = appearances.slice(0, maxVisible);
+  const hiddenCount = appearances.length - visible.length;
+  const labels = visible.map((appearance) => {
+    const yearPrefix = years.size === 1 ? "" : `${appearance.event.yearHeld} `;
+    return `${yearPrefix}${appearance.event.brigadeAbbr}${harmonyBrigadeTrackLabel(
+      appearance
+    )}`;
+  });
+
+  if (hiddenCount > 0) {
+    labels.push(`+${hiddenCount} more`);
+  }
+
+  return `${prefix}${labels.join(", ")}`;
+}
+
 export function harmonyBrigadeSelectionDescription(
   selectedYear: string | number,
   selectedBrigade: string,
@@ -296,6 +362,43 @@ export function resolveHarmonyBrigadeCandidates(
   }));
 }
 
+export function groupHarmonyBrigadeCandidates(
+  candidates: HarmonyBrigadeCandidate[]
+): HarmonyBrigadeGroupedCandidate[] {
+  const groups = new Map<string, HarmonyBrigadeGroupedCandidate>();
+
+  for (const candidate of candidates) {
+    const key = harmonyBrigadeSongIdentityKey(candidate);
+    const existing = groups.get(key);
+
+    if (existing) {
+      existing.appearances.push(candidate);
+      if (candidate.duplicateStatus === "exact") {
+        existing.duplicateStatus = "exact";
+      }
+      continue;
+    }
+
+    groups.set(key, {
+      key,
+      song: candidate.song,
+      duplicateStatus: candidate.duplicateStatus,
+      appearances: [candidate],
+    });
+  }
+
+  return Array.from(groups.values()).sort((a, b) => {
+    return (
+      a.song.songTitle.localeCompare(b.song.songTitle, undefined, {
+        sensitivity: "base",
+      }) ||
+      (a.song.arranger ?? "").localeCompare(b.song.arranger ?? "", undefined, {
+        sensitivity: "base",
+      })
+    );
+  });
+}
+
 export function searchHarmonyBrigadeCandidates(
   candidates: HarmonyBrigadeCandidate[],
   query: string
@@ -312,6 +415,29 @@ export function searchHarmonyBrigadeCandidates(
       row.song.startingWords,
       row.event.brigadeAbbr,
       row.event.brigadeName,
+    ].some((value) => normalizeSongText(value).includes(normalizedQuery));
+  });
+}
+
+export function searchHarmonyBrigadeGroupedCandidates(
+  candidates: HarmonyBrigadeGroupedCandidate[],
+  query: string
+) {
+  const normalizedQuery = normalizeSongText(query);
+  if (!normalizedQuery) return candidates;
+
+  return candidates.filter((group) => {
+    return [
+      group.song.songTitle,
+      group.song.arranger,
+      group.song.asSungBy,
+      group.song.learningTrackProvider,
+      group.song.startingWords,
+      ...group.appearances.flatMap((appearance) => [
+        appearance.event.brigadeAbbr,
+        appearance.event.brigadeName,
+        appearance.event.eventLabel,
+      ]),
     ].some((value) => normalizeSongText(value).includes(normalizedQuery));
   });
 }
@@ -350,12 +476,19 @@ export function buildHarmonyBrigadeAddInputs(
   for (const row of candidates
     .filter(
       (row) =>
-        Object.keys(selections[harmonyBrigadeEventSongKey(row)] ?? {}).length >
+        Object.keys(
+          selections[harmonyBrigadeEventSongKey(row)] ??
+            selections[harmonyBrigadeSongIdentityKey(row)] ??
+            {}
+        ).length >
           0 &&
         row.duplicateStatus === "eligible"
     )
   ) {
-    const rowSelections = selections[harmonyBrigadeEventSongKey(row)] ?? {};
+    const rowSelections =
+      selections[harmonyBrigadeEventSongKey(row)] ??
+      selections[harmonyBrigadeSongIdentityKey(row)] ??
+      {};
     const partConfidences = Object.entries(rowSelections)
       .filter((entry): entry is [Part, Confidence] => Boolean(entry[1]))
       .map(([part, confidence]) => ({ part, confidence }));


### PR DESCRIPTION
## Summary
- Group Harmony Brigade picker cards by normalized title + TTBB + normalized arranger, while preserving year/brigade/track appearances on the card.
- Key grouped picker part/confidence choices by song identity so selecting a grouped card still creates one My Songs row.
- Simplify the primary card metadata to title, TTBB, and arranger; event appearances now live on their own secondary line.

## Docs and tests
- Added tests for cross-brigade grouping, grouped-card add behavior, and blank arranger vs literal Unknown staying separate.
- Updated UI guardrail coverage for grouped cards and clean metadata.
- Updated `docs/imports.md` and `docs/supabase-contract.md` to document the grouped visible-card model.

## Verification
- npm run test:run
- npm run build

## Supabase / manual steps
- No migration required. This only changes how existing Harmony Brigade reference rows are grouped for display.
- No dashboard changes required.

Closes #327