### PR TITLE
Import International Songs into suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,12 @@ SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
 Use `npm run song-suggestions:import -- --dry-run` to parse and deduplicate the
 catalog file without writing to Supabase.
 
-To refresh the BHS Published Music source data and merge it into
-`data/song_suggestion_catalog.psv`, follow
-[docs/imports.md](docs/imports.md). The BHS transform is conservative: it uses
-Product Description as a voicing signal when needed, skips ambiguous rows, and
-splits clearly multi-voicing rows into separate catalog rows.
+To refresh the BHS Published Music or International Songs source data and merge
+it into `data/song_suggestion_catalog.psv`, follow
+[docs/imports.md](docs/imports.md). The catalog transforms are conservative:
+they import title, supported voicing, and arranger metadata only, skip ambiguous
+rows, preserve blank arranger versus literal `Unknown`, and split clearly
+multi-voicing rows into separate catalog rows.
 
 To refresh Harmony Brigade data, export read-only upstream snapshots and then
 import them into the Supabase reference tables after migrations are applied:

--- a/data/international_songs_with_arranger.csv
+++ b/data/international_songs_with_arranger.csv
@@ -1,0 +1,746 @@
+Title,Arranger,Voicing
+(I'm Afraid) The Masquerade Is Over,Ed Waesche,TTBB
+(Let's Start) Tomorrow Tonight (from Smash),Kevin Keller,TTBB
+(Let's Start) Tomorrow Tonight (from Smash),Larry Triplett,TTBB
+(Let's Start) Tomorrow Tonight (from Smash),Theo Hicks,TTBB
+(Now And Then There's) A Fool Such As I,Aaron Dale,TTBB
+(They Long To Be) Close To You,Jeremey Johnson,TTBB
+(Up A) Lazy River,Clay Hine,TTBB
+50 Shades Of Brown,Greg Mallett,TTBB
+A Change Is Gonna Come,Patrick McAlexander,TTBB
+A Cottage for Sale,Theo Hicks,TTBB
+A Foggy Day In London Town,Bryan Ziegler,TTBB
+A House Is Not A Home,Steve Tramack,TTBB
+A Little Patch Of Heaven,Aaron Dale,TTBB
+A Little Street Where Old Friends Meet,Aaron Dale,TTBB
+A Million Dreams (from The Greatest Showman),Kevin Keller,TTBB
+A Newfangled Tango,Patrick McAlexander,TTBB
+A Nightingale Sang In Berkeley Square,Kirk Young,TTBB
+A Nightingale Sang in Berkeley Square,Larry Wright,TTBB
+A Rainy Night In Rio,Kevin Keller,TTBB
+A Son Of The Sea,Ed Waesche,TTBB
+A Song Like Daddy Used To Play,Brian Beck,TTBB
+A Spoonful Of Sugar (from Mary Poppins),David Zimmerman,TTBB
+A Sunday Kind Of Love,Adam Reimnitz,TTBB
+A Thousand Things,Melody Hine,TTBB
+A Whole New World,Kevin Keller,TTBB
+A Wink And A Smile (from Sleepless In Seattle),Robert Rund,TTBB
+Ac-Cent-Tchu-Ate The Positive,Jeremey Johnson,TTBB
+Accidents Will Happen,Jay Giallombardo,TTBB
+After You've Gone,Don Gray,TTBB
+Ain't Misbehavin',Greg Volk,TTBB
+Ain't No Mountain High Enough,Patrick McAlexander,TTBB
+Ain't That A Kick In The Head?,Rich Hasty,TTBB
+Ain't That A Kick In The Head?/Don't Let It Go To Your Head,Mike Menefee/Jeremiah Pope,TTBB
+Ain't We Got Fun?,Anthony Bartholomew,TTBB
+Alabamy Bound,David Wright,TTBB
+All Aboard For Dixie Land,David Wright,TTBB
+All About Love,Kohl Kitzmiller,TTBB
+All I Do Is Dream Of You,Aaron Dale,TTBB
+All My Exes Live In Texas,Aaron Dale,TTBB
+All My Loving,Rasmus Krigström,TTBB
+All Star,Patrick McAlexander,TTBB
+All The Time,Steve Tramack,TTBB
+All The Way (from The Joker Is Wild),Joel Guyer,TTBB
+All The Way (from The Joker Is Wild),Tom Gentry,TTBB
+Almost There (from The Princess and the Frog),Aaron Dale,TTBB
+Almost There (from The Princess and the Frog),Jason Dyer,TTBB
+Almost There (from The Princess and the Frog),Joel Guyer,TTBB
+Almost There (from The Princess and the Frog),Simon Arnott,TTBB
+Always,Mark Hale/Don Gray,TTBB
+Always,Rob Hopkins,TTBB
+American Tune,Steve Tramack,TTBB
+And This Is My Beloved,David Wright,TTBB
+Any Time,Greg Volk,TTBB
+Anything Goes,Don Gray,TTBB
+Anytime At All,Greg Volk,TTBB
+Anytime At All,Wayne Grimmer,TTBB
+Are You Lonesome Tonight?,Tom Gentry,TTBB
+As Long As I'm Singin',Mike Menefee,TTBB
+As Long As I'm Singing,Mike Menefee,TTBB
+As Long As You're Mine (from Wicked),Theo Hicks,TTBB
+As Time Goes By,Walter Latzko,TTBB
+At A Georgia Camp Meeting,Clay Hine,TTBB
+At Last (from Sun Valley Serenade),Clay Hine,TTBB
+At Long Last Love (from You Never Know),Andrew Carolan,TTBB
+At This Moment,Patrick McAlexander,TTBB
+Audition (from La La Land),Matt Astle,TTBB
+B & O Line,Bob Disney,TTBB
+Baby Mine,Clay Hine,TTBB
+"Baby, It's You",Adam Reimnitz,TTBB
+Back In Business (from Dick Tracy),David Wright,TTBB
+Bananaphone,Kohl Kitzmiller,TTBB
+Barbershop In History Medley,Brent Graham,TTBB
+Bare Necessities,Clay Hine,TTBB
+Bare Necessities,Tom Gentry,TTBB
+Basin Street Blues,David Wright,TTBB
+Be My Life's Companion,Kohl KItzmiller,TTBB
+Be Our Guest,Greg Volk,TTBB
+Be The Hero,Steve Tramack,TTBB
+Before The Parade Passes By,Aaron Dale,TTBB
+Bei Mir Bist Du Schon,Wayne Grimmer,TTBB
+Best Of Me,Rasmus Krigström,TTBB
+Between The Devil And The Deep Blue Sea,David Wright,TTBB
+Between You And The Birds And The Bees And Cupid,Aaron Dale,TTBB
+Bill Grogan's Goat,Clay Hine,TTBB
+Birth Of The Blues,David Wright,TTBB
+Black Eyed Susan Brown,Mel Knight,TTBB
+Blame It On My Youth,Ed Waesche,TTBB
+Blame It On The Boogie,Kohl Kitzmiller,TTBB
+"Blow, Gabriel, Blow",Rasmus Krigström,TTBB
+Blue Ain't Your Color,David Harrington,TTBB
+Blue Moon Of Kentucky,Aaron Dale,TTBB
+Blues In The Night,Dan Wessler,TTBB
+Blues In The Night,Dave Briner,TTBB
+Boogie Down Medley,Aaron Dale,TTBB
+Booglie Wooglie Piggy,Cay Outerbridge,TTBB
+Break It To Me Gently,Robert Rund,TTBB
+Breaking Up Is Hard To Do,David Wright,TTBB
+Bright Was The Night,David Wright,TTBB
+Bring Me Sunshine,David Harrington,TTBB
+Bring Me Sunshine,Matt Astle,TTBB
+"Brother, Can You Spare A Dime?",Steve Armstrong,TTBB
+Brothers Love Song,Steve Delehanty,TTBB
+Build Me Up Buttercup,Rob Hopkins,TTBB
+Burnin' The Roadhouse Down,Aaron Dale,TTBB
+Butter Outta Cream,Dan Wessler,TTBB
+Bye Bye Blues,"SPEBSQSA, Inc.",TTBB
+Calendar Girl,Tom Gentry,TTBB
+California Here I Come,David Wright,TTBB
+Carolina Medley,Jay Giallombardo,TTBB
+Carrying The Banner (from Newsies),Adam Bock,TTBB
+Change Is Gonna Come,Patrick McAlexander,TTBB
+Chaplin Medley,David Wright,TTBB
+Charlie On The MTA,Joey Constantine,TTBB
+Chattanoogie Shoe Shine Boy,Jeremey Johnson,TTBB
+"Cheer Up, Charlie",Jim Henry,TTBB
+Childhood (from Free Willy 2),Kevin Keller,TTBB
+Come Dance With Me,Patrick McAlexander,TTBB
+Come Fly With Me,Kevin Keller,TTBB
+Come Follow The Band,Steve Tramack,TTBB
+Come Rain Or Come Shine,Adam Reimnitz,TTBB
+Come Rain Or Come Shine,Clay Hine,TTBB
+Come What May (from Moulin Rouge!),Kevin Keller,TTBB
+Coney Island Washboard Roundelay,Clay Hine,TTBB
+Corner Of The Sky (from Pippin),Patrick McAlexander,TTBB
+Could 'Ja?,Wayne Grimmer,TTBB
+Cry Me A River,Brent Graham,TTBB
+Crying My Heart Out For You,Kevin Keller,TTBB
+Daisy/Summer Time (Medley),Jay Giallombardo,TTBB
+Dance With My Father,Theo Hicks,TTBB
+Danny Boy,Ed Waesche,TTBB
+Danny Boy,Jim Clancy,TTBB
+Day By Day (from Day By Day),John Brockman,TTBB
+"Day In, Day Out",Rasmus Krigström,TTBB
+Death Of A Bachelor,David Harrington,TTBB
+'Deed I Do,Aaron Dale,TTBB
+Desperado,Tom Gentry,TTBB
+Destination Moon,Mike Louque and Sam Dabrusin,TTBB
+Destination Moon,Sam Dobrusin/Richmond/Wong,TTBB
+Devil May Care,Rasmus Krigström,TTBB
+Dinah,David Wright,TTBB
+Do I Love You?,Brent Graham,TTBB
+Do You Know The Muffin Man?,Adam Scott,TTBB
+"Don't Be A Baby, Baby",Aaron Dale,TTBB
+Don't Know Why,Alex Morris,TTBB
+Don't Like Goodbyes (from House Of Flowers),Matt Parks,TTBB
+Don't Rain On My Parade,David Wright,TTBB
+Don't Rain On My Parade,Patrick McAlexander,TTBB
+Don't You Worry 'Bout A Thing,Jackson Pinder,TTBB
+Dreams Of Gold/Down To The Sea,Rasmus Krigström,TTBB
+Drivin' Me Crazy,Bob Disney,TTBB
+Drown In My Own Tears,Mark Hale,TTBB
+Eight Days A Week,David Harrington,TTBB
+Embraceable You,Ed Waesche,TTBB
+Enjoy The Ride,Kirk Young,TTBB
+Epic Knight Medley,Various,TTBB
+Evermore (from Beauty And The Beast),Kevin Keller,TTBB
+Evermore (from Beauty And The Beast),Rasmus Krigström,TTBB
+Evermore (from Beauty And The Beast),Theo Hicks,TTBB
+Every Breath You Take,Aaron Dale,TTBB
+Every Time We Say Goodbye,Rob Hopkins,TTBB
+Everybody Loves Somebody,Kevin Keller,TTBB
+Everybody Wants To Be A Cat (from The Aristocats),Jason Dyer,TTBB
+Everything's Coming Up Roses,David Wright,TTBB
+Evolution Of Dance Medley,Clay Hine,TTBB
+F Sharp,Wayne Grimmer,TTBB
+Fascinating Rhythm,Jay Giallombardo,TTBB
+Feelin' Good,John Brockman,TTBB
+Fire Away,Jackson Pinder,TTBB
+Fit As A Fiddle,David Wright,TTBB
+"Five Foot Two, Eyes Of Blue",Clay Hine,TTBB
+"Five Foot Two, Eyes Of Blue",Joe Liles,TTBB
+Five Minutes More,Patrick McAlexander,TTBB
+Fly Me To The Moon,Kohl Kitzmiller,TTBB
+For All We Know,Rob Hopkins,TTBB
+For Good (from Wicked),Steve Tramack,TTBB
+For Once In My Life,Adam Reimnitz,TTBB
+Forgive Me,Earl Moon,TTBB
+Fortune In Dreams,Clay Hine,TTBB
+Frankie and Johnny,"Warren ""Buzz"" Haeger",TTBB
+French Revolution Medley,Al Baker,TTBB
+Frim Fram Sauce,Aaron Dale,TTBB
+From Now On/Come Alive (from The Greatest Showman),Aaron Dale,TTBB
+From The First Hello (To The Last Goodbye),Lou Perry,TTBB
+Funk Medley – Uptown Funk,Aaron Dale,TTBB
+Funny (But I Still Love You),Michael Webber,TTBB
+Gaston (from Beauty And The Beast)(Parody),Anthony Bartholomew,TTBB
+"Gee, I'm Glad It's Rainin'",Jeremey Johnson,TTBB
+Gentle Annie,Adam Reimnitz,TTBB
+Georgia May,Aaron Dale,TTBB
+Georgia On My Mind,David Harrington,TTBB
+Get Me To The Church On Time,Gary Lewis,TTBB
+Get Your Happy Days On Medley,Aaron Dale,TTBB
+Give Me A Barbershop Song,Steve Hall,TTBB
+Gold Can Turn To Sand,Patrick McAlexander,TTBB
+Gone Too Soon,Theo Hicks,TTBB
+Gonna Build A Mountain,Jay Giallombardo,TTBB
+Good Enough For Now,Rob Hopkins,TTBB
+Good Times Medley,Patrick McAlexander,TTBB
+Goodbye Yellowbrick Road,Simon Arnott,TTBB
+"Goodbye, My Coney Island Baby/We All Fall (Medley)",SPEBSQSA,TTBB
+"Goodbye, My Lady Love",Kevin Keller,TTBB
+Grow Old With Me,Andrew Carolan,TTBB
+Guilty,Scott Kitzmiller,TTBB
+"Hallelujah, I Love Her So",Aaron Dale,TTBB
+"Hallelujah, I Love Her So",Jay Giallombardo,TTBB
+"Hallelujah, I Love Her So",Kohl KItzmiller,TTBB
+Hand In Hand,Matt Astle,TTBB
+Happy Go Lucky Lane,Jay Giallombardo/Greg Volk,TTBB
+Happy/Sad,Adam Reimnitz,TTBB
+Hard Hearted Hannah,Clay Hine,TTBB
+Hard Times (No One Knows Better Than I),Theo Hicks,TTBB
+"Hard Times, Come Again No More",David Wright,TTBB
+Hard To Say I'm Sorry (from Summer Lovers),David Mastrull,TTBB
+Have You Met Miss Jones?,Rasmus Krigström,TTBB
+Haven't Met You Yet,Steve Tramack,TTBB
+"He Ain't Heavy, He's My Brother",Jay Giallombardo,TTBB
+Heartache Tonight,Rasmus Krigström,TTBB
+Heaven Medley (Cheek To Cheek/My Blue Heaven),John Brockman,TTBB
+Hello Mary Lou,David Wright,TTBB
+Hello My Baby,David Harrington,TTBB
+Hello My Baby,Kevin Keller,TTBB
+Hero,Kyle Kitzmiller,TTBB
+Hey Good Lookin',Tom Gentry,TTBB
+Hit Me With A Hot Note,Patrick McAlexander,TTBB
+Home (from Beauty And The Beast),Cay Outerbridge,TTBB
+Honey Medley,David Harrington,TTBB
+Honeysuckle Rose,David Wright,TTBB
+Hooray For Love,Alan Gordon,TTBB
+How About You?,Patrick McAlexander,TTBB
+How Could I Ever Know? (from The Secret Garden),Matt Gallagher,TTBB
+How Could I Ever Know? (from The Secret Garden),Theo Hicks,TTBB
+How Could You Believe Me ?/It's A Sin To Tell A Lie (Medley),Renee Craig,TTBB
+How Deep Is The Ocean (How High Is The Sky) (Parody),Ed Waesche,TTBB
+How Deep is Your Love?,Aaron Dale,TTBB
+How Far I'll Go (from Moana)(Parody),Ira Allen (tag)/Matt Astle,TTBB
+How It Ends (from Big Fish),Kevin Keller,TTBB
+How Lucky You Are (from Seussical),Dan Wessler,TTBB
+I Can See Clearly Now,Steve Armstrong,TTBB
+I Can't Give You Anything But Love,Clay Hine,TTBB
+I Can't Give You Anything But Love,David Harrington,TTBB
+I Could Have Danced All Night,Brent Graham,TTBB
+I Don't Know Enough About You,Chris Arnold,TTBB
+I Don't Know How To Say Goodbye,Theo Hicks,TTBB
+I Don't Remember Her Name,Paul Olguin,TTBB
+I Don't Want To Miss A Thing (from Armageddon),Dan Wessler,TTBB
+I Finally Found Someone,Steve Tramack,TTBB
+I Found A Million Dollar Baby,Rob Hopkins,TTBB
+I Get A Kick Out Of You,Adam Bock,TTBB
+I Get Along Without You Very Well (Except Sometimes),Adam Reimnitz,TTBB
+I Got Lucky,Aaron Dale,TTBB
+I Got Rhythm,David Wright,TTBB
+I Have Dreamed,David Wright,TTBB
+I Have Nothing (from The Bodyguard),Theo Hicks,TTBB
+I Know Where I've Been,Theo Hicks,TTBB
+I Love Being Here With You,Aaron Dale,TTBB
+I Love That We're Old Fashioned,Kevin Keller,TTBB
+I Love To Singa,Patrick McAlexander,TTBB
+I Miss Mother Most Of All,Joe Liles,TTBB
+I See The Light,Kevin Keller,TTBB
+I Thought She Knew,Theo Hicks,TTBB
+I Told Them All About You/You Dear (Medley),The Four Harmonizers,TTBB
+I Used To Be Color Blind,Adam Reimnitz,TTBB
+"I Want You, I Need You, I Love You",Aaron Dale,TTBB
+I Was Doing Alright,Joel Guyer,TTBB
+I Won't Dance,Liz Garnett,TTBB
+I Won't Send Roses (from Mack And Mabel),Theo Hicks,TTBB
+I Write The Songs,Steve Tramack,TTBB
+I’ll Drown In My Own Tears,Mark Hale,TTBB
+I’ve Got A Dream,Darin Drown,TTBB
+If Ever I Would Leave You,Clay Hine,TTBB
+If I Can Dream,Aaron Dale,TTBB
+If I Can Dream,Steve Armstrong,TTBB
+If I Didn't Care,Brent Graham,TTBB
+If I Ever Say I'm Over You (from It's Only Life),Brent Graham,TTBB
+If I Give My Heart To You,Jim Clancy,TTBB
+If I Had My Way,David Harrington,TTBB
+If I Knew,Jackson Pinder,TTBB
+If I Love Again,Katie Farrell,TTBB
+If I Love Again,Rob Hopkins,TTBB
+If I Loved You (from Carousel),Jay Giallombardo,TTBB
+If I Loved You (from Carousel),Rasmus Krigström,TTBB
+If I May,Patrick McAlexander,TTBB
+If I Only Had A Brain,Clay Hine,TTBB
+If I Ruled The World,Ed Waesche,TTBB
+If I Ruled The World,Jim Clancy,TTBB
+If I Were A Bell (from Guys And Dolls),Aaron Dale,TTBB
+If My Friends Could See Me Now Medley,Patrick McAlexander,TTBB
+If My Nose Was Running Money (I'd Blow It All On You),Steve Delehanty,TTBB
+If The Devil Danced (In Empty Pockets),Michael Webber,TTBB
+If You Go Away (Ne Me Quitte Pas),David Wright,TTBB
+"If You Love Me, Really Love Me",David Wright,TTBB
+I'll Be Here (from The Wild Party),Justin Miller,TTBB
+I'll Be Seeing You,Rob Hopkins,TTBB
+I'll Be Seeing You,Rob Hopkins/Eric Jackson,TTBB
+I'll Be With You In Apple Blossom Time,Clay Hine,TTBB
+I'll Make Love To You,Wayne Grimmer,TTBB
+I'll Take You Dreaming,Clay Hine,TTBB
+I'm Havin' A Ball (from Dirty Grandpa),Cay Outerbridge,TTBB
+I'm Into Something Good,John Fortino,TTBB
+I'm Just A Lucky So And So,Joel Guyer,TTBB
+I'm Looking Over A Four Leaf Clover,Ed Waesche,TTBB
+I'm Putting All My Eggs In One Basket,Aaron Dale,TTBB
+I'm Putting All My Eggs In One Basket,Patrick McAlexander,TTBB
+Imagine That,Mike Tipton,TTBB
+In A Little Red Barn (On A Farm Down In Indiana),Joel Guyer,TTBB
+In His Eyes,Greg Volk,TTBB
+In My Daughter's Eyes,Clay Hine,TTBB
+"In The Cool, Cool, Cool Of The Evening",Kohl KItzmiller,TTBB
+In The Wee Small Hours Of The Morning,Jimbob Kahlke,TTBB
+Into The Fire,Steve Tramack,TTBB
+Is This Just Another Song?,Bob Disney,TTBB
+Is You Is Or Is You Ain't (Ma Baby)?,Greg Volk,TTBB
+It Feels Good When You Sing a Song,Jackson Pinder,TTBB
+It Happened In Monterey,John Brockman,TTBB
+"It Only Takes A Moment (from Hello, Dolly!)",David Wright,TTBB
+It Only Took a Kiss,Adam Bock,TTBB
+It Sucks To Be Me (from Avenue Q)(Parody),Kohl Kitzmiller,TTBB
+It’s Party Time,Jackson Pinder,TTBB
+It's A Lovely Day Today (from Call Me Madam),Kohl Kitzmiller,TTBB
+It's A Most Unusual Day,Joel Guyer,TTBB
+It's A Pity To Say Goodnight,Rasmus Krigström,TTBB
+It's A Wonderful World,Joel Guyer,TTBB
+It's All Right With Me,Aaron Dale,TTBB
+It's Hairspray,Rasmus Krigström,TTBB
+It's No Secret Any More,Adam Scott,TTBB
+It's Not Where You Start (It's Where You Finish),Theo Hicks,TTBB
+It's Only A Paper Moon,Clay Hine,TTBB
+It's Today (from Mame),Bryan Ziegler,TTBB
+It's You (from The Music Man),Robert Rund,TTBB
+It's You I Like,Cay Outerbridge,TTBB
+I've Been Workin' On The Railroad,Roger Payne,TTBB
+I've Got No Strings,Jackson Pinder,TTBB
+I've Got No Strings,Jeremey Johnson,TTBB
+I've Got The World On A String,Kohl Kitzmiller,TTBB
+I've Got You Under My Skin,Wayne Grimmer,TTBB
+Jackson 5 Medley,Aaron Dale,TTBB
+Java Jive,Ed Waesche,TTBB
+Jeanie With The Light Brown Hair,Ed Waesche,TTBB
+Jeepers Creepers/I'm In Love Again,Erik Eliason,TTBB
+Just the Way You Are,Chip Davis/David Harrington,TTBB
+King Of New York (from Newsies),Josh Ehrlich/Larry Bomback,TTBB
+Kissing A Fool,Kyle Kitzmiller,TTBB
+Knighthood Medley,Roger Payne/Steve Tramack,TTBB
+Last Night On The Back Porch,The Gaynotes,TTBB
+Lately,Ben McDaniel,TTBB
+Lately,Matt Gallagher,TTBB
+Lazy River,Clay Hine,TTBB
+Lazybones,David Wright,TTBB
+Learnin' The Blues,Patrick McAlexander,TTBB
+Let It Go (from Frozen) (Parody),Mac Huff,TTBB
+Let's Burn Up The Town,Adam Reimnitz,TTBB
+Let's Call The Whole Thing Off Medley,Clay Hine,TTBB
+Let's Do It (Let's Fall In Love),Chris Arnold,TTBB
+Let's Do It (Let's Fall In Love),John Brockman,TTBB
+Let's Face The Music And Dance (from Follow The Fleet),Wayne Grimmer,TTBB
+Let's Just Stay In,Kevin Keller,TTBB
+Let's Live It Up,Aaron Dale,TTBB
+Let's Start Tomorrow Tonight,Theo Hicks,TTBB
+Liar Medley,Renee Craig,TTBB
+Life's A Happy Song,Aaron Dale,TTBB
+Like I'm Gonna Lose You,Matt Astle,TTBB
+Listen (from Dreamgirls),Theo Hicks,TTBB
+Little Girl,Mac Huff,TTBB
+Little Pal,Clay Hine,TTBB
+Little Pal (Parody),Clay Hine,TTBB
+Lose That Long Face,Kevin Keller,TTBB
+Losing My Mind (from Follies),Theo Hicks,TTBB
+Lost In The Stars,Tom Gentry,TTBB
+L-O-V-E,Ben Ferguson,TTBB
+Love Is A Many-Splendored Thing,Jay Giallombardo,TTBB
+Love Letters,John Piercy,TTBB
+Love Me Tender,Johan Wikström,TTBB
+"Love Me, And The World Is Mine",David Wright,TTBB
+"Love Medley (I Have A Love/One Hand, One Heart)",Kirk Young,TTBB
+Love Story,Theo Hicks,TTBB
+Love Walked In,David Wright,TTBB
+Love You Madly,Patrick McAlexander,TTBB
+Lovin' Life,Adam Bock,TTBB
+Luckiest,Rob Hopkins,TTBB
+Lullaby Of Birdland,Steve Tramack,TTBB
+"Ma, She's Making Eyes At Me",Mo Rector,TTBB
+Mad Scientist Idol,Steve Armstrong,TTBB
+Make 'Em Laugh,Clay Hine,TTBB
+Make Them Hear You (from Ragtime),Theo Hicks,TTBB
+Make You Feel My Love,Aaron Dale,TTBB
+Mama Says,Bryan Ziegler,TTBB
+Mango Tree,Eric Ruthenberg,TTBB
+Many Tears Ago,Michael Webber,TTBB
+Marching Along With Time,David Wright,TTBB
+Margie,Clay Hine,TTBB
+May I Never Love Again,Renee Craig,TTBB
+Mean To Me,David Wright,TTBB
+Meet Me In Rosetime Rosie,Ed Waesche,TTBB
+Memories Of A Song In My Heart,Bob Disney,TTBB
+Midnight Rose,Ed Waesche,TTBB
+Mistakes,Roy Keys,TTBB
+Mistakes (Parody),Roy Keys,TTBB
+"Mister, You've Gone And Got The Blues",Tony Nasto,TTBB
+Mobile,David Wright,TTBB
+Mona Lisa,Greg Volk,TTBB
+Moonlight Becomes You,Scott Kitzmiller,TTBB
+More Than You Know (from Great Day),Jason Dyer,TTBB
+Mr. Success,John Brockman,TTBB
+Mr. Tanner,Kevin Keller,TTBB
+My Blushin' Rosie,Aaron Dale,TTBB
+My Dear Old Irish Mammy,Doug Anderson/Larry Wright,TTBB
+My Foolish Heart/I Fall In Love Too Easily,Adam Reimnitz,TTBB
+My Heart Stood Still,Greg Volk,TTBB
+My Honey's Lovin' Arms,Don Gray,TTBB
+My Ideal,Mark Hale,TTBB
+My Lady Loves To Dance,Bob Dowma,TTBB
+My Melancholy Blues,Aaron Dale,TTBB
+My Melancholy Blues,Luke Stevenson,TTBB
+My One And Only Love,Clay Hine,TTBB
+My Romance,Rich Hasty,TTBB
+My Romance,Rob Campbell,TTBB
+My Shiny Teeth And Me,Ben Lewin,TTBB
+My Way,Clay Hine,TTBB
+Naughty Angeline,Clay Hine,TTBB
+Never Again,Steve Delehanty,TTBB
+Never Give All The Heart (from Smash),Brent Graham,TTBB
+Never Gonna Give You Up,Patrick McAlexander,TTBB
+Never Never Land (from Peter Pan),Jay Giallombardo,TTBB
+Never Never Land (from Peter Pan),Steve Tramack,TTBB
+New Year Medley,Bryan Ziegler,TTBB
+New York State Of Mind,Wayne Grimmer,TTBB
+Next Time I Love,Larry Wright,TTBB
+Nine People's Favorite Thing (Parody),Kohl Kitzmiller,TTBB
+No Moon At All,Jason Dyer,TTBB
+No Other Love,David Wright,TTBB
+"No, No, Nora",Clay Hine,TTBB
+Noah Animals Medley,Patrick McAlexander,TTBB
+Noah Flood Medley,Patrick McAlexander,TTBB
+Nobody But Me,Adam Bock,TTBB
+Not While I'm Around (from Sweeney Todd),Steve Tramack,TTBB
+Not While I'm Around (from Sweeney Todd),Theo Hicks,TTBB
+Nothing Can Change This Love,Aaron Dale,TTBB
+Nothing Can Change This love,Theo Hicks,TTBB
+Nothing Can Change This Love,Wayne Grimmer,TTBB
+O'Brien To Ryan To Goldberg,Steve Tramack,TTBB
+Oh Lonesome Me,David Wright,TTBB
+"Oh Suzanna, Dust Off That Old Pianna",Brian Mastrull,TTBB
+Oh! Darling,David Harrington,TTBB
+Oh! Look At Me Now,Aaron Dale,TTBB
+"Oh, Lonesome Me",David Wright,TTBB
+Old Devil Moon (from Finian's Rainbow),Aaron Dale,TTBB
+Old Me Better,Clay Hine,TTBB
+Old Piano Roll Blues,David Wright,TTBB
+On A Wonderful Day Like Today,Aaron Dale,TTBB
+On The Sunny Side Of The Street,Clay Hine,TTBB
+Once Upon A Dream,Steve Tramack,TTBB
+Once Upon A Time (from All American),Rob Campbell,TTBB
+One Of These Things Is Not Like The Others,Wayne Grimmer,TTBB
+Open Arms,Bryan Ziegler,TTBB
+Out There (from The Hunchback Of Notre Dame),Steve Tramack,TTBB
+Over The Rainbow,Ed Waesche,TTBB
+Over The Rainbow,Jay Giallombardo,TTBB
+P.S. I Love You,Adam Reimnitz,TTBB
+Paralyzed,Brian Mastrull,TTBB
+Pass Me The Jazz,Jeremey Johnson,TTBB
+PD Medley,Clay Hine,TTBB
+Perfect,Matt Astle,TTBB
+Pirates Of The Barbary Coast,Roger Payne,TTBB
+Please Send Me Someone To Love,Jackson Pinder,TTBB
+Pop Songs Medley II,Clay Hine,TTBB
+Pop Songs Medley III,Clay Hine,TTBB
+Prince Ali (from Aladdin),Steve Tramack,TTBB
+Proud Mary,Kohl Kitzmiller,TTBB
+Proud Of Your Boy,David Wright,TTBB
+Proud Of Your Boy,Patrick McAlexander,TTBB
+Proud Of Your Boy,Steve Tramack,TTBB
+Pure Imagination,Matt Gallagher,TTBB
+Put On A Happy Face,Kevin Keller,TTBB
+"Put Your Arms Around Me, Honey",Aaron Dale,TTBB
+"Put Your Arms Around Me, Honey",Rob Hopkins,TTBB
+Put Your Head On My Shoulder,Aaron Dale,TTBB
+Razzle Dazzle,Clay Hine,TTBB
+Reaching For The Moon,Robert Rund,TTBB
+"Ready, Willing And Able (from Young At Heart)",Aaron Dale,TTBB
+Recipe For Love,Ben Ferguson,TTBB
+Red Hot Henry Brown,Kevin Keller,TTBB
+Redhead,Jim Clancy/Ed Waesche,TTBB
+Religious Medley,Will Baughman,TTBB
+Remember Me (from Coco),Ken Potter,TTBB
+Remember Me (from Coco),Nick Luna,TTBB
+Retreat,Steve Tramack,TTBB
+Reuben And Rachel (Parody),Adam Scott,TTBB
+Rhythm Is Our Business,Patrick McAlexander,TTBB
+Rhythm Is Our Business (Parody),Patrick McAlexander,TTBB
+Rhythm Medley,Aaron Dale,TTBB
+Ring-A-Ding Ding!,Anthony Bartholomew,TTBB
+Rock It For Me,Aaron Dale,TTBB
+Rock This Town,Aaron Dale,TTBB
+Roses Of Picardy,Lou Perry,TTBB
+"Rosie (from Bye, Bye, Birdie)",Patrick McAlexander,TTBB
+Royal Garden Blues,Greg Volk,TTBB
+Run Away With Me,Patrick McAlexander,TTBB
+Same Old Saturday Night,Jim Halvorson,TTBB
+Santa Fe (from Newsies),Chris Lewis,TTBB
+Satan's Li'l Lamb,Kevin Keller,TTBB
+Save The Bones For Henry Jones,Eric Ruthenberg,TTBB
+Save The Last Dance For Me,Kohl Kitzmiller,TTBB
+Save The Last Dance/Sway (Medley),Aaron Dale,TTBB
+Saving All My Love For You,Wayne Grimmer,TTBB
+Secondhand White Baby Grand,Theo Hicks,TTBB
+Seeing For The Very First Time,David Wright,TTBB
+Seize The Day (from Newsies),Theo Hicks,TTBB
+Settle For Me (Parody),Patrick McAlexander,TTBB
+Seventy-Six Trombones,Tom Gentry,TTBB
+Sgt Pepper's Lonely Hearts Club Band,David Harrington,TTBB
+Sgt Pepper's Lonely Hearts Club Band/With A Little Help From My Friends (Medley),David Harrington,TTBB
+Shakin' The Blues Away (from Easter Parade),Cay Outerbridge,TTBB
+Shakin' The Blues Away (from Easter Parade),Clay Hine,TTBB
+Shaking The Blues Away,Cay Outerbridge,TTBB
+She Used To Be Mine (from Waitress),Theo Hicks,TTBB
+She's Always A Woman,Simon Rylander,TTBB
+She's Got A Way,David Wright,TTBB
+She's Out Of My Life,David Harrington,TTBB
+She's Out Of My Life,Kevin Keller,TTBB
+Shine,David Wright,TTBB
+Shoe Shine Boy,Jeremey Johnson,TTBB
+Show Me Where The Good Times Are,Gene Cokeroft/Dot Short,TTBB
+Side By Side,Tom Gentry,TTBB
+Since I Fell For You,Robert Rund,TTBB
+Small Fry,David Wright,TTBB
+Smile,Clay Hine,TTBB
+Smile,Kevin Keller,TTBB
+Smile,Tom Gentry,TTBB
+Smile Medley,Clay Hine,TTBB
+Smile Medley II,David Wright,TTBB
+Smilin' Through,Lou Perry/Ed Waesche,TTBB
+Smoke Gets In Your Eyes,Patrick McAlexander,TTBB
+So In Love,David Wright,TTBB
+So This Is Love,Gary Lewis,TTBB
+"Softly, As I Leave You",Brent Graham,TTBB
+Soliloquy,Jay Giallombardo,TTBB
+Somebody Knows,David Wright,TTBB
+Somebody Loves Me,Clay Hine,TTBB
+Somebody Stole My Gal/Five Foot Two (Medley),Ed Waesche,TTBB
+Somebody To Love,Patrick McAlexander,TTBB
+Someone Like You (from Jekyll And Hyde),Steve Tramack,TTBB
+Somethin' About Ya,Joe Liles,TTBB
+Something Good,David Wright,TTBB
+Songs Of Wonder,Matt Gallagher,TTBB
+Sorry Seems To Be The Hardest Word,Jackson Pinder,TTBB
+South Rampart Street Parade (Parody),David Wright,TTBB
+Spend My Life With You,Kyle Kitzmiller,TTBB
+Spider-Man Theme,Aaron Dale,TTBB
+Spongebob Medley,Kohl Kitzmiller,TTBB
+Stairway To Paradise,Dan Wessler,TTBB
+Star Wars Medley,Patrick McAlexander,TTBB
+Steal Away,Patrick McAlexander,TTBB
+Stella By Starlight (from The Uninvited),Jeremey Johnson,TTBB
+Stepping Out With A Star,Jackson Pinder,TTBB
+Stormy Weather,Aaron Dale,TTBB
+Stouthearted Men,David Wright,TTBB
+Strange Sight,Ken Potter,TTBB
+Such A Night,Aaron Dale,TTBB
+Suddenly,Rob Hopkins,TTBB
+Sugar (That Sugar Baby O'Mine),Adam Reimnitz,TTBB
+Sunny Side Up,Greg Volk,TTBB
+Supercalifragilisticexpialidocious (Parody),Anthony Bartholomew,TTBB
+Superhero Medley,Patrick McAlexander,TTBB
+Surfer Girl,Aaron Dale,TTBB
+Swan Song Medley,Matt Astle,TTBB
+Sweet Caroline,Gene Cokeroft,TTBB
+Sweet Lorraine,Mark Hale/David Wright,TTBB
+Sweet Pea,Aaron Dale,TTBB
+Sweet Roses Of Morn,Robert Rund,TTBB
+'Taint What You Do (It’s The Way That you Do It),Patrick McAlexander,TTBB
+Take Me As I Am,Theo Hicks,TTBB
+Taking A Chance On Love,Ed Waesche,TTBB
+Taking A Chance On Love,Jay Giallombardo,TTBB
+Tea For Two,Mark Hale,TTBB
+Tell Her About It,Rob Campbell,TTBB
+Tell My Father,Garrett Gillingham,TTBB
+Ten Minutes Ago (from Cinderella),Brent Graham,TTBB
+Ten Minutes Ago (from Cinderella),Patrick McAlexander,TTBB
+Tennessee Waltz,Aaron Dale,TTBB
+That Lucky Old Sun,David Wright,TTBB
+That Old Black Magic,Patrick McAlexander,TTBB
+That Old Feeling,David Wright,TTBB
+That Tumble-Down Shack In Athlone,Brent Graham,TTBB
+That's Life,David Harrington,TTBB
+That's What I Call A Pal,Ed Waesche,TTBB
+The Best Of Me,Rasmus Krigström,TTBB
+The Best Things Happen While You're Dancing (from White Christmas),Steve Tramack,TTBB
+The Birth Of The Blues,David Wright,TTBB
+The Brotherhood Of Man (Parody),Jay Giallombardo,TTBB
+The Coffee Song,Dan Wessler,TTBB
+The Curtain Falls,Clay Hine,TTBB
+The Darktown Strutters' Ball,Ed Waesche,TTBB
+The Frim Fram Sauce,Aaron Dale,TTBB
+The Girl I Love,Gary Lewis,TTBB
+The Hut-Sut Song,Rasmus Krigström,TTBB
+The Impossible Dream Medley,Matt Astle/Ken Potter,TTBB
+The Lady Is A Tramp,Wayne Grimmer,TTBB
+The Man That Got Away,Greg Mallett,TTBB
+The Masquerade Is Over (I'm Afraid),Ed Waesche,TTBB
+The More I See You,Brent Graham,TTBB
+The More I See You,John Brockman,TTBB
+The Nearness Of You (from Romance In The Dark),Ben Ferguson,TTBB
+The Nearness Of You (from Romance In The Dark),John Brockman,TTBB
+The Next Ten Minutes (from The Last Five Years),Theo Hicks,TTBB
+The One I Love (Belongs To Somebody Else),Clay Hine,TTBB
+The Party's Over,Steve Armstrong,TTBB
+The Right Girl For Me,Brent Graham,TTBB
+The Sound Of Music,David Wright,TTBB
+The Sunshine Of Your Smile,Tom Gentry,TTBB
+The Very Thought Of You,Adam Reimnitz,TTBB
+The Very Thought Of You,Jason Dyer,TTBB
+The Way You Look Tonight,Mark Hale,TTBB
+The Wells Fargo Wagon (Parody),Patrick McAlexander,TTBB
+Their Hearts Were Full Of Spring,Aaron Dale,TTBB
+"Theme From ""New York, New York""",Patrick McAlexander,TTBB
+There Used To Be A Ballpark,Roger Payne,TTBB
+There'll Be No New Tunes On This Old Piano,Tom Gentry,TTBB
+"There's a Fine, Fine Line (from Avenue Q)",Ben Brown,TTBB
+"There's A Long, Long Trail",Kevin Keller,TTBB
+There's A New Gang On The Corner,Gene Cokeroft,TTBB
+There's A Rainbow 'Round My Shoulder,Jeff Marks,TTBB
+There's Nothing That I Haven't Sung About,Clay Hine,TTBB
+These Are The Days,Stefan Pugliese,TTBB
+These Foolish Things (Remind Me Of You),Rasmus Krigström,TTBB
+They Can't Take That Away From Me,Aaron Dale,TTBB
+They Didn't Believe Me,David Wright,TTBB
+They Just Keep Moving The Line,Steve Tramack,TTBB
+Things Are Looking Up,Kevin Keller,TTBB
+Things Are Looking Up,Rasmus Krigström,TTBB
+Think,Patrick McAlexander,TTBB
+This Can't Be Love (from The Boys From Syracuse),Aaron Dale,TTBB
+This Can't Be Love (from The Boys From Syracuse),David Wright,TTBB
+This Can't Be Love (from The Boys From Syracuse),Wayne Grimmer,TTBB
+This Heart Of Mine,Brent Graham,TTBB
+This Is All I Ask,"Warren ""Buzz"" Haeger",TTBB
+This Is The Moment (from Jekyll & Hyde),Steve Armstrong,TTBB
+This Joint is Jumpin',Clay Hine,TTBB
+'Til I Hear You Sing (from Love Never Dies),Theo Hicks,TTBB
+Till There Was You (from The Music Man),Robert Rund,TTBB
+Time After Time,David Wright,TTBB
+Time Warp (from The Rocky Horror Show),Melody Hine,TTBB
+Together Again (from Sesame Street),Aaron Dale,TTBB
+Tomorrow,Rick Spencer,TTBB
+Tomorrow Is Promised To No One,Robert Rund,TTBB
+Too Darn Hot,Rasmus Krigström,TTBB
+Too Darn Hot/Fever,Aaron Dale,TTBB
+Too Marvelous For Words,Mark Hale,TTBB
+Too Young For The Blues,Aaron Dale,TTBB
+"Toot, Toot, Tootsie",Clay Hine,TTBB
+Top Of The World,Rob Hopkins,TTBB
+Top Of The World Medley,David Wright,TTBB
+Topsy Turvy,Patrick McAlexander,TTBB
+Toyland,Ed Waesche,TTBB
+True Colors,David Wright,TTBB
+Tuxedo Junction,Adam Scott,TTBB
+Two Of A Kind (Parody),Clay Hine,TTBB
+"Two Of A Kind, Workin' On A Full House",Aaron Dale,TTBB
+Vegas Medley,Tom Gentry,TTBB
+Very Weird Song,Roger Payne,TTBB
+Vincent,David Wright,TTBB
+"Wait Till The Sun Shines, Nellie","Warren ""Buzz"" Haeger",TTBB
+Waitin' For The Light To Shine (from Big River),Joel Guyer,TTBB
+Wake Me Up Before You Go-Go,Nick Luna,TTBB
+Wake Up Everybody,Patrick McAlexander,TTBB
+Walkin' After Midnight,Rick Spencer,TTBB
+We Got Us,Kevin Keller,TTBB
+We Kiss In A Shadow,David Wright,TTBB
+We The People (Parody),Clay Hine,TTBB
+Wedding Bells Are Breaking Up That Old Gang Of Mine,David Wright,TTBB
+Welcome To The Theatre/Applause (Medley),Mark Hale,TTBB
+We've Got A World That Swings,Melody Hine,TTBB
+What A Diff'rence a Day Makes,Adam Reimnitz,TTBB
+What Are You Doing New Year's Eve?,Aaron Dale,TTBB
+What I Did For Love (from Chorus Line),Brent Graham,TTBB
+What I Did For Love (from Chorus Line),David Wright,TTBB
+What Kind Of Fool Am I?,David Harrington,TTBB
+What Kind Of Fool Am I?,Don Gray,TTBB
+What More Can A Soldier Give?,Robert Rund,TTBB
+Whatcha Gonna Do When There Ain't No Jazz,Patrick McAlexander,TTBB
+What'll I Do?,Ed Waesche,TTBB
+When Day Is Done,Ed Waesche,TTBB
+When I Fall In Love,David Wright,TTBB
+When I Grow Too Old To Dream,Theo Hicks,TTBB
+When I Leave The World Behind,SPEBSQSA,TTBB
+When I Look At You,Rob Hopkins,TTBB
+When I Look At You (from The Scarlet Pimpernel),Rob Hopkins,TTBB
+When I Lost You,Steve Tramack,TTBB
+When It's Night Time Down In Dixieland/Original Dixieland One-Step (Parody),Brent Graham,TTBB
+When My Baby Smiles At Me,Mark Hale,TTBB
+When She Loved Me (from Toy Story 2),Jimbob Kahlke,TTBB
+When She Loved Me (from Toy Story 2),Rasmus Krigström,TTBB
+When The Gold Turns To Gray,Jay Giallombardo,TTBB
+"When The Red, Red Robin (Comes Bob, Bob, Bobbin' Along)",Ed Waesche,TTBB
+When Winter Comes,Brian Mastrull,TTBB
+Where The Southern Roses Grow,David Wright,TTBB
+Who Can I Turn To?,Jay Giallombardo,TTBB
+Who Can I Turn To?,Robert Rund,TTBB
+Who Cares? (from Of Thee I Sing),Johnny Bugarin,TTBB
+Who'll Dry Your Tears?,Steve Armstrong/Dennis Driscoll,TTBB
+Who's Lovin' You?,Aaron Dale,TTBB
+Why Don't You Fall In Love With Me?/Undecided (Medley),Clay Hine,TTBB
+Why Try To Change Me Now?,Cay Outerbridge,TTBB
+Wishing You Were Somehow Here Again,Theo Hicks,TTBB
+With A Little Help From My Friends,Patrick McAlexander,TTBB
+With You (from Ghost the Musical),Steve Armstrong,TTBB
+With You (from Pippin),David Wright,TTBB
+Wonderful Day Like Today,Mo Rector,TTBB
+Wonderful One,David Wright,TTBB
+Words Fail (from Dear Evan Hansen),Rasmus Krigström,TTBB
+Wouldn't It Be Loverly,Paul Davies/Ed Waesche,TTBB
+Wrap Your Troubles In Dreams,Mark Hale,TTBB
+Written In The Stars,Mark Hale,TTBB
+Yes I Can,Steve Tramack,TTBB
+Yesterday,David Harrington,TTBB
+Yesterday I Heard The Rain,Brent Graham,TTBB
+Yesterday/A Day In The Life,David Harrington,TTBB
+You And I,Kyle Kitzmiller,TTBB
+You And I (We Can Conquer The World),David Harrington,TTBB
+You And Me (But Mostly Me),Steve Tramack,TTBB
+You And Me And The Bottle Makes Three Tonight,Wayne Grimmer,TTBB
+You Are My Sunshine,Vicki Uhr,TTBB
+You Are The Top/Friendship/Anything Goes,Jeremey Johnson,TTBB
+You Belong To Me,Aaron Dale,TTBB
+You Brought A New Kind Of Love To Me,Brent Graham,TTBB
+You Brought A New Kind Of Love To Me,Larry Triplett,TTBB
+You Can't Make Me Love You,Clay Hine,TTBB
+You Can't Stop The Beat,David Wright,TTBB
+You Don't Know Me,Jim Clancy,TTBB
+You Gotta Have Charts,Roger Payne,TTBB
+You Keep Coming Back Like A Song,Fraser Brown,TTBB
+You Needed Me,Andrew Carolan,TTBB
+You Needed Me,Jim Halvorson,TTBB
+You Took Advantage Of Me (from Present Arms),Aaron Dale,TTBB
+You'd Be So Nice To Come Home To (from Something To Shout About),John Brockman,TTBB
+You'll Never Walk Alone,Adam Reimnitz,TTBB
+Your Cheatin' Heart,Aaron Dale,TTBB
+You're A Heavenly Thing,Dan Wessler,TTBB
+You're Falling In Love,Aaron Dale,TTBB
+You're From Heaven And You're Mine,David Wright,TTBB
+You're Nobody 'Til Somebody Loves You,Clay Hine,TTBB
+You're Nobody 'Til Somebody Loves You/Ain't That A Kick In The Head?,Jay Giallombardo,TTBB
+You're Still You,Theo Hicks,TTBB
+You've Changed,Patrick McAlexander,TTBB
+You've Got A Lot To See,Brent Graham,TTBB
+Zing! Went the Strings Of My Heart/Get Me To The Church On Time,Kohl Kitzmiller,TTBB

--- a/data/song_suggestion_catalog.psv
+++ b/data/song_suggestion_catalog.psv
@@ -6,10 +6,12 @@ Song Title|Voicing|Arranger
 'C' is for cookie|TTBB|Jay Dougherty
 'Round Midnight|TTBB|David Wright
 'Round Midnight|TTBB|Wayne Grimmer
+'Taint What You Do (It’s The Way That you Do It)|TTBB|Patrick McAlexander
 'Til I Hear You Sing|SATB|Theodore Hicks
 'Til I Hear You Sing|SSAA|June Berg
 'Til I Hear You Sing|SSAA|Theodore Hicks
 'Til I Hear You Sing|TTBB|Theodore Hicks
+'Til I Hear You Sing (from Love Never Dies)|TTBB|Theo Hicks
 'Til Tomorrow|SSAA|Jo Lund
 'Til Tomorrow|SSAA|Joey Minshall
 'Til Tomorrow|SSAA|Nancy Bergman
@@ -48,6 +50,9 @@ Song Title|Voicing|Arranger
 (I'm Afraid) The Masquerade Is Over|TTBB|Ed Waesche
 (It Must've Been Ol') Santa Claus|TTBB|Matt Astle
 (Let Me Be Your) Teddy Bear|TTBB|Aaron Dale
+(Let's Start) Tomorrow Tonight (from Smash)|TTBB|Kevin Keller
+(Let's Start) Tomorrow Tonight (from Smash)|TTBB|Larry Triplett
+(Let's Start) Tomorrow Tonight (from Smash)|TTBB|Theo Hicks
 (Love Is) The Tender Trap|SSAA|Steve Tramack
 (Love Is) The Tender Trap|TTBB|Jim Shubert
 (Love Is) The Tender Trap|TTBB|Steve Tramack
@@ -58,6 +63,7 @@ Song Title|Voicing|Arranger
 (They Long To Be) Close To You|TTBB|Jeremey Johnson
 (They Long To Be) Close To You|TTBB|Joe Liles
 (This Is) Dedicated to The One I Love|TTBB|Jeremey Johnson
+(Up A) Lazy River|TTBB|Clay Hine
 (When It's) Darkness on the Delta|SATB|Barbershop Harmony Society
 (When It's) Darkness on the Delta|TTBB|Inc. SPEBSQSA
 (You're My) Soul and Inspiration|TTBB|Larry Wright
@@ -73,6 +79,7 @@ Song Title|Voicing|Arranger
 25 or 6 to 4|TTBB|Aaron Dale
 3 X5|SATB|Deke Sharon
 409|TTBB|Marty Israel
+50 Shades Of Brown|TTBB|Greg Mallett
 50 States In Rhyme|TTBB|Jeremey Johnson
 50,000 Names|TTBB|Tom Gentry
 50's Rock and Roll Medley|TTBB|Kevin Keller
@@ -105,6 +112,7 @@ A Carol Medley|SSAA|Floyd Connett
 A Certain Smile|SSAA|Diane Clark
 A Certain Smile|TTBB|Joe Mannherz
 A Change In My Life|SATB|Deke Sharon
+A Change Is Gonna Come|TTBB|Patrick McAlexander
 A Child is Born|SATB|Joe Mannherz
 A Child is Born|TTBB|Wayne Grimmer
 A childs prayer|TTBB|Joe Mannherz
@@ -150,6 +158,7 @@ A Foggy Day|TTBB|Jim Shubert
 A Foggy Day|TTBB|Patrick McAlexander
 A Foggy Day|TTBB|Walter Latzko
 A Foggy Day In London Town|SSAA|Dede Nibler
+A Foggy Day In London Town|TTBB|Bryan Ziegler
 A Foggy Night In San Francisco|TTBB|Ted Byrne
 A Fool Such As I|SSAA|Aaron Dale
 A Fool Such As I|TTBB|Aaron Dale
@@ -204,6 +213,8 @@ A Little Closer|TTBB|Kevin Koehl
 A Little Less Conversation|SSAA|David Wright
 A Little Old Lady In Tennis Shoes|SSAA|Mary K. Coffman Music Fund
 A Little Old Lady In Tennis Shoes|SSAA|Tedda Lippincott
+A Little Patch Of Heaven|TTBB|Aaron Dale
+A Little Street Where Old Friends Meet|TTBB|Aaron Dale
 A Little Street Where Old Friends Meet|TTBB|Burt Szabo
 A Little Street Where Old Friends Meet|TTBB|Sam Breedon
 A Little Talk With Jesus|TTBB|Burt Szabo
@@ -234,6 +245,7 @@ A Million Dreams|TTBB|Liz Garnett
 A Million Dreams|TTBB|Melody Hine
 A Million Dreams|TTBB|Rowena Harper
 A Million Dreams|TTBB|Simon Arnott
+A Million Dreams (from The Greatest Showman)|TTBB|Kevin Keller
 A Million Miles Away|SSAA|Simon Arnott
 A Million Miles Away|TTBB|Simon Arnott
 A Million to One|TTBB|Jon Nicholas
@@ -248,6 +260,7 @@ A New Life|SSAA|Michael Gellert
 A New Ode to Joy|SATB|Liz Garnett
 A New Ode to Joy|TTBB|Liz Garnett
 A New Quartet|TTBB|Joe Liles
+A Newfangled Tango|TTBB|Patrick McAlexander
 A Night Like This|SSAA|Liz Garnett
 A Nightingale Sang In Berkeley Square|SATB|Anders Lindqvist
 A Nightingale Sang In Berkeley Square|SATB|Joe Mannherz
@@ -262,6 +275,7 @@ A Nightingale Sang In Berkeley Square|TTBB|Anders Lindqvist
 A Nightingale Sang In Berkeley Square|TTBB|David Harrington
 A Nightingale Sang In Berkeley Square|TTBB|Joe Mannherz
 A Nightingale Sang In Berkeley Square|TTBB|John Hohl
+A Nightingale Sang In Berkeley Square|TTBB|Kirk Young
 A Nightingale Sang In Berkeley Square|TTBB|Larry Wright
 A Nightingale Sang In Berkeley Square|TTBB|S. K. Grundy
 A Nightingale Sang In Berkeley Square|TTBB|Ted Byers
@@ -276,6 +290,7 @@ A Pretty Girl Is Like A Melody|TTBB|Robert Meyer
 A Quiet Girl|TTBB|Dennis Driscoll
 A Quiet Place|SSAA|Tedda Lippincott
 A Quiet Place|TTBB|Walter Latzko
+A Rainy Night In Rio|TTBB|Kevin Keller
 A Red Red Rose|TTBB|David Wright
 A Ring to the Name of Rosie|TTBB|Lloyd Steinkamp
 A Room With A View|TTBB|Rob Campbell
@@ -300,6 +315,7 @@ A Song For You|SATB|Kevin Keller
 A Song For You|TTBB|Adam Bock
 A Song For You|TTBB|Dan Wessler
 A Song For You|TTBB|Kevin Keller
+A Song Like Daddy Used To Play|TTBB|Brian Beck
 A Special Wish|SSAA|Linda Smith
 A Spoonful Of Sugar|SSAA|Joe Mannherz
 A Spoonful Of Sugar|SSAA|June Dale
@@ -307,6 +323,7 @@ A Spoonful Of Sugar|SSAA|Loretta Martin
 A Spoonful Of Sugar|TTBB|David Zimmerman
 A Spoonful Of Sugar|TTBB|Joe Mannherz
 A Spoonful Of Sugar|TTBB|Russ Foris
+A Spoonful Of Sugar (from Mary Poppins)|TTBB|David Zimmerman
 A Stable Prayer|SSAA|June Berg
 A Starry Night|TTBB|Derric Johnson
 A Straw Hat and a Cane|TTBB|BHS
@@ -364,6 +381,7 @@ A Wink And A Smile|SSAA|Michael Gellert
 A Wink And A Smile|TTBB|Kim Brittain
 A Wink And A Smile|TTBB|Robert Rund
 A Wink And A Smile|TTBB|Simon Arnott
+A Wink And A Smile (from Sleepless In Seattle)|TTBB|Robert Rund
 A Winter's Tale|SSAA|Hilary Allen
 A Woman Like You|TTBB|Larry Triplett
 A World Alone|SATB|Nicholas Wright
@@ -417,6 +435,7 @@ Ac-cent-tchu-ate The Positive|TTBB|Warren 'Buzz' Haeger
 Accident Waiting To Happen|SSAA|Kyle Snook
 Accidentally In Love|SATB|Deke Sharon
 Accidentally In Love|TTBB|Deke Sharon
+Accidents Will Happen|TTBB|Jay Giallombardo
 Achy Breaky Heart|SSAA|Marie Johnson
 Achy Breaky Heart|SSAA|Nancy Bergman
 Achy Breaky Heart|SSAA|Tedda Lippincott
@@ -528,6 +547,7 @@ Ain't Misbehavin'|SSAA|Carolyn Schmidt
 Ain't Misbehavin'|SSAA|Jay Giallombardo
 Ain't Misbehavin'|SSAA|Walter Latzko
 Ain't Misbehavin'|TTBB|Ed Howard
+Ain't Misbehavin'|TTBB|Greg Volk
 Ain't Misbehavin'|TTBB|Jay Giallombardo
 Ain't Misbehavin'|TTBB|Kevin Koehl
 Ain't Misbehavin'|TTBB|Larry Wright
@@ -542,6 +562,7 @@ Ain't No Mountain High Enough|SSAA|Larry Wright
 Ain't No Mountain High Enough|SSAA|Patrick McAlexander
 Ain't No Mountain High Enough|SSAA|Wayne Grimmer
 Ain't No Mountain High Enough|TTBB|Gabriel Lawson
+Ain't No Mountain High Enough|TTBB|Patrick McAlexander
 Ain't Nobody|SATB|Anders Lindqvist
 Ain't Nobody Here But Us Chickens|TTBB|Mark Goodney
 Ain't Nobody Here But Us Chickens|TTBB|Tom Parker
@@ -553,6 +574,8 @@ Ain't That A Kick In The Head|SSAA|Richard Hasty
 Ain't That A Kick In The Head|TTBB|Richard Hasty
 Ain't That A Kick In The Head|TTBB|Rowena Harper
 Ain't That A Kick In The Head|TTBB|Steve Hardy
+Ain't That A Kick In The Head?|TTBB|Rich Hasty
+Ain't That A Kick In The Head?/Don't Let It Go To Your Head|TTBB|Mike Menefee/Jeremiah Pope
 Ain't Too Proud to Beg|SATB|Deke Sharon
 Ain't Too Proud to Beg|TTBB|Aaron Dale
 Ain't We Got Fun|SATB|Kevin Keller
@@ -562,6 +585,7 @@ Ain't We Got Fun|SSAA|Kevin Keller
 Ain't We Got Fun|SSAA|Melody Hine
 Ain't We Got Fun|TTBB|Kevin Keller
 Ain't We Got Fun|TTBB|Robert Meyer
+Ain't We Got Fun?|TTBB|Anthony Bartholomew
 Ain't We Got Fun/Sunny Side of the Street|SSAA|Nancy Bergman
 Ain't-A That Good News|SSAA|Bev Sellers
 Ain't-A That Good News|TTBB|Jim West
@@ -585,6 +609,7 @@ Alabama Medley|SSAA|Jay Giallombardo
 Alabama Medley|TTBB|Jay Giallombardo
 Alabama Medley|TTBB|Tom Gentry
 Alabamy Bound|TTBB|Burt Szabo
+Alabamy Bound|TTBB|David Wright
 Alabamy Bound|TTBB|Joe Mannherz
 Aladdin Medley|SSAA|Aaron Dale
 Aladdin Medley|TTBB|Aaron Dale
@@ -630,8 +655,10 @@ Alice Blue Gown|TTBB|SPEBSQSA
 Alive|SATB|Nicholas Wright
 Alive|SSAA|Emily Moriarty
 All 4 Love|TTBB|III Eddie Holmes
+All Aboard For Dixie Land|TTBB|David Wright
 All Aboard For Dixie Land|TTBB|Earl Moon
 All Aboard For Slumberland|TTBB|Tom Gentry
+All About Love|TTBB|Kohl Kitzmiller
 All About That Bass|SATB|Anders Lindqvist
 All About That Bass|SATB|Wayne Grimmer
 All About That Bass|SSAA|Elaine Gain
@@ -746,6 +773,7 @@ All My Loving|SSAA|Carolyn Johnson
 All My Loving|SSAA|Carolyn Schmidt
 All My Loving|SSAA|June Berg
 All My Loving|TTBB|Deke Sharon
+All My Loving|TTBB|Rasmus Krigström
 All Nations Rise|SSAA|Jay Giallombardo
 All Nations Rise|TTBB|Jay Giallombardo
 All Night Long|SATB|Deke Sharon
@@ -833,6 +861,8 @@ All The Way|TTBB|David Briner
 All The Way|TTBB|Kohl Kitzmiller
 All The Way|TTBB|Robert Rund
 All The Way|TTBB|Tom Gentry
+All The Way (from The Joker Is Wild)|TTBB|Joel Guyer
+All The Way (from The Joker Is Wild)|TTBB|Tom Gentry
 All the World Will Be Jealous|TTBB|Barbershop Harmony Society
 All the World Will Be Jealous|TTBB|Earl Moon
 All The World Will Be Jealous|TTBB|BHS
@@ -888,6 +918,10 @@ Almost There|SSAA|Kevin Keller
 Almost There|TTBB|Aaron Dale
 Almost There|TTBB|Kevin Keller
 Almost There|TTBB|Simon Arnott
+Almost There (from The Princess and the Frog)|TTBB|Aaron Dale
+Almost There (from The Princess and the Frog)|TTBB|Jason Dyer
+Almost There (from The Princess and the Frog)|TTBB|Joel Guyer
+Almost There (from The Princess and the Frog)|TTBB|Simon Arnott
 Almost There (from THE PRINCESS AND THE FROG)|SSAA|Aaron Dale
 Aloha Oe|TTBB|T. W. De Crow
 Alone|SATB|Julianne Kallman
@@ -915,6 +949,8 @@ Always|TTBB|Jim West
 Always|TTBB|Joe Mannherz
 Always|TTBB|Mark Hale
 Always|TTBB|Mark Hale and Don Gray
+Always|TTBB|Mark Hale/Don Gray
+Always|TTBB|Rob Hopkins
 Always|TTBB|Walter Latzko
 Always A Bridesmaid|SSAA|David Wallace
 Always Be My Baby|SATB|Deke Sharon
@@ -1202,6 +1238,8 @@ Anything You Can Do I Can Do Better|TTBB|Steve Jamison
 Anything You Can Do I Can Do Better|TTBB|Tom Gentry
 Anything You Can Do I Can Do Better|TTBB|Walter Latzko
 Anytime / In My Honey's Lovin' Arms|SSAA|Carolyn Schmidt
+Anytime At All|TTBB|Greg Volk
+Anytime At All|TTBB|Wayne Grimmer
 Anyway|SATB|Nicholas Wright
 Anyway|SSAA|Jan Meyer
 Anyway|SSAA|Joey Minshall
@@ -1331,6 +1369,7 @@ As Long As I'm Singing My Song|TTBB|Larry Wright
 As Long As Were Singing Our Song|SSAA|Jo Lund
 As Long As You're Mine|SATB|Theodore Hicks
 As Long As You're Mine|TTBB|Theodore Hicks
+As Long As You're Mine (from Wicked)|TTBB|Theo Hicks
 As Long As You're Not In Love|SSAA|Carolyn Healey
 As She's Walking Away|TTBB|Deke Sharon
 As The Deer|TTBB|Jon Nicholas
@@ -1358,6 +1397,7 @@ Association Medley|TTBB|Larry Wright
 Astonishing|SATB|Melody Hine
 Astonishing|SSAA|Melody Hine
 Astonishing|TTBB|Robert Rund
+At A Georgia Camp Meeting|TTBB|Clay Hine
 At Last|SSAA|David Wright
 At Last|SSAA|Joe Mannherz
 At Last|SSAA|Nancy Bergman
@@ -1367,6 +1407,8 @@ At Last|TTBB|David Wright
 At Last|TTBB|Joe Mannherz
 At Last|TTBB|Nancy Bergman
 At Last|TTBB|Walter Latzko
+At Last (from Sun Valley Serenade)|TTBB|Clay Hine
+At Long Last Love (from You Never Know)|TTBB|Andrew Carolan
 At The Ball, That's All|TTBB|Mark Goodney
 At The Beginning|SSAA|Carolyn Schmidt
 At The Codfish Ball|SSAA|Doris Twardosky
@@ -1393,6 +1435,7 @@ At The Mississippi Cabaret|SSAA|Kevin Keller
 At The Mississippi Cabaret|TTBB|Kevin Keller
 At The Mississippi Cabaret|TTBB|Walter Latzko
 At The Moving Picture Ball|TTBB|Louis Perry
+At This Moment|TTBB|Patrick McAlexander
 Atlanta, Georgia|SSAA|Ann Minihane
 Atlantic City|SSAA|Carolyn Schmidt
 Atlantic City Medley|SSAA|Carolyn Schmidt
@@ -1402,6 +1445,7 @@ Auction Song|TTBB|Dennis Driscoll
 Auctioneer|SSAA|Doris Twardosky
 Auctioneer|SSAA|Tedda Lippincott
 Auctioneer|TTBB|Greg Blackwell
+Audition (from La La Land)|TTBB|Matt Astle
 Audition (the Fools Who Dream)|SSAA|Matt Astle
 Audition (the Fools Who Dream)|TTBB|Matt Astle
 Audition (the Fools Who Dream)|TTBB|Patrick McAlexander
@@ -1472,6 +1516,7 @@ Away In A Manger/Amazing Grace Medley|TTBB|Jay Giallombardo
 Axel F|SATB|Deke Sharon
 Axel F|TTBB|Deke Sharon
 Azizam|SATB|Mark Stevens
+B & O Line|TTBB|Bob Disney
 B & O Line|TTBB|Robert Disney
 B & O Line / My Cutey's Due At Two To Two Today Medley|TTBB|Ed Waesche
 B-I-R-D-I-E|TTBB|Tom Gentry
@@ -1494,6 +1539,7 @@ Baby Medley 1|SSAA|Carolyn Schmidt
 Baby Medley 1|SSAA|Jay Giallombardo
 Baby Medley 1|TTBB|Ed Waesche
 Baby Medley 1|TTBB|Jay Giallombardo
+Baby Mine|TTBB|Clay Hine
 Baby Mine|TTBB|Jim West
 Baby on Board|TTBB|Jay Krumbholz
 Baby on Board|TTBB|Michael Webber
@@ -1519,6 +1565,7 @@ Baby, I'm-A Want You|TTBB|Mark Stevens
 Baby, It's Cold Outside|SATB|Joe Mannherz
 Baby, It's Cold Outside|SATB|Joni Bescos
 Baby, It's Cold Outside|TTBB|Jon Nicholas
+Baby, It's You|TTBB|Adam Reimnitz
 Baby, Now that I've Found You|TTBB|Mark Stevens
 Baby, Oh Where Can You Be?|SSAA|Kay Bromert
 Baby, Save Your Kisses For Me|TTBB|Jim Shubert
@@ -1549,6 +1596,7 @@ Back In Business|SSAA|David Wright
 Back In Business|SSAA|Larry Wright
 Back In Business|TTBB|David Wright
 Back In Business|TTBB|Larry Wright
+Back In Business (from Dick Tracy)|TTBB|David Wright
 Back In Dad And Mother's Day|TTBB|Louis Perry
 Back In Dixie Again|TTBB|Earl Moon
 Back In My Home Town|TTBB|S. K. Grundy
@@ -1648,6 +1696,7 @@ Barbershop Girl Of My Dreams|TTBB|Einar Pedersen
 Barbershop Harmony Time|SSAA|Dave Stevens
 Barbershop Harmony Time|TTBB|Dave Stevens
 Barbershop in History|TTBB|Brent Graham
+Barbershop In History Medley|TTBB|Brent Graham
 Barbershop Memories|TTBB|Kevin Keller
 Barbershop Rag|TTBB|Louis Perry
 Barbershop Time of Your Life|TTBB|Joe Liles
@@ -1660,6 +1709,7 @@ Bare Necessities|SSAA|Jay Giallombardo
 Bare Necessities|SSAA|Sylvia Alsbury
 Bare Necessities|SSAA|Thomas Gentry
 Bare Necessities|SSAA|Tom Gentry
+Bare Necessities|TTBB|Clay Hine
 Bare Necessities|TTBB|Jay Giallombardo
 Bare Necessities|TTBB|Patrick McAlexander
 Bare Necessities|TTBB|Thomas Gentry
@@ -1715,6 +1765,7 @@ Be My Christmas Number One|TTBB|Liz Garnett
 Be My Friend The Facebook Song|SSAA|Dianne Goldrick
 Be My Friend The Facebook Song|TTBB|Dianne Goldrick
 Be My Friend The Facebook Song|TTBB|Greg Mallett
+Be My Life's Companion|TTBB|Kohl KItzmiller
 Be My Life's Companion|TTBB|Tom Gentry
 Be My Springtime|SSAA|Marie Johnson
 Be my wife|TTBB|Joe Mannherz
@@ -1726,6 +1777,7 @@ Be Our Guest|SSAA|Nancy Bergman
 Be Our Guest|SSAA|Steve Delehanty
 Be Our Guest|SSAA|Susan Kegley
 Be Our Guest|SSAA|Tedda Lippincott
+Be Our Guest|TTBB|Greg Volk
 Be Our Guest|TTBB|Jay Giallombardo
 Be Our Guest|TTBB|Steve Delehanty
 Be Our Guest (from Walt Disney's "Beauty and the Beast"|TTBB|Stephen Delehanty
@@ -1866,6 +1918,7 @@ Begin The Beguine|TTBB|Justin Miller
 Begin The Beguine|TTBB|Walter Latzko
 Behold, A Host, Arrayed in White|SSAA|Mark Rusch
 Behold, A Host, Arrayed in White|TTBB|Mark Rusch
+Bei Mir Bist Du Schon|TTBB|Wayne Grimmer
 Bein' Green|SATB|Deke Sharon
 Bein' Green|SSAA|Kay Bromert
 Bein' Green|SSAA|Liz Garnett
@@ -1915,6 +1968,7 @@ Beside An Open Fireplace|TTBB|Roy Keys
 Best Day of My Life|SATB|Deke Sharon
 Best Day of My Life|SATB|Nicholas Wright
 Best Day/Good Life Medley|SATB|Deke Sharon
+Best Of Me|TTBB|Rasmus Krigström
 Best Of My Love|SSAA|Deke Sharon
 Best Of Times|SSAA|Jo Lund
 Best Of Times|SSAA|Tedda Lippincott
@@ -2036,6 +2090,7 @@ Bill Bailey, Won't You Please Come Home? / The Man Song Medley|TTBB|David Harrin
 Bill Bailey/Big Bad Bill is Sweet William Now Medley|SSAA|Jay Giallombardo
 Bill Bailey/Big Bad Bill is Sweet William Now Medley|TTBB|Jay Giallombardo
 Bill Grogan's Goat|SSAA|Michael Hengelsberg
+Bill Grogan's Goat|TTBB|Clay Hine
 Bill Grogan's Goat|TTBB|Jay Giallombardo
 Bill Grogan's Goat|TTBB|Jim West
 Bill Medley (Keep Your Eye on the Girlie You Love/Bill Bailey)|SSAA|Jay Giallombardo
@@ -2090,6 +2145,7 @@ Blah-Blah-Blah|TTBB|Douglas Beck
 Blame It On My Youth|SSAA|Brent Graham
 Blame It On My Youth|TTBB|Adam Reimnitz
 Blame It On My Youth|TTBB|Brent Graham
+Blame It On My Youth|TTBB|Ed Waesche
 Blame It On The Beautiful Girls|TTBB|Burt Szabo
 Blame It On The Boogie|SATB|Deke Sharon
 Blame It On The Boogie|SATB|Kohl Kitzmiller
@@ -2133,10 +2189,12 @@ Blow Gabriel Blow|TTBB|Aaron Dale
 Blow Gabriel Blow|TTBB|Jay Giallombardo
 Blow The Man Down|TTBB|Jim West
 Blow The Winds Southerly|SATB|Matthew Spinner
+Blow, Gabriel, Blow|TTBB|Rasmus Krigström
 Blowin' In the Wind|SSAA|Kay Bromert
 Blue|SSAA|Jo Lund
 Blue|SSAA|Tedda Lippincott
 Blue|TTBB|Deke Sharon
+Blue Ain't Your Color|TTBB|David Harrington
 Blue And Sentimental|TTBB|Mark Goodney
 Blue Bayou|SSAA|Bev Sellers
 Blue Bayou|SSAA|Connie Kash
@@ -2216,6 +2274,7 @@ Blues In The Night|SSAA|David Briner
 Blues In The Night|SSAA|Mary K. Coffman Music Fund
 Blues In The Night|SSAA|Tom Gentry
 Blues In The Night|TTBB|Dan Wessler
+Blues In The Night|TTBB|Dave Briner
 Blues In The Night|TTBB|David Briner
 Blues In The Night|TTBB|David Wright
 Blues In The Night|TTBB|Don Gray
@@ -2251,6 +2310,7 @@ Boogie Woogie Bugle Boy|TTBB|Anastasio Rossi
 Boogie Woogie Bugle Boy|TTBB|David Wright
 Boogie Woogie Bugle Boy|TTBB|Deke Sharon
 Boogie Woogie Bugle Boy|TTBB|Tom Gentry
+Booglie Wooglie Piggy|TTBB|Cay Outerbridge
 Book Of Love|SSAA|Katherine Hardie
 Book Of Love|SSAA|Kevin Koehl
 Book Of Love|SSAA|Marsha Zwicker
@@ -2422,6 +2482,7 @@ Bring Me Sunshine|SSAA|Liz Garnett
 Bring Me Sunshine|SSAA|Matt Astle
 Bring Me Sunshine|SSAA|Theodore Hicks
 Bring Me Sunshine|TTBB|Dan Wessler
+Bring Me Sunshine|TTBB|David Harrington
 Bring Me Sunshine|TTBB|Dianne Goldrick
 Bring Me Sunshine|TTBB|Eric Ruthenberg
 Bring Me Sunshine|TTBB|Matt Astle
@@ -2485,11 +2546,13 @@ Brother Can You Spare A Dime|TTBB|David Wright
 Brother Can You Spare A Dime|TTBB|Joe Mannherz
 Brother Loves Travelin' Salvation Show|SSAA|Jean Shook
 Brother Noah Gave Out Checks for Rain|TTBB|Toban Dvoretsky
+Brother, Can You Spare A Dime?|TTBB|Steve Armstrong
 Brother, Can You Spare A Dime?|TTBB|Steven Armstrong
 Brother, My Brother|TTBB|Kevin Keller
 Brotherhood of Man|SSAA|Jay Giallombardo
 Brotherhood of Man|TTBB|Jay Giallombardo
 Brotherhood of Man|TTBB|Tony Nasto
+Brothers Love Song|TTBB|Steve Delehanty
 Brown Eyed Girl|SATB|Deke Sharon
 Brown Eyed Girl|TTBB|Adam Scott
 Brown Eyed Girl|TTBB|Deke Sharon
@@ -2602,6 +2665,7 @@ Bye Bye Blackbird/Bye Bye Baby Medley|SSAA|Larry Wright
 Bye Bye Blackbird/Bye Bye Baby Medley|TTBB|Larry Wright
 Bye Bye Blues|TTBB|BHS
 Bye Bye Blues|TTBB|SPEBSQSA
+Bye Bye Blues|TTBB|SPEBSQSA, Inc.
 Bye Bye Blues|TTBB|Val Hicks
 Bye Bye Bye|SSAA|Julianne Kallman
 Bye Bye Bye|TTBB|Deke Sharon
@@ -2903,6 +2967,7 @@ Carry On|SATB|Nicholas Wright
 Carry On Wayward Son|SSAA|Carole Prietto
 Carry On Wayward Son|TTBB|Kyle Kitzmiller
 Carrying The Banner|TTBB|Adam Bock
+Carrying The Banner (from Newsies)|TTBB|Adam Bock
 Cartoon Medley|TTBB|Kevin Keller
 Casey Jones|TTBB|J Rae Jamieson
 Casey's Odyssey|TTBB|Robert Rund
@@ -2941,6 +3006,7 @@ Chances Are|SSAA|Tedda Lippincott
 Chandelier|SATB|Nicholas Wright
 Chandelier|SSAA|Emily Moriarty
 Chandelier|SSAA|Nicholas Wright
+Change Is Gonna Come|TTBB|Patrick McAlexander
 Change My Heart, Oh God|SSAA|Tom Gentry
 Change My Heart, Oh God|TTBB|Tom Gentry
 Change the World|SATB|Deke Sharon & David Wright
@@ -2960,6 +3026,7 @@ Chantez, Chantez|TTBB|Walter Latzko
 Chapel Of Love|SATB|Joe Mannherz
 Chapel Of Love|SSAA|Anna Maria Parker
 Chapel Of Love|TTBB|Adam Bock
+Chaplin Medley|TTBB|David Wright
 Chapters Of Life|TTBB|Walter Latzko
 Charade|TTBB|Curt Kimball
 Charade|TTBB|Matthew Gallagher
@@ -2979,6 +3046,7 @@ Charley, My Boy|SSAA|Nancy Bergman
 Charlie Brown|SSAA|Larry Wright
 Charlie Brown|TTBB|Larry Wright
 Charlie Brown Christmas|SSAA|Carole Prietto
+Charlie On The MTA|TTBB|Joey Constantine
 Charmaine|TTBB|Jim West
 Charmaine|TTBB|John Stefero
 Charmaine|TTBB|Toban Dvoretsky
@@ -3001,6 +3069,7 @@ Chattanooga/Kalamazoo Medley|TTBB|Steve Jamison
 Chattanoogie Shoe Shine Boy|SSAA|Ed FLynn
 Chattanoogie Shoe Shine Boy|SSAA|Tedda Lippincott
 Chattanoogie Shoe Shine Boy|TTBB|Ed FLynn
+Chattanoogie Shoe Shine Boy|TTBB|Jeremey Johnson
 Cheap Thrills|SSAA|Deke Sharon
 Cheap Thrills|SSAA|Emily Moriarty
 Cheatin, On Me|TTBB|Dennis Driscoll
@@ -3016,6 +3085,7 @@ Cheer Up, Charlie|SSAA|Kevin Keller
 Cheer Up, Charlie|SSAA|Sharon Holmes
 Cheer Up, Charlie|TTBB|Brent Graham
 Cheer Up, Charlie|TTBB|James Henry
+Cheer Up, Charlie|TTBB|Jim Henry
 Cheer Up, Charlie|TTBB|Kevin Keller
 Cheeseburger In Paradise|TTBB|Eric Ruthenberg
 Chega De Saudade (No More Blues)|TTBB|Melody Hine
@@ -3041,6 +3111,7 @@ Chicken Fried|SATB|Kevin Keller
 Chicken Fried|SSAA|Kevin Keller
 Chicken Fried|TTBB|Kevin Keller
 Childhood|TTBB|Kevin Keller
+Childhood (from Free Willy 2)|TTBB|Kevin Keller
 Children Go Where I Send Thee|SSAA|Jon Nicholas
 Children Go Where I Send Thee|SSAA|Tedda Lippincott
 Children Go Where I Send Thee|TTBB|Jon Nicholas
@@ -3299,6 +3370,7 @@ Come Dance With Me|SSAA|Larry Wright
 Come Dance With Me|SSAA|Takako Fuke
 Come Dance With Me|TTBB|Joe Mannherz
 Come Dance With Me|TTBB|Larry Wright
+Come Dance With Me|TTBB|Patrick McAlexander
 Come Dance With Me / Come Fly With Me Medley|TTBB|Kevin Keller
 Come Dance with Me with Come Fly with Me|TTBB|Kevin Keller
 Come Fly With Me|SATB|Deke Sharon
@@ -3356,6 +3428,7 @@ Come What May|SSAA|Alex Kaiserman
 Come What May|SSAA|Glenda Lloyd
 Come What May|SSAA|Kevin Keller
 Come What May|TTBB|Kevin Keller
+Come What May (from Moulin Rouge!)|TTBB|Kevin Keller
 Come With Me|TTBB|Dave Stevens
 Come, Christians, Join to Sing|TTBB|Jon Nicholas
 Come, Come Ye Saints|TTBB|Aaron Dale
@@ -3393,6 +3466,7 @@ Coney Island Medley|SSAA|Jay Giallombardo
 Coney Island Medley|TTBB|Jay Giallombardo
 Coney Island Washboard|SSAA|Ardeth Fullmer
 Coney Island Washboard|TTBB|Barbershop Harmony Society
+Coney Island Washboard Roundelay|TTBB|Clay Hine
 Congratulate Me|SSAA|Jo Lund
 Congratulate Me|TTBB|Dennis Driscoll
 Congratulations|SATB|Karen Penketh
@@ -3429,12 +3503,14 @@ Corner Of The Sky|TTBB|David Wright
 Corner Of The Sky|TTBB|Matthew Gallagher
 Corner Of The Sky|TTBB|Melody Hine
 Corner Of The Sky|TTBB|Patrick McAlexander
+Corner Of The Sky (from Pippin)|TTBB|Patrick McAlexander
 Cornflake Girl|SSAA|Adam Bock
 Cottage For Sale|SSAA|Sharon Holmes
 Cottage For Sale|TTBB|Brent Graham
 Cottage For Sale|TTBB|Theodore Hicks
 Cotton Candy And A Toy Balloon|TTBB|Norm Benson
 Cotton Club Medley|TTBB|Tom Gentry
+Could 'Ja?|TTBB|Wayne Grimmer
 Could I Have This Dance|SSAA|Charlene Yazurlo
 Could I Have This Dance|SSAA|June Berg
 Could It Be Magic|SSAA|Sam Hubbard
@@ -3651,6 +3727,7 @@ Dance With Me|TTBB|Mark Stevens
 Dance With Me Tonight|SSAA|Liz Garnett
 Dance With Me Tonight|TTBB|Nicholas Wright
 Dance With My Father|TTBB|Cay Outerbridge
+Dance With My Father|TTBB|Theo Hicks
 Dance With My Father|TTBB|Theodore Hicks
 Dancin' Dan|TTBB|Dennis Driscoll
 Dancin' In The Moonlight|TTBB|Deke Sharon
@@ -3701,6 +3778,7 @@ Danny Boy|TTBB|Burt Szabo
 Danny Boy|TTBB|Ed Waesche
 Danny Boy|TTBB|Gene Cokeroft
 Danny Boy|TTBB|Jay Giallombardo
+Danny Boy|TTBB|Jim Clancy
 Danny Boy|TTBB|Jim West
 Danny Boy|TTBB|Jon Nicholas
 Danny Boy|TTBB|Mike Sotiriou
@@ -3740,9 +3818,11 @@ Day By Day|TTBB|Jim Shubert
 Day By Day|TTBB|Jon Nicholas
 Day By Day|TTBB|Robert Rund
 Day By Day|TTBB|Walter Latzko
+Day By Day (from Day By Day)|TTBB|John Brockman
 Day Dreamin'|TTBB|Louis Perry
 Day In, Day Out|SSAA|Adam Scott
 Day In, Day Out|TTBB|Jeremey Johnson
+Day In, Day Out|TTBB|Rasmus Krigström
 Daybreak|SSAA|Michael Gellert
 Daybreak|TTBB|Jay Giallombardo
 Daydream|SATB|Kevin Keller
@@ -3900,10 +3980,13 @@ Despondency|SATB|Jay Dougherty
 Destination Moon|SSAA|Kevin Keller
 Destination Moon|SSAA|Sonny Steffan
 Destination Moon|TTBB|Matthew Gallagher
+Destination Moon|TTBB|Mike Louque and Sam Dabrusin
+Destination Moon|TTBB|Sam Dobrusin/Richmond/Wong
 Details In The Fabric (sewing machine)|TTBB|Nicholas Wright
 Detour|TTBB|Jud Finley
 Devil May Care|TTBB|Grant Goulding
 Devil May Care|TTBB|Rasmus Krigstrom
+Devil May Care|TTBB|Rasmus Krigström
 Devil Sounds Just Like Me. The|TTBB|Jim Shubert
 Devoted to You|SSAA|Tom Gentry
 Devoted to You|TTBB|Tom Gentry
@@ -4171,6 +4254,7 @@ Don't Let The Sun Go Down On Me|TTBB|Jon Nicholas
 Don't Let The Sun Go Down On Me|TTBB|Mark Burnip
 Don't Lie|SATB|Deke Sharon
 Don't Like Goodbyes|TTBB|Matt Parks
+Don't Like Goodbyes (from House Of Flowers)|TTBB|Matt Parks
 Don't Look At Me That Way|SSAA|Kevin Keller
 Don't Look At Me That Way|TTBB|Kevin Keller
 Don't Look Back In Anger|SSAA|Simon Arnott
@@ -4190,6 +4274,8 @@ Don't Rain on My Parade|SSAA|Larry Wright
 Don't Rain on My Parade|SSAA|Melody Hine
 Don't Rain on My Parade|SSAA|Steve Tramack
 Don't Rain on My Parade|TTBB|David Harrington
+Don't Rain On My Parade|TTBB|David Wright
+Don't Rain On My Parade|TTBB|Patrick McAlexander
 Don't Sit under The Apple Tree|SSAA|David Harrington
 Don't Sit under The Apple Tree|SSAA|Larry Wright
 Don't Sit under The Apple Tree|SSAA|Walter Latzko
@@ -4238,6 +4324,7 @@ Don't Worry, Be Happy|SSAA|Cheryl Suhr
 Don't Worry, Be Happy|TTBB|Michael Webber
 Don't You Remember|SSAA|Emily Moriarty
 Don't You Remember The Time|TTBB|Walter Ingram
+Don't You Worry 'Bout A Thing|TTBB|Jackson Pinder
 Don't You Worry Bout A Thing|SATB|Joe Mannherz
 Don't You Worry Bout A Thing|SATB|Kevin Koehl
 Don't You Worry Bout A Thing|SSAA|Anna-Maria Nystrom
@@ -4396,6 +4483,7 @@ Dreamland Brings Memories of You|TTBB|Jay Giallombardo
 Dreamland/Sweetheart Medley|SSAA|Carolyn Johnson
 Dreams|SATB|Nicholas Wright
 Dreams|SSAA|Nicholas Wright
+Dreams Of Gold/Down To The Sea|TTBB|Rasmus Krigström
 Drift Away|SATB|Deke Sharon
 Drift Away|TTBB|Matt Astle
 Drifting|SSAA|Kevin Keller
@@ -4417,6 +4505,7 @@ Drive My Car|TTBB|Staffan Paulson
 Drive The Cold Winter Away|TTBB|Matt Astle
 Drivers License|SATB|Nicholas Wright
 Drivin' Me Crazy|SSAA|Robert Disney
+Drivin' Me Crazy|TTBB|Bob Disney
 Drivin' Me Crazy|TTBB|Robert Disney
 Drivin' My Life Away|TTBB|Jon Nicholas
 Driving Home The Cows From Pasture|TTBB|Ed Waesche
@@ -4424,6 +4513,7 @@ Drop Em Out|TTBB|Thomas Degan
 Drop Me Off In Harlem|TTBB|Wayne Grimmer
 Drops of Jupiter|SATB|Deke Sharon
 Drops of Jupiter|SSAA|Nicholas Wright
+Drown In My Own Tears|TTBB|Mark Hale
 Drumming Song|SATB|Nicholas Wright
 Drunken Sailor|SSAA|June Dale
 Drunken Sailor|TTBB|Jim West
@@ -4568,6 +4658,7 @@ End of a Love Affair|TTBB|Walter Latzko
 End Of The Way|TTBB|Jim West
 End Of Time|SATB|Deke Sharon
 Endless Love|SATB|Jo Lund
+Enjoy The Ride|TTBB|Kirk Young
 Enjoy Yourself (It's Later Than You Think)|TTBB|Jim Shubert
 Entangled|TTBB|Anders Lindqvist
 Enter Sandman|SSAA|Tom Gentry
@@ -4575,6 +4666,7 @@ Enter Sandman|TTBB|Tom Gentry
 Enterprise Theme (where My Heart Will Take Me)|TTBB|Chris Arnold
 Entrance Of The Gladiators|SSAA|Joey Minshall
 EPCOT Medley|TTBB|Deke Sharon
+Epic Knight Medley|TTBB|Various
 Eres Tu/Touch The Wind|SSAA|Doris Twardosky
 Eres Tu/Touch The Wind|SSAA|Judith Riley
 Erie Canal|TTBB|Keith Clark
@@ -4614,6 +4706,9 @@ Evermore|TTBB|Kevin Keller
 Evermore|TTBB|Kohl Kitzmiller
 Evermore|TTBB|Simon Arnott
 Evermore|TTBB|Theodore Hicks
+Evermore (from Beauty And The Beast)|TTBB|Kevin Keller
+Evermore (from Beauty And The Beast)|TTBB|Rasmus Krigström
+Evermore (from Beauty And The Beast)|TTBB|Theo Hicks
 Every Breath You Take|SSAA|Aaron Dale
 Every Breath You Take|TTBB|Aaron Dale
 Every Breath You Take|TTBB|Alex Morris
@@ -4631,6 +4726,7 @@ Every Tear Is A Smile|TTBB|Burt Szabo
 Every Time I Feel The Spririt|SATB|Derric Johnson
 Every Time I Join My Sister In A Song|SSAA|Paul C. Olguin
 Every Time I See You, I Cry|TTBB|Mac Huff
+Every Time We Say Goodbye|TTBB|Rob Hopkins
 Every Time We Say Goodbye|TTBB|Steve Jamison
 Every Which-a-way|SATB|David Wright
 Every Woman's Song|SSAA|Joey Minshall
@@ -4664,6 +4760,7 @@ Everybody Step|TTBB|Dennis Driscoll
 Everybody Step|TTBB|Jim Shubert
 Everybody Talks|SATB|Deke Sharon
 Everybody Talks|SATB|Nicholas Wright
+Everybody Wants To Be A Cat (from The Aristocats)|TTBB|Jason Dyer
 Everybody Wants To Go To Heaven|SSAA|Louis Perry
 Everybody Wants To Go To Heaven|TTBB|Louis Perry
 Everybody's Buddy|TTBB|Jay Giallombardo
@@ -4711,6 +4808,7 @@ Everywhere I Look|SSAA|Diane Clark
 Everywhere You Go|SSAA|Nancy Bergman
 Everywhere You Go|TTBB|Roy Keys
 Evil Like Me|SATB|Dan Wessler
+Evolution Of Dance Medley|TTBB|Clay Hine
 Ex's & Oh's|SSAA|Rowena Harper
 Exactly Like Me!|SSAA|Jo Lund
 Exactly Like You|SSAA|Joe Mannherz
@@ -4804,6 +4902,7 @@ Feel Again|TTBB|Nicholas Wright
 Feel It Still|TTBB|Kohl Kitzmiller
 Feelin' Alright|SATB|Deke Sharon
 Feelin' Fine|TTBB|Todd Troutman
+Feelin' Good|TTBB|John Brockman
 Feelin' Stronger Every Day|TTBB|Anders Lindqvist
 Feeling Blue|TTBB|Jud Finley
 Feeling Good|SATB|Joe Mannherz
@@ -4886,6 +4985,7 @@ Fire And Rain|SATB|Melody Hine
 Fire And Rain|SSAA|Melody Hine
 Fire And Rain|TTBB|Anders Lindqvist
 Fire And Rain|TTBB|Deke Sharon
+Fire Away|TTBB|Jackson Pinder
 Fire N Gold|SSAA|Nicholas Wright
 Firecracker|SATB|Deke Sharon
 Fireflies|TTBB|Nicholas Wright
@@ -4920,6 +5020,8 @@ Five Foot Two|TTBB|Clay Hine
 Five Foot Two|TTBB|Joe Liles
 Five Foot Two|TTBB|Jon Nicholas
 Five Foot Two Parody|TTBB|Rob Hopkins
+Five Foot Two, Eyes Of Blue|TTBB|Clay Hine
+Five Foot Two, Eyes Of Blue|TTBB|Joe Liles
 Five Foot Two, Eyes of Blue (Has Anybody Seen My Girl?)|TTBB|Joe Liles
 Five Hundred Guys|TTBB|James Halvorson
 Five Minutes More|SSAA|Adam Reimnitz
@@ -5064,6 +5166,7 @@ For Good|SSAA|Tom Gentry
 For Good|TTBB|Aaron Dale
 For Good|TTBB|Steve Tramack
 For Good|TTBB|Tom Gentry
+For Good (from Wicked)|TTBB|Steve Tramack
 For Her|TTBB|Dan Wessler
 For Just A Little While|SSAA|Larry Wright
 For Lovin' Me|TTBB|Roy Keys
@@ -5160,6 +5263,7 @@ Forgotten Dreams/Long Ago Medley|SSAA|Joe Mannherz
 Forties Medley|SSAA|Jay Giallombardo
 Forties Medley|TTBB|Jay Giallombardo
 Fortune In Dreams|SSAA|Earl Moon
+Fortune In Dreams|TTBB|Clay Hine
 Fortune In Dreams|TTBB|Earl Moon
 Fortune Teller|TTBB|John Spence
 Fortuosity|SSAA|Dan Wessler
@@ -5187,6 +5291,7 @@ Fragile|TTBB|Anders Lindqvist
 Fragile|TTBB|Deke Sharon
 Frank Sinatra Medley|SATB|Melody Hine
 Frank Sinatra Medley|TTBB|Melody Hine
+Frankie and Johnny|TTBB|Warren "Buzz" Haeger
 Freckles|TTBB|Jack Baird
 Freckles|TTBB|Toban Dvoretsky
 Freckles / Peck's Bad Boy Medley|SSAA|Tom Gentry
@@ -5202,6 +5307,7 @@ Freedom/Uhuru|SATB|David Avshalomov
 French Chorale Of Praise|SATB|Derric Johnson
 French Foreign Legion|TTBB|Walter Latzko
 French Medley|TTBB|Tom Gentry
+French Revolution Medley|TTBB|Al Baker
 Fresh Prince Of Bel-Air|TTBB|Melody Hine
 Friday I'm In Love|SATB|Deke Sharon
 Friday on My Mind|SSAA|Lyndal Thorburn
@@ -5226,6 +5332,7 @@ Friends Medley|TTBB|David Wright
 Friendship|SATB|Bryan Ziegler
 Friendship|SSAA|Jo Lund
 Friendship|TTBB|Richard Floersheimer
+Frim Fram Sauce|TTBB|Aaron Dale
 Frog Kissin'|SSAA|Nancy Bergman
 Frog Kissin'|TTBB|Bob Jones
 Frog Kissin'|TTBB|Dan Wilson
@@ -5242,7 +5349,9 @@ From Now On|SSAA|Melody Hine
 From Now On|TTBB|Adam Scott
 From Now On|TTBB|Sheryl Neal
 From Now On/Come Alive|TTBB|Aaron Dale
+From Now On/Come Alive (from The Greatest Showman)|TTBB|Aaron Dale
 From Sunrise to Sunset|SSAA|Joan D 'Agostino
+From The First Hello (To The Last Goodbye)|TTBB|Lou Perry
 From The First Hello To The Last Goodbye|SSAA|Brent Graham
 From The First Hello To The Last Goodbye|SSAA|Jim Arns
 From The First Hello To The Last Goodbye|TTBB|Brent Graham
@@ -5294,6 +5403,7 @@ Fun In Just One Lifetime|SSAA|Joe Liles
 Fun In Just One Lifetime|TTBB|Joe Liles
 Fun Medley|SATB|Deke Sharon
 Funk Medley|TTBB|Aaron Dale
+Funk Medley – Uptown Funk|TTBB|Aaron Dale
 Funniest Clown In The Big Top|SSAA|Carolyn Schmidt
 Funniest Clown In The Big Top|TTBB|Michael McCord
 Funny But I Still Love You|TTBB|Michael Webber
@@ -5318,6 +5428,7 @@ Garland Of Old Fashioned Roses|TTBB|Ed Waesche
 Garland Of Old Fashioned Roses|TTBB|Louis Perry
 Garland Of Old Fashioned Roses|TTBB|Robert Strand
 Gary, Indiana|TTBB|Walter Latzko
+Gaston (from Beauty And The Beast)(Parody)|TTBB|Anthony Bartholomew
 Gaudete|SSAA|Erica Kelch-Slesnick
 Gaudete|SSAA|Liz Garnett
 Gay Nineties Medley|SSAA|Jeanne Elmuccio
@@ -5335,6 +5446,7 @@ Gee, I Wish I Was Back in the Army|TTBB|Tom Gentry
 Gee, I'm Glad It's Rainin'|TTBB|Jeremey Johnson
 Gee! But I Hate To Go Home Alone|TTBB|Dennis Driscoll
 Gentle Annie|SSAA|Diane Clark
+Gentle Annie|TTBB|Adam Reimnitz
 Gentle Mary Laid Her Child|SSAA|Carolyn Johnson
 Gentlemen Medley|SSAA|Carolyn Johnson
 George M. Cohan Medley|SSAA|Nancy Bergman
@@ -5386,6 +5498,7 @@ Get Me To The Church On Time|SSAA|Carolyn Schmidt
 Get Me To The Church On Time|SSAA|Jay Giallombardo
 Get Me To The Church On Time|SSAA|Tom Gentry
 Get Me To The Church On Time|TTBB|Aaron Dale
+Get Me To The Church On Time|TTBB|Gary Lewis
 Get Me To The Church On Time|TTBB|Jay Giallombardo
 Get Me To The Church On Time|TTBB|Kohl Kitzmiller
 Get Me To The Church On Time|TTBB|Tom Gentry
@@ -5405,6 +5518,7 @@ Get Ready|TTBB|James Henry
 Get Together|SSAA|Lauren Kahn
 Get Up And Go|SSAA|Kevin Keller
 Get Up And Go|TTBB|Kevin Keller
+Get Your Happy Days On Medley|TTBB|Aaron Dale
 Get Your Happy Days On!|TTBB|Aaron Dale
 Get'cha Head in the Game|SATB|Deke Sharon
 Getting Some Fun Out Of Life|SSAA|David Briner
@@ -5661,6 +5775,7 @@ Going Home|TTBB|David Wright
 Going Home|TTBB|Mike Menefee
 Going Home|TTBB|Tom Gentry
 Gold|SATB|Nicholas Wright
+Gold Can Turn To Sand|TTBB|Patrick McAlexander
 Gold Mine|TTBB|Adam Bock
 Golden|SSAA|Simon Arnott
 Golden Barefoot Days|TTBB|Dennis Driscoll
@@ -5680,6 +5795,7 @@ Gone|SSAA|Tom Gentry
 Gone|TTBB|Ed Waesche
 Gone|TTBB|Roy Keys
 Gone|TTBB|Tom Gentry
+Gone Too Soon|TTBB|Theo Hicks
 Gone, Gone, Gone|SATB|Deke Sharon
 Gone, Gone, Gone|SATB|Mark Stevens
 Gone, Gone, Gone|SATB|Melody Hine
@@ -5689,6 +5805,7 @@ Gone, Gone, Gone|TTBB|Melody Hine
 Gonna Build A Mountain|SSAA|Aileen Nightingale Music
 Gonna Build A Mountain|SSAA|Michael Gellert
 Gonna Build A Mountain|TTBB|Ed Waesche
+Gonna Build A Mountain|TTBB|Jay Giallombardo
 Gonna Build A Mountain|TTBB|Jim West
 Gonna Get a Girl|TTBB|Tom Gentry
 Gonna Get Along Without You Now|SSAA|Nancy Bergman
@@ -5710,6 +5827,7 @@ Good Enough for Now|TTBB|Ken Potter
 Good Enough for Now|TTBB|Matt Astle
 Good Enough for Now|TTBB|Steven Armstrong
 Good Enough for Now|TTBB|Tom Gentry
+Good Enough For Now|TTBB|Rob Hopkins
 Good Job|SSAA|Melody Hine
 Good King Wenceslas|SATB|Deke Sharon
 Good King Wenceslas|SATB|Marshall Webb
@@ -5773,6 +5891,7 @@ Good Thing Going|TTBB|Rob Hopkins
 Good Time Tavern|SATB|Kohl Kitzmiller
 Good Time Tavern|SSAA|Kohl Kitzmiller
 Good Time Tavern|TTBB|Kohl Kitzmiller
+Good Times Medley|TTBB|Patrick McAlexander
 Good To Be Alive|SSAA|Kohl Kitzmiller
 Good To Be Alive|TTBB|Nicholas Wright
 Good Vibrations|SATB|Staffan Paulson
@@ -5827,8 +5946,10 @@ Goodbye Yellow Brick Road|SSAA|Lauren Kahn
 Goodbye Yellow Brick Road|TTBB|Anders Lindqvist
 Goodbye Yellow Brick Road|TTBB|Rasmus Krigstrom
 Goodbye Yellow Brick Road|TTBB|Simon Arnott
+Goodbye Yellowbrick Road|TTBB|Simon Arnott
 Goodbye, Dixie, Goodbye|TTBB|Unknown
 Goodbye, My Coney Island Baby/We All Fall|TTBB|BHS
+Goodbye, My Coney Island Baby/We All Fall (Medley)|TTBB|SPEBSQSA
 Goodbye, Rose|TTBB|Burt Szabo
 Goodbye, You Phony Lyin' Baby|SSAA|Nancy Bergman
 Goodnight Angeline|TTBB|David Briner
@@ -6003,6 +6124,7 @@ Grouch Anthem|SSAA|Dianne Goldrick
 Grouch Anthem|TTBB|Dianne Goldrick
 Grow As We Go|SATB|Justin Miller
 Grow Old With Me|SATB|John Cowlishaw
+Grow Old With Me|TTBB|Andrew Carolan
 Grow Old With You|SSAA|Aaron Dale
 Grow Old With You|TTBB|Aaron Dale
 Grow Old With You|TTBB|Larry Wright
@@ -6078,12 +6200,14 @@ Hallelujah Chorus|TTBB|Jay Giallombardo
 Hallelujah Chorus|TTBB|Mark Goodney
 Hallelujah Christmas|SSAA|Kay Bromert
 Hallelujah, I Love Her So|TTBB|Aaron Dale
+Hallelujah, I Love Her So|TTBB|Jay Giallombardo
 Hallelujah, I Love Her So|TTBB|Kohl Kitzmiller
 Hallelujah, I Love Her So|TTBB|Tom Gentry
 Halls Of Ivy|SSAA|Jay Giallombardo
 Halls Of Ivy|TTBB|Don Gray
 Halls Of Ivy|TTBB|Jay Giallombardo
 Halo|SATB|Deke Sharon
+Hand In Hand|TTBB|Matt Astle
 Hand Medley|TTBB|Dennis Driscoll
 Handclap|SATB|Nicholas Wright
 Handful Of Keys|SSAA|David Wright
@@ -6182,6 +6306,7 @@ Happy Ending|TTBB|Matt Astle
 Happy Feet|SSAA|Jim Arns
 Happy Feet Medley|TTBB|Ed Waesche
 Happy Go Lucky Lane|TTBB|Jay Giallombardo
+Happy Go Lucky Lane|TTBB|Jay Giallombardo/Greg Volk
 Happy Hanukkah, My Friend|SSAA|Jeanne Elmuccio
 Happy Hanukkah, My Friend|SSAA|Nancy Bergman
 Happy Happy Birthday Baby|TTBB|Aaron Dale
@@ -6231,6 +6356,7 @@ Happy Trails|TTBB|Tom Gentry
 Happy Trails|TTBB|Tom Parker
 Happy Working Song|SSAA|Hilary Allen
 Happy/All About That Bass Medley|SSAA|Larry Wright
+Happy/Sad|TTBB|Adam Reimnitz
 Harbor Lights|SSAA|Mary K. Coffman Music Fund
 Harbor Lights|TTBB|Paul Jorg
 Hard Boiled Rose|TTBB|Marty Israel
@@ -6243,12 +6369,14 @@ Hard Hearted Hannah|SSAA|LaVeda Redfield
 Hard Hearted Hannah|SSAA|Linda Edmondson
 Hard Hearted Hannah|SSAA|Marge Bailey
 Hard Hearted Hannah|SSAA|Michael Gellert
+Hard Hearted Hannah|TTBB|Clay Hine
 Hard Hearted Hannah|TTBB|Dennis Driscoll
 Hard Hearted Hannah|TTBB|Howard Jones Jr.
 Hard Hearted Hannah|TTBB|Larry Wright
 Hard Hearted Hannah|TTBB|Todd Troutman
 Hard Hearted Hannah|TTBB|Walter Latzko
 Hard Times (No One Knows Better Than I)|TTBB|Kevin Keller
+Hard Times (No One Knows Better Than I)|TTBB|Theo Hicks
 Hard Times Come Again No More|SATB|Thomas Degan
 Hard Times Come Again No More|TTBB|David Wright
 Hard To Get Gertie|TTBB|Ed Waesche
@@ -6256,6 +6384,7 @@ Hard To Say I'm Sorry|SATB|Deke Sharon
 Hard To Say I'm Sorry|SSAA|Brian Mastrull
 Hard To Say I'm Sorry|TTBB|Brian Mastrull
 Hard To Say I'm Sorry|TTBB|Deke Sharon
+Hard To Say I'm Sorry (from Summer Lovers)|TTBB|David Mastrull
 Harder To Breathe|TTBB|Deke Sharon
 Hark the Herald Angels Sing/Angels We Have Heard on High|TTBB|Jay Giallombardo
 Hark! The Herald Angels Sing|SATB|David Harrington
@@ -6321,6 +6450,7 @@ Have You Met Miss Jones|SSAA|Jo Lund
 Have You Met Miss Jones|TTBB|Dan Wessler
 Have You Met Miss Jones|TTBB|Rasmus Krigstrom
 Have You Met Miss Jones|TTBB|Walter Latzko
+Have You Met Miss Jones?|TTBB|Rasmus Krigström
 Have You Seen The Child|TTBB|Jay Giallombardo
 Have Yourself a Mary Little Christmas|TTBB|M. Gill
 Have Yourself A Merry Little Christmas|SATB|Chris Arnold
@@ -6361,6 +6491,7 @@ Haven't Met You Yet|SSAA|Aaron Dale
 Haven't Met You Yet|TTBB|Aaron Dale
 Haven't Met You Yet|TTBB|Jay Giallombardo
 Haven't Met You Yet|TTBB|Liz Garnett
+Haven't Met You Yet|TTBB|Steve Tramack
 Hawaii, I'll Love You Forever|TTBB|Einar Pedersen
 Hawaiian Roller Coaster Ride|SATB|Deke Sharon
 Hawaiian Roller Coaster Ride|SATB|Melody Hine
@@ -6456,6 +6587,7 @@ Heart Of Stone|SSAA|Jen Squires
 Heart-breaking Baby Doll|TTBB|Burt Szabo
 Heartache Tonight|TTBB|Aaron Dale
 Heartache Tonight|TTBB|Deke Sharon
+Heartache Tonight|TTBB|Rasmus Krigström
 Heartaches|SSAA|Marsha Zwicker
 Heartaches|TTBB|John Eby
 Heartbeat Song|SATB|Nicholas Wright
@@ -6475,6 +6607,7 @@ Heaven|SATB|Nicholas Wright
 Heaven|TTBB|Joe Grimme
 Heaven Can Wait|SATB|Don Staffin
 Heaven Can Wait|TTBB|Don Staffin
+Heaven Medley (Cheek To Cheek/My Blue Heaven)|TTBB|John Brockman
 Heaven Will Protect The Working Girl|TTBB|Burt Szabo
 Heaven Will Protect The Working Girl|TTBB|Jack Baird
 Heaven's Light|TTBB|Adam Bock
@@ -6731,6 +6864,7 @@ Hit Me With A Hot Note|SSAA|June Berg
 Hit Me With A Hot Note|SSAA|Michael Gellert
 Hit Me With A Hot Note|SSAA|Patrick McAlexander
 Hit Me With A Hot Note|TTBB|June Berg
+Hit Me With A Hot Note|TTBB|Patrick McAlexander
 Hit Me With a Hot Note/Too Darn Hot Medley|SSAA|Liz Garnett
 Hit Me With Your Best Shot|SATB|Deke Sharon
 Hit Me With Your Best Shot|SSAA|Deke Sharon
@@ -6838,6 +6972,7 @@ Home|TTBB|Michael Gellert
 Home|TTBB|Roy Keys
 Home|TTBB|Steve Tramack
 Home|TTBB|Walter Latzko
+Home (from Beauty And The Beast)|TTBB|Cay Outerbridge
 Home Again|SSAA|Kay Bromert
 Home Among The Gumtrees|SSAA|Emily Moriarty
 Home For The Holidays|SATB|Burt Szabo
@@ -6881,6 +7016,7 @@ Honesty|TTBB|Kohl Kitzmiller
 Honey / Little 'Lize Medley|TTBB|Floyd Connett
 Honey Boy|SSAA|Walter Latzko
 Honey Bun|TTBB|Dennis Driscoll
+Honey Medley|TTBB|David Harrington
 Honey Medley|TTBB|Tom Gentry
 Honey of Mine|TTBB|Aaron Dale
 Honey Pie|TTBB|Todd Troutman
@@ -6926,6 +7062,7 @@ Hooray For Hollywood|TTBB|Edward Boehm
 Hooray For Hollywood|TTBB|Jay Giallombardo
 Hooray For Love|SSAA|Aaron Dale
 Hooray For Love|SSAA|Larry Wright
+Hooray For Love|TTBB|Alan Gordon
 Hooray For Love|TTBB|Larry Wright
 Hooray For Love|TTBB|Walter Latzko
 Hooray For Love/Glory Of Love|SSAA|Marsha Zwicker
@@ -6969,6 +7106,7 @@ How About Me?|SSAA|Charlotte Pernert
 How About Me?|SSAA|David Briner
 How About Me?|SSAA|Jo Lund
 How About Me?|SSAA|Wilma Williams
+How About You?|TTBB|Patrick McAlexander
 How Am I Supposed To Live Without You|TTBB|Theodore Hicks
 How Am I To Know|TTBB|Walter Latzko
 How Are Things In Glocca Morra|SATB|Kevin Keller
@@ -7003,9 +7141,12 @@ How Could I Ever Know?|SATB|Theodore Hicks
 How Could I Ever Know?|SSAA|Theodore Hicks
 How Could I Ever Know?|TTBB|Matthew Gallagher
 How Could I Ever Know?|TTBB|Theodore Hicks
+How Could I Ever Know? (from The Secret Garden)|TTBB|Matt Gallagher
+How Could I Ever Know? (from The Secret Garden)|TTBB|Theo Hicks
 How Could You Believe Me|SATB|Nancy Bergman
 How Could You Believe Me|SSAA|Sylvia Alsbury
 How Could You Believe Me|TTBB|Mark Goodney
+How Could You Believe Me ?/It's A Sin To Tell A Lie (Medley)|TTBB|Renee Craig
 How D'Ya Like Your Eggs in the Morning|SSAA|Emily Moriarty
 How D'Ya Like Your Eggs in the Morning|SSAA|Joey Minshall
 How D'Ya Like Your Eggs in the Morning|SSAA|Tom Gentry
@@ -7024,6 +7165,7 @@ How Deep Is the Ocean (How High Is the Sky)|SSAA|Ed Waesche
 How Deep Is the Ocean (How High Is the Sky)|TTBB|Ed Waesche
 How Deep Is The Ocean (How High Is The Sky)|SSAA|Rob Hopkins
 How Deep Is The Ocean (How High Is The Sky)|TTBB|Rob Hopkins
+How Deep Is The Ocean (How High Is The Sky) (Parody)|TTBB|Ed Waesche
 How Deep Is The Ocean/Remember|TTBB|Walter Latzko
 How Deep Is Your Love?|SSAA|Larry Wright
 How Deep Is Your Love?|TTBB|Aaron Dale
@@ -7043,6 +7185,7 @@ How Far I'll Go|SSAA|Matthew Gallagher
 How Far I'll Go|SSAA|Tamra Perez
 How Far I'll Go|TTBB|Aaron Dale
 How Far I'll Go|TTBB|Matthew Gallagher
+How Far I'll Go (from Moana)(Parody)|TTBB|Ira Allen (tag)/Matt Astle
 How Far Is It To Bethlehem|SATB|Larry Triplett
 How Far Is It To Bethlehem|SSAA|Larry Triplett
 How Far Is It To Bethlehem|TTBB|Larry Triplett
@@ -7060,6 +7203,7 @@ How High The Moon|SSAA|Melody Hine
 How High The Moon|SSAA|Walter Latzko
 How High The Moon|TTBB|Mark Hale
 How It Ends|TTBB|Kevin Keller
+How It Ends (from Big Fish)|TTBB|Kevin Keller
 How Little We Know|SSAA|Joe Mannherz
 How Little We Know|TTBB|Adam Reimnitz
 How Little We Know|TTBB|Joe Mannherz
@@ -7075,6 +7219,7 @@ How Lucky You Are|SSAA|Patrick McAlexander
 How Lucky You Are|TTBB|Dan Wessler
 How Lucky You Are|TTBB|Katie Farrell
 How Lucky You Are|TTBB|Patrick McAlexander
+How Lucky You Are (from Seussical)|TTBB|Dan Wessler
 How Many Hearts Have You Broken?|SSAA|Jim Arns
 How Many Hearts Have You Broken?|SSAA|Marie Johnson
 How Many Hearts Have You Broken?|TTBB|Dennis Driscoll
@@ -7233,6 +7378,7 @@ I Can See Clearly Now|TTBB|Cay Outerbridge
 I Can See Clearly Now|TTBB|Jay Giallombardo
 I Can See Clearly Now|TTBB|Mark Burnip
 I Can See Clearly Now|TTBB|Mark Stevens
+I Can See Clearly Now|TTBB|Steve Armstrong
 I Can See Clearly Now|TTBB|Steven Armstrong
 I Can Sing A Rainbow|SSAA|Carole Prietto
 I Can't Begin To Tell You|SSAA|Burt Szabo
@@ -7341,6 +7487,7 @@ I Don't Know How To Say Goodbye|SSAA|Joe Mannherz
 I Don't Know How To Say Goodbye|TTBB|Adam Scott
 I Don't Know How To Say Goodbye|TTBB|Jay Giallombardo
 I Don't Know How To Say Goodbye|TTBB|Joe Mannherz
+I Don't Know How To Say Goodbye|TTBB|Theo Hicks
 I Don't Know How To Say Goodbye|TTBB|Theodore Hicks
 I Don't Know If I Should Call Her|TTBB|Jon Nicholas
 I Don't Know Where I'm Going But I'm On My Way|SSAA|Carolyn Johnson
@@ -7357,6 +7504,7 @@ I Don't Mind Being All Alone|SSAA|Barbershop Harmony Society
 I Don't Mind Being All Alone|SSAA|BHS
 I Don't Mind Being All Alone|TTBB|Barbershop Harmony Society
 I Don't Mind Being All Alone|TTBB|George Hulst
+I Don't Remember Her Name|TTBB|Paul Olguin
 I Don't Stand A Ghost Of A Chance|TTBB|Jim Shubert
 I Don't Understand The Poor|TTBB|Greg Mallett
 I don't wanna be the one|SSAA|Joe Mannherz
@@ -7377,6 +7525,7 @@ I Don't Want to Miss a Thing|SATB|Dan Wessler
 I Don't Want to Miss a Thing|SSAA|Dan Wessler
 I Don't Want to Miss a Thing|SSAA|Liz Garnett
 I Don't Want to Miss a Thing|TTBB|Dan Wessler
+I Don't Want To Miss A Thing (from Armageddon)|TTBB|Dan Wessler
 I Don't Want To Play In Your Yard|SSAA|Walter Latzko
 I Don't Want To Set The World On Fire|SATB|Jay Dougherty
 I Don't Want To Set The World On Fire|SSAA|Jay Dougherty
@@ -7424,6 +7573,7 @@ I Feel The Earth Move|SSAA|Glenda Lloyd
 I Feel The Earth Move|SSAA|Larry Wright
 I Felt a Funeral in My Brain|SATB|Jay Dougherty
 I Finally Found Someone|SSAA|Tedda Lippincott
+I Finally Found Someone|TTBB|Steve Tramack
 I Find Your Love|SSAA|Liz Garnett
 I Followed Her Around|SATB|Deke Sharon
 I Found A Million Dollar Baby|SSAA|Carolyn Schmidt
@@ -7539,6 +7689,7 @@ I Have Dreamed|TTBB|Walter Latzko
 I Have Nothing|SSAA|Kay Bromert
 I Have Nothing|TTBB|Aaron Dale
 I Have Nothing|TTBB|Theodore Hicks
+I Have Nothing (from The Bodyguard)|TTBB|Theo Hicks
 I Have Seen The Light|TTBB|Jay Giallombardo
 I Hear Music|TTBB|Dennis Driscoll
 I Hear Music|TTBB|Walter Latzko
@@ -7598,6 +7749,7 @@ I Know An Old Lady Who Swallowed A Fly|TTBB|Tom Gentry
 I Know That You Know|TTBB|Walter Latzko
 I Know What It Means To Be Lonesome|TTBB|Rob Campbell
 I Know Where I've Been|TTBB|Kyle Kitzmiller
+I Know Where I've Been|TTBB|Theo Hicks
 I Know Where I've Been|TTBB|Theodore Hicks
 I Know Why And So Do You|SSAA|Ig Jakovac
 I Know Why And So Do You|SSAA|Joe Mannherz
@@ -7685,6 +7837,7 @@ I Love To Laugh|TTBB|Val Hicks
 I Love To Laugh (from Walt Disney's MARY POPPINS)|TTBB|Val Hicks
 I Love To See You Smile|TTBB|Jim Emery
 I Love To See You Smile|TTBB|Matt Astle
+I Love To Singa|TTBB|Patrick McAlexander
 I Love To Tell The Story|SSAA|Walter Latzko
 I Love To Tell The Story|TTBB|Walter Latzko
 I Love Trash|TTBB|Cay Outerbridge
@@ -7861,6 +8014,7 @@ I Thought About You|SSAA|Jay Giallombardo
 I Thought About You|TTBB|Jay Giallombardo
 I Thought About You|TTBB|Steve Hardy
 I Thought She Knew|SSAA|Theodore Hicks
+I Thought She Knew|TTBB|Theo Hicks
 I Thought She Knew|TTBB|Theodore Hicks
 I Thought She Knew|TTBB|Walter Latzko
 I Thrill When They Mention Your Name|TTBB|Jim Franklin
@@ -7877,6 +8031,7 @@ I Tore Up Your Picture When You Said Goodbye|TTBB|John Hohl
 I Tried To Forget You (In Vain)|TTBB|Toban Dvoretsky
 I Tried Your Love|TTBB|Jon Nicholas
 I Turned the Corner|TTBB|Adam Scott
+I Used To Be Color Blind|TTBB|Adam Reimnitz
 I Used To Call Her Baby|TTBB|John Muir
 I Used To Call Her Baby|TTBB|Rob Hopkins
 I Used To Call Her Baby|TTBB|Tom Gentry
@@ -7992,6 +8147,7 @@ I Was Born Seventy Years Too Late|TTBB|Barbershop Harmony Society
 I Was Born Seventy Years Too Late|TTBB|SPEBSQSA
 I Was Doing All Right|SATB|Dan Wessler
 I Was Doing All Right|TTBB|Dan Wessler
+I Was Doing Alright|TTBB|Joel Guyer
 I Was Floating Down The Old Green River|TTBB|Steve Hardy
 I Was Here|SATB|Jay Giallombardo
 I Was Here|SSAA|Jay Giallombardo
@@ -8115,6 +8271,7 @@ I Won't Send Roses|TTBB|Archie Steen
 I Won't Send Roses|TTBB|Joe Mannherz
 I Won't Send Roses|TTBB|Theo Hicks
 I Won't Send Roses|TTBB|Theodore Hicks
+I Won't Send Roses (from Mack And Mabel)|TTBB|Theo Hicks
 I Won't Tell A Soul|TTBB|George Hulst
 I Wonder as I Wander|TTBB|John Wernega
 I Wonder As I Wander|SSAA|Joey Minshall
@@ -8211,6 +8368,7 @@ I'll Be Around|TTBB|Mark Goodney
 I'll Be Back|TTBB|Rob Campbell
 I'll Be Easy To Find|SSAA|Joey Minshall
 I'll Be Here|TTBB|Justin Miller
+I'll Be Here (from The Wild Party)|TTBB|Justin Miller
 I'll Be Here With You|SSAA|Brent Graham
 I'll Be Here With You|TTBB|Brent Graham
 I'll Be Home for Christmas|TTBB|BHS
@@ -8255,6 +8413,7 @@ I'll Be Seeing You|TTBB|Jim Shubert
 I'll Be Seeing You|TTBB|Joe Mannherz
 I'll Be Seeing You|TTBB|Patrick Bauer
 I'll Be Seeing You|TTBB|Rob Hopkins
+I'll Be Seeing You|TTBB|Rob Hopkins/Eric Jackson
 I'll Be Seeing You|TTBB|Walter Latzko
 I'll Be Seeing You/Once In A Lifetime Medley|SATB|Rob Hopkins
 I'll Be Seeing You/Once In A Lifetime Medley|SSAA|Rob Hopkins
@@ -8273,6 +8432,7 @@ I'll Be Walkin With My Honey|TTBB|Mo Rector
 I'll Be With You In Apple Blossom Time|SSAA|Nancy Bergman
 I'll Be With You In Apple Blossom Time|SSAA|Walter Latzko
 I'll Be With You In Apple Blossom Time|TTBB|Burt Szabo
+I'll Be With You In Apple Blossom Time|TTBB|Clay Hine
 I'll Be With You In Apple Blossom Time|TTBB|Robert Standley
 I'll Be With You In Apple Blossom Time|TTBB|Steve Delehanty
 I'll Be Your Friend Until Forever|SSAA|Tedda Lippincott
@@ -8292,6 +8452,7 @@ I'll Close My Eyes (and make believe it's you)|SATB|Karen Penketh
 I'll Do It All Over Again|TTBB|Burt Szabo
 I'll Dream of You Again/And So To Sleep Again Medley|SSAA|Kevin Keller
 I'll Dream of You Again/And So To Sleep Again Medley|TTBB|Kevin Keller
+I’ll Drown In My Own Tears|TTBB|Mark Hale
 I'll Fight|SSAA|Carole Prietto
 I'll Fly Away|TTBB|Burt Szabo
 I'll Fly Away|TTBB|Dennis Driscoll
@@ -8349,6 +8510,7 @@ I'll Take Care Of Your Cares|TTBB|Louis Perry
 I'll Take Care Of Your Cares|TTBB|Munson Hinman
 I'll Take Her Back|TTBB|Val Hicks
 I'll Take Romance|SSAA|Marshall Webb
+I'll Take You Dreaming|TTBB|Clay Hine
 I'll Take You Dreaming|TTBB|Larry Triplett
 I'll Take You Home Again, Kathleen|TTBB|Barbershop Harmony Society
 I'll Take You Home Again, Kathleen|TTBB|Jay Giallombardo
@@ -8498,6 +8660,7 @@ I'm Gonna Steal Somebody Else's Baby|SSAA|Avis Fellows
 I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ken Potter
 I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ruby Rhea
 I'm Gonna' Be A Star|TTBB|Jim West
+I'm Havin' A Ball (from Dirty Grandpa)|TTBB|Cay Outerbridge
 I'm Having A Ball|SSAA|Larry Wright
 I'm Having A Ball|TTBB|Kevin Koehl
 I'm Headin' South|TTBB|Jay Giallombardo
@@ -8526,6 +8689,7 @@ I'm Just A Dancing Sweetheart|SATB|Karen Penketh
 I'm Just a Gigolo/I Ain't Got Nobody|TTBB|Liz Garnett
 I'm Just A Kid|SATB|Nicholas Wright
 I'm Just A Little Blue|TTBB|Burt Szabo
+I'm Just A Lucky So And So|TTBB|Joel Guyer
 I'm Just Ken|SATB|Liz Garnett
 I'm Just Ken|SSAA|Adam Bock
 I'm Just Ken|SSAA|Melody Hine
@@ -8591,6 +8755,7 @@ I'm Pretty Good At Drinkin' Beer|TTBB|Jim West
 I'm Proud To Be An American|TTBB|Jim West
 I'm Putting All My Eggs In One Basket|TTBB|Aaron Dale
 I'm Putting All My Eggs In One Basket|TTBB|Jim Shubert
+I'm Putting All My Eggs In One Basket|TTBB|Patrick McAlexander
 I'm Putting All My Eggs In One Basket|TTBB|Robert Rund
 I'm Ready|TTBB|Nicholas Wright
 I'm Returning Everything|SSAA|Tom Gentry
@@ -8713,6 +8878,7 @@ I've Got A Crush On You|TTBB|Joe Mannherz
 I've Got A Crush On You|TTBB|Kevin Keller
 I've Got A Crush On You|TTBB|Walter Latzko
 I've Got A Dream|TTBB|Soren Detlefsen
+I’ve Got A Dream|TTBB|Darin Drown
 I've Got A Feeling I'm Falling|SSAA|David Wright
 I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
 I've Got A Feeling I'm Falling|TTBB|David Wright
@@ -8740,6 +8906,7 @@ I've Got My Love To Keep Me Warm|TTBB|Anastasio Rossi
 I've Got My Love To Keep Me Warm|TTBB|Kohl Kitzmiller
 I've Got My Love To Keep Me Warm|TTBB|Mark Goodney
 I've Got My Love To Keep Me Warm|TTBB|Wayne Grimmer
+I've Got No Strings|TTBB|Jackson Pinder
 I've Got No Strings|TTBB|Jeremey Johnson
 I've Got Rings On My Fingers|TTBB|Walter Latzko
 I've Got The Blues For Tennessee|SSAA|Marie Johnson
@@ -8759,6 +8926,7 @@ I've Got The World On A String|TTBB|Todd Troutman
 I've Got The World On A String|TTBB|Tom Gentry
 I've Got The World On A String|TTBB|Walter Latzko
 I've Got You Under My Skin|TTBB|Walter Latzko
+I've Got You Under My Skin|TTBB|Wayne Grimmer
 I've Gotta Be Me|SSAA|Larry Wright
 I've Gotta Be Me|TTBB|Theodore Hicks
 I've Gotta Crow|SSAA|Larry Wright
@@ -8819,6 +8987,7 @@ If All My Dreams Were Made of Gold, I'd Buy the World for You|TTBB|Louis Perry
 If Anything Happened to You|TTBB|Tom Gentry
 If Ever I Would Leave You|SSAA|Brent Graham
 If Ever I Would Leave You|TTBB|Brent Graham
+If Ever I Would Leave You|TTBB|Clay Hine
 If He Can Fight Like He Can Love, Good Night Germany|SSAA|Marie Johnson
 If He Can Fight Like He Can Love, Good Night Germany|SSAA|Russ Foris
 If He Can Fight Like He Can Love, Good Night Germany|TTBB|C. J. Sams Jr.
@@ -8836,6 +9005,7 @@ If I Can Dream|SSAA|Kay Bromert
 If I Can Dream|SSAA|Kevin Koehl
 If I Can Dream|SSAA|Tom Gentry
 If I Can Dream|TTBB|Aaron Dale
+If I Can Dream|TTBB|Steve Armstrong
 If I Can Dream|TTBB|Steven Armstrong
 If I Can Dream|TTBB|Tom Gentry
 If I Can't Have You|SATB|Nicholas Wright
@@ -8865,11 +9035,13 @@ If I Didn't Have You|TTBB|Tom Gentry
 If I Ever Leave This World Alive|TTBB|Aaron Dale
 If I Ever Say I'm Over You|SSAA|Brent Graham
 If I Ever Say I'm Over You|TTBB|Brent Graham
+If I Ever Say I'm Over You (from It's Only Life)|TTBB|Brent Graham
 If I Fell|SSAA|Brian Harding
 If I Fell|SSAA|Carolyn Schmidt
 If I Fell|TTBB|Brian Harding
 If I Find Another Boy Like You|TTBB|Tom Gentry
 If I Give My Heart To You|TTBB|Jay Giallombardo
+If I Give My Heart To You|TTBB|Jim Clancy
 If I Give My Heart To You|TTBB|Marilyn Penketh
 If I Give Up The Saxophone (Will You Come Back to Me)|TTBB|Jay Giallombardo
 If I Had A Bulldozer|TTBB|Tom Gentry
@@ -8919,6 +9091,7 @@ If I Had You|TTBB|Robert Martin
 If I Had You|TTBB|Walter Latzko
 If I Had You/Cuddle Up a Little Closer Medley|SSAA|Jo Lund
 If I Have To Go To War|TTBB|Kim Brittain
+If I Knew|TTBB|Jackson Pinder
 If I Lose Myself|SSAA|Nicholas Wright
 If I Lose Myself|TTBB|Nicholas Wright
 If I Love Again|SSAA|Ed Waesche
@@ -8943,6 +9116,8 @@ If I Loved You|TTBB|Mike Sobeleski
 If I Loved You|TTBB|Robert Rund
 If I Loved You|TTBB|Tom Gentry
 If I Loved You|TTBB|Walter Latzko
+If I Loved You (from Carousel)|TTBB|Jay Giallombardo
+If I Loved You (from Carousel)|TTBB|Rasmus Krigström
 If I Loved You More|SSAA|Avis Fellows
 If I May|SSAA|Patrick McAlexander
 If I May|TTBB|Patrick McAlexander
@@ -8953,6 +9128,7 @@ If I Never See You Again|TTBB|Walter Latzko
 If I Only Had A Brain|SATB|Kyle Snook
 If I Only Had A Brain|SSAA|Clay Hine
 If I Only Had A Brain|SSAA|Jo Lund
+If I Only Had A Brain|TTBB|Clay Hine
 If I Only Had A Brain / Heart Medley|TTBB|Lloyd Steinkamp
 If I Only Had A Heart (Brain)|SATB|Deke Sharon
 If I Only Knew Where She's Gone|TTBB|Robert Rund
@@ -8964,6 +9140,7 @@ If I Ruled The World|TTBB|Don Gray
 If I Ruled The World|TTBB|Ed Waesche
 If I Ruled The World|TTBB|Fred King
 If I Ruled The World|TTBB|Hal Snyder
+If I Ruled The World|TTBB|Jim Clancy
 If I Ruled The World|TTBB|Joe Mannherz
 If I Ruled The World|TTBB|Todd Troutman
 If I Stay Away Too Long from Carolina|TTBB|Tom Gentry
@@ -8971,6 +9148,7 @@ If I Were A Bell|SSAA|Adam Reimnitz
 If I Were A Bell|SSAA|Joey Minshall
 If I Were A Bell|SSAA|Tony Nasto
 If I Were A Bell|TTBB|Aaron Dale
+If I Were A Bell (from Guys And Dolls)|TTBB|Aaron Dale
 If I Were a Boy/Girls Medley|SATB|Liz Garnett
 If I Were a Boy/Girls Medley|SSAA|Liz Garnett
 If I Were A Fish|SATB|Melody Hine
@@ -8991,12 +9169,15 @@ If My Friends Could See Me Now|TTBB|Ray Danley
 If My Friends Could See Me Now|TTBB|Renee Craig
 If My Friends Could See Me Now|TTBB|Rob Hopkins
 If My Friends Could See Me Now|TTBB|Walter Latzko
+If My Friends Could See Me Now Medley|TTBB|Patrick McAlexander
 If My Nose Was Running Money|TTBB|David Lorenz
 If My Nose Was Running Money|TTBB|Steven Sturgis
+If My Nose Was Running Money (I'd Blow It All On You)|TTBB|Steve Delehanty
 If She Looks Good To Mother, Don't Look For Another|TTBB|Louis Perry
 If She Means What I Think She Means|TTBB|Burt Szabo
 If She Means What I Think She Means|TTBB|Larry Wright
 If The Devil Danced|TTBB|Michael Webber
+If The Devil Danced (In Empty Pockets)|TTBB|Michael Webber
 If The Lord Be Willin'|SSAA|Jay Giallombardo
 If The Lord Be Willin'|TTBB|Don Gray
 If The Lord Be Willin'|TTBB|Jay Giallombardo
@@ -9047,6 +9228,7 @@ If You Go Away|SATB|Kevin Keller
 If You Go Away|SSAA|Kevin Keller
 If You Go Away|TTBB|David Wright
 If You Go Away|TTBB|Kevin Keller
+If You Go Away (Ne Me Quitte Pas)|TTBB|David Wright
 If You Had All The World And It's Gold|TTBB|Unknown
 If You Had All The World And Its Gold|SSAA|Jay Giallombardo
 If You Had All The World And Its Gold|TTBB|Barbershop Harmony Society
@@ -9100,6 +9282,7 @@ Imagine|SSAA|Marge Bailey
 Imagine|TTBB|Chris Arnold
 Imagine|TTBB|Wendy Hofmann
 Imagine That|SATB|Mark Stevens
+Imagine That|TTBB|Mike Tipton
 Immanuel|TTBB|Kevin Keller
 Immortals|SATB|Deke Sharon
 Impossible|TTBB|Liz Garnett
@@ -9108,6 +9291,7 @@ Impossible Year|TTBB|Simon Arnott
 In a Box on a Shelf|SSAA|Kay Bromert
 In A Little Red Barn|TTBB|Jerry Tracey
 In A Little Red Barn|TTBB|John Mulkin
+In A Little Red Barn (On A Farm Down In Indiana)|TTBB|Joel Guyer
 In A Mellow Tone|SSAA|Larry Wright
 In A Mellow Tone|TTBB|Larry Wright
 In A Sentimental Mood|TTBB|Joe Grimme
@@ -9128,6 +9312,7 @@ In Flander's Fields|TTBB|Douglas Smith
 In Heavens Eyes|SSAA|Carolyn Schmidt
 In His Eyes|SSAA|Adam Bock
 In His Eyes|SSAA|Michael Gellert
+In His Eyes|TTBB|Greg Volk
 In Louisiana|SSAA|Jo Lund
 In Moments Like These|TTBB|Derric Johnson
 In My Album of Memories|SSAA|Tom Gentry
@@ -9242,6 +9427,7 @@ In the Still of the Nite|TTBB|Tom Gentry
 In The Sweet Long Ago|SSAA|Walter Latzko
 In The Wee Small Hours Of The Morning|SSAA|Jim Arns
 In The Wee Small Hours Of The Morning|TTBB|Adam Scott
+In The Wee Small Hours Of The Morning|TTBB|Jimbob Kahlke
 In The Wee Small Hours Of The Morning|TTBB|Kevin Keller
 In This Heart|SSAA|Kevin Keller
 In This Life|TTBB|Mark Stevens
@@ -9279,6 +9465,7 @@ Intermission|SSAA|Avis Fellows
 Into My Arms|SSAA|Hannah Braham
 Into My Arms|TTBB|Luke Stevenson
 Into The Fire|TTBB|Aaron Dale
+Into The Fire|TTBB|Steve Tramack
 Into the Unknown|SATB|David Wright
 Into the Unknown|SATB|Deke Sharon
 Into the Unknown|SATB|Deke Sharon & David Wright
@@ -9327,8 +9514,10 @@ Irish Songs Give Me A Pain (Parody)|SSAA|Marie Johnson
 Is She Really Going Out With Him|SATB|Nicholas Wright
 Is This Just Another Song|SSAA|Robert Disney
 Is This Just Another Song|TTBB|Robert Disney
+Is This Just Another Song?|TTBB|Bob Disney
 Is You Is Or Is You Ain't (Ma Baby)|SSAA|Jean McFadyen
 Is You Is Or Is You Ain't (Ma Baby)|TTBB|Ian Crane
+Is You Is Or Is You Ain't (Ma Baby)?|TTBB|Greg Volk
 Island Life|SATB|Joe Mannherz
 Island of Dreams|SATB|Tom Gentry
 Island of Dreams|SSAA|Tom Gentry
@@ -9385,6 +9574,7 @@ It Don't Mean A Thing|TTBB|Deke Sharon
 It Don't Mean A Thing|TTBB|Mark Goodney
 It Don't Mean A Thing (If It Ain't Got That Swing)|TTBB|Dan Mulligan
 It Don't Mean A Thing/Classical Music Parody|TTBB|Jay Giallombardo
+It Feels Good When You Sing a Song|TTBB|Jackson Pinder
 It Feels Like Christmas|SSAA|Debbie Keretz
 It Feels Like Christmas|TTBB|Matt Astle
 It Feels Like Home|SSAA|Mark Burnip
@@ -9452,9 +9642,12 @@ It Only Takes A Moment|SSAA|Joe Mannherz
 It Only Takes A Moment|TTBB|David Wright
 It Only Takes A Moment|TTBB|Ed Waesche
 It Only Takes A Moment|TTBB|Joe Mannherz
+It Only Takes A Moment (from Hello, Dolly!)|TTBB|David Wright
+It Only Took a Kiss|TTBB|Adam Bock
 It Rained Last Night|TTBB|Walter Latzko
 It Shouldn't Happen To A Dream|TTBB|Cay Outerbridge
 It Snowed|SSAA|Adam Reimnitz
+It Sucks To Be Me (from Avenue Q)(Parody)|TTBB|Kohl Kitzmiller
 It Takes All Day for Me to Do (What I Did All Day Long)|TTBB|Jim Shubert
 It Takes Two|SSAA|Dom Finetti
 It Takes Two|TTBB|Dom Finetti
@@ -9531,6 +9724,7 @@ It's A Long Way To Tipperary|TTBB|Joe Samuel
 It's A Lovely Day Today|SSAA|Larry Wright
 It's A Lovely Day Today|TTBB|Jim Shubert
 It's A Lovely Day Today|TTBB|Kohl Kitzmiller
+It's A Lovely Day Today (from Call Me Madam)|TTBB|Kohl Kitzmiller
 It's A Lovely Day Today/I Love To Singa Medley|SSAA|Larry Wright
 It's a Man, Every Time, It's a Man|SSAA|Tom Gentry
 It's a Man, Every Time, It's a Man|TTBB|Tom Gentry
@@ -9543,6 +9737,7 @@ It's A Most Unusual Day|SATB|Kohl Kitzmiller
 It's A Most Unusual Day|SSAA|Kohl Kitzmiller
 It's A Most Unusual Day|TTBB|David Wright
 It's A Most Unusual Day|TTBB|Dick Stuart
+It's A Most Unusual Day|TTBB|Joel Guyer
 It's A Most Unusual Day|TTBB|Tom Ball
 It's A Most Unusual Day|TTBB|Walter Latzko
 It's A Pity To Say Goodnight|SATB|Kohl Kitzmiller
@@ -9553,6 +9748,7 @@ It's A Pity To Say Goodnight|SSAA|Kohl Kitzmiller
 It's A Pity To Say Goodnight|TTBB|Joe Mannherz
 It's A Pity To Say Goodnight|TTBB|Kohl Kitzmiller
 It's A Pity To Say Goodnight|TTBB|Rasmus Krigstrom
+It's A Pity To Say Goodnight|TTBB|Rasmus Krigström
 It's A Pity To Say Goodnight|TTBB|Walter Latzko
 It's A Sign Of Spring|TTBB|Walter Latzko
 It's A Sin To Tell A Lie|SATB|David Briner
@@ -9568,6 +9764,7 @@ It's A Sin To Tell A Lie/Lies Medley|TTBB|David Briner
 It's A Small World|SATB|Deke Sharon
 It's A Small World|SSAA|Mary K. Coffman Music Fund
 It's A Wonderful Life|TTBB|Walter Latzko
+It's A Wonderful World|TTBB|Joel Guyer
 It's A Wonderful World (Loving Wonderful You)|TTBB|Joel Guyer
 It's About Time|TTBB|Derric Johnson
 It's All Over / So Long, Dearie Medley|TTBB|Rob Campbell
@@ -9624,6 +9821,7 @@ It's Goin' To Be A Cold, Cold Winter|TTBB|Dennis Driscoll
 It's Goin' To Be A Cold, Cold Winter|TTBB|Toban Dvoretsky
 It's Gonna Rain|TTBB|Todd Troutman
 It's Good To Know I'm Welcome (In My Old Hometown)|TTBB|the 1967 H.E.P. Advanced Arrangers Class
+It's Hairspray|TTBB|Rasmus Krigström
 It's Hard To Be Humble (Oh, Lord)|SSAA|Mary K. Coffman Music Fund
 It's Hard To Be Humble (Oh, Lord)|TTBB|Jim West
 It's Impossible|SSAA|Rob Hopkins
@@ -9643,6 +9841,7 @@ It's My Life|TTBB|Joey Minshall
 It's My Party|SSAA|Carolyn Schmidt
 It's My Party|SSAA|Deke Sharon
 It's My Song|SSAA|Jim Arns
+It's No Secret Any More|TTBB|Adam Scott
 It's No Secret Anymore|TTBB|Adam Scott
 It's Not For Me To Say|TTBB|Brian Mastrull
 It's Not For Me To Say|TTBB|Jeremey Johnson
@@ -9651,6 +9850,7 @@ It's Not Unusual|SATB|Kohl Kitzmiller
 It's Not Unusual|SSAA|Kohl Kitzmiller
 It's Not Unusual|TTBB|Dan Mulligan
 It's Not Unusual|TTBB|Kohl Kitzmiller
+It's Not Where You Start (It's Where You Finish)|TTBB|Theo Hicks
 It's Not Where You Start It's Where You Finish|SSAA|Doris Twardosky
 It's Not Where You Start It's Where You Finish|SSAA|Jim Arns
 It's Not Where You Start It's Where You Finish|SSAA|Larry Wright
@@ -9670,6 +9870,7 @@ It's Over|SSAA|Jo Lund
 It's Over Isn't It|SSAA|Steve Tramack
 It's Over Isn't It|SSAA|Theodore Hicks
 It's Over Isn't It|TTBB|Theodore Hicks
+It’s Party Time|TTBB|Jackson Pinder
 It's Ragtime (That I Love)|TTBB|Jay Giallombardo
 It's Raining|SATB|Melody Hine
 It's Raining|TTBB|Burt Szabo
@@ -9733,6 +9934,7 @@ It's Time To Sing Sweet Adeline Again|TTBB|Steve Jamison
 It's Today|SSAA|Melody Hine
 It's Today|SSAA|Tom Gentry
 It's Today|TTBB|Tom Gentry
+It's Today (from Mame)|TTBB|Bryan Ziegler
 It's You|SSAA|Cris Conerty
 It's You|SSAA|Robert Rund
 It's You|TTBB|Larry Wright
@@ -9794,6 +9996,7 @@ Java Jive|SSAA|Jon Nicholas
 Java Jive|SSAA|June Dale
 Java Jive|SSAA|Larry Wright
 Java Jive|TTBB|Bluegrass Student Union
+Java Jive|TTBB|Ed Waesche
 Java Jive|TTBB|Joe Mannherz
 Java Jive|TTBB|Larry Wright
 Java Jive (SSAA) (arr. Bluegrass Student Union) (Australia & New Zealand)|SSAA|Bluegrass Student Union
@@ -9842,6 +10045,7 @@ Jeepers Creepers|SSAA|Marsha Zwicker
 Jeepers Creepers|TTBB|C. J. Spatafora
 Jeepers Creepers|TTBB|Fred King
 Jeepers Creepers|TTBB|Jay Giallombardo
+Jeepers Creepers/I'm In Love Again|TTBB|Erik Eliason
 Jenny Rebecca|SSAA|Tom Gentry
 Jenny Rebecca|TTBB|Tom Gentry
 Jeopardy Theme|SSAA|Jim Arns
@@ -10095,6 +10299,7 @@ Just Sing|TTBB|Dan Wessler
 Just Sing (from "Trolls World Tour")|SATB|Dan Wessler
 Just Sing (from "Trolls World Tour")|SSAA|Dan Wessler
 Just Sing (from "Trolls World Tour")|TTBB|Dan Wessler
+Just the Way You Are|TTBB|Chip Davis/David Harrington
 Just The Way You Are|SATB|Craig Minor
 Just The Way You Are|SATB|Deke Sharon
 Just The Way You Are|SATB|Joe Mannherz
@@ -10188,6 +10393,7 @@ Kindred Spirits|TTBB|Kevin Keller
 King Hymn Medley|TTBB|Jim Clancy
 King of Anything|SSAA|Deke Sharon
 King Of My Heart|SATB|Nicholas Wright
+King Of New York (from Newsies)|TTBB|Josh Ehrlich/Larry Bomback
 King Of The Road|SATB|Anders Lindqvist
 King Of The Road|SATB|Joe Mannherz
 King Of The Road|SATB|Kevin Keller
@@ -10236,9 +10442,11 @@ Kiss, Kiss, Kissin' In The Corn|SSAA|Walter Latzko
 Kisses Sweeter Than Wine|TTBB|David Briner
 Kisses Sweeter Than Wine|TTBB|Walter Latzko
 Kissing A Fool|TTBB|Jay Giallombardo
+Kissing A Fool|TTBB|Kyle Kitzmiller
 Kitten On The Keys|TTBB|Walter Latzko
 Knee Deep|TTBB|Kevin Keller
 Knight School Medley|TTBB|Tom Gentry
+Knighthood Medley|TTBB|Roger Payne/Steve Tramack
 Knighthood Quest Medley|TTBB|Tom Gentry
 Knighthood Rhythm Medley|TTBB|Tom Gentry
 Knights Of The Round Table|TTBB|Theodore Hicks
@@ -10260,6 +10468,7 @@ L-O-V-E|SSAA|Anastasio Rossi
 L-O-V-E|SSAA|Larry Triplett
 L-O-V-E|SSAA|Nancy Bergman
 L-O-V-E|SSAA|Tony Nasto
+L-O-V-E|TTBB|Ben Ferguson
 L-O-V-E|TTBB|Chris Arnold
 L-O-V-E|TTBB|Dan Mulligan
 L-O-V-E|TTBB|Ed Waesche
@@ -10305,6 +10514,7 @@ Last Night On The Back Porch|TTBB|Burt Szabo
 Last Night On The Back Porch|TTBB|Dennis Driscoll
 Last Night On The Back Porch|TTBB|Dick Belote
 Last Night On The Back Porch|TTBB|Gay Notes
+Last Night On The Back Porch|TTBB|The Gaynotes
 Last Night On The Back Porch|TTBB|Tom Gentry
 Last Night Was The End Of The World|SATB|Barbershop Harmony Society
 Last Night Was The End Of The World|SSAA|Barbershop Harmony Society
@@ -10326,7 +10536,9 @@ Latch|SATB|Nicholas Wright
 Latch|TTBB|Nicholas Wright
 Lately|SATB|David Wright
 Lately|SSAA|Matthew Gallagher
+Lately|TTBB|Ben McDaniel
 Lately|TTBB|Jeremey Johnson
+Lately|TTBB|Matt Gallagher
 Lately|TTBB|Matthew Gallagher
 Lately|TTBB|Sam Hubbard
 Latika's Theme|SATB|Nicholas Wright
@@ -10403,6 +10615,7 @@ Leaning On A Lamppost|SSAA|Larry Wright
 Leaning On A Lamppost|TTBB|Larry Wright
 Leaning On The Everlasting Arms|TTBB|Derric Johnson
 Learnin' The Blues|TTBB|Aaron Dale
+Learnin' The Blues|TTBB|Patrick McAlexander
 Learnin' The Blues|TTBB|Tom Gentry
 Learning To Lean|TTBB|Paul Jorg
 Leave The Door Open|SATB|Soren Detlefsen
@@ -10447,6 +10660,7 @@ Let It Go|SSAA|Larry Wright
 Let It Go|TTBB|Deke Sharon
 Let It Go|TTBB|Gabriel Lawson
 Let It Go|TTBB|Nicholas Wright
+Let It Go (from Frozen) (Parody)|TTBB|Mac Huff
 Let It Rain|SSAA|Dawn Haggerty
 Let It Rain Let It Pour|TTBB|Burt Szabo
 Let It Rain Let It Pour|TTBB|Jay Giallombardo
@@ -10565,14 +10779,17 @@ Let's All Sing Like The Birdies Sing|SSAA|Zona Snyder
 Let's Be Bad|SATB|Melody Hine
 Let's Be Buddies|SSAA|David Briner
 Let's Be Buddies|TTBB|David Briner
+Let's Burn Up The Town|TTBB|Adam Reimnitz
 Let's Call The Whole Thing Off|SATB|Gene Cokeroft
 Let's Call The Whole Thing Off|SSAA|Carolyn Schmidt
 Let's Call The Whole Thing Off|SSAA|Joe Mannherz
 Let's Call The Whole Thing Off|TTBB|Joe Mannherz
 Let's Call The Whole Thing Off|TTBB|Steve Jamison
 Let's Call The Whole Thing Off|TTBB|Walter Latzko
+Let's Call The Whole Thing Off Medley|TTBB|Clay Hine
 Let's Do It (Let's Fall In Love)|SSAA|John Brockman
 Let's Do It (Let's Fall In Love)|TTBB|Bruce Bonnyard
+Let's Do It (Let's Fall In Love)|TTBB|Chris Arnold
 Let's Do It (Let's Fall In Love)|TTBB|David Briner
 Let's Do It (Let's Fall In Love)|TTBB|John Brockman
 Let's Do It (Let's Fall In Love) / Let's Misbehave Medley|TTBB|Matthew Gallagher
@@ -10583,6 +10800,7 @@ Let's Face The Music And Dance|SSAA|Liz Garnett
 Let's Face The Music And Dance|TTBB|Kohl Kitzmiller
 Let's Face The Music And Dance|TTBB|Liz Garnett
 Let's Face The Music And Dance|TTBB|Walter Latzko
+Let's Face The Music And Dance (from Follow The Fleet)|TTBB|Wayne Grimmer
 Let's Fall In Love|TTBB|Kevin Keller
 Let's Gather Round The Parlor Piano|SSAA|Michael Hengelsberg
 Let's Get Away From It All|SATB|Joe Mannherz
@@ -10643,6 +10861,7 @@ Let's Start Tomorrow Tonight|SSAA|Joe Mannherz
 Let's Start Tomorrow Tonight|SSAA|Kevin Keller
 Let's Start Tomorrow Tonight|SSAA|Larry Wright
 Let's Start Tomorrow Tonight|TTBB|Kevin Keller
+Let's Start Tomorrow Tonight|TTBB|Theo Hicks
 Let's Start Tomorrow Tonight|TTBB|Theodore Hicks
 Let's Stay Together|TTBB|Adam Bock
 Let's Take A Walk|TTBB|Michael Webber
@@ -10659,6 +10878,7 @@ Let's Twist Again|TTBB|Kevin Koehl
 Levitating|SATB|Nicholas Wright
 Li'l Red Riding Hood|SATB|Deke Sharon
 Liability|SATB|Nicholas Wright
+Liar Medley|TTBB|Renee Craig
 Liar With An Achin' Breakin' Heart Medley|TTBB|David Wright
 Lida Rose|TTBB|Floyd Connett
 Lida Rose|TTBB|Larry Wright
@@ -10749,6 +10969,7 @@ Lion Sleeps Tonight|TTBB|Scott Turnbull
 Lion Sleeps Tonight|TTBB|Thomas Degan
 Listen|SSAA|Liz Garnett
 Listen|TTBB|Theodore Hicks
+Listen (from Dreamgirls)|TTBB|Theo Hicks
 Listen To My Heart|SSAA|Larry Wright
 Listen To My Heart|SSAA|Michael Gellert
 Listen To That Dixie Band|SSAA|Melvin Knight
@@ -10852,9 +11073,11 @@ Little On The Lonely Side|TTBB|Brent Graham
 Little On The Lonely Side|TTBB|Kirk Roose
 Little On The Lonely Side|TTBB|Mark Goodney
 Little On The Lonely Side|TTBB|Ray Buntaine
+Little Pal|TTBB|Clay Hine
 Little Pal|TTBB|Dennis Burnett
 Little Pal|TTBB|Louis Perry
 Little Pal|TTBB|Tom Gentry
+Little Pal (Parody)|TTBB|Clay Hine
 Little Pal (TTBB) (arr. Perry) - as sung by The Four Rascals|TTBB|Louis Perry
 Little Patch Of Heaven|SSAA|Aaron Dale
 Little Patch Of Heaven|SSAA|Michael Gellert
@@ -11044,6 +11267,7 @@ Losing My Mind|TTBB|Greg Mallett
 Losing My Mind|TTBB|Jay Giallombardo
 Losing My Mind|TTBB|Simon Arnott
 Losing My Mind|TTBB|Theodore Hicks
+Losing My Mind (from Follies)|TTBB|Theo Hicks
 Losing You|TTBB|Mark Burnip
 Lost (A Wonderful Girl)|TTBB|Robert Rund
 Lost Boy|SATB|Nicholas Wright
@@ -11171,6 +11395,7 @@ Love Me Tender|SSAA|David Wright
 Love Me Tender|SSAA|Norma Andersen
 Love Me Tender|SSAA|Tom Gentry
 Love Me Tender|TTBB|David Wright
+Love Me Tender|TTBB|Johan Wikström
 Love Me Tender|TTBB|Jon Nicholas
 Love Me Tender / Aura Lee Medley|TTBB|Kirk Roose
 Love Me With All Your Heart|SSAA|Carolyn Schmidt
@@ -11178,6 +11403,7 @@ Love Me With All Your Heart|SSAA|LaVeda Redfield
 Love Me With All Your Heart|SSAA|Mary Lou Gomez-Leon
 Love Me With All Your Heart|SSAA|Nancy Bergman
 Love Medley|TTBB|Robert Rund
+Love Medley (I Have A Love/One Hand, One Heart)|TTBB|Kirk Young
 Love Never Fails|TTBB|Deke Sharon
 Love Of My Life|SATB|Anders Lindqvist
 Love Of My Life|SSAA|Alex Kaiserman
@@ -11206,6 +11432,7 @@ Love Shack|SATB|Deke Sharon
 Love Song|SATB|Deke Sharon
 Love Story|SSAA|Deke Sharon
 Love Story|TTBB|Simon Arnott
+Love Story|TTBB|Theo Hicks
 Love Story|TTBB|Theodore Hicks
 Love Story (Where Do I Begin)|TTBB|Dennis Driscoll
 Love The One You're With|SSAA|Deke Sharon
@@ -11218,6 +11445,7 @@ Love Walked In|SSAA|Anastasio Rossi
 Love Walked In|SSAA|David Wright
 Love Walked In|SSAA|Joe Mannherz
 Love Walked In|TTBB|Anastasio Rossi
+Love Walked In|TTBB|David Wright
 Love Walked In|TTBB|Jim Shubert
 Love Walked In|TTBB|Joe Mannherz
 Love Was Waiting Here|SATB|Richard Curtis
@@ -11275,6 +11503,7 @@ Lovesick Blues|SSAA|Tom Gentry
 Lovesick Blues|TTBB|Robert Rund
 Lovesick Blues|TTBB|Tom Gentry
 Lovesick Blues|TTBB|Walter Latzko
+Lovin' Life|TTBB|Adam Bock
 Lovin', Touchin', Squeezin'|TTBB|Dan Wessler
 Loving You|TTBB|Ralph Urquhart
 Lovingless Day|TTBB|Walter Latzko
@@ -11298,6 +11527,7 @@ Luck Be A Lady|TTBB|Joe Mannherz
 Luck Be A Lady|TTBB|Kohl Kitzmiller
 Luck Be A Lady|TTBB|Steve Jamison
 Luck Be A Lady|TTBB|Walter Latzko
+Luckiest|TTBB|Rob Hopkins
 Lucky Day|SSAA|Joni Bescos
 Lucky Day|TTBB|Barbershop Harmony Society
 Lucky Day|TTBB|Jon Nicholas
@@ -11394,6 +11624,7 @@ MacNamara's Band|SSAA|Paul Grimm
 MacNamara's Band|TTBB|Barbershop Harmony Society
 MacNamara's Band|TTBB|SPEBSQSA
 Mad Dogs and Englishmen|TTBB|Jay Giallombardo
+Mad Scientist Idol|TTBB|Steve Armstrong
 made You Look|SSAA|Tom Gentry
 Madonna Medley|SSAA|Liz Garnett
 Maenner|TTBB|Tom Gentry
@@ -11421,6 +11652,7 @@ Mairzy Doats|TTBB|Mark Goodney
 Make 'Em Laugh|SSAA|Brent Graham
 Make 'Em Laugh|SSAA|Clay Hine
 Make 'Em Laugh|SSAA|Debbie Keretz
+Make 'Em Laugh|TTBB|Clay Hine
 Make 'Em Laugh|TTBB|Joe Mannherz
 Make 'Em Laugh|TTBB|Mark Goodney
 Make 'Em Laugh|TTBB|Patrick McAlexander
@@ -11441,9 +11673,11 @@ Make Someone Happy|TTBB|John Brockman
 Make Them Hear You|TTBB|Dan Wessler
 Make Them Hear You|TTBB|Kevin Keller
 Make Them Hear You|TTBB|Matt Parks
+Make Them Hear You (from Ragtime)|TTBB|Theo Hicks
 Make You Feel My Love|SATB|Gary Thiel
 Make You Feel My Love|SSAA|Hari Birtles
 Make You Feel My Love|SSAA|Jack Bridges
+Make You Feel My Love|TTBB|Aaron Dale
 Make You Feel My Love|TTBB|Alex Kaiserman
 Make You Feel My Love|TTBB|Clay Hine
 Make You Feel My Love|TTBB|Eric Ruthenberg
@@ -11471,6 +11705,7 @@ Mam'selle|TTBB|Adam Reimnitz
 Mam'selle|TTBB|Joe Mannherz
 Mam'selle|TTBB|Tom Sando
 Mama Don't Low|SSAA|Mary K. Coffman Music Fund
+Mama Says|TTBB|Bryan Ziegler
 Mama Who Bore Me|SSAA|Simon Arnott
 Mama Yo Quiero|SSAA|Jim Campbell
 Mama, I'm a Big Girl now|SSAA|Deke Sharon
@@ -11550,6 +11785,7 @@ Manger in Bethlehem Medley|SSAA|Carolyn Johnson
 Mango Tree|SATB|Kohl Kitzmiller
 Mango Tree|TTBB|Adam Bock
 Mango Tree|TTBB|Dom Finetti
+Mango Tree|TTBB|Eric Ruthenberg
 Manhattan|SSAA|Liz Garnett
 Manhattan|SSAA|Nicholas Wright
 Manhattan|TTBB|Adam Bock
@@ -11584,6 +11820,7 @@ Mardi Gras March / South Rampart Street Parade Medley|TTBB|David Wright
 Margaritaville|TTBB|Thomas Degan
 Margate|TTBB|Matthew Spinner
 Margie|TTBB|Burt Szabo
+Margie|TTBB|Clay Hine
 Margie|TTBB|David Harrington
 Margie|TTBB|Jim Shubert
 Margie|TTBB|Tom Gentry
@@ -11946,6 +12183,7 @@ Memories|TTBB|SPEBSQSA
 Memories|TTBB|Val Hicks
 Memories|TTBB|Walter Latzko
 Memories / Will You Remember|TTBB|Frank Leitnaker
+Memories Of A Song In My Heart|TTBB|Bob Disney
 Memories Of You|TTBB|Fred King
 Memories Of You|TTBB|Joe Liles
 Memories Only Now|SSAA|Nancy Bergman
@@ -12094,6 +12332,7 @@ Mistaken In You|TTBB|Dennis Driscoll
 Mistakes|SSAA|Roy Keys
 Mistakes|TTBB|Joe Mannherz
 Mistakes|TTBB|Roy Keys
+Mistakes (Parody)|TTBB|Roy Keys
 Mister And Mississippi|SSAA|Walter Latzko
 Mister Booze|TTBB|Michael Webber
 Mister Broadway Medley|TTBB|Ed Waesche
@@ -12110,6 +12349,7 @@ Mister Sandman|TTBB|George Hulst
 Mister Sandman|TTBB|Val Hicks
 Mister Touchdown, U.S.A.|SSAA|Nancy Bergman
 Mister Touchdown, U.S.A.|TTBB|Ed Waesche
+Mister, You've Gone And Got The Blues|TTBB|Tony Nasto
 Mistletoe and Wine|SATB|Karen Penketh
 Misty|SATB|Kevin Keller
 Misty|SSAA|Lauren Kahn
@@ -12278,6 +12518,7 @@ More Than You Know|TTBB|David Wallace
 More Than You Know|TTBB|Jay Giallombardo
 More Than You Know|TTBB|Joe Mannherz
 More Than You Know|TTBB|Steve Delehanty
+More Than You Know (from Great Day)|TTBB|Jason Dyer
 More Than You Need To Know|TTBB|Jay Giallombardo
 Morning Glories Twine|SSAA|Carolyn Johnson
 Morning Glow|TTBB|Todd Troutman
@@ -12354,6 +12595,8 @@ Mr. Pinstripe Suit|TTBB|Dan Wessler
 Mr. Rogers Medley|TTBB|Brent Graham
 Mr. Rogers Medley|TTBB|Jeremey Johnson
 Mr. Rogers Medley|TTBB|Matt Parks
+Mr. Success|TTBB|John Brockman
+Mr. Tanner|TTBB|Kevin Keller
 Mr. Wonderful|SSAA|Kay Bromert
 Mr. Wonderful|SSAA|Walter Latzko
 Mrs. Santa Claus|SSAA|Kay Bromert
@@ -12463,6 +12706,7 @@ My Daddy Is Only A Picture|TTBB|Louis Perry
 My Daddy's Still Singing His Song|TTBB|Joe Liles
 My Darling, My Darling|TTBB|Jim Shubert
 My Days|SSAA|Erica Kelch-Slesnick
+My Dear Old Irish Mammy|TTBB|Doug Anderson/Larry Wright
 My Defenses Are Down|TTBB|Todd Troutman
 My Diane|SATB|Joe Mannherz
 My Diane|TTBB|Joe Mannherz
@@ -12502,6 +12746,7 @@ My Foolish Heart|TTBB|Jay Giallombardo
 My Foolish Heart|TTBB|Mark Burnip
 My Foolish Heart|TTBB|Rob Hopkins
 My Foolish Heart|TTBB|Tom Gentry
+My Foolish Heart/I Fall In Love Too Easily|TTBB|Adam Reimnitz
 My Fraternity Pin|TTBB|Thomas Gentry
 My Fraternity Pin|TTBB|Tom Gentry
 My Friend|TTBB|Fred King
@@ -12540,6 +12785,7 @@ My Heart Is Aching For You|TTBB|Joe Liles
 My Heart Is Open|SATB|Nicholas Wright
 My Heart Stood Still|SSAA|Anna Maria Parker
 My Heart Stood Still|SSAA|Walter Latzko
+My Heart Stood Still|TTBB|Greg Volk
 My Heart Stood Still|TTBB|John Hohl
 My Heart Stood Still|TTBB|Steve Tramack
 My Heart Stood Still|TTBB|Walter Latzko
@@ -12561,11 +12807,13 @@ My Honey's Lovin' Arms|TTBB|Don Gray
 My Honey's Lovin' Arms|TTBB|Walter Latzko
 My House|TTBB|Greg Mallett
 My Ideal|TTBB|Jim West
+My Ideal|TTBB|Mark Hale
 My Immortal|TTBB|Nicholas Wright
 My Jesus, I Love Thee|TTBB|Derric Johnson
 My Kind Of Girl|TTBB|Brian Mastrull
 My Kind Of Town (Chicago Is)|TTBB|Dan Wessler
 My Kind Of Town (Chicago Is)|TTBB|Deke Sharon
+My Lady Loves To Dance|TTBB|Bob Dowma
 My Life|TTBB|Liz Garnett
 My Life Flows On (How Can I Keep from Singing)|SSAA|Tom Gentry
 My Life Flows On (How Can I Keep from Singing)|TTBB|Tom Gentry
@@ -12615,7 +12863,9 @@ My Melancholy Baby|TTBB|Ed Waesche
 My Melancholy Baby|TTBB|Jay Giallombardo
 My Melancholy Baby|TTBB|Kirk Roose
 My Melancholy Baby|TTBB|Louis Perry
+My Melancholy Blues|TTBB|Aaron Dale
 My Melancholy Blues|TTBB|Kirk Young
+My Melancholy Blues|TTBB|Luke Stevenson
 My Melody Of Love|SSAA|Joan D 'Agostino
 My Melody Of Love|TTBB|Jim West
 My Mom|SSAA|Nancy Bergman
@@ -12650,6 +12900,7 @@ My Old Man|TTBB|Larry Wright
 My Old Man's A Sailor|TTBB|James Henry
 My Old Montana Home|TTBB|Kevin Keller
 My Once Upon A Time|SSAA|Tony Nasto
+My One And Only Love|TTBB|Clay Hine
 My One And Only Love|TTBB|Mark Jennings
 My One And Only Love|TTBB|Melody Hine
 My One And Only Love|TTBB|Simon Arnott
@@ -12670,11 +12921,14 @@ My Romance|TTBB|David Zimmerman
 My Romance|TTBB|Jay Giallombardo
 My Romance|TTBB|Joe Mannherz
 My Romance|TTBB|Larry Wright
+My Romance|TTBB|Rich Hasty
 My Romance|TTBB|Richard Hasty
+My Romance|TTBB|Rob Campbell
 My Romance|TTBB|Tom Gentry
 My Sally|TTBB|Tom Gentry
 My Sally, Just The Same|TTBB|Barbershop Harmony Society
 My Sally, Just The Same|TTBB|Harold Ulring
+My Shiny Teeth And Me|TTBB|Ben Lewin
 My Sin|TTBB|Brent Graham
 My Song in the Night|SATB|Dianne Goldrick
 My Song in the Night|SSAA|Dianne Goldrick
@@ -12704,6 +12958,7 @@ My Valentine|TTBB|Aaron Dale
 My Way|SSAA|Joey Minshall
 My Way|SSAA|Mark Burnip
 My Way|SSAA|Takako Fuke
+My Way|TTBB|Clay Hine
 My Way|TTBB|Eric Ruthenberg
 My Way|TTBB|Jay Giallombardo
 My Way|TTBB|Kevin Koehl
@@ -12755,6 +13010,7 @@ Nature Boy|TTBB|Jim Shubert
 Nature Boy|TTBB|Joe Mannherz
 Naughty|SSAA|Melody Hine
 Naughty|TTBB|Aaron Dale
+Naughty Angeline|TTBB|Clay Hine
 Naughty Lady Of Shady Lane|TTBB|Adam Scott
 Naughty Lady Of Shady Lane|TTBB|Dennis Driscoll
 Naughty Lady Of Shady Lane|TTBB|Tom Gentry
@@ -12781,6 +13037,7 @@ Nellie Kelly, I Love You|TTBB|Sheldon Nelson
 Nellie Kelly, I Love You|TTBB|Steve Hardy
 Neutron Dance|TTBB|Tom Gentry
 Never Again|SSAA|Mary K. Coffman Music Fund
+Never Again|TTBB|Steve Delehanty
 Never Again|TTBB|Walter Latzko
 Never Enough|SSAA|Brent Graham
 Never Ever|SSAA|Sam Hubbard
@@ -12789,10 +13046,12 @@ Never Get Old To Me|TTBB|Dan Wessler
 Never Getting Rid Of Me|SSAA|Jen Squires
 Never Getting Rid Of Me|SSAA|Melody Hine
 Never Give All the Heart|TTBB|Brent Graham
+Never Give All The Heart (from Smash)|TTBB|Brent Graham
 Never Going Back Again|TTBB|Gabriel Lawson
 Never Gonna Give You Up|SATB|Deke Sharon
 Never Gonna Give You Up|TTBB|Gabriel Lawson
 Never Gonna Give You Up|TTBB|Nicholas Wright
+Never Gonna Give You Up|TTBB|Patrick McAlexander
 Never Gonna Let You Down|SSAA|Carole Prietto
 Never Gonna Not Dance Again|SSAA|Kohl Kitzmiller
 Never Hit Your Grandma With A Shovel|TTBB|Jerry Koskela
@@ -12804,6 +13063,8 @@ Never Let No Man Worry Your Mind|SSAA|David Wright
 Never Let The Same Bee|SSAA|Marie Johnson
 Never My Love|SSAA|Jon Nicholas
 Never My Love|TTBB|Jon Nicholas
+Never Never Land (from Peter Pan)|TTBB|Jay Giallombardo
+Never Never Land (from Peter Pan)|TTBB|Steve Tramack
 Never Neverland|SATB|David Wright
 Never Neverland|SSAA|Joe Mannherz
 Never Neverland|TTBB|Joe Mannherz
@@ -12846,6 +13107,7 @@ New Words|SSAA|Michael Gellert
 New Words|TTBB|Craig Minor
 New Year Medley|SATB|Bryan Ziegler
 New Year Medley|SSAA|Bryan Ziegler
+New Year Medley|TTBB|Bryan Ziegler
 New Year's Day|SATB|Nicholas Wright
 New York Ain't New York Anymore|SSAA|Jay Giallombardo
 New York Ain't New York Anymore|TTBB|Jay Giallombardo
@@ -12887,6 +13149,7 @@ Newborn Friend|SATB|Vince Peterson
 Next Door Angel Medley|SSAA|Jan-Ake Westin
 Next Door To An Angel|TTBB|Brian Mastrull
 Next Time I Love|SSAA|Larry Wright
+Next Time I Love|TTBB|Larry Wright
 Next To Lovin (I Like Fightin Best)|SSAA|Marge Bailey
 Nice 'n Easy|SSAA|Doris Twardosky
 Nice 'n Easy|TTBB|Ig Jakovac
@@ -12915,6 +13178,7 @@ Nightswimming|SSAA|Deke Sharon
 Nina|TTBB|Walter Latzko
 Nine Million Bicycles|TTBB|Hilary Allen
 Nine People's Favorite Thing|TTBB|Kohl Kitzmiller
+Nine People's Favorite Thing (Parody)|TTBB|Kohl Kitzmiller
 Nine To Five|SATB|Kohl Kitzmiller
 Nine To Five|SATB|Matthew Spinner
 Nine To Five|SSAA|Jo Lund
@@ -12938,6 +13202,7 @@ No Love Song|SSAA|Joe Liles
 No Man Left For Me|SSAA|Aaron Dale
 No Matter What|SSAA|Valerie Hoy
 No Matter What Happens|SSAA|Soren Detlefsen
+No Moon At All|TTBB|Jason Dyer
 No More (My Baby Don't Love Me)|SSAA|Charlene Yazurlo
 No More (My Baby Don't Love Me)|SSAA|Marsha Zwicker
 No More Nights|TTBB|Aaron Dale
@@ -12967,9 +13232,12 @@ No Vacancy|TTBB|Steve Jamison
 No Wonder I'm Happy|TTBB|Jay Giallombardo
 No Wonder I'm Happy|TTBB|John Hohl
 No, No, Nora|TTBB|Burt Szabo
+No, No, Nora|TTBB|Clay Hine
 No, No, Nora|TTBB|Walter Latzko
 No, No, Nora / I know that you know Medley|TTBB|David Harrington
 No! No! A Thousand Times No!!|TTBB|Dennis Morrissey
+Noah Animals Medley|TTBB|Patrick McAlexander
+Noah Flood Medley|TTBB|Patrick McAlexander
 Noah's Wife Lived A Wonderful Life|TTBB|Bill Packard
 Nobody But Me|TTBB|Adam Bock
 Nobody Cares Like Me|TTBB|Michael Webber
@@ -13023,11 +13291,15 @@ Not My Father's Son|TTBB|Greg Mallett
 Not While I'm Around|SSAA|Joe Mannherz
 Not While I'm Around|TTBB|Jeremiah Pope
 Not While I'm Around|TTBB|Joe Mannherz
+Not While I'm Around (from Sweeney Todd)|TTBB|Steve Tramack
+Not While I'm Around (from Sweeney Todd)|TTBB|Theo Hicks
 Nothing But The Best|TTBB|Andrew Carolan
 Nothing But The Best|TTBB|Dom Finetti
 Nothing But The Best|TTBB|Kevin Koehl
 Nothing But The Blood/At The Cross|TTBB|Derric Johnson
+Nothing Can Change This love|TTBB|Theo Hicks
 Nothing Can Change This Love|TTBB|Aaron Dale
+Nothing Can Change This Love|TTBB|Wayne Grimmer
 Nothing Can Stop Me Now|SSAA|Aaron Dale
 Nothing Can Stop Me Now|TTBB|Adam Bock
 Nothing Compares 2 U|SSAA|Deke Sharon
@@ -13163,6 +13435,7 @@ O, America|SSAA|Tom Gentry
 O, America|TTBB|Tom Gentry
 O'Brien Is Tryin' To Learn To Talk Hawaiian|TTBB|Burt Szabo
 O'Brien To Ryan To Goldberg|TTBB|J Rae Jamieson
+O'Brien To Ryan To Goldberg|TTBB|Steve Tramack
 Ob-La-Di, Ob-La-Da|SSAA|Carolyn Schmidt
 Ob-La-Di, Ob-La-Da|SSAA|Karen McCarville
 Ob-La-Di, Ob-La-Da|TTBB|Jim Shubert
@@ -13201,6 +13474,7 @@ Oh Mabel|TTBB|Steve Hardy
 Oh My Father|TTBB|Aaron Dale
 Oh My God|TTBB|Nicholas Wright
 Oh Sherrie!|TTBB|Will Makra
+Oh Suzanna, Dust Off That Old Pianna|TTBB|Brian Mastrull
 Oh What A Beautiful Morning!|SATB|Deke Sharon
 Oh What A Beautiful Morning!|SSAA|Nancy Bergman
 Oh What A Beautiful Morning!|TTBB|Nancy Bergman
@@ -13297,6 +13571,7 @@ Old Cape Cod|TTBB|William Behrendt
 Old Devil Moon|TTBB|Aaron Dale
 Old Devil Moon|TTBB|Justin Miller
 Old Devil Moon|TTBB|Mark Goodney
+Old Devil Moon (from Finian's Rainbow)|TTBB|Aaron Dale
 Old Familiar Faces|TTBB|Dennis Driscoll
 Old Fashioned Girl|TTBB|Barbershop Harmony Society
 Old Fashioned Girl|TTBB|Doug Ward
@@ -13331,6 +13606,7 @@ Old Love Letters|TTBB|Burt Szabo
 Old Macdonald Had A Farm|SATB|Derric Johnson
 Old Macdonald Had A Farm|SSAA|Asuka Ichikawa
 Old Man Time|TTBB|John Hohl
+Old Me Better|TTBB|Clay Hine
 Old Mother Hubbard|TTBB|Dan Wessler
 Old Pals Are The Best Pals After All|TTBB|Louis Perry
 Old Piano Roll Blues|SSAA|David Wright
@@ -13522,6 +13798,7 @@ Once Upon a Dream|SSAA|Jay Dougherty
 Once Upon A Dream|SATB|Jay Dougherty
 Once Upon A Dream|SSAA|Sheryl Neal
 Once Upon A Dream|TTBB|Jay Dougherty
+Once Upon A Dream|TTBB|Steve Tramack
 Once Upon A Summertime|TTBB|Walter Latzko
 Once Upon A Time|SSAA|Frank Marzocco
 Once Upon A Time|SSAA|Jo Lund
@@ -13532,6 +13809,7 @@ Once Upon A Time|SSAA|Tom Gentry
 Once Upon A Time|TTBB|Larry Wright
 Once Upon A Time|TTBB|Rob Campbell
 Once Upon A Time|TTBB|Tom Gentry
+Once Upon A Time (from All American)|TTBB|Rob Campbell
 Once You Lose Your Heart|SSAA|Gayle Haley
 Once You Lose Your Heart|SSAA|Jan-Ake Westin
 One|SSAA|Liz Garnett
@@ -13608,6 +13886,7 @@ One More Time|TTBB|Lloyd Steinkamp
 One Note Samba|SATB|Joe Mannherz
 One Note Samba|SSAA|Larry Wright
 One Note Samba|TTBB|Larry Wright
+One Of These Things Is Not Like The Others|TTBB|Wayne Grimmer
 One Of Those Songs|SSAA|Kay Bromert
 One Of Those Songs|SSAA|Nancy Bergman
 One Of Those Songs|TTBB|R. B. Easterlin
@@ -13697,6 +13976,7 @@ Open A New Window|TTBB|Adam Scott
 Open Arms|SATB|Nicholas Wright
 Open Arms|SSAA|Adam Bock
 Open Arms|SSAA|Michael Gellert
+Open Arms|TTBB|Bryan Ziegler
 Open Arms|TTBB|Mark Stevens
 Open My Eyes That I May See|TTBB|Joe Liles
 Open Your Eyes|TTBB|Nicholas Wright
@@ -13765,6 +14045,7 @@ Out Of The Woods|SATB|Nicholas Wright
 Out Of This World|TTBB|Ron Rank
 Out There|TTBB|Brent Graham
 Out There|TTBB|Steve Tramack
+Out There (from The Hunchback Of Notre Dame)|TTBB|Steve Tramack
 Over The Hill|SSAA|Marge Bailey
 Over The Rainbow|SATB|Ed Waesche
 Over The Rainbow|SATB|Melody Hine
@@ -13811,6 +14092,7 @@ Overture Curtain Lights (This Is It)|TTBB|Larry Wright
 Oye Como Va|SATB|Deke Sharon
 Oye Como Va|SATB|Joe Mannherz
 P.S. I Love You|SSAA|Jo Lund
+P.S. I Love You|TTBB|Adam Reimnitz
 P.S. I Love You|TTBB|Robert Rund
 Pachelbel Canon|SATB|Joe Mannherz
 Pachelbel Canon|SSAA|Greg Mallett
@@ -13906,6 +14188,7 @@ Patriotic Medley|TTBB|Larry Wright
 Payphone|SATB|Joe Mannherz
 Payphone|SATB|Nicholas Wright
 Payphone|TTBB|Nicholas Wright
+PD Medley|TTBB|Clay Hine
 Peace I Leave With You|TTBB|Joe Liles
 Peace Like A River|TTBB|Adam Scott
 Peace On Earth/Little Drummer Boy medley|SSAA|Jay Giallombardo
@@ -14031,6 +14314,7 @@ Piping down the Valleys Wild|SATB|David Avshalomov
 Pirate Parody On Moonlight Bay|SSAA|Carolyn Johnson
 Pirate Seaside Medley|SSAA|Carolyn Johnson
 Pirate's Life|TTBB|Denny Stiers
+Pirates Of The Barbary Coast|TTBB|Roger Payne
 Pirates of the Sea|TTBB|Jon Nicholas
 Pirates Who Don't Do Anything|SATB|Michael Hengelsberg
 Pirates Who Don't Do Anything|SSAA|Jay Giallombardo
@@ -14110,6 +14394,7 @@ Please Mr. Columbus|TTBB|Mo Rector
 Please Please Me|TTBB|Carolyn Schmidt
 Please Please Please|SSAA|Dan Wessler
 Please Please Please|SSAA|Kyle Snook
+Please Send Me Someone To Love|TTBB|Jackson Pinder
 Plenty To Be Thankful For|SSAA|Adam Bock
 Poems, Prayers, and Promises|TTBB|Mark Stevens
 Poinciana (Song of the Tree)|SSAA|Anastasio Rossi
@@ -14147,6 +14432,8 @@ Poor Little Rich Girl|TTBB|Rob Campbell
 Poor Monty|SSAA|Gabriel Spector
 Poor Unfortunate Souls|SSAA|Adam Scott
 Poor Unfortunate Souls|SSAA|Doris Twardosky
+Pop Songs Medley II|TTBB|Clay Hine
+Pop Songs Medley III|TTBB|Clay Hine
 Pop, Pop, Popin, Popcorn|SSAA|Avis Fellows
 Popeye Medley|TTBB|Tom Gentry
 Popular|SSAA|Dianne Goldrick
@@ -14216,6 +14503,7 @@ Primetime|SATB|Alex Morris
 Primetime|SSAA|Nicholas Wright
 Prince Ali|SATB|Deke Sharon
 Prince Ali|TTBB|Steve Tramack
+Prince Ali (from Aladdin)|TTBB|Steve Tramack
 Prison Medley|TTBB|Tom Gentry
 Prisoner of Love|TTBB|Brent Graham
 Private Eyes|SATB|Nicholas Wright
@@ -14232,6 +14520,7 @@ Proud of Your Boy|TTBB|David Wright
 Proud of Your Boy|TTBB|Kevin Keller
 Proud of Your Boy|TTBB|Simon Arnott
 Proud of Your Boy|TTBB|Steve Tramack
+Proud Of Your Boy|TTBB|Patrick McAlexander
 Public Melody Number One|SATB|Kyle Snook
 Public Melody Number One|TTBB|Dan Wessler
 Puff The Magic Dragon|SATB|Kevin Keller
@@ -14260,6 +14549,7 @@ Pure Imagination|TTBB|David Briner
 Pure Imagination|TTBB|Jay Giallombardo
 Pure Imagination|TTBB|Joe Mannherz
 Pure Imagination|TTBB|Kevin Keller
+Pure Imagination|TTBB|Matt Gallagher
 Pure Imagination|TTBB|Matthew Gallagher
 Pure Imagination|TTBB|Richard Curtis
 Pure Imagination|TTBB|Walter Latzko
@@ -14295,6 +14585,7 @@ Put Your Arms Around Me Honey|SSAA|Nancy Bergman
 Put Your Arms Around Me Honey|TTBB|Aaron Dale
 Put Your Arms Around Me Honey|TTBB|Burt Szabo
 Put Your Arms Around Me Honey|TTBB|Lloyd Steinkamp
+Put Your Arms Around Me, Honey|TTBB|Rob Hopkins
 Put Your Arms Around Me/Side By Side|SSAA|Nancy Bergman
 Put Your Dreams Away (For Another Day)|TTBB|Dylan Oxford
 Put Your Dreams Away (For Another Day)|TTBB|Jim Shubert
@@ -14395,6 +14686,7 @@ Razzle Dazzle|SSAA|Anna Maria Parker
 Razzle Dazzle|SSAA|Carolyn Johnson
 Razzle Dazzle|SSAA|Jo Lund
 Razzle Dazzle|SSAA|Tom Gentry
+Razzle Dazzle|TTBB|Clay Hine
 Razzle Dazzle|TTBB|Jim West
 Razzle Dazzle|TTBB|Tom Gentry
 Re Your Brains|TTBB|Jay Dougherty
@@ -14410,9 +14702,11 @@ Reach Out To Jesus|SSAA|Tedda Lippincott
 Reaching For The Moon|TTBB|Robert Rund
 Reading Rainbow Theme Song|SSAA|Brent Graham
 Ready, Willing and Able|TTBB|Aaron Dale
+Ready, Willing And Able (from Young At Heart)|TTBB|Aaron Dale
 Real American Folk Song, The (Is A Rag)|SSAA|Becky Cartine
 Real American Folk Song, The (Is A Rag)|TTBB|Walter Latzko
 Real Emotional Girl|TTBB|Michael Webber
+Recipe For Love|TTBB|Ben Ferguson
 Recipe For Love|TTBB|Dennis Driscoll
 Recipe For Love|TTBB|Dianne Goldrick
 Recycle Song|TTBB|Murray Shaw
@@ -14449,6 +14743,7 @@ Redemption Song|SSAA|Jay Dougherty
 Redhead|TTBB|A Polaneczky
 Redhead|TTBB|Burt Szabo
 Redhead|TTBB|Ed Waesche
+Redhead|TTBB|Jim Clancy/Ed Waesche
 Redhead|TTBB|Mo Rector
 Redhead|TTBB|Ozzie Westley
 Redneck Kind of Guy|TTBB|Tom Gentry
@@ -14471,6 +14766,7 @@ Rejoice With Exceeding Great Joy|TTBB|Derric Johnson
 Relax (Take It Easy)|SATB|Deke Sharon
 Release Me|SSAA|Nancy Bergman
 Release Me|TTBB|Nancy Bergman
+Religious Medley|TTBB|Will Baughman
 Remedy|SSAA|Lauren Kahn
 Remedy|SSAA|Sheryl Neal
 Remember|SATB|Joe Mannherz
@@ -14481,6 +14777,8 @@ Remember Me|SSAA|Debbie Keretz
 Remember Me|SSAA|Julie Starr
 Remember Me|TTBB|Gabriel Lawson
 Remember Me|TTBB|Walter Latzko
+Remember Me (from Coco)|TTBB|Ken Potter
+Remember Me (from Coco)|TTBB|Nick Luna
 Remember My Boy Medley|TTBB|Jack Baird
 Remember Pearl Harbor|TTBB|Don Hallock
 Remembering Time Medley|TTBB|Dennis Driscoll
@@ -14496,10 +14794,12 @@ Respect|SATB|Deke Sharon
 Respect|SSAA|Deke Sharon
 Respect|SSAA|Larry Wright
 Restless|TTBB|Mark Stevens
+Retreat|TTBB|Steve Tramack
 Return to Pooh Corner|SSAA|Joey Minshall
 Return to Pooh Corner|TTBB|Manoj Padki
 Return To Sender|SSAA|Kohl Kitzmiller
 Return To Sender|TTBB|Duane Enders
+Reuben And Rachel (Parody)|TTBB|Adam Scott
 Reunite Commercial|SSAA|Jo Lund
 Revolting Children|SATB|James Henry
 Rewrite The Stars|SATB|Simon Lubkowski
@@ -14516,7 +14816,9 @@ Rhythm In My Nursery Rhymes/ABC Medley|SSAA|Larry Wright
 Rhythm Is Gonna Get You|SSAA|Jon Nicholas
 Rhythm Is Our Business|SSAA|Marsha Zwicker
 Rhythm Is Our Business|TTBB|Patrick McAlexander
+Rhythm Is Our Business (Parody)|TTBB|Patrick McAlexander
 Rhythm Medley|SSAA|Larry Wright
+Rhythm Medley|TTBB|Aaron Dale
 Rhythm Medley|TTBB|Larry Wright
 Rhythm Medley (I Got Rhythm/Fascinating Rhythm/Crazy Rhythm)|TTBB|Aaron Dale
 Rhythm of Love|SSAA|Deke Sharon & David Wright
@@ -14745,6 +15047,7 @@ Roses Of Picardy|SSAA|Nancy Bergman
 Roses Of Picardy|SSAA|Walter Latzko
 Roses Of Picardy|TTBB|Earl Moon
 Roses Of Picardy|TTBB|Ed Waesche
+Roses Of Picardy|TTBB|Lou Perry
 Roses Of Picardy|TTBB|Louis Perry
 Roses Of Picardy|TTBB|Roy Keys
 Roses Of Picardy|TTBB|Tom Gentry
@@ -14756,6 +15059,7 @@ Roses Of Yesterday|TTBB|Elling Sagen
 Rosetta|TTBB|Jon Nicholas
 Rosie|SSAA|Nancy Bergman
 Rosie|TTBB|Carl Walters
+Rosie (from Bye, Bye, Birdie)|TTBB|Patrick McAlexander
 Rosie Medley|TTBB|Archie Steen
 Rosie Medley|TTBB|Steve Jamison
 Rosie The Riveter|SSAA|Larry Wright
@@ -14791,6 +15095,7 @@ Roy Rogers Medley|TTBB|Larry Wright
 Royal Garden Blues|SSAA|David Wright
 Royal Garden Blues|SSAA|Tom Gentry
 Royal Garden Blues|TTBB|David Wright
+Royal Garden Blues|TTBB|Greg Volk
 Royal Garden Blues|TTBB|Renee Craig
 Royal Garden Blues|TTBB|Tom Gentry
 Royals|SATB|Deke Sharon
@@ -14828,6 +15133,7 @@ Rum And Coca Cola|SSAA|Walter Latzko
 Rumor Has It|SATB|Kevin Keller
 Rumor Has It|SSAA|Deke Sharon
 Rumor Has It|SSAA|Timari Thorstenson
+Run Away With Me|TTBB|Patrick McAlexander
 Run for the Roses|SSAA|Tom Gentry
 Run for the Roses|TTBB|Tom Gentry
 Run On|SATB|Nicholas Wright
@@ -14917,6 +15223,7 @@ Sam, You Made The Pants Too Long|SSAA|Tedda Lippincott
 Sam, You Made The Pants Too Long|TTBB|Walter Latzko
 Samba Do Aviao|SATB|Joe Mannherz
 Same Boat|SATB|Melody Hine
+Same Old Saturday Night|TTBB|Jim Halvorson
 Sammy Put the Paper on the Wall|SSAA|Tom Gentry
 Sammy Put the Paper on the Wall|TTBB|Tom Gentry
 Samson|SATB|Nicholas Wright
@@ -14958,6 +15265,7 @@ Santa Claus Is Coming To Town|TTBB|Joe Liles
 Santa Claus Parade|TTBB|Tom Gentry
 Santa Fe|TTBB|Gabriel Lawson
 Santa Fe|TTBB|Theodore Hicks
+Santa Fe (from Newsies)|TTBB|Chris Lewis
 Santa is Watching|TTBB|Todd Troutman
 Santa Lost His Keys|TTBB|Jim Shubert
 Santa Lucia|SSAA|Carole Prietto
@@ -15102,6 +15410,7 @@ Second Time Around|SSAA|June Berg
 Second Time Around|TTBB|Jim Emery
 Second Time Around|TTBB|Steve Delehanty
 Secondhand White Baby Grand|SSAA|Larry Wright
+Secondhand White Baby Grand|TTBB|Theo Hicks
 Secondhand White Baby Grand|TTBB|Theodore Hicks
 Secret For The Mad|SSAA|Lauren Kahn
 Secret Love|SSAA|Tom Gentry
@@ -15117,12 +15426,14 @@ See You In September|TTBB|Brent Graham
 See You In September|TTBB|Mark Goodney
 See You In September|TTBB|Walter Latzko
 Seeds and Stems Again|TTBB|Tom Gentry
+Seeing For The Very First Time|TTBB|David Wright
 Seems Like Old Times|SSAA|Debbie Porter
 Seems Like Old Times|SSAA|Dorothy Short
 Seems Like Old Times|TTBB|Louis Perry
 Seize The Day|SSAA|Jim Arns
 Seize The Day|TTBB|Aaron Dale
 Seize The Day|TTBB|Theodore Hicks
+Seize The Day (from Newsies)|TTBB|Theo Hicks
 Semi Charmed Life|SATB|Deke Sharon
 Semper Paratus|TTBB|Jim West
 Send In The Clowns|SSAA|Joey Minshall
@@ -15197,6 +15508,7 @@ Sesame Street Theme|TTBB|Kirk Young
 Sesame Street Theme|TTBB|Michael Webber
 Settle Down|SATB|Nicholas Wright
 Settle Down|SSAA|Nicholas Wright
+Settle For Me (Parody)|TTBB|Patrick McAlexander
 Settlin'|SSAA|Nicholas Wright
 Seven Bridges Road|SATB|Jeremey Johnson
 Seven Bridges Road|SSAA|Jeremey Johnson
@@ -15228,6 +15540,8 @@ Seventy-Six Trombones|TTBB|Walter Latzko
 Seventy-Six Trombones (from "The Music Man")|TTBB|John Peterson
 Sexy Lady|SSAA|Hannah Briggs
 Sexyback|SATB|Deke Sharon
+Sgt Pepper's Lonely Hearts Club Band|TTBB|David Harrington
+Sgt Pepper's Lonely Hearts Club Band/With A Little Help From My Friends (Medley)|TTBB|David Harrington
 Sh Boom|SSAA|Marsha Zwicker
 Sh Boom|SSAA|Tedda Lippincott
 Sh Boom|TTBB|Dan Naumann
@@ -15243,7 +15557,10 @@ Shadrach|TTBB|Derric Johnson
 Shake It Off|SATB|Deke Sharon
 Shake It Off|SSAA|Erica Kelch-Slesnick
 Shake It Out|SATB|Nicholas Wright
+Shakin' The Blues Away (from Easter Parade)|TTBB|Cay Outerbridge
+Shakin' The Blues Away (from Easter Parade)|TTBB|Clay Hine
 Shaking The Blues Away|SSAA|Renee Craig
+Shaking The Blues Away|TTBB|Cay Outerbridge
 Shaking The Blues Away|TTBB|Jay Giallombardo
 Shaking The Blues Away|TTBB|Steve Delehanty
 Shall We Dance|SSAA|Carolyn Schmidt
@@ -15297,6 +15614,7 @@ She Used To Be Mine|SSAA|Steve Tramack
 She Used To Be Mine|SSAA|Theodore Hicks
 She Used To Be Mine|TTBB|Simon Arnott
 She Used To Be Mine|TTBB|Theodore Hicks
+She Used To Be Mine (from Waitress)|TTBB|Theo Hicks
 She Walks In Beauty|SATB|David Zimmerman
 She Was An Acrobat's Daughter|TTBB|Alden Parker
 She Was Five And He Was Ten|SSAA|Mary Santomeno
@@ -15306,6 +15624,7 @@ She Will Be Loved|SATB|Nicholas Wright
 She'll Be Comin' Round The Mountain|SSAA|Nancy Bergman
 She's A Typical Tip from Tipperary|TTBB|Tom Parker
 She's All I Ever Had|TTBB|Steve Jamison
+She's Always A Woman|TTBB|Simon Rylander
 She's Funny That Way|TTBB|Walter Latzko
 She's Gonna Fly|SSAA|Michael Gellert
 She's Gonna Love That Barbershop Song|TTBB|David Longroy
@@ -15362,6 +15681,7 @@ Shipoopi|TTBB|Walter Latzko
 Shipping Out Medley|TTBB|Steve Jamison
 Shiver My Timbers|SSAA|Carole Prietto
 Shiver My Timbers|TTBB|Jon Nicholas
+Shoe Shine Boy|TTBB|Jeremey Johnson
 Shoo Fly Pie and Apple Pan Dowdy|TTBB|Chris Droegemueller
 Shoo-shoo Baby|SSAA|Larry Wright
 Shoop-Shoop Song, The (It's In His Kiss)|SSAA|Deke Sharon
@@ -15392,6 +15712,7 @@ Show Me Where The Good Times Are|TTBB|C. C. Gerheim
 Show Me Where The Good Times Are|TTBB|Dick Kneeland
 Show Me Where The Good Times Are|TTBB|Don Gray
 Show Me Where The Good Times Are|TTBB|Gene Cokeroft
+Show Me Where The Good Times Are|TTBB|Gene Cokeroft/Dot Short
 Show Opener|SSAA|Jo Lund
 Shuffle Off To Buffalo|TTBB|Al Baker
 Shut De Do|SATB|Dr. Kirby Shaw
@@ -15705,16 +16026,20 @@ Smile|SSAA|Carolyn Schmidt
 Smile|SSAA|Dot Calvin
 Smile|SSAA|Kevin Keller
 Smile|SSAA|Steve Tramack
+Smile|TTBB|Clay Hine
+Smile|TTBB|Kevin Keller
 Smile|TTBB|Steve Tramack
 Smile|TTBB|Tom Gentry
 Smile Away Each Rainy Day|TTBB|Mark Goodney
 Smile Medley|SSAA|Jay Giallombardo
 Smile Medley|SSAA|Jim Arns
+Smile Medley|TTBB|Clay Hine
 Smile Medley|TTBB|Ed Waesche
 Smile Medley|TTBB|Jay Giallombardo
 Smile Medley|TTBB|Ron Black
 Smile Medley|TTBB|Steve Delehanty
 Smile Medley (Pack Up Your Troubles / Smile, Darn Ya, Smile / Let A Smile Be Your Umbrella)|SSAA|Nancy Bergman
+Smile Medley II|TTBB|David Wright
 Smile Will Go A Long Long Way|TTBB|Dennis Driscoll
 Smile Will Go A Long Long Way|TTBB|Vern Knapp
 Smile, Darn Ya, Smile|TTBB|Burt Szabo
@@ -15733,8 +16058,10 @@ Smilin' Through|TTBB|David Wright
 Smilin' Through|TTBB|Ed Waesche
 Smilin' Through|TTBB|Howard Dale
 Smilin' Through|TTBB|Larry Triplett
+Smilin' Through|TTBB|Lou Perry/Ed Waesche
 Smilin' Through|TTBB|Louis Perry
 Smoke Gets In Your Eyes|SSAA|Bev Sellers
+Smoke Gets In Your Eyes|TTBB|Patrick McAlexander
 Smoke Gets In Your Eyes|TTBB|Todd Troutman
 Smoke Gets In Your Eyes|TTBB|Walter Latzko
 Smoke Rings|TTBB|Kyle Snook
@@ -15790,6 +16117,7 @@ So Many Voices Sing America's Song|TTBB|Tom Gentry
 So Much In Love|SSAA|David Harrington
 So Much In Love|TTBB|David Harrington
 So Rare|TTBB|Robert Rund
+So This Is Love|TTBB|Gary Lewis
 So Tired|TTBB|Jesse Turner
 So What|SATB|Deke Sharon
 So What's New|SSAA|Jean Shook
@@ -15816,6 +16144,7 @@ Sold|TTBB|Aaron Dale
 Sold|TTBB|Deke Sharon
 Soldier Soldier Will You Marry Me|TTBB|Larry Wright
 Solid As A Rock|SATB|Adam Bock
+Soliloquy|TTBB|Jay Giallombardo
 Solitaire|SSAA|Tom Gentry
 Solitaire|TTBB|Tom Gentry
 Some Children See Him|SSAA|Kay Bromert
@@ -15870,6 +16199,7 @@ Somebody Like You|SATB|Deke Sharon
 Somebody Loves Me|SSAA|Charlene Yazurlo
 Somebody Loves Me|SSAA|Sheryl Neal
 Somebody Loves Me|SSAA|Walter Latzko
+Somebody Loves Me|TTBB|Clay Hine
 Somebody Loves Me|TTBB|Jim Shubert
 Somebody Loves Me/Let's Talk About My Sweetie|SSAA|Sheryl Neal
 Somebody Loves You|SSAA|Diana Franceschi
@@ -15940,6 +16270,7 @@ Someone Like You|TTBB|Matt Astle
 Someone Like You|TTBB|Rob Hopkins
 Someone Like You|TTBB|Simon Arnott
 Someone Like You|TTBB|Steve Tramack
+Someone Like You (from Jekyll And Hyde)|TTBB|Steve Tramack
 Someone That I Used To Love|SSAA|Jean McFadyen
 Someone To Watch Over Me|SSAA|Carolyn Schmidt
 Someone To Watch Over Me|SSAA|David Briner
@@ -15968,6 +16299,7 @@ Someone's Waiting For You|TTBB|Dan Wessler
 Someone's Waiting For You|TTBB|Eric Ruthenberg
 Someone's Waiting For You|TTBB|Jeremey Johnson
 Somethin' About December|SSAA|Matt Parks
+Somethin' About Ya|TTBB|Joe Liles
 Somethin' Stupid|SATB|Kyle Snook
 Somethin' Stupid|TTBB|Kevin Koehl
 Something|SATB|Joe Mannherz
@@ -16104,6 +16436,7 @@ Songs of Christmas Medley|SSAA|Jim Clancy
 Songs of Christmas Medley|TTBB|Jim Clancy
 Songs of Love|TTBB|Deke Sharon
 Songs Of The West|TTBB|Derric Johnson
+Songs Of Wonder|TTBB|Matt Gallagher
 Sonny Boy|TTBB|Al Baker
 Sonny Boy|TTBB|Bruce Wenner
 Sonny Boy|TTBB|Burt Szabo
@@ -16125,6 +16458,7 @@ Sophie|TTBB|Al Baker
 Sophisticated Ladies Medley|SSAA|Jo Lund
 Sophisticated Lady|SATB|Joe Mannherz
 Sorry|TTBB|Nicholas Wright
+Sorry Seems To Be The Hardest Word|TTBB|Jackson Pinder
 Soul Man|TTBB|Jay Giallombardo
 Soul Man|TTBB|Melody Hine
 Soulful Hallelujah|TTBB|Deke Sharon
@@ -16157,6 +16491,7 @@ South Rampart Street Parade|TTBB|David Wright
 South Rampart Street Parade|TTBB|Don Gray
 South Rampart Street Parade|TTBB|Frank Smith
 South Rampart Street Parade|TTBB|William Behrendt
+South Rampart Street Parade (Parody)|TTBB|David Wright
 South Rampart Street Parade/Way Down Yonder in New Orleans Medley|SSAA|Larry Wright
 Southern Cross|TTBB|Mark Stevens
 Southern Medley|TTBB|Barbershop Harmony Society
@@ -16184,6 +16519,7 @@ Speechless|TTBB|Melody Hine
 Spend My Life With You|SSAA|Kyle Kitzmiller
 Spend My Life With You|TTBB|Kyle Kitzmiller
 Spend My Life With You|TTBB|Rob Hopkins
+Spider-Man Theme|TTBB|Aaron Dale
 Spiderman Theme|SSAA|Sam Hubbard
 Spiderman Theme|TTBB|Aaron Dale
 Spiderman Theme|TTBB|Sam Hubbard
@@ -16199,6 +16535,7 @@ Spiritual Medley|TTBB|Barbershop Harmony Society
 Splanky|SATB|Joe Mannherz
 Splish Splash|SSAA|Tom Gentry
 Splish Splash|TTBB|Cay Outerbridge
+Spongebob Medley|TTBB|Kohl Kitzmiller
 Spooky Scary Skeletons|TTBB|Kyle Hottel
 Spoonful of Sugar/Jolly Holiday Medley|TTBB|Liz Garnett
 Sposin|SSAA|Diana Franceschi
@@ -16217,6 +16554,7 @@ St. James Infirmary|TTBB|Dan Wessler
 St. Patrick's Day Parade Medley|TTBB|Don Gray
 Stacy's Mom|SATB|Deke Sharon
 Stacy's Mom|TTBB|Nicholas Wright
+Stairway To Paradise|TTBB|Dan Wessler
 Stairway To The Stars|TTBB|Walter Latzko
 Stand A Little Rain|TTBB|Mark Stevens
 Stand By Me|SATB|Deke Sharon
@@ -16272,6 +16610,7 @@ Star Spangled Banner|TTBB|Steve Jamison
 Star Spangled Banner|TTBB|Tom Campbell
 Star Spangled Banner|TTBB|Val Hicks
 Star Trek: The Next Generation - Main Title|SATB|Joey Minshall
+Star Wars Medley|TTBB|Patrick McAlexander
 Starboy|TTBB|Nicholas Wright
 Stardust|SATB|Joe Mannherz
 Stardust|TTBB|Walter Latzko
@@ -16316,6 +16655,7 @@ Stayin' Alive|TTBB|Deke Sharon
 Stayin' Home|TTBB|Liz Garnett
 Steal Away|SSAA|David Wright
 Steal Away|TTBB|David Wright
+Steal Away|TTBB|Patrick McAlexander
 Steal Away To Jesus|TTBB|Derric Johnson
 Steal My Kisses|SATB|Deke Sharon
 Steal My Kisses|TTBB|Deke Sharon
@@ -16325,6 +16665,7 @@ Steam Heat|TTBB|Craig Minor
 Steam Heat|TTBB|Tom Gentry
 Steamin' Down The River|TTBB|Val Hicks
 Stella By Starlight|TTBB|Jeremey Johnson
+Stella By Starlight (from The Uninvited)|TTBB|Jeremey Johnson
 Step In Time|SSAA|Deke Sharon
 Step In Time|SSAA|June Dale
 Step In Time|TTBB|David Wright
@@ -16355,6 +16696,7 @@ Steppin' Out With My Baby|TTBB|Deke Sharon
 Steppin' Out With My Baby|TTBB|Lance Fisher
 Steppin' Out With My Baby|TTBB|Rob Hopkins
 Stepping Around|TTBB|Rob Campbell
+Stepping Out With A Star|TTBB|Jackson Pinder
 Stick To The Status Quo|SATB|Soren Detlefsen
 Stickshifts and Safety Belts|TTBB|Aaron Dale
 Still Crazy After All These Years|TTBB|Deke Sharon
@@ -16420,6 +16762,7 @@ Story Of The Rose|TTBB|Barbershop Harmony Society
 Story Of The Rose|TTBB|Brent Graham
 Story Of The Rose|TTBB|Jon Nicholas
 Storybook|SATB|Robert Rund
+Stouthearted Men|TTBB|David Wright
 Stouthearted Men|TTBB|Dick Stuart
 Stouthearted Men|TTBB|Don Gray
 Stouthearted Men|TTBB|Jim West
@@ -16433,6 +16776,7 @@ Straighten Up And Fly Right|SSAA|Liz Garnett
 Straighten Up And Fly Right|SSAA|Mary K. Coffman Music Fund
 Straighten Up And Fly Right|TTBB|Jim Shubert
 Straighten Up And Fly Right|TTBB|Liz Garnett
+Strange Sight|TTBB|Ken Potter
 Stranger in Paradise|TTBB|Rob Campbell and Mark Hale
 Stranger on the Shore|SSAA|Joe Mannherz
 Strangers|SSAA|Audrey Oakley
@@ -16497,6 +16841,7 @@ Sucker|SSAA|Joe Mannherz
 Sucker|TTBB|Joe Mannherz
 Sudbury Saturday Night|TTBB|Tom Gentry
 Sudden Love|TTBB|David Wright
+Suddenly|TTBB|Rob Hopkins
 Suddenly I See|SSAA|Robert Rund
 Suddenly There's A Valley|TTBB|Adam Reimnitz
 Suddenly There's A Valley|TTBB|Nancy Bergman
@@ -16584,6 +16929,7 @@ Sunny In Seattle|TTBB|Patrick McAlexander
 Sunny Side Medley|SSAA|Nancy Bergman
 Sunny Side Up|SSAA|Nancy Bergman
 Sunny Side Up|TTBB|Ed Waesche
+Sunny Side Up|TTBB|Greg Volk
 Sunny Side Up/When You're Smiling Medley|TTBB|John Fortino
 Sunny Southern Smiles|TTBB|Russ Foris
 Sunrise, Sunset|SSAA|Carolyn Johnson
@@ -16607,6 +16953,8 @@ Supercalifragilisticexpialidocious|SATB|Deke Sharon
 Supercalifragilisticexpialidocious|SSAA|Takako Fuke
 Supercalifragilisticexpialidocious|TTBB|Anthony Bartholomew
 Supercalifragilisticexpialidocious|TTBB|Robert Rund
+Supercalifragilisticexpialidocious (Parody)|TTBB|Anthony Bartholomew
+Superhero Medley|TTBB|Patrick McAlexander
 Superman (It's Not Easy)|SATB|Deke Sharon
 Superman (It's Not Easy)|TTBB|Deke Sharon
 Supermarket Flowers|SATB|Nicholas Wright
@@ -16639,6 +16987,7 @@ Suzanna Pianna Medley|TTBB|Jay Giallombardo
 Suzanne|SATB|Vince Peterson
 Suzy Snowflake|TTBB|Mason Eubank
 Swan Song|TTBB|Rob Campbell
+Swan Song Medley|TTBB|Matt Astle
 Swanee|TTBB|Burt Szabo
 Sway|SSAA|Carole Prietto
 Sway|SSAA|Larry Wright
@@ -16705,6 +17054,7 @@ Sweet Lorraine|TTBB|David Wright
 Sweet Lorraine|TTBB|Ed Waesche
 Sweet Lorraine|TTBB|J Rae Jamieson
 Sweet Lorraine|TTBB|Larry Wright
+Sweet Lorraine|TTBB|Mark Hale/David Wright
 Sweet Mae|TTBB|Bob Jones
 Sweet Man|TTBB|Todd Troutman
 Sweet Nothing|SATB|Nicholas Wright
@@ -16803,6 +17153,7 @@ Take It To The Limit|TTBB|Melody Hine
 Take It Up A Step|SATB|David Wright
 Take It Up A Step|SSAA|Michael Gellert
 Take Me Along|SSAA|Becky Cartine
+Take Me As I Am|TTBB|Theo Hicks
 Take Me As I Am|TTBB|Theodore Hicks
 Take Me Back To Toyland|SSAA|DeDe Crow
 Take Me Home|TTBB|Mark Stevens
@@ -16900,6 +17251,7 @@ Taylor The Latte Boy|SSAA|Michael Gellert
 Taylor The Latte Boy|SSAA|Simon Arnott
 Taylor The Latte Boy|SSAA|Steve Tramack
 Taylor The Latte Boy|TTBB|Tom Gentry
+Tea For Two|TTBB|Mark Hale
 Tea For Two|TTBB|Walter Latzko
 Teach Everybody To Sing|SSAA|Joe Liles
 Teach Me Tonight|SSAA|Sam Hubbard
@@ -16952,6 +17304,7 @@ Tell Me You'll Forgive Me|SSAA|Walter Latzko
 Tell Me You'll Forgive Me|TTBB|Jack Baird
 Tell Me You'll Forgive Me|TTBB|Joe Liles
 Tell Me You'll Forgive Me|TTBB|Louis Perry
+Tell My Father|TTBB|Garrett Gillingham
 Tell My Father|TTBB|Tom Gentry
 Tell Santy I Live In A Shanty|SSAA|Tedda Lippincott
 Telling It To The Daisies|SSAA|Walter Latzko
@@ -16970,6 +17323,8 @@ Ten Minutes Ago|SSAA|Brent Graham
 Ten Minutes Ago|TTBB|Brent Graham
 Ten Minutes Ago|TTBB|Patrick McAlexander
 Ten Minutes Ago|TTBB|Simon Arnott
+Ten Minutes Ago (from Cinderella)|TTBB|Brent Graham
+Ten Minutes Ago (from Cinderella)|TTBB|Patrick McAlexander
 Ten Pins In The Sky|TTBB|Jon Nicholas
 Ten Thousand Men Of Harvard|TTBB|Kevin Keller
 Tenderly|SATB|Joe Mannherz
@@ -17270,12 +17625,14 @@ The Best Is Yet To Come|TTBB|Brent Graham
 The Best Is Yet To Come|TTBB|Joe Grimme
 The Best Man|TTBB|Matt Astle
 The Best of Days|SSAA|Joey Minshall
+The Best Of Me|TTBB|Rasmus Krigström
 The Best Thing For You|SSAA|Kohl Kitzmiller
 The Best Thing For You|TTBB|Kohl Kitzmiller
 The Best Thing in the World Today Cafe|SATB|Dan Naumann
 The Best Things Happen While You're Dancing|SSAA|Steve Tramack
 The Best Things Happen While You're Dancing|SSAA|Tom Gentry
 The Best Things Happen While You're Dancing|TTBB|Tom Gentry
+The Best Things Happen While You're Dancing (from White Christmas)|TTBB|Steve Tramack
 The Best Time Of Your Life|SSAA|Marie Johnson
 The Best Times I Ever Had|SSAA|Larry Wright
 The Best Times I Ever Had|TTBB|Larry Wright
@@ -17283,6 +17640,7 @@ The Big Bang Theory|SSAA|Patricia Godfrey
 The Big Parade|SSAA|Michael Gellert
 The Biggest Parakeets in Town|TTBB|Tom Gentry
 The Birds And The Bees|TTBB|TJ Barranger
+The Birth Of The Blues|TTBB|David Wright
 The Birthday Of A King|SSAA|Jay Giallombardo
 The Birthday Of A King|SSAA|Nancy Bergman
 The Birthday Of A King|TTBB|David Wright
@@ -17306,6 +17664,7 @@ The Brain|TTBB|Simon Arnott
 The Briar and the Rose|SSAA|Diane Clark
 The Broadway Blues|TTBB|Burt Szabo
 The Brooklyn Bridge|SSAA|Sonny Steffan
+The Brotherhood Of Man (Parody)|TTBB|Jay Giallombardo
 The Bunny Hug|TTBB|Jim Shubert
 The Candy Man|TTBB|Kevin Keller
 The Captain Of The Toy Brigade|SSAA|Jay Giallombardo
@@ -17386,6 +17745,7 @@ The Clod & the Pebble|SATB|David Avshalomov
 The Closest Thing To Crazy|TTBB|Hilary Allen
 The Clouds Will Soon Roll By|SSAA|Zona Snyder
 The Coffee Song|SATB|Dan Wessler
+The Coffee Song|TTBB|Dan Wessler
 The Colors of My Life|SSAA|Jo Lund
 The Colors of My Life|TTBB|Simon Arnott
 The Colour of My Love|SSAA|Jo Lund
@@ -17397,9 +17757,11 @@ The Crimond|TTBB|Richard Curtis
 The Croquet Song|TTBB|Walter Latzko
 The Cross, The Crown, The Nail|TTBB|Derric Johnson
 The Curtain Falls|SSAA|Tom Gentry
+The Curtain Falls|TTBB|Clay Hine
 The Curtain Falls|TTBB|Tom Gentry
 The Dance|SSAA|Jeanne Elmuccio
 The Dance|TTBB|Patrick McAlexander
+The Darktown Strutters' Ball|TTBB|Ed Waesche
 The Daughter of Sweet Adeline|TTBB|John Minsker
 The Day After Thanksgiving|SATB|Kay Bromert
 The Day After Thanksgiving|TTBB|Eric Ruthenberg
@@ -17484,6 +17846,7 @@ The Girl From Ipanema|SSAA|Gloria Kuchenbecker
 The Girl From Ipanema|TTBB|Deke Sharon
 The Girl from Kodak Town|SSAA|Tom Gentry
 The Girl from Kodak Town|TTBB|Tom Gentry
+The Girl I Love|TTBB|Gary Lewis
 The Girl in 14G|SSAA|Michael Gellert
 The Girl in 14G|SSAA|Simon Arnott
 The Girl in 14G|SSAA|Tom Gentry
@@ -17551,6 +17914,7 @@ The Holy City|TTBB|Walter Latzko
 The House At The End Of The Lane|TTBB|Burt Szabo
 The House Is Haunted|SSAA|Kristina Roper
 The Human Abstract|SATB|David Avshalomov
+The Hut-Sut Song|TTBB|Rasmus Krigström
 The Impossible Dream|SATB|Manoj Padki
 The Impossible Dream|SSAA|Clay Hine
 The Impossible Dream|SSAA|Jay Giallombardo
@@ -17561,6 +17925,7 @@ The Impossible Dream|TTBB|Larry Wright
 The Impossible Dream|TTBB|Scott Kitzmiller
 The Impossible Dream|TTBB|Steven Armstrong
 The Impossible Dream|TTBB|Theodore Hicks
+The Impossible Dream Medley|TTBB|Matt Astle/Ken Potter
 The Impression That I Get|TTBB|Kari Francis
 The International Rag|SSAA|Kevin Keller
 The International Rag|TTBB|Kevin Keller
@@ -17581,6 +17946,7 @@ The Kingdom of Shy|SATB|Joe Mannherz
 The Lady Down the Hall|SSAA|Michael Gellert
 The Lady From 29 Palms|SSAA|Marie Johnson
 The Lady In Red|SSAA|Kohl Kitzmiller
+The Lady Is A Tramp|TTBB|Wayne Grimmer
 The Lady Takes The Cowboy Every Time|SSAA|Nancy Bergman
 The Lady's In Love With You|TTBB|Wayne Grimmer
 The Lamb|SATB|David Avshalomov
@@ -17691,6 +18057,7 @@ The Masquerade Is Over|SSAA|Jay Giallombardo
 The Masquerade Is Over|TTBB|Ed Waesche
 The Masquerade Is Over|TTBB|Jay Giallombardo
 The Masquerade Is Over|TTBB|Joe Mannherz
+The Masquerade Is Over (I'm Afraid)|TTBB|Ed Waesche
 The Meeting In The Air|TTBB|Derric Johnson
 The Memory Of You Lives On|SSAA|Marie Johnson
 The Merry Christmas Polka|SATB|Tom Gentry
@@ -17705,6 +18072,7 @@ The More I See You|SSAA|Joe Mannherz
 The More I See You|SSAA|Kevin Keller
 The More I See You|TTBB|Brent Graham
 The More I See You|TTBB|Joe Mannherz
+The More I See You|TTBB|John Brockman
 The More I See You|TTBB|Kevin Keller
 The More I See You|TTBB|Walter Latzko
 The Most Beautiful Girl|TTBB|Jon Nicholas
@@ -17739,9 +18107,12 @@ The Nearness Of You|TTBB|Kevin Keller
 The Nearness Of You|TTBB|Rob Hopkins
 The Nearness Of You|TTBB|Ron Rank
 The Nearness Of You|TTBB|Walter Latzko
+The Nearness Of You (from Romance In The Dark)|TTBB|Ben Ferguson
+The Nearness Of You (from Romance In The Dark)|TTBB|John Brockman
 The New Ashmolean Marching Society and Students Co|TTBB|Dave Briner
 The Next Right Thing|SSAA|Katie Taylor
 The Next Right Thing|SSAA|Sam Hubbard
+The Next Ten Minutes (from The Last Five Years)|TTBB|Theo Hicks
 The Night Before Christmas|SSAA|Joan Melling
 The Night Before Christmas|TTBB|Burt Szabo
 The Night Before Christmas|TTBB|Toban Dvoretsky
@@ -17775,6 +18146,7 @@ The Old Spinning Wheel|SSAA|Tom Gentry
 The Old Spinning Wheel|TTBB|Earl Moon
 The Old Spinning Wheel|TTBB|Tom Gentry
 The Older I Get|SSAA|Sheryl Neal
+The One I Love (Belongs To Somebody Else)|TTBB|Clay Hine
 The One I Love Belongs to Somebody Else|TTBB|Jim Shubert
 The One I Love Belongs To Somebody Else|SATB|Joe Mannherz
 The One I Love Belongs To Somebody Else|SSAA|Joe Mannherz
@@ -17796,6 +18168,7 @@ The Parting Glass|TTBB|Manoj Padki
 The Parting Glass|TTBB|Nicholas Wright
 The Parting Glass|TTBB|Thomas Degan
 The Party's Over|TTBB|Brent Graham
+The Party's Over|TTBB|Steve Armstrong
 The Party's Over|TTBB|Steven Armstrong
 The Peace Carol|SSAA|David Wallace
 The Peace Carol|SSAA|June Berg
@@ -17915,6 +18288,7 @@ The Song that Doesn't End|TTBB|Jim Emery
 The Song That Goes Like This|SSAA|Carole Prietto
 The Songs We Sang Together|TTBB|Steve Tramack
 The Sound|TTBB|Nicholas Wright
+The Sound Of Music|TTBB|David Wright
 The Sound of Music with Climb Every Mountain|TTBB|Joe Liles
 The Sound Of Silence|SATB|Deke Sharon
 The Sound Of Silence|SATB|Marilyn Penketh
@@ -18042,6 +18416,7 @@ The Very Thought Of You|SSAA|Jim Arns
 The Very Thought Of You|SSAA|Joanne Dockrell
 The Very Thought Of You|SSAA|Tom Wheeler
 The Very Thought Of You|TTBB|Adam Reimnitz
+The Very Thought Of You|TTBB|Jason Dyer
 The Very Thought Of You|TTBB|Jim Shubert
 The Very Thought Of You|TTBB|Mark Goodney
 The Victors|TTBB|Tom Gentry
@@ -18080,6 +18455,7 @@ The Way You Look Tonight|TTBB|Tom Gentry
 The Way You Look Tonight|TTBB|Walter Latzko
 The Weekend|TTBB|Nicholas Wright
 The Wells Fargo Wagon|TTBB|Howard Jones
+The Wells Fargo Wagon (Parody)|TTBB|Patrick McAlexander
 The Whiffenpoof Song|TTBB|Louis Perry
 The Windmills of your Mind|SATB|Dennis Driscoll
 The Windmills of your Mind|SATB|Joe Mannherz
@@ -18108,6 +18484,7 @@ Their Hearts Were Full Of Spring|TTBB|Tom Gentry
 Them There Eyes|SSAA|Dave Stevens
 Them Was The Good Old Days|SSAA|Larry Wright
 Them Was The Good Old Days|TTBB|Larry Wright
+Theme From "New York, New York"|TTBB|Patrick McAlexander
 Theme from Cheers|SSAA|Larry Wright
 Theme from Cheers|TTBB|Larry Wright
 Theme from Ice Castles|SSAA|Tom Gentry
@@ -18163,6 +18540,7 @@ There Used To Be A Ball Park|SSAA|Jay Giallombardo
 There Used To Be A Ball Park|TTBB|Brent Graham
 There Used To Be A Ball Park|TTBB|Jay Giallombardo
 There Used To Be A Ball Park|TTBB|Kevin Keller
+There Used To Be A Ballpark|TTBB|Roger Payne
 There Used To Be A Ballpark Right Here|SSAA|Doris Twardosky
 There Used To Be A Ballpark Right Here|SSAA|Val Hicks
 There Used To Be A Ballpark Right Here|TTBB|Doris Twardosky
@@ -18204,6 +18582,7 @@ There's a Fine Fine Line|SATB|Deke Sharon
 There's a Fine Fine Line|SSAA|Aaron Dale
 There's a Fine Fine Line|SSAA|Theodore Hicks
 There's a Fine Fine Line|TTBB|Theodore Hicks
+There's a Fine, Fine Line (from Avenue Q)|TTBB|Ben Brown
 There's A Frost On The Moon|SSAA|Lauren Kahn
 There's A Full Moon Tonight|TTBB|Walter Latzko
 There's A Girl In The Heart Of Maryland|TTBB|Jack Baird
@@ -18224,6 +18603,7 @@ There's A New Gang On The Corner|TTBB|Floyd Connett
 There's A New Gang On The Corner|TTBB|Gene Cokeroft
 There's A Place|SSAA|Emily Moriarty
 There's A Place For Us|TTBB|Greg Mallett
+There's A Rainbow 'Round My Shoulder|TTBB|Jeff Marks
 There's A Rainbow 'Round My Shoulder|TTBB|Kyle Snook
 There's A Rainbow 'Round My Shoulder|TTBB|SPEBSQSA
 There's a Rose On Your Cheek|TTBB|Hal Staab
@@ -18256,6 +18636,7 @@ There's Nobody Else But You|SSAA|Suzy Lobaugh
 There's Nobody Else But You|TTBB|Louis Perry
 There's Nobody Just Like You|TTBB|Jack Baird
 There's Nothing I Wouldn't Do|SSAA|Dianne Goldrick
+There's Nothing That I Haven't Sung About|TTBB|Clay Hine
 There's Something About A Soldier|SSAA|Jay Giallombardo
 There's Something About A Soldier|SSAA|Joe Mannherz
 There's Something About A Soldier|SSAA|Judy Vidal
@@ -18267,6 +18648,7 @@ There's Something About That Name|TTBB|John Hale
 There's Something About That Name|TTBB|Randall Weir
 There's Something I Like About Broadway|TTBB|Louis Perry
 There's Yes Yes In Your Eyes|TTBB|Tim Wheeler
+These Are The Days|TTBB|Stefan Pugliese
 These Are the Days of Our Lives|SATB|Liz Garnett
 These Are The Special Times|SSAA|Larry Wright
 These Boots Are Made For Walkin'|SSAA|Brian Beck
@@ -18276,6 +18658,7 @@ These Boots Are Made For Walkin'|TTBB|Emily Moriarty
 These Dreams|SATB|Manoj Padki
 These Foolish Things|SSAA|Nancy Bergman
 These Foolish Things|TTBB|Melody Hine
+These Foolish Things (Remind Me Of You)|TTBB|Rasmus Krigström
 They|SATB|Deke Sharon
 They All Call It Canada|SATB|Beverly Kennedy
 They All Call It Canada|SSAA|Beverly Kennedy
@@ -18376,12 +18759,14 @@ Things Are Looking Up|SSAA|Sheryl Neal
 Things Are Looking Up|TTBB|Cay Outerbridge
 Things Are Looking Up|TTBB|David Briner
 Things Are Looking Up|TTBB|Kevin Keller
+Things Are Looking Up|TTBB|Rasmus Krigström
 Things We Do For Love|SATB|Anders Lindqvist
 Things We Do For Love|SSAA|Anders Lindqvist
 Things We Do For Love|TTBB|Anders Lindqvist
 Things We Do For Love|TTBB|Kohl Kitzmiller
 Think|SSAA|Erica Kelch-Slesnick
 Think|SSAA|Staffan Paulson
+Think|TTBB|Patrick McAlexander
 Think Of Me|SSAA|Sheila Cope
 Thinking Of You|TTBB|Bob Weiss
 Thinking Out Loud|SATB|Deke Sharon
@@ -18397,6 +18782,9 @@ This Can't Be Love|SSAA|George Avener
 This Can't Be Love|TTBB|Aaron Dale
 This Can't Be Love|TTBB|David Wright
 This Can't Be Love|TTBB|Eric Ruthenberg
+This Can't Be Love (from The Boys From Syracuse)|TTBB|Aaron Dale
+This Can't Be Love (from The Boys From Syracuse)|TTBB|David Wright
+This Can't Be Love (from The Boys From Syracuse)|TTBB|Wayne Grimmer
 This Christmas|SSAA|Simon Arnott
 This Christmas|TTBB|Deke Sharon
 This Christmastide|SATB|James Hoover
@@ -18478,8 +18866,10 @@ This Is The Moment|TTBB|Nick Bryant
 This Is The Moment|TTBB|Simon Arnott
 This Is The Moment|TTBB|Steve Jamison
 This Is The Moment|TTBB|Steven Armstrong
+This Is The Moment (from Jekyll & Hyde)|TTBB|Steve Armstrong
 This Is Why I Sing|SATB|Melody Hine
 This Is Worth Fighting For|TTBB|Bernie Pitkin
+This Joint is Jumpin'|TTBB|Clay Hine
 This Kiss|SSAA|Dianne Goldrick
 This Land is Home|TTBB|Todd Troutman
 This Land Is Your Land|SATB|Manoj Padki
@@ -18641,6 +19031,7 @@ Till There Was You|TTBB|Willis Diekema
 Till There Was You (from "The Music Man")|SSAA|Roger Payne
 Till There Was You (from "The Music Man")|TTBB|Roger Payne
 Till There Was You (from "The Music Man")|TTBB|Willis Diekema
+Till There Was You (from The Music Man)|TTBB|Robert Rund
 Till We Meet Again|TTBB|Louis Perry
 Timber|SSAA|Deke Sharon
 Time After Time|SATB|Deke Sharon
@@ -18679,6 +19070,7 @@ Time Of My Life|SSAA|Debbie Keretz
 Time Of Our Lives|SATB|Nicholas Wright
 Time Of Season/What's Your Name|SATB|Deke Sharon
 Time To Dance|TTBB|SPEBSQSA
+Time Warp (from The Rocky Horror Show)|TTBB|Melody Hine
 Time Was|SSAA|Brent Graham
 Time Was|SSAA|Debbie Keretz
 Time Was|SSAA|Tedda Lippincott
@@ -18739,6 +19131,7 @@ Together Again|SSAA|Aaron Dale
 Together Again|SSAA|Sharon Vitkovsky
 Together Again|TTBB|Aaron Dale
 Together Again|TTBB|Simon Arnott
+Together Again (from Sesame Street)|TTBB|Aaron Dale
 Together in Harmony|SSAA|Joey Minshall
 Together On New Year's Eve|TTBB|Scott Kitzmiller
 Together We Are One|SSAA|Glenda Lloyd
@@ -18754,6 +19147,7 @@ TOGOM|TTBB|Joe Mannherz
 Tomboy|SSAA|Walter Latzko
 Tomorrow|SATB|Cay Outerbridge
 Tomorrow|SSAA|Michael Gellert
+Tomorrow|TTBB|Rick Spencer
 Tomorrow Is Promised To No One|SSAA|Robert Rund
 Tomorrow Is Promised To No One|TTBB|Robert Rund
 Tomorrow Never Dies|SATB|Deke Sharon
@@ -18778,6 +19172,8 @@ Too Darn Hot|SSAA|Kevin Keller
 Too Darn Hot|TTBB|Aaron Dale
 Too Darn Hot|TTBB|Jay Giallombardo
 Too Darn Hot|TTBB|Kevin Keller
+Too Darn Hot|TTBB|Rasmus Krigström
+Too Darn Hot/Fever|TTBB|Aaron Dale
 Too Easy|TTBB|Kyle Snook
 Too Fat Polka|SSAA|Deke Sharon
 Too Human|SATB|Joe Mannherz
@@ -18824,6 +19220,7 @@ Toot, Toot, Tootsie|SSAA|Nancy Bergman
 Toot, Toot, Tootsie|TTBB|Bill Biffle
 Toot, Toot, Tootsie|TTBB|Burt Szabo
 Toot, Toot, Tootsie|TTBB|Carolyn Butler
+Toot, Toot, Tootsie|TTBB|Clay Hine
 Toot, Toot, Tootsie|TTBB|David Wallace
 Toot, Toot, Tootsie|TTBB|Dennis Burnett
 Toot, Toot, Tootsie|TTBB|Ed Waesche
@@ -18840,7 +19237,10 @@ Top Of The World|TTBB|John Hohl
 Top Of The World|TTBB|Liz Garnett
 Top Of The World|TTBB|Mark Goodney
 Top Of The World|TTBB|Mark Stevens
+Top Of The World|TTBB|Rob Hopkins
+Top Of The World Medley|TTBB|David Wright
 Topping The Bill|TTBB|John Wiggins
+Topsy Turvy|TTBB|Patrick McAlexander
 Topsy Turvy Day|SSAA|Kevin Keller
 Topsy Turvy Day|TTBB|Kevin Keller
 Total Eclipse of the Heart|SATB|Deke Sharon
@@ -18990,6 +19390,7 @@ Tuxedo Junction|SSAA|June Dale
 Tuxedo Junction|SSAA|Larry Wright
 Tuxedo Junction|SSAA|Sonny Steffan
 Tuxedo Junction|SSAA|Tom Gentry
+Tuxedo Junction|TTBB|Adam Scott
 Tuxedo Junction|TTBB|Jay Giallombardo
 Tuxedo Junction|TTBB|Joe Mannherz
 Tuxedo Junction|TTBB|Larry Wright
@@ -19027,6 +19428,8 @@ Two Less Lonely People in the World|TTBB|Kevin Keller
 Two O'clock Jump|SATB|Joe Mannherz
 Two Of A Kind|SSAA|Melody Hine
 Two Of A Kind|TTBB|Aaron Dale
+Two Of A Kind (Parody)|TTBB|Clay Hine
+Two Of A Kind, Workin' On A Full House|TTBB|Aaron Dale
 Two Out of Three Ain't Bad|TTBB|Liz Garnett
 Two Patriotic Classics|TTBB|Joe Liles
 Two Patriotic Classics|TTBB|Val Hicks
@@ -19220,12 +19623,14 @@ Vaya Con Dios|SATB|Kevin Keller
 Vaya Con Dios|SSAA|Kay Bromert
 Vaya Con Dios|SSAA|Kevin Keller
 Vaya Con Dios|TTBB|Kevin Keller
+Vegas Medley|TTBB|Tom Gentry
 Vegemite|TTBB|Tom Gentry
 Velvet|SATB|Joe Mannherz
 Velvet|TTBB|Joe Mannherz
 Veni Creator Spiritu|SATB|Joe Mannherz
 Verge|SATB|Nicholas Wright
 Very Last Day|TTBB|Jon Nicholas
+Very Weird Song|TTBB|Roger Payne
 Via Dolorosa|TTBB|David Wright
 Vict'ry Polka|TTBB|Ron Middlestaedt
 Victorious|SATB|Nicholas Wright
@@ -19242,6 +19647,7 @@ Vienna|SSAA|Lauren Kahn
 Vienna|TTBB|Brent Graham
 Vienna|TTBB|Dom Finetti
 Vienna|TTBB|Sam Hubbard
+Vincent|TTBB|David Wright
 Vincent (Starry Starry Night)|SATB|Cay Outerbridge
 Vincent (Starry Starry Night)|SSAA|David Wright
 Vincent (Starry Starry Night)|SSAA|Tom Gentry
@@ -19292,6 +19698,7 @@ Wait Till You Get Them Up In The Air Boys|TTBB|John Hohl
 Wait Till You Get Them Up In The Air Boys|TTBB|Rob Hopkins
 Wait'll You See My Girl|TTBB|Brian Beck
 Waitin' For The Evening Train|TTBB|Mac Huff
+Waitin' For The Light To Shine (from Big River)|TTBB|Joel Guyer
 Waitin' For The Train To Come In|SSAA|Barbara McNeill
 Waitin' For The Train To Come In|SSAA|Dorothy Herivel
 Waitin' For The Train To Come In|SSAA|Ig Jakovac
@@ -19307,11 +19714,13 @@ Waiting For The End|TTBB|Nicholas Wright
 Waiting For The Guy To Die|SSAA|Margaret Cornell
 Waiting For The Robert E. Lee|TTBB|Rob Campbell
 Waiting On The World To Change|SATB|Deke Sharon
+Wake Me Up Before You Go-Go|TTBB|Nick Luna
 Wake Me Up!|SSAA|Deke Sharon
 Wake Me Up!|SSAA|Melody Hine
 Wake Me Up!|TTBB|Deke Sharon
 Wake The Town And Tell The People|SSAA|Walter Latzko
 Wake Up|SATB|Deke Sharon
+Wake Up Everybody|TTBB|Patrick McAlexander
 Wake Up Little Girl|TTBB|Joe Mannherz
 Wake Up Little Girl|TTBB|Norm Benson
 Wake Up Little Susie|TTBB|Larry Wright
@@ -19480,6 +19889,7 @@ We Have This Moment|SSAA|Doris Twardosky
 We Just Couldn't Say Goodbye|SSAA|Carole Prietto
 We Just Couldn't Say Goodbye|TTBB|Howie Sponseller
 We Kinda Miss Those Good Old Songs|TTBB|Louis Perry
+We Kiss In A Shadow|TTBB|David Wright
 We Live On Borrowed Time|SSAA|Tedda Lippincott
 We Make A Beautiful Pair|SSAA|Marge Bailey
 We Meet Again|TTBB|Mark Burnip
@@ -19509,6 +19919,7 @@ We Shall Overcome|TTBB|David Wright
 We Sing That They Shall Speak|TTBB|Barbershop Harmony Society
 We Sing That They Shall Speak|TTBB|Clarence Burgess
 We The People|TTBB|Derric Johnson
+We The People (Parody)|TTBB|Clay Hine
 We Three (My Echo, My Shadow and Me)|SSAA|Kay Bromert
 We Three Kings|SSAA|Carolyn Johnson
 We Three Kings|SSAA|Jay Giallombardo
@@ -19654,6 +20065,7 @@ Welcome to the 60's|SSAA|Jeremey Johnson
 Welcome To The Black Parade|TTBB|Kohl Kitzmiller
 Welcome To The Fold, Sweet Adeline|SSAA|Nancy Bergman
 Welcome To The Rock|TTBB|Steven Armstrong
+Welcome To The Theatre/Applause (Medley)|TTBB|Mark Hale
 Wellerman|SATB|David Zimmerman
 Wellerman|SSAA|David Zimmerman
 Wellerman|TTBB|Adam Scott
@@ -19674,6 +20086,7 @@ Wet / Dry Medley|TTBB|Ed Waesche
 Wexford Carol|SSAA|Carole Prietto
 Wha Do Ya Do|SSAA|Marie Johnson
 What A Country|TTBB|Dave Stevens
+What A Diff'rence a Day Makes|TTBB|Adam Reimnitz
 What A Difference A Day Made|SSAA|Becky Cartine
 What A Difference A Day Made|TTBB|Adam Reimnitz
 What A Difference A Day Made|TTBB|Eric Ruthenberg
@@ -19791,6 +20204,8 @@ What I Did For Love|TTBB|Joe Mannherz
 What I Did For Love|TTBB|Theodore Hicks
 What I Did For Love|TTBB|Walter Latzko
 What I Did For Love|TTBB|Wayne Grimmer
+What I Did For Love (from Chorus Line)|TTBB|Brent Graham
+What I Did For Love (from Chorus Line)|TTBB|David Wright
 What I Like About You|TTBB|Deke Sharon
 What I Want Is A Proper Cup Of Coffee|TTBB|Soren Detlefsen
 What If|SSAA|Connie Moore
@@ -19812,6 +20227,7 @@ What Kind Of Fool Am I|TTBB|Joe Mannherz
 What Kind Of Fool Am I|TTBB|Kevin Keller
 What Kind Of Fool Am I|TTBB|Steve Tramack
 What Kind Of Fool Am I|TTBB|Walter Latzko
+What Kind Of Fool Am I?|TTBB|Don Gray
 What Kind Of King|SSAA|Charlotte Rubio
 What Makes You Beautiful|TTBB|Aaron Dale
 What Makes You Beautiful|TTBB|Dan Wessler
@@ -19960,6 +20376,7 @@ When I Grow Too Old To Dream|TTBB|Frank Nanney
 When I Grow Too Old To Dream|TTBB|George Hulst
 When I Grow Too Old To Dream|TTBB|Renee Craig
 When I Grow Too Old To Dream|TTBB|Robert Standley
+When I Grow Too Old To Dream|TTBB|Theo Hicks
 When I Grow Too Old To Dream|TTBB|Theodore Hicks
 When I Grow Too Old To Dream|TTBB|Tim Wheeler
 When I Grow Too Old To Dream|TTBB|Tom Gentry
@@ -19979,6 +20396,7 @@ When I Look At You|SSAA|Joe Liles
 When I Look At You|SSAA|Theodore Hicks
 When I Look At You|TTBB|Joe Liles
 When I Look At You|TTBB|Rob Hopkins
+When I Look At You (from The Scarlet Pimpernel)|TTBB|Rob Hopkins
 When I Look In Your Eyes|SATB|Joe Mannherz
 When I Look In Your Eyes|SATB|Larry Triplett
 When I Look In Your Eyes|SSAA|David Wright
@@ -20066,6 +20484,7 @@ When is Sometime|SSAA|Robert Rund
 When is Sometime|TTBB|Robert Rund
 When It Comes To Lovin' The Girls / They're All Sweeties Medley|TTBB|Ed Waesche
 When It's Circus Day Back Home|TTBB|Mel Knight
+When It's Night Time Down In Dixieland/Original Dixieland One-Step (Parody)|TTBB|Brent Graham
 When It's Night Time In Dixie Land|TTBB|Earl Moon
 When It's Night time in Italy, It's Wednesday Over Here|SSAA|Jo Lund
 When It's Sleepy Time Down South|SSAA|Larry Wright
@@ -20088,6 +20507,7 @@ When Mother Played The Organ|TTBB|Wes Farmer
 When My Baby Smiles At Me|SSAA|Carole Prietto
 When My Baby Smiles At Me|TTBB|Burt Szabo
 When My Baby Smiles At Me|TTBB|Gerald Hooper
+When My Baby Smiles At Me|TTBB|Mark Hale
 When My Baby Smiles At Me|TTBB|Walter Latzko
 When My Heart Finds Christmas|SATB|Joe Mannherz
 When My Heart Finds Christmas|TTBB|Steve Tramack
@@ -20124,6 +20544,7 @@ When She Loved Me|TTBB|Kevin Keller
 When She Loved Me|TTBB|Kirk Young
 When She Loved Me|TTBB|Kohl Kitzmiller
 When She Loved Me|TTBB|Luke Stevenson
+When She Loved Me (from Toy Story 2)|TTBB|Rasmus Krigström
 When She Loved Me (from TOY STORY 2)|TTBB|Jimbob Kahlke
 When Sunny Gets Blue|SATB|Joe Mannherz
 When Sunny Gets Blue|SATB|Rob Campbell
@@ -20219,6 +20640,7 @@ When Will I Be Loved|SSAA|Tedda Lippincott
 When Will I Be Loved|TTBB|David Wright
 When Will I Be Loved|TTBB|Marilyn Penketh
 When Will My Life Begin|SSAA|Simon Arnott
+When Winter Comes|TTBB|Brian Mastrull
 When You And I Were Young Maggie|TTBB|Burt Szabo
 When You And I Were Young Maggie|TTBB|David Wright
 When You And I Were Young Maggie|TTBB|Jack Baird
@@ -20474,6 +20896,8 @@ White Winter Hymnal|SSAA|Takako Fuke
 White Winter Hymnal|TTBB|Brian Mastrull
 Whiter Than Snow|TTBB|Jon Nicholas
 Who Am I|TTBB|Jim West
+Who Can I Turn To?|TTBB|Jay Giallombardo
+Who Can I Turn To?|TTBB|Robert Rund
 Who Can I Turn To? (When Nobody Needs Me)|SSAA|Kevin Keller
 Who Can I Turn To? (When Nobody Needs Me)|SSAA|Scott Kitzmiller
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Adam Scott
@@ -20484,6 +20908,7 @@ Who Can I Turn To? (When Nobody Needs Me)|TTBB|Robert Rund
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Simon Arnott
 Who Cares|SSAA|Avis Fellows
 Who Cares|TTBB|Burt Szabo
+Who Cares? (from Of Thee I Sing)|TTBB|Johnny Bugarin
 Who Do You Think You Are Kidding Mr. Hit|TTBB|Liz Garnett
 Who I Am|SSAA|Elaine Gain
 Who I Am|SSAA|Jay Giallombardo
@@ -20525,6 +20950,7 @@ Who'll Dry Your Tears When You Cry?|TTBB|Burt Szabo
 Who'll Dry Your Tears When You Cry?|TTBB|Dennis Driscoll
 Who'll Dry Your Tears When You Cry?|TTBB|Rob Hopkins
 Who'll Dry Your Tears When You Cry?|TTBB|Steven Armstrong
+Who'll Dry Your Tears?|TTBB|Steve Armstrong/Dennis Driscoll
 Who'll Take My Place When I'm Gone|SSAA|Barbara Bianchi
 Who'll Take My Place When I'm Gone|SSAA|Marie Johnson
 Who'll Take My Place When I'm Gone|TTBB|Gregory Lyne
@@ -20588,6 +21014,7 @@ Why Don't We Just Dance|SATB|Nicholas Wright
 Why Don't We Just Dance|TTBB|Aaron Dale
 Why Don't You Fall In Love With Me?|SSAA|Larry Wright
 Why Don't You Fall In Love With Me?|TTBB|Larry Wright
+Why Don't You Fall In Love With Me?/Undecided (Medley)|TTBB|Clay Hine
 Why Georgia|TTBB|Aaron Dale
 Why Haven't I Heard From You|SSAA|Kevin Keller
 Why Haven't I Heard From You|SSAA|Tedda Lippincott
@@ -20707,6 +21134,7 @@ Wishing|SSAA|Avis Fellows
 Wishing|TTBB|Dennis Driscoll
 Wishing You Were Somehow Here Again|SSAA|Julie Starr
 Wishing You Were Somehow Here Again|TTBB|David Wright
+Wishing You Were Somehow Here Again|TTBB|Theo Hicks
 Witch Doctor|TTBB|Steve Jamison
 Witchcraft|SSAA|Dave Briner
 Witchcraft|TTBB|Dave Briner
@@ -20717,6 +21145,7 @@ With A Little Help From My Friends|SATB|Deke Sharon
 With A Little Help From My Friends|SSAA|Joey Minshall
 With A Little Help From My Friends|SSAA|Richard Hasty
 With A Little Help From My Friends|SSAA|Suzy Lobaugh
+With A Little Help From My Friends|TTBB|Patrick McAlexander
 With A Little Help From My Friends|TTBB|Richard Hasty
 With A Little Help From My Friends|TTBB|Steve Jamison
 With A Little Help From My Friends|TTBB|Steve Tramack
@@ -20745,6 +21174,8 @@ With You|SSAA|Kevin Keller
 With You|TTBB|David Wright
 With You|TTBB|Kevin Keller
 With You|TTBB|Steven Armstrong
+With You (from Ghost the Musical)|TTBB|Steve Armstrong
+With You (from Pippin)|TTBB|David Wright
 With You So Far Away|TTBB|Walter Latzko
 Without A Song|SSAA|Jay Giallombardo
 Without A Song|SSAA|Sam Hubbard
@@ -20808,6 +21239,7 @@ Woot Woot Song|SATB|Robert Rund
 Words|SSAA|Tedda Lippincott
 Words|TTBB|Gary Thiel
 Words Fail|TTBB|Greg Mallett
+Words Fail (from Dear Evan Hansen)|TTBB|Rasmus Krigström
 Work Song|SATB|Nicholas Wright
 Working in a Coal Mine|TTBB|Jon Nicholas
 Working My Way Back to You|TTBB|Jay Giallombardo
@@ -20827,6 +21259,7 @@ Would Jesus Wear a Rolex|TTBB|Tom Gentry
 Would You Like To Take A Walk|TTBB|Walter Latzko
 Wouldja Be My Valentine|SSAA|Doris Twardosky
 Wouldn't It Be Loverly|SSAA|Jay Giallombardo
+Wouldn't It Be Loverly|TTBB|Paul Davies/Ed Waesche
 Wouldn't It Be Nice|TTBB|Jay Giallombardo
 Wouldn't It Be Nice|TTBB|Steve Delehanty
 Wrap Your Troubles In Dreams|SSAA|Jo Lund
@@ -20846,6 +21279,7 @@ Writing's On the Wall|SSAA|Matt Astle
 Writing's On the Wall|TTBB|Kohl Kitzmiller
 Writing's On the Wall|TTBB|Matt Astle
 Writing's On the Wall|TTBB|Nicholas Wright
+Written In The Stars|TTBB|Mark Hale
 WWI Medley|SSAA|Jay Giallombardo
 WWI Medley|TTBB|Jay Giallombardo
 WWI Smile Medley|SSAA|Tom Gentry
@@ -20887,6 +21321,7 @@ Yellow Rose Of Texas|TTBB|Paul Jorg
 Yellow Submarine|SATB|Manoj Padki
 Yellow Submarine|SSAA|Jan-Ake Westin
 Yellow Submarine|TTBB|Jan-Ake Westin
+Yes I Can|TTBB|Steve Tramack
 Yes Indeed|SATB|Earl Moon
 Yes Indeed|SSAA|Earl Moon
 Yes Indeed|SSAA|Karen McCarville
@@ -20912,6 +21347,7 @@ Yesterday|SSAA|Diana DeBruycker
 Yesterday|SSAA|Mark Burnip
 Yesterday|SSAA|Renee Craig
 Yesterday|SSAA|Tom Gentry
+Yesterday|TTBB|David Harrington
 Yesterday|TTBB|Jay Giallombardo
 Yesterday|TTBB|Jim Shubert
 Yesterday|TTBB|Mark Burnip
@@ -20929,6 +21365,7 @@ Yesterday Once More|TTBB|Mark Stevens
 Yesterday, When I Was Young|SSAA|Tom Gentry
 Yesterday, When I Was Young|TTBB|Tom Gentry
 Yesterday's Roses Medley|TTBB|Tom Gentry
+Yesterday/A Day In The Life|TTBB|David Harrington
 Yesterdays|TTBB|Walter Latzko
 Yo-Ho A Pirate's Life For Me|TTBB|Chris Hebert
 Yona From Arizona|TTBB|Aaron Dale
@@ -20958,6 +21395,7 @@ You And I|TTBB|Joey Minshall
 You And I|TTBB|Kevin Keller
 You And I|TTBB|Kyle Kitzmiller
 You And I|TTBB|Louis Perry
+You And I (We Can Conquer The World)|TTBB|David Harrington
 You And Me|SSAA|Tamra Perez
 You and Me (But Mostly Me)|SSAA|Kohl Kitzmiller
 You and Me (But Mostly Me)|TTBB|Steve Tramack
@@ -20965,6 +21403,7 @@ You and Me (We Wanted It All)|SSAA|Tom Gentry
 You and Me (We Wanted It All)|TTBB|Tom Gentry
 You And Me Against The World|SSAA|Jean McFadyen
 You And Me Against The World|SSAA|Tony Nasto
+You And Me And The Bottle Makes Three Tonight|TTBB|Wayne Grimmer
 You and the Night and the Music|SSAA|Joe Mannherz
 You and the Night and the Music|TTBB|Aaron Dale
 You and the Night and the Music|TTBB|Joe Mannherz
@@ -21002,6 +21441,7 @@ You Are The Sunshine Of My Life|SSAA|Larry Wright
 You Are The Sunshine Of My Life|TTBB|Jeremey Johnson
 You Are The Sunshine Of My Life|TTBB|Jim Shubert
 You Are The Sunshine Of My Life|TTBB|Larry Wright
+You Are The Top/Friendship/Anything Goes|TTBB|Jeremey Johnson
 You Are There|TTBB|Michael Webber
 You Belong To Me|SSAA|Aaron Dale
 You Belong To Me|SSAA|Carolyn Schmidt
@@ -21045,6 +21485,7 @@ You Can't Hurry Love|SATB|Adam Scott
 You Can't Hurry Love|SSAA|Joey Minshall
 You Can't Hurry Love|SSAA|Kevin Keller
 You Can't Hurry Love|SSAA|Liz Garnett
+You Can't Make Me Love You|TTBB|Clay Hine
 You Can't Make Old Friends|SSAA|Adam Bock
 You Can't Make Old Friends|TTBB|Corinna Garriock
 You Can't Stop The Beat|SATB|Kohl Kitzmiller
@@ -21109,6 +21550,7 @@ You Gotta Be A Football Hero|TTBB|Don Coldren
 You Gotta Be A Football Hero|TTBB|Jack Baird
 You Gotta Be A Football Hero|TTBB|Jay Giallombardo
 You Gotta Be A Football Hero / Betty Coed Medley|TTBB|Steve Jamison
+You Gotta Have Charts|TTBB|Roger Payne
 You Gotta Have Love|TTBB|Louis Perry
 You Gotta Have Skin|TTBB|Dennis Driscoll
 You Gotta Start Off Each Day with a Song|SSAA|Sonny Steffan
@@ -21120,6 +21562,7 @@ You Keep Coming Back Like A Song|SSAA|Jim Arns
 You Keep Coming Back Like A Song|SSAA|Nancy Bergman
 You Keep Coming Back Like A Song|TTBB|Brent Graham
 You Keep Coming Back Like A Song|TTBB|Douglas Smith
+You Keep Coming Back Like A Song|TTBB|Fraser Brown
 You Know My Name|SATB|Deke Sharon
 You Know You Belong To Somebody Else|TTBB|Tom Gentry
 You Light Up My Life|SSAA|David Wright
@@ -21181,8 +21624,10 @@ You Must Have Been A Beautiful Baby|TTBB|Walter Latzko
 You Must Have Been A Beautiful Baby / You're Some Pretty Doll Medley|TTBB|David Briner
 You Need Hands|SSAA|Tedda Lippincott
 You Needed Me|SSAA|Joe Mannherz
+You Needed Me|TTBB|Andrew Carolan
 You Needed Me|TTBB|Dennis Driscoll
 You Needed Me|TTBB|James Halvorson
+You Needed Me|TTBB|Jim Halvorson
 You Needed Me|TTBB|Joe Mannherz
 You Never Had It So Good|TTBB|Dan Wessler
 You Never Miss The Water Till The Well Runs Dry|TTBB|Walter Latzko
@@ -21220,6 +21665,7 @@ You Took Advantage Of Me|SSAA|Joe Mannherz
 You Took Advantage Of Me|TTBB|Aaron Dale
 You Took Advantage Of Me|TTBB|Jay Giallombardo
 You Took Advantage Of Me|TTBB|Joe Mannherz
+You Took Advantage Of Me (from Present Arms)|TTBB|Aaron Dale
 You Turned The Tables On Me|SSAA|Nancy Bergman
 You Turned The Tables On Me|TTBB|Dan Mulligan
 You Turned The Tables On Me|TTBB|Nancy Bergman
@@ -21247,6 +21693,7 @@ You, You, You|TTBB|Todd Troutman
 You'd Be So Nice To Come Home To|SSAA|Betty Steele
 You'd Be So Nice To Come Home To|TTBB|Joe Mannherz
 You'd Be So Nice To Come Home To|TTBB|John Bober
+You'd Be So Nice To Come Home To (from Something To Shout About)|TTBB|John Brockman
 You'd Be Surprised|SSAA|Charlotte Pernert
 You'd Be Surprised|SSAA|Joan D 'Agostino
 You'd Be Surprised|SSAA|Marsha Zwicker
@@ -21321,6 +21768,7 @@ You're Breaking My Heart|SSAA|Becky Cartine
 You're Cheatin Yourself When You're Cheatin On Me|TTBB|Matthew Gallagher
 You're Driving Me Crazy|SSAA|Anna Maria Parker
 You're Driving Me Crazy|SSAA|Marsha Zwicker
+You're Falling In Love|TTBB|Aaron Dale
 You're Falling Love|TTBB|Aaron Dale
 You're From Heaven And You're Mine|SSAA|David Wright
 You're From Heaven And You're Mine|TTBB|David Wright
@@ -21371,6 +21819,7 @@ You're Nobody 'Til Somebody Loves You|TTBB|Jon Nicholas
 You're Nobody 'Til Somebody Loves You|TTBB|Lance Fisher
 You're Nobody 'Til Somebody Loves You|TTBB|Mark Goodney
 You're Nobody 'Til Somebody Loves You|TTBB|Walter Latzko
+You're Nobody 'Til Somebody Loves You/Ain't That A Kick In The Head?|TTBB|Jay Giallombardo
 You're Nobody Til Somebody Loves You/Ain't That A Kick|SSAA|Jay Giallombardo
 You're Nobody Til Somebody Loves You/Ain't That A Kick|TTBB|Jay Giallombardo
 You're Nobody's Sweetheart Medley|TTBB|Renee Craig
@@ -21385,6 +21834,7 @@ You're Some Pretty Doll|TTBB|Walter Latzko
 You're Still In Style Wearing A Smile|TTBB|Dave Briner
 You're Still The One|SSAA|Jay Krumbholz
 You're Still You|SSAA|Michael Gellert
+You're Still You|TTBB|Theo Hicks
 You're Still You|TTBB|Theodore Hicks
 You're The Best|TTBB|Gabriel Lawson
 You're The Best|TTBB|Jeremey Johnson
@@ -21411,6 +21861,7 @@ You're Welcome|SATB|Deke Sharon
 You're Welcome|TTBB|Dan Wessler
 You're Welcome|TTBB|Nicholas Wright
 You've Been A Good Ol Wagon|SSAA|Joan D 'Agostino
+You've Changed|TTBB|Patrick McAlexander
 You've Changed|TTBB|Walter Latzko
 You've Got A Friend|SSAA|Jack Bridges
 You've Got A Friend|SSAA|Lauren Kahn
@@ -21504,6 +21955,7 @@ Zing! Went The Strings Of My Heart|TTBB|James Della Badin
 Zing! Went The Strings Of My Heart|TTBB|Ray Buntaine
 Zing! Went The Strings Of My Heart|TTBB|Todd Troutman
 Zing! Went The Strings Of My Heart|TTBB|Walter Latzko
+Zing! Went the Strings Of My Heart/Get Me To The Church On Time|TTBB|Kohl Kitzmiller
 Zip A Dee Doo Dah|SATB|Deke Sharon
 Zip A Dee Doo Dah|SSAA|Joe Mannherz
 Zip A Dee Doo Dah|TTBB|Larry Wright

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -101,6 +101,62 @@ transform attempts to parse a clear `arranged by` or `arr.` value from Product
 Description or Product Name. Product Description is used only as import signal;
 it is not stored in `song_suggestion_catalog`.
 
+## International Songs With Arranger Refresh
+
+The International Songs source workbook was inspected and committed as a
+cleaned CSV at:
+
+```text
+data/international_songs_with_arranger.csv
+```
+
+Workbook inspection notes:
+
+- Workbook name: `International Songs with Arranger.xlsx`
+- Sheet: `Sheet1`
+- Columns: `Title`, `Arranger`, `Voicing`
+- Inspected source row count: 745 data rows
+- Source voicings in the uploaded workbook: `TTBB`
+- No blank title, arranger, or voicing values were found in the uploaded
+  workbook.
+
+To refresh the source file, export or save the workbook to CSV with the same
+three headers:
+
+```text
+Title, Arranger, Voicing
+```
+
+Then inspect the transform without changing the PSV catalog:
+
+```bash
+npm run international-songs:import
+```
+
+After reviewing the report, merge the International rows into the PSV catalog:
+
+```bash
+npm run international-songs:import -- --write-catalog
+```
+
+Finally, dry-run and apply the Supabase catalog import:
+
+```bash
+npm run song-suggestions:import -- --dry-run
+SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
+```
+
+The transform imports only title, voicing, and arranger. It does not import
+lyrics, sheet music, notes, or source-only descriptive fields. Supported
+voicings are `TTBB`, `SSAA`, and `SATB`; clearly multi-voicing rows are split
+into one suggestion row per supported voicing. Missing, unsupported, or mixed
+supported/unsupported voicing values are skipped and counted in the report.
+
+Arranger handling follows the app-wide semantics: blank arranger stays blank,
+and literal `Unknown` stays `Unknown`. Dedupe uses normalized title + voicing +
+normalized arranger. This import adds optional suggestions only; it never writes
+to any user's My Songs.
+
 ## Harmony Brigade Songs
 
 Harmony Brigade data comes from Ross Wilkins' read-only Harmony Brigade MySQL

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -195,13 +195,16 @@ Established by migrations:
 
 Purpose: optional autocomplete reference data for song entry, imported from
 `data/song_suggestion_catalog.psv`. The PSV catalog is maintained from
-controlled metadata sources including `data/bhs_published_music_catalog.csv`;
-see `docs/imports.md`.
+controlled metadata sources including `data/bhs_published_music_catalog.csv`
+and `data/international_songs_with_arranger.csv`; see `docs/imports.md`.
 
 Code:
 - Imported by `scripts/import-song-suggestions.mjs`
 - BHS source data is transformed by `scripts/import-bhs-published-music.mjs`
   before being merged into `data/song_suggestion_catalog.psv`
+- International Songs source data is transformed by
+  `scripts/import-international-songs.mjs` before being merged into
+  `data/song_suggestion_catalog.psv`
 - Preserved by `scripts/delete-user.mjs`; catalog rows are global suggestions,
   not user-owned data.
 - Read only through `public.search_repertoire_song_suggestions`
@@ -231,6 +234,9 @@ Required database contract:
 - The BHS transform also splits clearly multi-voicing product rows into one row
   per supported voicing and skips ambiguous, unsupported, non-four-part, or
   collection products.
+- The International Songs transform parses `Title`, `Arranger`, and `Voicing`
+  only, splits clearly multi-voicing rows into one row per supported voicing,
+  and skips missing, unsupported, or ambiguous voicing values.
 - Product descriptions are used only as import signal for voicing and arranger
   parsing; full descriptions are not stored in the suggestion catalog.
 - Catalog rows are suggestions only and must never be inserted into

--- a/lib/__tests__/internationalSongsImport.test.mjs
+++ b/lib/__tests__/internationalSongsImport.test.mjs
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+const { transformInternationalSongsCatalog } = await import(
+  "../../scripts/import-international-songs.mjs"
+);
+const { mergeCatalogRows, formatSongSuggestionCatalog } = await import(
+  "../../scripts/import-bhs-published-music.mjs"
+);
+const { parseSongSuggestionCatalog } = await import(
+  "../../scripts/import-song-suggestions.mjs"
+);
+
+function csv(rows) {
+  return [
+    "Title,Arranger,Voicing",
+    ...rows.map((row) =>
+      [row.title ?? "", row.arranger ?? "", row.voicing ?? ""]
+        .map((value) => `"${String(value).replaceAll('"', '""')}"`)
+        .join(",")
+    ),
+  ].join("\n");
+}
+
+describe("International Songs import", () => {
+  it("transforms clear source rows into suggestion catalog rows", () => {
+    const { rows, report } = transformInternationalSongsCatalog(
+      csv([
+        {
+          title: "A Fool Such As I",
+          arranger: "Aaron Dale",
+          voicing: "TTBB",
+        },
+      ])
+    );
+
+    expect(report).toMatchObject({
+      sourceRows: 1,
+      importedRows: 1,
+      skippedRows: 0,
+      duplicateRows: 0,
+    });
+    expect(rows).toEqual([
+      {
+        title: "A Fool Such As I",
+        normalized_title: "a fool such as i",
+        voicing: "TTBB",
+        arranger: "Aaron Dale",
+        normalized_arranger: "aaron dale",
+        source: "International Songs with Arranger",
+      },
+    ]);
+  });
+
+  it("splits multi-voicing rows into supported app voicings", () => {
+    const { rows } = transformInternationalSongsCatalog(
+      csv([
+        {
+          title: "Shared Song",
+          arranger: "Shared Arranger",
+          voicing: "TTBB, SSAA, SATB",
+        },
+      ])
+    );
+
+    expect(rows.map((row) => row.voicing)).toEqual(["SATB", "SSAA", "TTBB"]);
+  });
+
+  it("skips ambiguous or unsupported voicings", () => {
+    const { rows, report } = transformInternationalSongsCatalog(
+      csv([
+        { title: "No Voice", arranger: "A", voicing: "" },
+        { title: "Duo Song", arranger: "B", voicing: "Duet" },
+        { title: "Mixed Unsupported", arranger: "C", voicing: "TTBB, Duet" },
+      ])
+    );
+
+    expect(rows).toEqual([]);
+    expect(report.reasonCounts).toEqual({
+      missing_or_ambiguous_voicing: 1,
+      unsupported_or_ambiguous_voicing: 2,
+    });
+  });
+
+  it("keeps blank arranger and literal Unknown distinct", () => {
+    const { rows } = transformInternationalSongsCatalog(
+      csv([
+        { title: "Mystery Song", arranger: "", voicing: "TTBB" },
+        { title: "Mystery Song", arranger: "Unknown", voicing: "TTBB" },
+      ])
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        arranger: null,
+        normalized_arranger: null,
+      }),
+      expect.objectContaining({
+        arranger: "Unknown",
+        normalized_arranger: "unknown",
+      }),
+    ]);
+  });
+
+  it("deduplicates source rows and existing catalog rows by normalized key", () => {
+    const { rows: importedRows, report } = transformInternationalSongsCatalog(
+      csv([
+        { title: "Duplicate Song", arranger: "Person", voicing: "TTBB" },
+        { title: "Duplicate Song", arranger: "Person", voicing: "ttbb" },
+      ])
+    );
+    const existingRows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
+Duplicate Song|TTBB|Person
+`);
+    const merged = mergeCatalogRows(existingRows, importedRows);
+
+    expect(report.duplicateRows).toBe(1);
+    expect(importedRows).toHaveLength(1);
+    expect(merged.duplicateCount).toBe(1);
+    expect(formatSongSuggestionCatalog(merged.rows)).toBe(
+      "Song Title|Voicing|Arranger\nDuplicate Song|TTBB|Person\n"
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bhs-published-music:import": "node scripts/import-bhs-published-music.mjs",
     "harmony-brigade:export-source": "node scripts/export-harmony-brigade-source.mjs",
     "harmony-brigade:import": "node scripts/import-harmony-brigade-songs.mjs",
+    "international-songs:import": "node scripts/import-international-songs.mjs",
     "song-suggestions:import": "node scripts/import-song-suggestions.mjs",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/import-international-songs.mjs
+++ b/scripts/import-international-songs.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  formatSongSuggestionCatalog,
+  mergeCatalogRows,
+  parseCsv,
+} from "./import-bhs-published-music.mjs";
+import {
+  normalizeSearchText,
+  parseSongSuggestionCatalog,
+} from "./import-song-suggestions.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const defaultSourcePath = path.join(
+  repoRoot,
+  "data/international_songs_with_arranger.csv"
+);
+const defaultCatalogPath = path.join(
+  repoRoot,
+  "data/song_suggestion_catalog.psv"
+);
+const supportedVoicings = new Set(["TTBB", "SATB", "SSAA"]);
+const sourceName = "International Songs with Arranger";
+
+function cleanText(value) {
+  const trimmed = String(value ?? "").replace(/\s+/g, " ").trim();
+  return trimmed || null;
+}
+
+function catalogKey(row) {
+  return [
+    row.normalized_title,
+    row.voicing,
+    row.normalized_arranger ?? "",
+  ].join("|");
+}
+
+function toCatalogRow({ title, voicing, arranger }) {
+  const normalizedTitle = normalizeSearchText(title);
+  const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
+
+  return {
+    title,
+    normalized_title: normalizedTitle,
+    voicing,
+    arranger,
+    normalized_arranger: normalizedArranger,
+    source: sourceName,
+  };
+}
+
+function splitVoicingTokens(value) {
+  return String(value ?? "")
+    .split(/[,+/&;]/)
+    .map((token) => token.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function mapVoicings(value) {
+  const tokens = splitVoicingTokens(value);
+  if (tokens.length === 0) {
+    return { voicings: [], reason: "missing_or_ambiguous_voicing" };
+  }
+
+  const voicings = Array.from(
+    new Set(tokens.filter((token) => supportedVoicings.has(token)))
+  );
+
+  if (voicings.length !== tokens.length || voicings.length === 0) {
+    return { voicings: [], reason: "unsupported_or_ambiguous_voicing" };
+  }
+
+  return { voicings, reason: null };
+}
+
+function parseInternationalRows(contents) {
+  const [header, ...rows] = parseCsv(contents).filter((row) =>
+    row.some((field) => field.trim())
+  );
+  const expectedHeader = ["Title", "Arranger", "Voicing"];
+
+  if (!header || header.join("|") !== expectedHeader.join("|")) {
+    throw new Error(`Expected International CSV header: ${expectedHeader.join(",")}`);
+  }
+
+  return rows.map((row, index) => ({
+    rowNumber: index + 2,
+    title: row[0] ?? "",
+    arranger: row[1] ?? "",
+    voicing: row[2] ?? "",
+  }));
+}
+
+export function transformInternationalSongsCatalog(contents) {
+  const sourceRows = parseInternationalRows(contents);
+  const deduped = new Map();
+  const skipped = [];
+  let duplicateCount = 0;
+
+  for (const row of sourceRows) {
+    const title = cleanText(row.title);
+    if (!title) {
+      skipped.push({
+        rowNumber: row.rowNumber,
+        reason: "missing_title",
+      });
+      continue;
+    }
+
+    const { voicings, reason } = mapVoicings(row.voicing);
+    if (voicings.length === 0) {
+      skipped.push({
+        rowNumber: row.rowNumber,
+        title,
+        voicing: row.voicing,
+        reason,
+      });
+      continue;
+    }
+
+    const arranger = cleanText(row.arranger);
+
+    for (const voicing of voicings) {
+      const catalogRow = toCatalogRow({ title, voicing, arranger });
+      const key = catalogKey(catalogRow);
+
+      if (deduped.has(key)) {
+        duplicateCount += 1;
+        continue;
+      }
+
+      deduped.set(key, catalogRow);
+    }
+  }
+
+  const rows = Array.from(deduped.values()).sort((a, b) => {
+    return (
+      a.title.localeCompare(b.title) ||
+      a.voicing.localeCompare(b.voicing) ||
+      (a.arranger ?? "").localeCompare(b.arranger ?? "")
+    );
+  });
+  const reasonCounts = skipped.reduce((counts, skip) => {
+    counts[skip.reason] = (counts[skip.reason] ?? 0) + 1;
+    return counts;
+  }, {});
+
+  return {
+    rows,
+    report: {
+      sourceRows: sourceRows.length,
+      importedRows: rows.length,
+      skippedRows: skipped.length,
+      duplicateRows: duplicateCount,
+      reasonCounts,
+      skipped,
+    },
+  };
+}
+
+function printReport(report, { mergedRows, existingDuplicateRows } = {}) {
+  console.log(`International source rows: ${report.sourceRows}`);
+  console.log(`International imported suggestion rows: ${report.importedRows}`);
+  console.log(`International duplicate source rows collapsed: ${report.duplicateRows}`);
+  console.log(`International skipped rows: ${report.skippedRows}`);
+
+  for (const [reason, count] of Object.entries(report.reasonCounts).sort()) {
+    console.log(`  ${reason}: ${count}`);
+  }
+
+  if (typeof existingDuplicateRows === "number") {
+    console.log(
+      `Duplicates already covered by existing catalog: ${existingDuplicateRows}`
+    );
+  }
+
+  if (typeof mergedRows === "number") {
+    console.log(`Merged catalog rows: ${mergedRows}`);
+  }
+}
+
+function optionValue(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const sourcePath = path.resolve(optionValue("source") ?? defaultSourcePath);
+  const catalogPath = path.resolve(optionValue("catalog") ?? defaultCatalogPath);
+  const outputPath = path.resolve(optionValue("output") ?? catalogPath);
+  const writeCatalog = args.has("--write-catalog");
+  const printSkipped = args.has("--print-skipped");
+
+  const sourceContents = await readFile(sourcePath, "utf8");
+  const { rows: importedRows, report } =
+    transformInternationalSongsCatalog(sourceContents);
+
+  if (!writeCatalog) {
+    printReport(report);
+    if (printSkipped) {
+      console.log(JSON.stringify(report.skipped.slice(0, 100), null, 2));
+    }
+    return;
+  }
+
+  const existingContents = await readFile(catalogPath, "utf8");
+  const existingRows = parseSongSuggestionCatalog(existingContents);
+  const merged = mergeCatalogRows(existingRows, importedRows);
+
+  await writeFile(outputPath, formatSongSuggestionCatalog(merged.rows), "utf8");
+  printReport(report, {
+    mergedRows: merged.rows.length,
+    existingDuplicateRows: merged.duplicateCount,
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- Added the cleaned International Songs source CSV at `data/international_songs_with_arranger.csv` after inspecting the uploaded workbook.
- Added `scripts/import-international-songs.mjs` and `npm run international-songs:import` to transform and merge International song suggestions into the PSV catalog.
- Merged the source into `data/song_suggestion_catalog.psv`; the transform read 745 source rows, produced 744 unique source suggestions, skipped 0 rows, and collapsed 1 source duplicate.

## Workbook inspection
- Workbook: `International Songs with Arranger.xlsx`
- Sheet: `Sheet1`
- Columns: `Title`, `Arranger`, `Voicing`
- Source rows: 745
- Source voicings: all `TTBB`
- Blank title/arranger/voicing rows found: 0

## Docs and tests
- Added tests for transform output, multi-voicing splitting, unsupported voicing skips, blank arranger versus literal Unknown, and duplicate avoidance.
- Updated `docs/imports.md`, `docs/supabase-contract.md`, and README with refresh/import instructions and source-contract details.

## Verification
- npm run international-songs:import
- npm run international-songs:import -- --write-catalog
- npm run test:run
- npm run build

## Supabase / manual steps
- No migration required.
- After this PR merges, run `npm run song-suggestions:import -- --dry-run`, then `SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import` to apply the updated committed PSV catalog to Supabase.

Closes #301