### PR TITLE
Add BarbershopTracks suggestion scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # testing
 /coverage
+/tmp
 
 # next.js
 /.next/
@@ -19,6 +20,7 @@
 
 # production
 /build
+/data/backups/
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ The Supabase project should have the current production schema applied:
   rows are not added to anyone's repertoire unless a user chooses to save one.
   Import expands comma-separated voicing values into one row per supported
   voicing (`TTBB`, `SSAA`, `SATB`). The BHS Published Music source CSV and
-  refresh process are documented in [docs/imports.md](docs/imports.md).
+  BarbershopTracks/International refresh processes are documented in
+  [docs/imports.md](docs/imports.md).
 - Harmony Brigade reference data is maintained from Ross Wilkins' read-only
   MySQL source through controlled CSV snapshots in `data/harmony-brigade/`.
   The app reads dedicated Supabase reference tables for the secondary
@@ -128,12 +129,13 @@ SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
 Use `npm run song-suggestions:import -- --dry-run` to parse and deduplicate the
 catalog file without writing to Supabase.
 
-To refresh the BHS Published Music or International Songs source data and merge
-it into `data/song_suggestion_catalog.psv`, follow
+To refresh BHS Published Music, International Songs, or BarbershopTracks source
+data and merge it into `data/song_suggestion_catalog.psv`, follow
 [docs/imports.md](docs/imports.md). The catalog transforms are conservative:
 they import title, supported voicing, and arranger metadata only, skip ambiguous
 rows, preserve blank arranger versus literal `Unknown`, and split clearly
-multi-voicing rows into separate catalog rows.
+multi-voicing rows into separate catalog rows where a source provides multiple
+supported voicings.
 
 To refresh Harmony Brigade data, export read-only upstream snapshots and then
 import them into the Supabase reference tables after migrations are applied:

--- a/data/song_suggestion_catalog.psv
+++ b/data/song_suggestion_catalog.psv
@@ -9,9 +9,11 @@ Song Title|Voicing|Arranger
 'Taint What You Do (It’s The Way That you Do It)|TTBB|Patrick McAlexander
 'Til I Hear You Sing|SATB|Theodore Hicks
 'Til I Hear You Sing|SSAA|June Berg
+'Til I Hear You Sing|SSAA|Theo Hicks
 'Til I Hear You Sing|SSAA|Theodore Hicks
 'Til I Hear You Sing|TTBB|Theodore Hicks
 'Til I Hear You Sing (from Love Never Dies)|TTBB|Theo Hicks
+'Til the Season Comes 'Round Again|TTBB|Adam Reimnitz
 'Til Tomorrow|SSAA|Jo Lund
 'Til Tomorrow|SSAA|Joey Minshall
 'Til Tomorrow|SSAA|Nancy Bergman
@@ -36,15 +38,18 @@ Song Title|Voicing|Arranger
 "You Can't Play ""Sweet Adeline"" On No Piano"|TTBB|David Wright
 ('til) I Kissed You|TTBB|Larry Wright
 (Everybody's Waitin' for) The Man with the Bag|TTBB|Dave Briner
+(Everybody's Waitin' For) The Man With The Bag|TTBB|Tom Gentry
 (Ghost) Riders In The Sky|SATB|Larry Triplett
 (Ghost) Riders In The Sky|SSAA|Larry Wright
 (Ghost) Riders In The Sky|TTBB|Anastasio Rossi
+(Ghost) Riders In The Sky|TTBB|Dave Briner
 (Ghost) Riders In The Sky|TTBB|Jon Nicholas
 (Ghost) Riders In The Sky|TTBB|Larry Wright
 (He's A) Rag Picker|TTBB|Robert Rund
 (Here Am I) Broken Hearted|TTBB|Thomas Gentry
 (Hey Won't You Play) Another Somebody Done Somebody Wrong Song|TTBB|Mark Goodney
 (Hey, Won't You Play) Another Somebody Done Somebody Wrong Song|TTBB|Burt Szabo
+(I Found A) Million Dollar Baby|SSAA|Renee Craig
 (I'll) Tell My Ma|SATB|Mark Stevens
 (I'm Afraid) The Masquerade Is Over|SSAA|Ed Waesche
 (I'm Afraid) The Masquerade Is Over|TTBB|Ed Waesche
@@ -57,6 +62,7 @@ Song Title|Voicing|Arranger
 (Love Is) The Tender Trap|TTBB|Jim Shubert
 (Love Is) The Tender Trap|TTBB|Steve Tramack
 (Now and Then There's) A Fool Such as I|TTBB|Aaron Dale
+(Them Was The) Good Old Days|SSAA|Brian Beck
 (There's No Place Like) Home for the Holidays|SATB|Russ Foris & Burt Szabo
 (There's No Place Like) Home for the Holidays|SSAA|Russ Foris & Burt Szabo
 (There's No Place Like) Home for the Holidays|TTBB|Russ Foris & Burt Szabo
@@ -66,41 +72,66 @@ Song Title|Voicing|Arranger
 (Up A) Lazy River|TTBB|Clay Hine
 (When It's) Darkness on the Delta|SATB|Barbershop Harmony Society
 (When It's) Darkness on the Delta|TTBB|Inc. SPEBSQSA
+(You Are) My Special Angel|SSAA|Kevin Keller
 (You're My) Soul and Inspiration|TTBB|Larry Wright
+*On Eagles' Wings|SSAA|Jarmela Speta
 10,000 Hours|TTBB|Cay Outerbridge
 100 Years|SSAA|Carole Prietto
 1927 Kansas City|SSAA|Jay Giallombardo
+1927 Kansas City|TTBB|Brian Beck
 1927 Kansas City|TTBB|Jay Giallombardo
 1957|SATB|Deke Sharon
+2:57 Ed Sullivan Show|TTBB|Clay Hine
 20 Years|SATB|Nicholas Wright
 20th Century Rag|TTBB|Walter Latzko
 22|SATB|Nicholas Wright
+23rd Psalm (Vicar Of Dibley Theme)|SSAA|Howard Goodall
 24K Magic|TTBB|Nicholas Wright
 25 or 6 to 4|TTBB|Aaron Dale
+3 Little Fishies|SSAA|Saxie Dowell
 3 X5|SATB|Deke Sharon
 409|TTBB|Marty Israel
 50 Shades Of Brown|TTBB|Greg Mallett
 50 States In Rhyme|TTBB|Jeremey Johnson
 50,000 Names|TTBB|Tom Gentry
+50,60,70 Medley|SSAA|Brian Beck
 50's Rock and Roll Medley|TTBB|Kevin Keller
+50s Medley|TTBB|Jay Giallombardo
+59th Street Bridge Song|SSAA|Bev Sellers
+59th Street Bridge Song|SSAA|Marge Bailey
+59th Street Bridge Song (Feelin' Groovy)|TTBB|Don Gray
+59th Street Bridge Song (Feelin' Groovy) (Adult)|SSAA|Marge Bailey
+59th Street Bridge Song (Feelin' Groovy) (YWIH)|SSAA|Marge Bailey
 7|SSAA|Deke Sharon
+70's Medley|SSAA|Jim Arns
+76 Trombones|SSAA|Nancy Bergman
+789|TTBB|Steve Wolf
 8 (circle)|TTBB|Nicholas Wright
 93 Million Miles|SATB|Ken Potter
 99 Bottles of Beer|TTBB|Tom Gentry
 A Band Of Brothers|TTBB|Larry Triplett
 A Barbershop Hello!|SSAA|Jo Lund
+A Barbershop Tango|TTBB|Sherwyn Heckt, Alden Parker
 A Barbershop Time Of Your Life|TTBB|Joe Liles
+A Beatles Celebration|TTBB|Greg Volk
 A Beautiful Friendship|SSAA|Walter Latzko
+A Beautiful Lady In Blue|TTBB|Chris Arnold
 A Bird Without Wings|SSAA|Kay Bromert
 A Bit of Earth|SSAA|Steve Tramack
 A Bit of Earth|TTBB|Theodore Hicks
 A Blossom Fell|TTBB|Earl Moon
 A Blossom Fell|TTBB|Robert Rund
+A Boy And A Girl|SATB|Eric Whitacre
 A Brand New Day|SATB|Deke Sharon
 A Broken Heart|TTBB|Burt Szabo
+A Bundle of Old Love Letter|SSAA|Carolyn Schmidt
+A Bundle of Old Love Letter|SSAA|Nancy Bergman
 A Bundle of Old Love Letters|TTBB|SPEBSQSA
+A Bundle Of Old Love Letters|SSAA|Carolyn Schmidt
+A Bundle Of Old Love Letters|SSAA|David Wright
 A Bushel And A Peck|SSAA|Jay Giallombardo
 A Bushel And A Peck|SSAA|Jeanne Elmuccio
+A Bushel And A Peck|SSAA|Marge Bailey
 A Bushel And A Peck|SSAA|Patrick McAlexander
 A Bushel And A Peck|TTBB|Jay Giallombardo
 A Bushel And A Peck|TTBB|Mark Goodney
@@ -123,6 +154,8 @@ A Christmas Carol|SSAA|Dawn Haggerty
 A Christmas Love Song|SATB|Joe Mannherz
 A Christmas Love Song|SSAA|Patricia Godfrey
 A Christmas Night Story|SSAA|Nancy Bergman
+A Christmas To Remember|TTBB|Jim Clancy
+A Christmas Wish|TTBB|Richard Loebakka
 A Cottage for Sale|TTBB|Theo Hicks
 A Couple of Swells|SSAA|Nancy Bergman
 A Cover Is Not The Book|TTBB|David Wright
@@ -138,12 +171,15 @@ A Day Just For You|SSAA|Lois Barrett
 A Dream (the Lost Ant)|SATB|David Avshalomov
 A Dream Come True|SSAA|Tom Gentry
 A Dream Come True|TTBB|Tom Gentry
+A Dream is a Wish Your Heart Makes|SSAA|Lorraine Rochefort
 A Dream Is A Wish Your Heart Makes|SATB|Larry Triplett
 A Dream Is A Wish Your Heart Makes|SSAA|Joe Mannherz
 A Dream Is A Wish Your Heart Makes|SSAA|Joey Minshall
 A Dream Is A Wish Your Heart Makes|SSAA|Kohl Kitzmiller
 A Dream Is A Wish Your Heart Makes|SSAA|Larry Triplett
+A Dream Is A Wish Your Heart Makes|SSAA|Lorraine Rochefort Joey Minshall
 A Dream Is A Wish Your Heart Makes|SSAA|Tom Gentry
+A Dream Is A Wish Your Heart Makes|TTBB|David Wright
 A Dream Is A Wish Your Heart Makes|TTBB|Derric Johnson
 A Dream Is A Wish Your Heart Makes|TTBB|Gene Cokeroft
 A Dream Is A Wish Your Heart Makes|TTBB|Joe Mannherz
@@ -164,6 +200,7 @@ A Fool Such As I|SSAA|Aaron Dale
 A Fool Such As I|TTBB|Aaron Dale
 A Friend of Yours|SSAA|Mary Ann Wydra
 A G-Nu|TTBB|Bob Dowma
+A Gaelic Blessing|TTBB|Jon Nicholas
 A Garden In The Rain|SSAA|David Harrington
 A Garden In The Rain|SSAA|Diane Clark
 A Garden In The Rain|TTBB|Bud Arberg
@@ -173,10 +210,12 @@ A Garden In The Rain|TTBB|Walter Latzko
 A Garland Of Old Fashioned Roses|TTBB|Louis Perry
 A Gathering Montage|SSAA|Jay Giallombardo
 A Girl Whose Name Begins With 'M'|TTBB|Rob Hopkins
+A Good Man Is Hard To Find|SSAA|Floyd Connett
 A Good Man Is Hard To Find|SSAA|Walter Latzko
 A Good Old Barbershop Song|SSAA|Larry Wright
 A Good Old Barbershop Song|TTBB|Burt Szabo
 A Good Old Barbershop Song|TTBB|Larry Wright
+A Grinch Medley|SSAA|Nancy Bergman
 A Groovy Kind of Love|TTBB|Tom Gentry
 A Groovy Kind Of Love|SSAA|Tom Gentry
 A Hand For Mrs. Claus|SSAA|Erica Kelch-Slesnick
@@ -184,11 +223,14 @@ A Hand For Mrs. Claus|SSAA|Simon Arnott
 A Hand For Mrs. Claus|TTBB|Erica Kelch-Slesnick
 A Handful Of Stars|SSAA|Walter Latzko
 A Handful Of Stars|TTBB|Steve Tramack
+A Hard Day's Night|TTBB|Jon Nicholas
 A Hard Day's Night|TTBB|Liz Garnett
 A Hard Days Night|TTBB|Alex Morris
 A Hard Days Night|TTBB|Jon Nicholas
+A Hard Days Night|TTBB|Liz Garnet
 A Hard Days Night|TTBB|Liz Garnett
 A Heart Like Thine|SSAA|Rebecca J. Wood
+A Holly Jolly Christmas|TTBB|Kirby Shaw
 A House Is Not A Home|SATB|Joe Mannherz
 A House Is Not A Home|SATB|Larry Triplett
 A House Is Not A Home|SSAA|Larry Triplett
@@ -198,9 +240,11 @@ A House Is Not A Home|TTBB|Steve Tramack
 A House With Love In It|SATB|Joe Mannherz
 A Hundred And Sixty Acres|TTBB|Jordan Johnson
 A Hundred Years from Now|SSAA|Diane Clark
+A Hundred Years From Today|SSAA|Marsha Zwicker
 A Hundred Years From Today|TTBB|Walter Latzko
 A Jingle Bell Travelogue|SSAA|Kay Bromert
 A Kid at Christmas|TTBB|Aaron Dale
+A Kid Named Joe|TTBB|David Wright
 A Kiss To Build A Dream On|SATB|Kevin Keller
 A Kiss To Build A Dream On|SSAA|Kevin Keller
 A Kiss To Build A Dream On|TTBB|Brent Graham
@@ -209,22 +253,34 @@ A Life That's Good|SATB|Melody Hine
 A Life That's Good|SSAA|Melody Hine
 A Life That's Good|TTBB|Melody Hine
 A Life With You|TTBB|Eric Ruthenberg
+A Little Bit O' Heaven|SSAA|Jay Giallombardo
+A Little Bit O' Heaven|TTBB|Jay Giallombardo
+A Little Bit Of Happiness|TTBB|Unspecified
+A Little Bit of Heaven|SSAA|Renee Craig/Joni Bescos
+A Little Bit of Heaven, Sure They Called It Ireland|TTBB|Steve Jamison
 A Little Closer|TTBB|Kevin Koehl
 A Little Less Conversation|SSAA|David Wright
+A Little Old Lady in Tennis Shoes|SSAA|Mary Coffman
 A Little Old Lady In Tennis Shoes|SSAA|Mary K. Coffman Music Fund
 A Little Old Lady In Tennis Shoes|SSAA|Tedda Lippincott
+A Little Patch Of Heaven|SSAA|Aaron Dale
 A Little Patch Of Heaven|TTBB|Aaron Dale
 A Little Street Where Old Friends Meet|TTBB|Aaron Dale
 A Little Street Where Old Friends Meet|TTBB|Burt Szabo
+A Little Street Where Old Friends Meet|TTBB|Rob Hopkins
 A Little Street Where Old Friends Meet|TTBB|Sam Breedon
 A Little Talk With Jesus|TTBB|Burt Szabo
 A Long, Long Time|SSAA|Jay Giallombardo
 A Long, Long Time|TTBB|Jay Giallombardo
 A Long, Slow Train|TTBB|Jon Nicholas
 A Lot of Livin' To Do|SSAA|Joey Minshall
+A Lot of Living to Do|SSAA|Joey Minshall
+A Love That Will Last|SSAA|Henrik Rosenberg
 A Lovely Night|SSAA|Patrick McAlexander
+A Lovely Way To Spend An Evening|TTBB|Earl Moon / Ed Waesche
 A Lover's Question|TTBB|Jon Nicholas
 A Major Chord|SATB|Kevin Koehl
+A Man Of Constant Sorrow|TTBB|Aaron Dale
 A Marshmallow World|SSAA|Joni Bescos
 A Marshmallow World|SSAA|Mary Santomeno
 A Marshmallow World|TTBB|Adam Scott
@@ -233,6 +289,7 @@ A Matter of Policy|TTBB|Jeremey Johnson
 A Mighty Fortress|SATB|David Wallace
 A Mighty Fortress|TTBB|Derric Johnson
 A Mighty Fortress|TTBB|Walter Latzko
+A Mighty Fortress Is Our God|TTBB|Joe Johnson
 A Million Dreams|SATB|Melody Hine
 A Million Dreams|SSAA|Kay Bromert
 A Million Dreams|SSAA|Kevin Keller
@@ -260,9 +317,13 @@ A New Life|SSAA|Michael Gellert
 A New Ode to Joy|SATB|Liz Garnett
 A New Ode to Joy|TTBB|Liz Garnett
 A New Quartet|TTBB|Joe Liles
+A New York Medley In Three Quarter Time|TTBB|Burt Szabo
 A Newfangled Tango|TTBB|Patrick McAlexander
 A Night Like This|SSAA|Liz Garnett
+A Nightingale Sang In Berekely Square|SSAA|Joni Bescos
+A Nightingale Sang in Berkeley Square|SSAA|Joni Bescos
 A Nightingale Sang In Berkeley Square|SATB|Anders Lindqvist
+A Nightingale Sang In Berkeley Square|SATB|Gene Puerling
 A Nightingale Sang In Berkeley Square|SATB|Joe Mannherz
 A Nightingale Sang In Berkeley Square|SSAA|Ann Minihane
 A Nightingale Sang In Berkeley Square|SSAA|David Harrington
@@ -272,29 +333,46 @@ A Nightingale Sang In Berkeley Square|SSAA|Tedda Lippincott
 A Nightingale Sang In Berkeley Square|SSAA|Tom Gentry
 A Nightingale Sang In Berkeley Square|SSAA|Walter Latzko
 A Nightingale Sang In Berkeley Square|TTBB|Anders Lindqvist
+A Nightingale Sang In Berkeley Square|TTBB|Brian Beck
 A Nightingale Sang In Berkeley Square|TTBB|David Harrington
 A Nightingale Sang In Berkeley Square|TTBB|Joe Mannherz
 A Nightingale Sang In Berkeley Square|TTBB|John Hohl
 A Nightingale Sang In Berkeley Square|TTBB|Kirk Young
 A Nightingale Sang In Berkeley Square|TTBB|Larry Wright
 A Nightingale Sang In Berkeley Square|TTBB|S. K. Grundy
+A Nightingale Sang In Berkeley Square|TTBB|SK Grundy
 A Nightingale Sang In Berkeley Square|TTBB|Ted Byers
 A Nightingale Sang In Berkeley Square|TTBB|Tom Gentry
 A Nightingale Sang In Berkeley Square|TTBB|Walter Latzko
+A Nightingale Sang in Berkely Square|SSAA|Tedda Lippincott
+A Nightingale Sang In Berkely Square|TTBB|Brian Beck
+A Nightingale Sang In Berkely Square|TTBB|Webb Comfort
+A Nightingale Sang In Berkley Square|SATB|Gene Puerling
+A Nightingale Sang In Berkley Square|SSAA|A Minihane
+A Nightingale Sang In Berkley Square|SSAA|Renee Craig
 A Piece of Sky|TTBB|Ken Potter
 A Pitch Pipe, A Song, and A Smile|TTBB|Val Hicks
 A Pitchpipe, A Song, And A Smile|TTBB|Val Hicks
+A Place in the Choir|SSAA|Lorraine Rochefort
+A Place in the Choir|SSAA|Tom Gentry
 A Poison Tree|SATB|David Avshalomov
 A Pony Shy Medley|TTBB|Frank Leitnaker
+A Prayer For You|TTBB|Richard Loebakka
 A Pretty Girl Is Like A Melody|TTBB|Robert Meyer
+A Pretty Girl Is Like A Melody/With A Song In My Heart Medley(Jay Giallomb|TTBB|Jay Giallombardo
 A Quiet Girl|TTBB|Dennis Driscoll
+A Quiet Place|SATB|Jerry Rubino
 A Quiet Place|SSAA|Tedda Lippincott
 A Quiet Place|TTBB|Walter Latzko
 A Rainy Night In Rio|TTBB|Kevin Keller
 A Red Red Rose|TTBB|David Wright
+A Ride With Glen Miller (Medley)|TTBB|Paul Davies
 A Ring to the Name of Rosie|TTBB|Lloyd Steinkamp
+A Room With a View|SSAA|Liz Garnett
 A Room With A View|TTBB|Rob Campbell
 A Rose And A Prayer|TTBB|Dennis Driscoll
+A Shanty in Old Shanty Town|SSAA|Sylvia Alsbury
+A Shanty In Old Shanty Town|TTBB|Unspecified
 A Shine On Your Shoes|SATB|Melody Hine
 A Shine On Your Shoes|SSAA|Aaron Dale
 A Shine On Your Shoes|SSAA|Joy McGregor
@@ -310,12 +388,14 @@ A Sky Full of Stars|SATB|Nicholas Wright
 A Soldier's Medley|TTBB|Rex Jamieson
 A Son Of The Sea|TTBB|Ed Waesche
 A Son Of The Sea|TTBB|SPEBSQSA
+A Song For Mary|TTBB|Jay Giallombardo
 A Song For The Little Guy|TTBB|David Wright
 A Song For You|SATB|Kevin Keller
 A Song For You|TTBB|Adam Bock
 A Song For You|TTBB|Dan Wessler
 A Song For You|TTBB|Kevin Keller
 A Song Like Daddy Used To Play|TTBB|Brian Beck
+A Song of Friendship|SSAA|Joanne Chambers
 A Special Wish|SSAA|Linda Smith
 A Spoonful Of Sugar|SSAA|Joe Mannherz
 A Spoonful Of Sugar|SSAA|June Dale
@@ -328,12 +408,14 @@ A Stable Prayer|SSAA|June Berg
 A Starry Night|TTBB|Derric Johnson
 A Straw Hat and a Cane|TTBB|BHS
 A Straw Hat And A Cane|SSAA|Connie Kash
+A Straw Hat And A Cane|TTBB|Unspecified
 A Summer Place|TTBB|Jay Giallombardo
 A Sunday Kind of Love|TTBB|Adam Reimnitz
 A Sunday Kind Of Love|SSAA|Gene Cokeroft
 A Teenager In Love|TTBB|Duane Enders
 A Thousand Stars in the Sky|SSAA|Joan D 'Agostino
 A Thousand Things|SSAA|Melody Hine
+A Thousand Things|TTBB|Adam Scott
 A Thousand Things|TTBB|Melody Hine
 A Thousand Thoughts Of You|SATB|Larry Triplett
 A Thousand Thoughts Of You|SSAA|Larry Triplett
@@ -342,13 +424,16 @@ A Thousand Thoughts Of You|TTBB|Larry Triplett
 A Thousand Thoughts Of You|TTBB|Tom Gentry
 A Thousand Years|SSAA|Carole Prietto
 A Thousand Years|SSAA|Deke Sharon
+A Thousand Years|SSAA|Henrik Rosenberg
 A Thousand Years|SSAA|Nicholas Wright
 A Thousand Years|SSAA|Rowena Harper
 A Thousand Years|TTBB|Simon Arnott
 A Time For Joy|SSAA|Tedda Lippincott
 A Time For Love|TTBB|Todd Troutman
 A Time For Us (Love Theme from Romeo and Juliet)|SSAA|Nancy Bergman
+A Tisket A Tasket|SSAA|Greg Volk
 A Town In Old New Hampshire|TTBB|Roger Payne
+A Tree in the Meadow|SSAA|Ann Minihane
 A Tree in the Meadow|SSAA|Kay Bromert
 A Tree in the Meadow|SSAA|Ken Potter
 A Tree in the Meadow|SSAA|Ruby Rhea
@@ -369,10 +454,13 @@ A Whole New World|SSAA|Larry Wright
 A Whole New World|SSAA|Tedda Lippincott
 A Whole New World|SSAA|Tom Gentry
 A Whole New World|TTBB|Aaron Dale
+A Whole New World|TTBB|David Gillingham
 A Whole New World|TTBB|Derric Johnson
 A Whole New World|TTBB|Kevin Keller
 A Whole New World|TTBB|Larry Wright
 A Whole New World|TTBB|Tom Gentry
+A Wink and a Smile|TTBB|Steve Jamison
+A Wink and A Smile|SSAA|Dave Briner
 A Wink And A Smile|SATB|Kim Brittain
 A Wink And A Smile|SSAA|David Briner
 A Wink And A Smile|SSAA|Jan Meyer
@@ -384,8 +472,14 @@ A Wink And A Smile|TTBB|Simon Arnott
 A Wink And A Smile (from Sleepless In Seattle)|TTBB|Robert Rund
 A Winter's Tale|SSAA|Hilary Allen
 A Woman Like You|TTBB|Larry Triplett
+A Wonderful Day Like Today|SSAA|Tedda Lippincott
+A Wonderful Day Like Today|TTBB|Dick Floersheimer
+A Wonderful Day Like Today|TTBB|Rob Hopkins
+A Wonderful Day Medley|SSAA|Joey Minshall
+A Wonderful Time Up There|TTBB|Kay Brooks
 A World Alone|SATB|Nicholas Wright
 A World Of Your Own|SSAA|Sam Hubbard
+A-Tisket A-Tasket|SSAA|David Harrington
 A, You're Adorable|SSAA|Walter Latzko
 A, You're Adorable|TTBB|Dan Wessler
 A, You're Adorable|TTBB|Dennis Driscoll
@@ -395,7 +489,9 @@ A, You're Adorable|TTBB|Walter Latzko
 Aba Daba Honeymoon|SSAA|Nancy Bergman
 Aba Daba Honeymoon|TTBB|Mark Goodney
 Aba Daba Honeymoon|TTBB|Walter Latzko
+ABBA Medley|SSAA|Brian Beck
 ABBA Medley|SSAA|Dan Naumann
+ABBA Medley|SSAA|Debbie Hopkinson
 ABBA Medley|SSAA|Larry Wright
 ABBA Medley|TTBB|Dan Naumann
 ABBA Medley|TTBB|Larry Wright
@@ -405,11 +501,13 @@ ABC|SSAA|David Wright
 ABC|SSAA|Glenda Lloyd
 ABC|SSAA|Larry Wright
 ABC|TTBB|David Wright
+Abide with Me|TTBB|Ig Jakovac
 Abide With Me|SSAA|Walter Latzko
 Abide With Me|TTBB|Adam Scott
 Abide With Me|TTBB|Dennis Driscoll
 Abide With Me|TTBB|Joe Liles
 Abide With Me|TTBB|Walter Latzko
+Abilene|TTBB|G.E. Howe
 Abilene|TTBB|Mason Eubank
 Abilene|TTBB|Todd Troutman
 About A Quarter To Nine|TTBB|Eugene McHugh
@@ -421,6 +519,8 @@ Abraham, Martin, and John|SSAA|Kay Bromert
 Absolutely Everybody|SATB|Alex Morris
 Absolutely Everybody|SSAA|Alex Morris
 Absolutely Everybody|SSAA|Glenda Lloyd
+Ac-cent-chu-ate the Positive|TTBB|Jim West
+Ac-cent-tch-uate the Positive|TTBB|Buzz Haeger
 Ac-cent-tchu-ate The Positive|SSAA|Diana DeBruycker
 Ac-cent-tchu-ate The Positive|SSAA|Tedda Lippincott
 Ac-cent-tchu-ate The Positive|SSAA|Tom Gentry
@@ -432,6 +532,9 @@ Ac-cent-tchu-ate The Positive|TTBB|Marilyn Penketh
 Ac-cent-tchu-ate The Positive|TTBB|Tom Gentry
 Ac-cent-tchu-ate The Positive|TTBB|Walter Latzko
 Ac-cent-tchu-ate The Positive|TTBB|Warren 'Buzz' Haeger
+Accentchuate The Positive|TTBB|Buzz Haeger
+Accentuate the Positive|TTBB|Adam Reimnitz
+Accentuate the Positive|TTBB|Clay Hine
 Accident Waiting To Happen|SSAA|Kyle Snook
 Accidentally In Love|SATB|Deke Sharon
 Accidentally In Love|TTBB|Deke Sharon
@@ -448,9 +551,12 @@ Across the Field|TTBB|Kevin Keller
 Across The Universe|SATB|Deke Sharon
 Across The Universe|TTBB|Jay Giallombardo
 Act Naturally|SSAA|Carolyn Johnson
+Adelaide's Lament|SATB|Steven Armstrong
 Adelaide's Lament|SSAA|Larry Wright
+Adiemus|SSAA|Karl Jenkins
 Adieu, My Lovely Nancy|TTBB|Rob Campbell
 Adios, Aurevoir, Auf Wiedersehn|SSAA|Carolyn Johnson
+Advance Australia Fair|SSAA|Renee Craig
 Advance Australia Fair|TTBB|Linc Abbott
 Adventure Day|TTBB|Deke Sharon
 Affair To Remember|TTBB|Bob Weiss
@@ -463,12 +569,15 @@ Africa|SSAA|Alex Morris
 Africa|SSAA|Dianne Goldrick
 Africa|SSAA|Kevin Keller
 Africa|SSAA|Liz Garnett
+Africa|SSAA|Lorraine Rochefort
+Africa|SSAA|Sandra Kerr
 Africa|SSAA|Tom Gentry
 Africa|TTBB|Alex Morris
 Africa|TTBB|Dianne Goldrick
 Africa|TTBB|Kevin Keller
 Africa|TTBB|Nicholas Wright
 Africa|TTBB|Tom Gentry
+Africa|TTBB|Tony Searle
 After All I've Been To You|TTBB|Louis Perry
 After All That I've Been To You|TTBB|Burt Szabo
 After Dark|SSAA|Tom Gentry
@@ -481,7 +590,9 @@ After I've Called You Sweetheart|TTBB|Munson Hinman
 After My Laughter Came Tears|TTBB|Larry Newth
 After The Ball|SSAA|Tom Gentry
 After The Ball|TTBB|Ed Waesche
+After The Ball|TTBB|Ted Hanna
 After The Ball|TTBB|Tom Gentry
+After the Curtain Comes Down|SSAA|Mary Coffman
 After The Disco|TTBB|Gabriel Lawson
 After The Gold Rush|SATB|Joey Minshall
 After The Gold Rush|SATB|Peter Knight
@@ -513,10 +624,16 @@ After You Get What You Want You Don't Want It|TTBB|Joe Mannherz
 After You Get What You Want You Don't Want It|TTBB|Mason Eubank
 After You, Who?|SSAA|Carole Prietto
 After You've Gone|SSAA|Anna Maria Parker
+After You've Gone|SSAA|Bergman/Wright
 After You've Gone|SSAA|Bev Sellers
 After You've Gone|SSAA|Carolyn Johnson
 After You've Gone|SSAA|Don Gray
+After You've Gone|SSAA|Joni Bescos
 After You've Gone|SSAA|Nancy Bergman
+After You've Gone|SSAA|Nancy Bergman/Leola Wright
+After You've Gone|SSAA|Renee Craig
+After You've Gone|SSAA|Steve Jamison
+After You've Gone|TTBB|Alan Siegal
 After You've Gone|TTBB|Anders Lindqvist
 After You've Gone|TTBB|Dennis Driscoll
 After You've Gone|TTBB|Don Gray
@@ -537,23 +654,35 @@ Against The Grain|SSAA|Jim Massey
 Aging Superheroes Medley|TTBB|Tom Gentry
 Ah! Sun-Flower|SATB|David Avshalomov
 Ahead By A Century|SSAA|Elaine Gain
+Ain't Goin Down Till The Sun Comes Up|TTBB|Aaron Dale
 Ain't Goin' Down ('Til The Sun Comes Up)|SSAA|Aaron Dale
 Ain't Goin' Down ('Til The Sun Comes Up)|TTBB|Aaron Dale
+Ain't He Sweet|SSAA|Lorraine Rochefort
+Ain't He Sweet/Yes Sir, That's My Baby|SSAA|Clay Hine
 Ain't It The Truth|SATB|Kevin Keller
 Ain't It The Truth|SSAA|Kevin Keller
 Ain't It The Truth|TTBB|Kevin Keller
 Ain't Misbehavin'|SSAA|Carole Prietto
 Ain't Misbehavin'|SSAA|Carolyn Schmidt
+Ain't Misbehavin'|SSAA|Dot Calvin
+Ain't Misbehavin'|SSAA|Earl Moon, Ed Waesche
 Ain't Misbehavin'|SSAA|Jay Giallombardo
+Ain't Misbehavin'|SSAA|Lorraine Rochefort
+Ain't Misbehavin'|SSAA|Marge Bailey
+Ain't Misbehavin'|SSAA|Tedda Lippincott
 Ain't Misbehavin'|SSAA|Walter Latzko
+Ain't Misbehavin'|TTBB|Earl Moon / Ed Waesche
+Ain't Misbehavin'|TTBB|Earl Moon and Ed Waesche
 Ain't Misbehavin'|TTBB|Ed Howard
 Ain't Misbehavin'|TTBB|Greg Volk
 Ain't Misbehavin'|TTBB|Jay Giallombardo
 Ain't Misbehavin'|TTBB|Kevin Koehl
 Ain't Misbehavin'|TTBB|Larry Wright
+Ain't Misbehavin'|TTBB|Mel Knight
 Ain't Misbehavin'|TTBB|Walter Latzko
 Ain't Misbehavin' Medley|SSAA|David Wright
 Ain't Misbehavin' Medley|SSAA|Jo Lund
+Ain't Misbehaving|SSAA|Greg Volk
 Ain't No Love In Oklahoma|TTBB|Mark Stevens
 Ain't No Mountain High Enough|SATB|Deke Sharon
 Ain't No Mountain High Enough|SSAA|Deke Sharon
@@ -566,11 +695,15 @@ Ain't No Mountain High Enough|TTBB|Patrick McAlexander
 Ain't Nobody|SATB|Anders Lindqvist
 Ain't Nobody Here But Us Chickens|TTBB|Mark Goodney
 Ain't Nobody Here But Us Chickens|TTBB|Tom Parker
+Ain't She (He) Sweet|SSAA|Lorraine Rochefort
 Ain't She Sweet|TTBB|Barbershop Harmony Society
+Ain't She Sweet / Yes Sir That's My Baby|TTBB|Unspecified
 Ain't She Sweet / Yes Sir, That's My Baby Medley|SSAA|Joe Mannherz
 Ain't She Sweet / Yes Sir, That's My Baby Medley|TTBB|Joe Mannherz
+Ain't That A Kick in the Head|SSAA|Rich Hasty
 Ain't That A Kick In The Head|SSAA|Debbie Keretz
 Ain't That A Kick In The Head|SSAA|Richard Hasty
+Ain't That A Kick In The Head|TTBB|Rich Hasty
 Ain't That A Kick In The Head|TTBB|Richard Hasty
 Ain't That A Kick In The Head|TTBB|Rowena Harper
 Ain't That A Kick In The Head|TTBB|Steve Hardy
@@ -581,6 +714,7 @@ Ain't Too Proud to Beg|TTBB|Aaron Dale
 Ain't We Got Fun|SATB|Kevin Keller
 Ain't We Got Fun|SSAA|Carolyn Johnson
 Ain't We Got Fun|SSAA|Jo Anne Ingels
+Ain't We Got Fun|SSAA|JoAnne Ingels
 Ain't We Got Fun|SSAA|Kevin Keller
 Ain't We Got Fun|SSAA|Melody Hine
 Ain't We Got Fun|TTBB|Kevin Keller
@@ -588,12 +722,19 @@ Ain't We Got Fun|TTBB|Robert Meyer
 Ain't We Got Fun?|TTBB|Anthony Bartholomew
 Ain't We Got Fun/Sunny Side of the Street|SSAA|Nancy Bergman
 Ain't-A That Good News|SSAA|Bev Sellers
+Ain't-A That Good News|TTBB|Bev Sellers
 Ain't-A That Good News|TTBB|Jim West
+Ain't-A That Good News (YWIH)|SSAA|Bev Sellers
+Ain'ta That Good News|SSAA|Bev Sellers
+Aint Misbehavin'|SSAA|Earl Moon/Ed Waesche
+Aint No Mountain High Enough|SSAA|Joey Minshall
 Air Conditioner|SATB|Melody Hine
 Air Conditioner|SSAA|Melody Hine
+Air For Advent|TTBB|Tom Fetke
 Air on a G Swing|SSAA|Mark Burnip
 Air on a G Swing|TTBB|Mark Burnip
 Air So Sweet|SSAA|Lauren Kahn
+Aka-tombo|TTBB|Jim Henry
 Alabama|TTBB|Joe Mannherz
 Alabama Jazzbo Band|SSAA|Jay Giallombardo
 Alabama Jazzbo Band|TTBB|Jay Giallombardo
@@ -606,20 +747,34 @@ Alabama Jubilee|TTBB|Rob Campbell
 Alabama Jubilee|TTBB|Tom Gentry
 Alabama Jubilee|TTBB|Walter Latzko
 Alabama Medley|SSAA|Jay Giallombardo
+Alabama Medley|TTBB|Ed Waesche
 Alabama Medley|TTBB|Jay Giallombardo
 Alabama Medley|TTBB|Tom Gentry
+Alabama/Cottontown|SSAA|Nancy Bergman
+Alabamy Bound|SSAA|Unspecified
 Alabamy Bound|TTBB|Burt Szabo
 Alabamy Bound|TTBB|David Wright
 Alabamy Bound|TTBB|Joe Mannherz
+Alabamy Bound/Alabama Jubilee Medley|SSAA|Tom Gentil
 Aladdin Medley|SSAA|Aaron Dale
 Aladdin Medley|TTBB|Aaron Dale
+Aladdin Medley|TTBB|David Wright
 Aladdin Medley|TTBB|Deke Sharon
 Aladdin Medley|TTBB|Jay Giallombardo
+Aladdin Medley 1|TTBB|Jay Giallombardo
 Alarm Clock Blues|SSAA|Tom Gentry
 Alarm Clock Blues|TTBB|Tom Gentry
+Alaska Flag Song|SSAA|Mac Huff
+Alaska Medley|SSAA|Tom Gentry
 Alaska Medley|TTBB|Tom Gentry
+Alaska's Flag Song|TTBB|Unspecified
+Alexander's Band Medley|SSAA|Dave Briner
+Alexander's Band Medley|TTBB|Dave Briner
 Alexander's Got A Jazz Band Now|TTBB|Jim Jim McKee
+Alexander's Ragtime Band|SSAA|Bergman/Beck
+Alexander's Ragtime Band|SSAA|Brian Beck
 Alexander's Ragtime Band|SSAA|David Wright
+Alexander's Ragtime Band|SSAA|Greg Volk
 Alexander's Ragtime Band|SSAA|Joni Bescos
 Alexander's Ragtime Band|SSAA|Nancy Bergman
 Alexander's Ragtime Band|TTBB|Barbershop Harmony Society
@@ -634,6 +789,7 @@ Alexander's Ragtime Band|TTBB|S. K. Grundy
 Alexander's Ragtime Band|TTBB|Steven Armstrong
 Alexander's Ragtime Band|TTBB|the Barbershop Harmony Society
 Alexander's Ragtime Band|TTBB|Walter Latzko
+Alexanders Ragtime Band|TTBB|Burt Szabo
 Alfie|SSAA|Barbara Huffman
 Alfie|SSAA|Larry Wright
 Alfie|TTBB|Larry Wright
@@ -657,9 +813,11 @@ Alive|SSAA|Emily Moriarty
 All 4 Love|TTBB|III Eddie Holmes
 All Aboard For Dixie Land|TTBB|David Wright
 All Aboard For Dixie Land|TTBB|Earl Moon
+All Aboard For Dixieland|TTBB|David Wright
 All Aboard For Slumberland|TTBB|Tom Gentry
 All About Love|TTBB|Kohl Kitzmiller
 All About That Bass|SATB|Anders Lindqvist
+All About That Bass|SATB|Henrik Rosenberg
 All About That Bass|SATB|Wayne Grimmer
 All About That Bass|SSAA|Elaine Gain
 All About That Bass|SSAA|Emily Moriarty
@@ -674,9 +832,11 @@ All Alone|SSAA|Joan D 'Agostino
 All Alone|SSAA|Tom Gentry
 All Alone|TTBB|David Harrington
 All Alone|TTBB|Dennis Driscoll
+All Alone|TTBB|Ed Waesche
 All Alone|TTBB|Jim Shubert
 All Alone|TTBB|Robert Meyer
 All Alone|TTBB|Tom Gentry
+All Alone / What'll I Do?|TTBB|Walter Latzko
 All American Girl|SSAA|Jay Giallombardo
 All American Girl|SSAA|Joni Bescos
 All American Girl|SSAA|Nancy Bergman
@@ -695,6 +855,7 @@ All By Myself|TTBB|Joe Mannherz
 All By Myself|TTBB|Lance Fisher
 All By Myself|TTBB|Michael Webber
 All Creatures Of Our God And King|TTBB|Derric Johnson
+All Creatures Of Our God And King|TTBB|Joe Johnson
 All Dressed Up With A Broken Heart|SATB|Tom Gentry
 All Dressed Up With A Broken Heart|SSAA|Betty Grant
 All Dressed Up With A Broken Heart|SSAA|Carolyn Schmidt
@@ -703,11 +864,13 @@ All Dressed Up With A Broken Heart|SSAA|Kay Bromert
 All Dressed Up With A Broken Heart|SSAA|Mary K. Coffman Music Fund
 All Dressed Up With A Broken Heart|SSAA|Sharon Vitkovsky
 All Dressed Up With A Broken Heart|TTBB|Joe Mannherz
+All Dressed Up With A Broken Heart|TTBB|Rob Hopkins
 All Dressed Up With A Broken Heart|TTBB|Scott Kitzmiller
 All Dressed Up With A Broken Heart|TTBB|Thomas Gentry
 All Dressed Up With A Broken Heart|TTBB|Tom Gentry
 All For The Love Of Mike|SSAA|Carolyn Schmidt
 All For The Love Of Mike|SSAA|Jay Giallombardo
+All God's Chillun Got Rhythm/Clap Yo' Hands|TTBB|Mark Hale
 All God's Chillun Got Rhythm/Clap Yo' Hands Medley|TTBB|Mark Hale
 All Hail Our Alma Mater|TTBB|Joe Liles
 All Hail The Power Of Jesus|TTBB|Joe Liles
@@ -728,6 +891,7 @@ All I Do Is Dream Of You|TTBB|Aaron Dale
 All I Do Is Dream Of You|TTBB|David Wallace
 All I Do Is Dream Of You|TTBB|Kevin Keller
 All I Do Is Dream Of You|TTBB|Walter Latzko
+All I Have to Do Is Dream|SSAA|LaVeda Redfield
 All I Have To Do Is Dream|SATB|Thomas Degan
 All I Have To Do Is Dream|SATB|Tom Gentry
 All I Have To Do Is Dream|SSAA|Dianne Goldrick
@@ -735,22 +899,28 @@ All I Have To Do Is Dream|SSAA|Emily Moriarty
 All I Have To Do Is Dream|SSAA|Kathy Hanneson
 All I Have To Do Is Dream|SSAA|Tedda Lippincott
 All I Have To Do Is Dream|SSAA|Tom Gentry
+All I Have To Do Is Dream|TTBB|Barbershop Harmony Society
 All I Have To Do Is Dream|TTBB|Dianne Goldrick
 All I Have To Do Is Dream|TTBB|Jon Nicholas
 All I Have To Do Is Dream|TTBB|Larry Wright
 All I Have To Do Is Dream|TTBB|R. Tony Baroni
 All I Have To Do Is Dream|TTBB|Tom Gentry
+All I Have To Do Is Dream (Adult)|SSAA|Tedda Lippincott
 All I Have to Do is Dream (SATB) (arr. Gentry) (International Orders)|SATB|Tom Gentry
 All I Have to Do is Dream (SATB) (arr. Gentry) (USA Orders)|SATB|Tom Gentry
 All I Have to Do is Dream (SSAA) (arr. Gentry) (International Orders)|SSAA|Tom Gentry
 All I Have to Do is Dream (SSAA) (arr. Gentry) (USA Orders)|SSAA|Tom Gentry
 All I Have To Do Is Dream (TTBB) (arr. Gentry) (International orders)|TTBB|Tom Gentry
 All I Have To Do Is Dream (TTBB) (arr. Gentry) (USA orders)|TTBB|Tom Gentry
+All I Have To Do Is Dream (YWIH)|SSAA|Tedda Lippincott
 All I Know|SATB|David Wright
 All I Need is Just a Girl Like You|TTBB|Jay Giallombardo
 All I Need Is The Girl|TTBB|Kevin Keller
 All I Need Is The Girl|TTBB|Robert Martin
 All I Want|SATB|Deke Sharon
+All I Want for Christmas is My Two Front Teeth|SSAA|Nancy Bergman
+All I Want for Christmas is You|SSAA|June Berg
+All I Want for Christmas Is You|SSAA|Kate Morrical
 All I Want For Christmas Is You|SATB|Deke Sharon
 All I Want For Christmas Is You|SATB|Larry Triplett
 All I Want For Christmas Is You|SSAA|Adam Bock
@@ -769,16 +939,20 @@ All Is Found|SSAA|Simon Arnott
 All Is Well|SATB|Theodore Hicks
 All Is Well|TTBB|Richard Curtis
 All My Exes Live In Texas|TTBB|Aaron Dale
+All My Lovin'|SSAA|Carolyn Schmidt
+All My Lovin'|SSAA|June Berg
 All My Loving|SSAA|Carolyn Johnson
 All My Loving|SSAA|Carolyn Schmidt
 All My Loving|SSAA|June Berg
 All My Loving|TTBB|Deke Sharon
 All My Loving|TTBB|Rasmus Krigström
+All Nation Rise|SATB|Jay Giallombardo
 All Nations Rise|SSAA|Jay Giallombardo
 All Nations Rise|TTBB|Jay Giallombardo
 All Night Long|SATB|Deke Sharon
 All Night Long|SSAA|Tom Gentry
 All Night Long|TTBB|Tom Gentry
+All of Me|SSAA|Joan D'Agostino
 All Of Me|SSAA|Carole Prietto
 All Of Me|SSAA|Dawn Haggerty
 All Of Me|SSAA|Elaine Gain
@@ -788,12 +962,16 @@ All Of Me|SSAA|Joe Mannherz
 All Of Me|SSAA|Lauren Kahn
 All Of Me|SSAA|Sofia De Rama
 All Of Me|SSAA|Tedda Lippincott
+All Of Me|TTBB|Alan Levine
 All Of Me|TTBB|Deke Sharon
+All Of Me|TTBB|Dennis Driscoll
+All Of Me|TTBB|Dennis Malone
 All Of Me|TTBB|Glenda Lloyd
 All Of Me|TTBB|Joe Mannherz
 All Of Me|TTBB|Luke Stevenson
 All Of Me|TTBB|Nicholas Wright
 All Of Me|TTBB|Scott Kitzmiller
+All of Me (Loves All of You)|SSAA|Elaine Gain
 All Of My Life|SSAA|June Berg
 All Of My Life|SSAA|Larry Wright
 All Of My Life|SSAA|Mary Grace Lodico
@@ -805,11 +983,15 @@ All Or Nothing|TTBB|Deke Sharon
 All Or Nothing|TTBB|Grant Goulding
 All Or Nothing|TTBB|Walter Latzko
 All Out Of Love|TTBB|Mark Stevens
+All Over Nothing at All|SSAA|Ig Jakovac
+All Over Nothing at All|TTBB|Ig Jakovac
 All Over The World|SATB|Alexander Ronneburg
 All Over The World|SATB|Patrick McAlexander
 All Over The World|SSAA|Kohl Kitzmiller
 All Over The World|TTBB|Kohl Kitzmiller
+All People That On Earth Do Dwell|TTBB|Jim Henry
 All Purpose Carol|SSAA|Jim Arns
+All Rise|SATB|Dave Williamson
 All Shook Up|TTBB|Deke Sharon
 All Sing Hail|SATB|Jay Dougherty
 All Star|TTBB|Patrick McAlexander
@@ -822,7 +1004,12 @@ All That I Ask Of You Is Love|TTBB|Barbershop Harmony Society
 All That I Ask Of You Is Love|TTBB|Earl Moon
 All That I Ask Of You Is Love|TTBB|Jack Baird
 All That I Ask Of You Is Love|TTBB|SPEBSQSA
+All That Jazz|SSAA|Ann Minihane
+All That Jazz|SSAA|Clay Hine
+All That Jazz|TTBB|Clay Hine
 All That Jazz|TTBB|Walter Latzko
+All That Jazz / Razzle Dazzle Medley|SSAA|Ann Minihane/Renee Craig
+All That Jazz/Razzle Dazzle|SSAA|Ann Minihane/Renee Craig
 All That She Wants|TTBB|Tom Gentry
 All The Gifts I Need|TTBB|Kohl Kitzmiller
 All the Little Toy Soldiers|TTBB|Jay Giallombardo
@@ -849,6 +1036,7 @@ All The Time|SSAA|Jay Giallombardo
 All The Time|SSAA|Susan Kegley
 All The Time|TTBB|Jay Giallombardo
 All The Time|TTBB|Steve Tramack
+All the Way|SSAA|Clay Hine
 All the Way|SSAA|Dave Briner
 All the Way|TTBB|Dave Briner
 All The Way|SSAA|Brent Graham
@@ -856,9 +1044,11 @@ All The Way|SSAA|David Briner
 All The Way|SSAA|Joni Bescos
 All The Way|SSAA|Larry Wright
 All The Way|SSAA|Tom Gentry
+All The Way|SSAA|Unspecified
 All The Way|TTBB|Brent Graham
 All The Way|TTBB|David Briner
 All The Way|TTBB|Kohl Kitzmiller
+All The Way|TTBB|Pete Rupay
 All The Way|TTBB|Robert Rund
 All The Way|TTBB|Tom Gentry
 All The Way (from The Joker Is Wild)|TTBB|Joel Guyer
@@ -871,9 +1061,11 @@ All The World Will Be Jealous Of Me|TTBB|Burt Szabo
 All The World Will Be Jealous Of Me|TTBB|David Briner
 All The World Will Be Jealous Of Me|TTBB|David Wright
 All The World Will Be Jealous Of Me|TTBB|Larry Triplett
+All The World Will Be Jealous Of Me Verse|TTBB|David Wright
 All These Things That I've Done|SATB|Deke Sharon
 All These Things That I've Done|SATB|Simon Lubkowski
 All Things Bright and Beautiful|SSAA|June Berg
+All Things Bright Medley|TTBB|Joe Johnson
 All Through The Night|SSAA|Carolyn Johnson
 All Through The Night|TTBB|Burt Szabo
 All Through The Night|TTBB|Jim West
@@ -887,13 +1079,20 @@ All You Need Is Love|TTBB|Deke Sharon
 Allegheny Moon|TTBB|Jim Shubert
 Allegheny Moon|TTBB|Jim West
 Allegheny Moon|TTBB|Todd Troutman
+Alleluia|SSAA|G. Blackwell
 Alleluia|SSAA|Joan Melling
 Alleluia|SSAA|Kay Bromert
+Alleluia|TTBB|David Wright
 Alleluia|TTBB|James Henry
+Alleluia|TTBB|Jim Henry
+Alleluia|TTBB|Ralph Manuel
+Alleluia|TTBB|Randall Thompson
 Almost (sweet music)|SATB|Nicholas Wright
 Almost Christmas Time|SSAA|Jay Giallombardo
 Almost Christmas Time|TTBB|Jay Giallombardo
 Almost Is Never Enough|TTBB|Grant Goulding
+Almost Like A Song|SSAA|Unspecified
+Almost Like Being in Love|SSAA|Sonny Steffan
 Almost Like Being in Love|TTBB|Eric King
 Almost Like Being In Love|SATB|Ruby Rhea
 Almost Like Being In Love|SSAA|David Harrington
@@ -905,6 +1104,7 @@ Almost Like Being In Love|TTBB|Dennis Driscoll
 Almost Like Being In Love|TTBB|Dianne Goldrick
 Almost Like Being In Love|TTBB|Erik King
 Almost Like Being In Love|TTBB|James Bongard
+Almost Like Being In Love|TTBB|Jay Giallombardo
 Almost Like Being In Love|TTBB|Jim Shubert
 Almost Like Being In Love|TTBB|Sonny Steffan
 Almost Like Being In Love|TTBB|Steve Delehanty
@@ -943,12 +1143,14 @@ Always|SATB|Thomas Degan
 Always|SSAA|Carolyn Schmidt
 Always|SSAA|Joe Mannherz
 Always|SSAA|Joni Bescos
+Always|SSAA|Mark Hale/Don Gray
 Always|SSAA|Walter Latzko
 Always|TTBB|Don Gray
 Always|TTBB|Jim West
 Always|TTBB|Joe Mannherz
 Always|TTBB|Mark Hale
 Always|TTBB|Mark Hale and Don Gray
+Always|TTBB|Mark Hale, Don Gray
 Always|TTBB|Mark Hale/Don Gray
 Always|TTBB|Rob Hopkins
 Always|TTBB|Walter Latzko
@@ -956,11 +1158,14 @@ Always A Bridesmaid|SSAA|David Wallace
 Always Be My Baby|SATB|Deke Sharon
 Always Be My Baby|SSAA|Deke Sharon
 Always Be My Baby|TTBB|Deke Sharon
+Always Leave 'Em Laughing|TTBB|Dick Floersheimer
+Always Live Down By The Firehouse|TTBB|Will Hamblet
 Always Look On The Bright Side Of Life|SSAA|Will Hamblet
 Always Look On The Bright Side Of Life|TTBB|Will Hamblet
 Always On My Mind|SSAA|Adam Scott
 Always On My Mind|SSAA|Larry Wright
 Always On My Mind|TTBB|Brent Graham
+Always On My Mind|TTBB|David Gillingham
 Always On My Mind|TTBB|Jim Shubert
 Always On My Mind|TTBB|Kevin Koehl
 Always On My Mind|TTBB|Kohl Kitzmiller
@@ -974,12 +1179,14 @@ Am I Blue?|TTBB|David Harrington
 Am I Ever Gonna See Your Face Again|SSAA|Emily Moriarty
 Am I Ever Gonna See Your Face Again|SSAA|Glenda Lloyd
 Am I Ready|TTBB|Jon Nicholas
+Am I Ready?|TTBB|Jon Nicholas
 Am I Wasting My Time On You|SSAA|Jo Lund
 Am I Wasting My Time On You|TTBB|Dennis Driscoll
 Am I Wasting My Time On You|TTBB|Kirk Roose
 Am I Wasting My Time On You|TTBB|Wayne Grimmer
 Am I Wrong|SATB|Nicholas Wright
 Amapola (Pretty Little Poppy)|SATB|Carolyn Schmidt
+Amarillo (Is This The Way To)|TTBB|Linda Corcoran
 Amazed|SSAA|Steve Jamison
 Amazing|SATB|Robert Rund
 Amazing|TTBB|Dan Wessler
@@ -993,11 +1200,16 @@ Amazing Grace|SSAA|Jan Meyer
 Amazing Grace|SSAA|Jay Giallombardo
 Amazing Grace|SSAA|Jo Lund
 Amazing Grace|SSAA|Lynne Alice Peterson
+Amazing Grace|SSAA|Margaret Little
 Amazing Grace|SSAA|Mary Grace Lodico
+Amazing Grace|SSAA|Mo Rector/Kim Hulbert
+Amazing Grace|SSAA|Sylvia Alsbury
 Amazing Grace|SSAA|Tedda Lippincott
 Amazing Grace|SSAA|Tom Gentry
 Amazing Grace|TTBB|Burt Szabo
+Amazing Grace|TTBB|Dennis Malone
 Amazing Grace|TTBB|Jay Giallombardo
+Amazing Grace|TTBB|Joe Johnson
 Amazing Grace|TTBB|Jon Nicholas
 Amazing Grace|TTBB|Kirk Young
 Amazing Grace|TTBB|Michael Webber
@@ -1007,20 +1219,26 @@ Amazing Grace|TTBB|Paul Jorg
 Amazing Grace|TTBB|Robert Standley
 Amazing Grace|TTBB|Tom Gentry
 Amazing Grace / Old Time Religion Medley|SSAA|Nancy Bergman
+Amazing Grace/ My Chains Are Broken|SSAA|Jay Giallombardo
 Amazing Grace/Marvelous Grace|TTBB|Derric Johnson
 Amazing Grace/My Chains Are Broken|SSAA|Jay Giallombardo
 Amazing Grace/My Chains Are Broken|TTBB|Jay Giallombardo
+Amazing Grace/Oldtime Religion|SSAA|Nancy Bergman
 Amazing Graceland|SATB|Deke Sharon
+Amazing-I Gotta Feeling-Firework|SSAA|Joey Minshall
 Amber|SATB|Deke Sharon
 Amen|TTBB|Aaron Dale
 Amen|TTBB|Jim West
+Amen|TTBB|Unspecified
 Amen! Christmas, Amen!|SSAA|Carolyn Schmidt
 America|SATB|Deke Sharon
 America|SATB|Joe Mannherz
 America|SATB|Sam Hubbard
 America|SSAA|Jo Lund
+America|SSAA|Joe Liles
 America|SSAA|Peg Millard
 America|SSAA|Tom Gentry
+America|TTBB|Jim Clancy
 America|TTBB|SPEBSQSA
 America|TTBB|Steve Tramack
 America|TTBB|Tom Gentry
@@ -1030,12 +1248,19 @@ America (My Country, 'Tis Of Thee)|TTBB|Earl Moon
 America (My Country, 'Tis Of Thee)|TTBB|TJ Barranger
 America I Love You|TTBB|Ed Waesche
 America In Song|SATB|Deke Sharon
+America Medley|SSAA|Mary Coffman
+America Medley (Am The Beautiful God Bless Am)|SSAA|Judy Vidal
+America the Beautiful|SSAA|Joe Liles
+America the Beautiful|SSAA|Nancy Bergman, Joni Bescos
+America the Beautiful|TTBB|John Hayden
+America the Beautiful|TTBB|Sean Milligan
 America The Beautiful|SATB|Burt Szabo
 America The Beautiful|SATB|Deke Sharon
 America The Beautiful|SATB|Derric Johnson
 America The Beautiful|SATB|James Hoover
 America The Beautiful|SATB|Nancy Bergman
 America The Beautiful|SATB|Rob Hopkins
+America The Beautiful|SSAA|Bergman/Bescos
 America The Beautiful|SSAA|Carolyn Johnson
 America The Beautiful|SSAA|Deke Sharon
 America The Beautiful|SSAA|Dianne Goldrick
@@ -1050,8 +1275,19 @@ America The Beautiful|TTBB|Jon Nicholas
 America The Beautiful|TTBB|Rob Hopkins
 America The Beautiful|TTBB|Tom Gentry
 America The Beautiful / God Bless America|SSAA|Tedda Lippincott
+America the Beautiful Medley|SSAA|Tedda Lippincott
+America The Beautiful Overlay|SSAA|Joe Liles
+America The Beautiful Overlay|TTBB|Joe Liles
+America, The Beautiful|SATB|Darmon Meader
+America, The Beautiful|TTBB|Dennis Malone
+America, The Beautiful|TTBB|Mark Hayes
+America, The Beautiful / Liberty Anthem Medley|TTBB|Shaun Agnew
 America, The Dream Goes On|SSAA|Tedda Lippincott
+America/Give Me Your Tired|TTBB|Jim Clancy
+America/God Bless the USA Medley|TTBB|Unspecified
 American|TTBB|Alex Morris
+American / Canadian Ode To Joy|TTBB|Jay Giallombardo
+American Anthem|SSAA|Joey Minshall
 American Anthem|SSAA|Larry Wright
 American Anthem|TTBB|Jack Schievelbein
 American Armed Forces Medley|SSAA|Jim Clancy
@@ -1064,6 +1300,7 @@ American Pie|SSAA|Joe Mannherz
 American Pie|TTBB|Aaron Dale
 American Pie|TTBB|Joe Mannherz
 American Revolution Medley|TTBB|Dave Stevens
+American Revolution Medley - with narration|TTBB|Barbershop Harmony Society
 American Rock n' Roll|TTBB|Larry Wright
 American Tears|SSAA|Gene Cokeroft
 American Trilogy|TTBB|Jim Clancy
@@ -1075,17 +1312,25 @@ Among My Souvenirs|SSAA|Tom Gentry
 Among My Souvenirs|TTBB|Barbershop Harmony Society
 Among My Souvenirs|TTBB|BHS
 Among My Souvenirs|TTBB|Tom Gentry
+Amy|TTBB|Alex Kaiserman
 An Affair To Remember|SSAA|Nancy Bergman
 An Affair To Remember|TTBB|Walter Latzko
 An American Hymn|TTBB|Tom Gentry
 An American In Paris|TTBB|David Wright
+An American Medley|TTBB|Mike Wallen
 An American Soldier|TTBB|Aaron Dale
+An American Trilogy|TTBB|Jim Clancy
+An American Tune (Simon & Garfunkel)|TTBB|Steve Tramack
 An Hour Never Passes|SSAA|Karen Penketh
+An Irish Blessing|SSAA|Sylvia Alsbury
 An Uptune In Search Of A Song|SSAA|Larry Triplett
 An Uptune In Search Of A Song|TTBB|Larry Triplett
+Anchor's Aweigh|SSAA|June Dale
 Anchors Aweigh|SSAA|June Dale
 Anchors Aweigh|TTBB|Burt Szabo
+Anchors Aweigh|TTBB|Unspecified
 Anchors Aweigh / Don't Sit Under The Apple Tree|TTBB|Steve Jamison
+And All That Jazz|SSAA|Ann Minihane
 And I Am All Alone|TTBB|Burt Szabo
 And I Love Him|SSAA|Carolyn Johnson
 And I Love You So|SSAA|Liz Garnett
@@ -1093,11 +1338,14 @@ And I Love You So|TTBB|Joe Grimme
 And I Love You So|TTBB|Walter Latzko
 And I'll Be There|SSAA|Walter Latzko
 And I'll Be There|TTBB|Walter Latzko
+And So it Goes|TTBB|Kirby Shaw
+And So It Goes|SATB|Bob Chilcott
 And So It Goes|SATB|Joe Mannherz
 And So It Goes|SSAA|Barbara McNeill
 And So It Goes|SSAA|Carolyn Schmidt
 And So It Goes|SSAA|Dianne Goldrick
 And So It Goes|SSAA|Tedda Lippincott
+And So It Goes|SSAA|Unspecified
 And So It Goes|TTBB|Adam Scott
 And So It Goes|TTBB|Alex Morris
 And So It Goes|TTBB|Dianne Goldrick
@@ -1105,6 +1353,10 @@ And So It Goes|TTBB|Gabriel Lawson
 And So It Goes|TTBB|Hilary Allen
 And So It Goes|TTBB|Kirk Young
 And So It Goes|TTBB|Nick Bryant
+And So It Goes (Lippincott)|SSAA|Tedda Lippincott
+And So It Goes (Shaw)|SSAA|Kirby Shaw
+And So It Goes (SSAA)|SSAA|Kirby Shaw
+And So To Sleep Again|SATB|Buzz Haeger
 And So To Sleep Again|SATB|Joe Mannherz
 And So To Sleep Again|SATB|Warren 'Buzz' Haeger
 And The Angels Sing|SSAA|Jo Lund
@@ -1112,10 +1364,13 @@ And The Angels Sing|TTBB|Melody Hine
 And the Beat goes on|SATB|Joe Mannherz
 And This is My Beloved|TTBB|David Wright
 Andrews Sisters Medley|SSAA|Larry Wright
+Angbatsblues|TTBB|Niclas Lindgren
 Angel Eyes|SSAA|Avis Fellows
+Angel Eyes|TTBB|Hal Maples
 Angel Eyes|TTBB|Mark Stevens
 Angel Eyes|TTBB|Wayne Grimmer
 Angel Of Music / Phantom Of The Opera Medley|SSAA|David Wright
+Angel Of Music/Phantom Of The Opera|SSAA|David Wright
 Angel Of The Morning|TTBB|Mark Stevens
 Angelic Anthem|SSAA|Jay Giallombardo
 Angelic Anthem|TTBB|Jay Giallombardo
@@ -1125,6 +1380,7 @@ Angelo State University Fight Song|TTBB|Mason Eubank
 Angels|SSAA|Rebecca J. Wood
 Angels|TTBB|Anders Lindqvist
 Angels|TTBB|Kirk Roose
+Angels (Robbie Williams)|TTBB|Brad Stephenson
 Angels Among Us|SSAA|Donna Emfield
 Angels Among Us|SSAA|June Dale
 Angels Among Us|SSAA|Marge Bailey
@@ -1134,29 +1390,38 @@ Angels Blush|TTBB|Jay Giallombardo
 Angels From The Realms Of Glory|SSAA|Carolyn Johnson
 Angels Medley|SSAA|Jeremey Johnson
 Angels Medley|TTBB|Jeremey Johnson
+Angels On Your Pillow|TTBB|Cary Burns
 Angels We Have Heard On High|SATB|David Wallace
 Angels We Have Heard On High|SATB|Deke Sharon
 Angels We Have Heard On High|SSAA|Carole Prietto
 Angels We Have Heard On High|SSAA|Mark Rusch
+Angels We Have Heard On High|SSAA|Renee Craig
 Angels We Have Heard On High|SSAA|Sylvia Alsbury
 Angels We Have Heard On High|TTBB|Aaron Dale
+Angels We Have Heard On High|TTBB|Barbershop Harmony Society
 Angels We Have Heard On High|TTBB|Burt Szabo
 Angels We Have Heard On High|TTBB|Deke Sharon
 Angels We Have Heard On High|TTBB|Jim West
 Angels We Have Heard On High|TTBB|Jon Nicholas
 Angels We Have Heard On High|TTBB|Mark Rusch
+Angels We Have Heard On High|TTBB|Yuletide Favorites
+Angina in the Morning|TTBB|Unspecified
 Angry|SSAA|Marsha Zwicker
 Angry|SSAA|Norma Holzmeier
 Angry|TTBB|Dennis Driscoll
 Angry|TTBB|Jim West
+Angry Bill Bailey Medley|SSAA|Nancy Bergman
+Angry Bill Bailey Medley (heavy interp)|SSAA|Nancy Bergman
 Angry/Bill Bailey|SSAA|Nancy Bergman
 Animal|SATB|Nicholas Wright
+Animal Crackers|SSAA|Tom Gentry
 Animal Crackers In My Soup|SSAA|Tom Gentry
 Animal Crackers In My Soup|TTBB|Tom Gentry
 Animal Fair|TTBB|Don Fraser
 Animals|SATB|Nicholas Wright
 Aniron (Theme for Aragorn and Arwen)|SSAA|Deke Sharon
 Anna Sun|SATB|Nicholas Wright
+Annie|TTBB|Burt Szabo
 Annie Medley|SSAA|Larry Wright
 Annie Medley|TTBB|Larry Wright
 Annie Waits|TTBB|Deke Sharon
@@ -1166,6 +1431,7 @@ Annie's Song|SSAA|Matt Astle
 Annie's Song|SSAA|Tedda Lippincott
 Annie's Song|SSAA|Tom Gentry
 Annie's Song|TTBB|Matt Astle
+Annie's Song|TTBB|Pete Benson
 Annie's Song|TTBB|Peter Benson
 Annie's Song|TTBB|Tom Gentry
 Anniversary Song|SSAA|Norma Andersen
@@ -1181,17 +1447,27 @@ Another Day of Sun|TTBB|Simon Arnott
 Another Hallelujah|SSAA|Takako Fuke
 Another Hallelujah|TTBB|Paul Jorg
 Another Op'nin|SSAA|Dot Calvin
+Another Op'nin, Another Show|SSAA|Ann Minihane
+Another Op'nin' Another Show|SSAA|Dot Calvin
+Another Op'nin' Another Show|SSAA|Tom Gentry
+Another Op'nin', Another Show|TTBB|Tom Gentry
 Another Op'ning, Another Show|SSAA|Nancy Bergman
 Another Op'ning, Another Show|SSAA|Tom Gentry
 Another Op'ning, Another Show|TTBB|Jay Giallombardo
 Another Op'ning, Another Show|TTBB|Tom Gentry
+Another Openin' Another Show|SSAA|Dot Calvin
 Another Somebody Done Somebody Wrong Song|SSAA|Nancy Bergman
 Another Somebody Done Somebody Wrong Song|SSAA|Tedda Lippincott
+Another Somebody Done Somebody Wrong Song|TTBB|Barbershop Harmony Society
 Another Somebody Done Somebody Wrong Song|TTBB|Burt Szabo
 Another Somebody Done Somebody Wrong Song|TTBB|Jim Shubert
 Another You|TTBB|Theodore Hicks
 Answer Me, My Love|SATB|Kevin Koehl
+Anthem|SSAA|Growing Girls
+Anthem|SSAA|Olle Nyman
+Anthem|TTBB|Olle Nyman
 Anthem|TTBB|Steve Tramack
+Anthem (Chess)|SSAA|Olle Nyman
 Anthem For The Millennium (America My Home)|TTBB|Fran Wilson
 Anti-Hero|SATB|Jay Dougherty
 Anti-Marriage Medley|TTBB|Tom Gentry
@@ -1203,10 +1479,12 @@ Any Man Of Mine|SSAA|Elaine Gain
 Any Man Of Mine|SSAA|Tedda Lippincott
 Any Man Of Mine|TTBB|Thomas Degan
 Any Place I Hang My Hat is Home|TTBB|Walter Latzko
+Any Time|SSAA|Greg Volk
 Any Time|SSAA|Jo Lund
 Any Time|SSAA|Tedda Lippincott
 Any Time|TTBB|Earl Moon
 Any Time|TTBB|Greg Volk
+Any Time At All|TTBB|Unspecified
 Any Way You Want It|SATB|Deke Sharon
 Anything Can Happen|SSAA|Nancy Bergman
 Anything Can Happen|TTBB|Theodore Hicks
@@ -1224,9 +1502,15 @@ Anything Goes|TTBB|Joe Mannherz
 Anything Goes|TTBB|Kevin Keller
 Anything Goes|TTBB|Rob Hopkins
 Anything Goes|TTBB|Tom Gentry
+Anything is Nice If It Comes From Dixieland|SSAA|Nancy Bergman
 Anything is Possible|SATB|Melody Hine
 Anything is Possible|SSAA|Melody Hine
 Anything is Possible|TTBB|Melody Hine
+Anything You Can Do|SATB|Don Gray
+Anything You Can Do|SATB|Tom Gentry
+Anything You Can Do|SSAA|Tom Gentry
+Anything You Can Do|TTBB|Don Gray
+Anything You Can Do|TTBB|Jay Giallombardo
 Anything You Can Do I Can Do Better|SATB|Larry Wright
 Anything You Can Do I Can Do Better|SATB|Tom Gentry
 Anything You Can Do I Can Do Better|SATB|Walter Latzko
@@ -1237,23 +1521,29 @@ Anything You Can Do I Can Do Better|TTBB|Jay Giallombardo
 Anything You Can Do I Can Do Better|TTBB|Steve Jamison
 Anything You Can Do I Can Do Better|TTBB|Tom Gentry
 Anything You Can Do I Can Do Better|TTBB|Walter Latzko
+Anytime|TTBB|Greg Volk
 Anytime / In My Honey's Lovin' Arms|SSAA|Carolyn Schmidt
 Anytime At All|TTBB|Greg Volk
 Anytime At All|TTBB|Wayne Grimmer
 Anyway|SATB|Nicholas Wright
 Anyway|SSAA|Jan Meyer
 Anyway|SSAA|Joey Minshall
+Anyway|SSAA|Steve Jamison
 Anyway|TTBB|Steve Jamison
+Anywhere I Wander|SSAA|Nancy Bergman
 Anywhere I Wander|TTBB|Lance Fisher
 Anywhere I Wonder|TTBB|Jim West
 Apologize|SATB|Deke Sharon
 Applause|SSAA|Jay Giallombardo
 Applause|SSAA|Marge Bailey
 Applause|SSAA|Marie Johnson
+Applause|TTBB|Don Gray
 Applause|TTBB|Jay Giallombardo
 Apple Blossom Medley|SSAA|Jay Giallombardo
+Apple Blossom Time|SSAA|Nancy Bergman
 Apple Blossom Time/Don't Sit Under the Apple Tree Medley|SSAA|Jo Lund
 Apple for The Teacher|TTBB|Walter Latzko
+April Fool|SSAA|Sylvia Alsbury
 April Fooled Me|TTBB|David Wright
 April In Paris|SSAA|Carolyn Schmidt
 April Love|SSAA|Jay Giallombardo
@@ -1268,6 +1558,7 @@ April Showers|TTBB|Rob Hopkins
 Aquarius|SATB|Deke Sharon
 Aquarius|SSAA|Carolyn Schmidt
 Aquarius|SSAA|Dorothy Short
+Aquarius|SSAA|Dot Calvin
 Aquarius|SSAA|Larry Wright
 Aquarius|TTBB|Carolyn Schmidt
 Aquarius|TTBB|Gary Thiel
@@ -1276,6 +1567,8 @@ Aquarius|TTBB|Larry Wright
 Aquarius|TTBB|Tom Gentry
 Aquarius/Let The Sunshine Medley|TTBB|Keith Harris
 Ar Hyd Y Nos (All Through The Night)|TTBB|Jim West
+Are You From Dixie?|TTBB|Barbershop Harmony Society
+Are You From Dixie? (Cause I'm From Dixie Too)|TTBB|Lloyd Steinkamp
 Are You Havin' Any Fun|SATB|Kevin Keller
 Are You Havin' Any Fun|SATB|Melody Hine
 Are You Havin' Any Fun|SSAA|Kevin Keller
@@ -1283,6 +1576,13 @@ Are You Havin' Any Fun|SSAA|Melody Hine
 Are You Havin' Any Fun|TTBB|Kevin Keller
 Are You Havin' Any Fun|TTBB|Melody Hine
 Are You Havin' Any Fun|TTBB|Tom Gentry
+Are You Havin' Any Fun?|SSAA|Kevin Keller
+Are You Havin' Any Fun?|TTBB|Kevin Keller
+Are You Lonesome Tonight|SSAA|Brent Graham
+Are You Lonesome Tonight|SSAA|Nancy Bergman
+Are You Lonesome Tonight|SSAA|Tom Gentry
+Are You Lonesome Tonight|TTBB|Brent Graham
+Are You Lonesome Tonight|TTBB|Nancy Bergman
 Are You Lonesome Tonight?|SSAA|Brent Graham
 Are You Lonesome Tonight?|SSAA|Tom Gentry
 Are You Lonesome Tonight?|TTBB|Barbershop Harmony Society
@@ -1290,23 +1590,31 @@ Are You Lonesome Tonight?|TTBB|Brent Graham
 Are You Lonesome Tonight?|TTBB|Nancy Bergman
 Are You Lonesome Tonight?|TTBB|Steve Jamison
 Are You Lonesome Tonight?|TTBB|Tom Gentry
+Are You Lonesone Tonight?|TTBB|Barbershop Harmony Society
 Are You Making Any Money|TTBB|Joe Simone
 Are You The One|SSAA|Adam Reimnitz
 Are You The One|TTBB|Adam Reimnitz
 Arizona Big A|TTBB|Nancy Bergman
 Arizona, Big A|SSAA|Nancy Bergman
+Armed Forces Medley|SATB|Barbara Lyle
 Armed Forces Medley|SATB|Steve Delehanty
 Armed Forces Medley|SSAA|Jo Lund
 Armed Forces Medley|SSAA|Nancy Bergman
 Armed Forces Medley|SSAA|Steve Delehanty
 Armed Forces Medley|SSAA|Tedda Lippincott
+Armed Forces Medley|TTBB|Darin Drown
 Armed Forces Medley|TTBB|Derric Johnson
+Armed Forces Medley|TTBB|Fred King
 Armed Forces Medley|TTBB|Fred King, John R. Grant, Steve Delehanty, Tom Ewald
 Armed Forces Medley|TTBB|Jay Giallombardo
+Armed Forces Medley|TTBB|John Grant, Fred King, Tom Ewald
 Armed Forces Medley|TTBB|Larry Wright
 Armed Forces Medley|TTBB|Nancy Bergman
 Armed Forces Medley|TTBB|Steve Delehanty
+Armed Forces Medley|TTBB|Terry Ludwig
+Armed Services Medley|SSAA|Dot Short
 Arms Of A Stranger|TTBB|Mark Stevens
+Army Medley|TTBB|Jay Giallombardo
 Around the World|SSAA|Larry Wright
 Around the World|TTBB|Kohl Kitzmiller
 Around the World|TTBB|Liz Garnett
@@ -1350,14 +1658,18 @@ As Long As I Live|SATB|Kevin Keller
 As Long As I Live|SSAA|Kevin Keller
 As Long As I Live|TTBB|Adam Bock
 As Long As I Live|TTBB|Kevin Keller
+As Long as I'm Singin'|SSAA|Brian Beck
 As Long as I'm Singin'|SSAA|Mike Menefee
 As Long as I'm Singin'|TTBB|David Wright
 As Long as I'm Singin'|TTBB|Mike Menefee
+As Long As I'm Singin'|SSAA|Tom Gentry
+As Long As I'm Singin'|TTBB|Tom Gentry
 As Long as I'm Singin' My Song/Sing|SSAA|Elaine Gain
 As Long As I'm Singing|SATB|Kohl Kitzmiller
 As Long As I'm Singing|SSAA|Elaine Gain
 As Long As I'm Singing|SSAA|Joey Minshall
 As Long As I'm Singing|SSAA|Kohl Kitzmiller
+As Long As I'm Singing|SSAA|Larry Wright
 As Long As I'm Singing|SSAA|Mike Menefee
 As Long As I'm Singing|SSAA|Tom Gentry
 As Long As I'm Singing|TTBB|David Wright
@@ -1366,15 +1678,22 @@ As Long As I'm Singing|TTBB|Mike Menefee
 As Long As I'm Singing|TTBB|Tom Gentry
 As Long As I'm Singing My Song|SSAA|Larry Wright
 As Long As I'm Singing My Song|TTBB|Larry Wright
+As Long As She Needs Me|TTBB|Jay Giallombardo
+As Long As We're Singin'|TTBB|Will Hamblet
 As Long As Were Singing Our Song|SSAA|Jo Lund
 As Long As You're Mine|SATB|Theodore Hicks
 As Long As You're Mine|TTBB|Theodore Hicks
 As Long As You're Mine (from Wicked)|TTBB|Theo Hicks
 As Long As You're Not In Love|SSAA|Carolyn Healey
+As Long as You're Not in Love With Anyone Else / Undecided Medley|SSAA|Clay Hine
+As Long As You're Not In Love/Undecided|SSAA|Clay Hine
+As Long As You're Not in Love/You Were Meant|SSAA|Clay Hine
 As She's Walking Away|TTBB|Deke Sharon
 As The Deer|TTBB|Jon Nicholas
 As The World Caves In|SSAA|Rowena Harper
 As Time Goes By|SSAA|Carolyn Schmidt
+As Time Goes By|SSAA|Dot Calvin
+As Time Goes By|SSAA|Marge Bailey
 As Time Goes By|TTBB|Dick Barrett
 As Time Goes By|TTBB|J Rae Jamieson
 As Time Goes By|TTBB|Rob Hopkins
@@ -1399,6 +1718,7 @@ Astonishing|SSAA|Melody Hine
 Astonishing|TTBB|Robert Rund
 At A Georgia Camp Meeting|TTBB|Clay Hine
 At Last|SSAA|David Wright
+At Last|SSAA|Jean McFadyen
 At Last|SSAA|Joe Mannherz
 At Last|SSAA|Nancy Bergman
 At Last|SSAA|Walter Latzko
@@ -1411,6 +1731,7 @@ At Last (from Sun Valley Serenade)|TTBB|Clay Hine
 At Long Last Love (from You Never Know)|TTBB|Andrew Carolan
 At The Ball, That's All|TTBB|Mark Goodney
 At The Beginning|SSAA|Carolyn Schmidt
+At the Beginning (from Anastasia)|SSAA|Carolyn Schmidt
 At The Codfish Ball|SSAA|Doris Twardosky
 At The Codfish Ball|SSAA|Jeff Veteto
 At The Crazy Bones Skeleton Ball|SSAA|Michael McCord
@@ -1422,12 +1743,14 @@ At The End Of A Cobblestone Road|TTBB|Bruce Wenner
 At The End Of A Cobblestone Road|TTBB|Burt Szabo
 At The End Of A Cobblestone Road|TTBB|SPEBSQSA
 At The End Of A Lane|TTBB|Burt Szabo
+At the End of the Day With You|SSAA|Ed Waesche
 At The End Of The Day With You|TTBB|Ed Waesche
 At The End Of The Day With You|TTBB|Renee Craig
 At the End of the Road|TTBB|Burt Szabo
 At the End of the Road|TTBB|Fred King
 At The Hop|SSAA|Sonny Steffan
 At The Hop|TTBB|Gary Thiel
+At the Jazz Band Ball|SSAA|Joni Bescos
 At The Jazz Band Ball|TTBB|Brian Beck
 At The Jazz Band Ball|TTBB|David Wright
 At The Mississippi Cabaret|SSAA|Doris Twardosky
@@ -1436,11 +1759,14 @@ At The Mississippi Cabaret|TTBB|Kevin Keller
 At The Mississippi Cabaret|TTBB|Walter Latzko
 At The Moving Picture Ball|TTBB|Louis Perry
 At This Moment|TTBB|Patrick McAlexander
+Atchison, Topeka And the Santa Fe|TTBB|Jay Giallombardo
 Atlanta, Georgia|SSAA|Ann Minihane
 Atlantic City|SSAA|Carolyn Schmidt
 Atlantic City Medley|SSAA|Carolyn Schmidt
 Attention|SATB|Joe Mannherz
 Attention|TTBB|Joe Mannherz
+Attitude Dance|SSAA|Rasmus Krigstrom
+Auction Cries|TTBB|John Biggs
 Auction Song|TTBB|Dennis Driscoll
 Auctioneer|SSAA|Doris Twardosky
 Auctioneer|SSAA|Tedda Lippincott
@@ -1450,27 +1776,37 @@ Audition (the Fools Who Dream)|SSAA|Matt Astle
 Audition (the Fools Who Dream)|TTBB|Matt Astle
 Audition (the Fools Who Dream)|TTBB|Patrick McAlexander
 Auf Wiederseh'n, Sweetheart|TTBB|Jim West
+Auld Land Syne|SSAA|Sylvia Alsbury
 Auld Lang Syne|SATB|Deke Sharon
 Auld Lang Syne|SATB|Mike Menefee
 Auld Lang Syne|SSAA|Carolyn Johnson
 Auld Lang Syne|SSAA|Carolyn Schmidt
 Auld Lang Syne|SSAA|Charlene Yazurlo
+Auld Lang Syne|SSAA|Clay Hine
 Auld Lang Syne|SSAA|David Briner
 Auld Lang Syne|SSAA|Dianne Goldrick
+Auld Lang Syne|SSAA|Don Gray
 Auld Lang Syne|SSAA|Jan Meyer
 Auld Lang Syne|SSAA|Jo Lund
 Auld Lang Syne|SSAA|Roberta Street
+Auld Lang Syne|TTBB|Clay Hine
+Auld Lang Syne|TTBB|Dave Briner
 Auld Lang Syne|TTBB|David Briner
 Auld Lang Syne|TTBB|Dianne Goldrick
+Auld Lang Syne|TTBB|Don Gray
 Auld Lang Syne|TTBB|Donn Updegrove
 Auld Lang Syne|TTBB|Jack Baird
 Auld Lang Syne|TTBB|Jim Clancy
+Auld Lang Syne|TTBB|Kris Olson
 Auld Lang Syne|TTBB|Steve Jamison
 Auld Lang Syne / I Love You Truly / Tell Me Why (3 Song Set)|TTBB|SPEBSQSA
 Auld Lang Syne Christmas|SSAA|Kay Bromert
 Auld Lang Syne/I Love You Truly/Tell Me Why|TTBB|SPEBSQSA
+Auntie Skinner's Chicken Dinner|TTBB|Unspecified
 Aura Lee|SATB|Thomas Degan
+Aura Lee|TTBB|Barbershop Harmony Society
 Aura Lee|TTBB|SPEBSQSA
+Aura Lee / Love Me Tender|TTBB|Tom Gentry
 Aura Lee / Love Me Tender Medley|TTBB|Tom Gentry
 Aussie Road Medley|TTBB|Tom Gentry
 Autumn In New Hampshire|TTBB|Brad Taylor
@@ -1478,6 +1814,7 @@ Autumn In New York|TTBB|Kohl Kitzmiller
 Autumn Leaves|SATB|Deke Sharon
 Autumn Leaves|SSAA|Diane Landry
 Autumn Leaves|SSAA|Kay Bromert
+Autumn Leaves|TTBB|Adam Reimnitz
 Autumn Leaves|TTBB|Stephen Delehanty
 Autumn Leaves|TTBB|Steve Delehanty
 Autumn Leaves|TTBB|Walter Latzko
@@ -1489,24 +1826,34 @@ Ave Maria|SSAA|Carole Prietto
 Ave Maria|SSAA|Tom Gentry
 Ave Maria|TTBB|Carole Prietto
 Ave Maria|TTBB|Deke Sharon
+Ave Maria|TTBB|Franz Biebl
 Ave Maria|TTBB|Joe Mannherz
 Ave Maria|TTBB|Tom Gentry
+Ave Maria (Angelus Domini)|TTBB|Unspecified
+Ave Maria (Schubert)|SSAA|Carolyn Healey
+Ave Maria Angelus Domini|TTBB|Franz Biebl
 Ave Verum|TTBB|Walter Latzko
 Aw Heck|SSAA|Charlene Yazurlo
 Awake My Soul|SSAA|Nicholas Wright
 Away In A Manager / Cradle Song Medley|TTBB|Paul Jorg
+Away In a Manger|TTBB|Barbershop Harmony Society
+Away In a Manger|TTBB|Bradley Ellingboe
 Away In A Manger|SATB|Brian Doepke
 Away In A Manger|SATB|Derric Johnson
 Away In A Manger|SATB|Simon Lubkowski
 Away In A Manger|SSAA|Carole Prietto
 Away In A Manger|SSAA|Carolyn Johnson
+Away In A Manger|SSAA|Chris Arnold
+Away In A Manger|SSAA|Dave Briner
 Away In A Manger|SSAA|David Briner
 Away In A Manger|SSAA|Joey Minshall
 Away In A Manger|SSAA|Joni Bescos
+Away In A Manger|SSAA|Judy Vidal
 Away In A Manger|SSAA|Nancy Bergman
 Away In A Manger|SSAA|Walter Latzko
 Away In A Manger|TTBB|Aaron Dale
 Away In A Manger|TTBB|Adam Reimnitz
+Away In A Manger|TTBB|Chris Arnold
 Away In A Manger|TTBB|David Briner
 Away In A Manger|TTBB|Jon Nicholas
 Away In A Manger|TTBB|Nick Bryant
@@ -1524,30 +1871,42 @@ Babe|TTBB|Gary Thiel
 Babe|TTBB|William Biehl
 Baby Blue|SATB|Jay Dougherty
 Baby Can Dance|SSAA|Aaron Dale
+Baby Driver|SATB|Rasmus Krigstrom
 Baby Face|SSAA|Joni Bescos
 Baby Face|SSAA|June Dale
 Baby Face|TTBB|Dave Stevens
 Baby Face|TTBB|Ted Cobb
 Baby Face|TTBB|Tom Ball
+Baby Face (May 5, 2008 Version)|SSAA|Clay Hine
 Baby Face / You Must Have Been A Beautiful Baby Medley|SSAA|Jo Lund
 Baby Face / You Must Have Been A Beautiful Baby Medley|TTBB|John Muir
 Baby Face Medley|SSAA|Jo Lund
+Baby Face Parody|TTBB|Rob Hopkins
+Baby I'm Sayin' Goodbye|SSAA|Lynnell Diamond
 Baby Love|SSAA|David Wright
 Baby Love|SSAA|Kevin Keller
 Baby Love|SSAA|Larry Wright
+Baby Medley|TTBB|Tom Gentry
 Baby Medley 1|SSAA|Carolyn Schmidt
 Baby Medley 1|SSAA|Jay Giallombardo
 Baby Medley 1|TTBB|Ed Waesche
 Baby Medley 1|TTBB|Jay Giallombardo
+Baby Mine|SSAA|Adam Scott
+Baby Mine|SSAA|Clay Hine
+Baby Mine|SSAA|Nancy Bergman
 Baby Mine|TTBB|Clay Hine
 Baby Mine|TTBB|Jim West
+Baby Mine|TTBB|Nancy Bergman
 Baby on Board|TTBB|Jay Krumbholz
 Baby on Board|TTBB|Michael Webber
 Baby on Board|TTBB|Tom Gentry
+Baby On Board|TTBB|Kyle Kitzmiller
+Baby On Board|TTBB|The Be Sharps
 Baby One More Time|SSAA|Sheryl Neal
 Baby One More Time|TTBB|Patrick McAlexander
 Baby plays around|SATB|Joe Mannherz
 Baby plays around|TTBB|Joe Mannherz
+Baby Please Come Home|SSAA|Lorraine Rochefort
 Baby Rose|TTBB|Dennis Burnett
 Baby Sister Blues|SSAA|Tom Campbell
 Baby Song Medley|SSAA|Tom Gentry
@@ -1555,6 +1914,7 @@ Baby Song Medley|TTBB|Tom Gentry
 Baby What You Gonna Be?|TTBB|Adam Scott
 Baby Won't You Please Come Home|SSAA|Charlotte Pernert
 Baby Won't You Please Come Home|SSAA|Earl Moon
+Baby Won't You Please Come Home|TTBB|Barbershop Harmony Society
 Baby Won't You Please Come Home|TTBB|Eugene McHugh
 Baby Won't You Please Come Home|TTBB|Paul Smith
 Baby Your Mother|TTBB|Barbershop Harmony Society
@@ -1577,6 +1937,7 @@ Baby's Request|SSAA|Jon Nicholas
 Baby's Request|SSAA|Sam Hubbard
 Baby's Request|TTBB|Jon Nicholas
 Baby's Request|TTBB|Sam Hubbard
+Babys Request|SSAA|Unspecified
 Bach Fugue In D Minor|SSAA|Larry Wright
 Bach Fugue In D Minor|TTBB|Larry Wright
 Back At One|TTBB|Lance Fisher
@@ -1603,7 +1964,10 @@ Back In My Home Town|TTBB|S. K. Grundy
 Back In The Good Old Days|TTBB|Burt Szabo
 Back In The High Life Again|TTBB|Deke Sharon
 Back In The Old Neighborhood|SSAA|Lauren Lindeman
+Back in the Old Routine|SSAA|Renee Craig
+Back in the Old Routine|TTBB|Renee Craig
 Back In The Old Routine|SSAA|Nancy Bergman
+Back In The Old Routine|TTBB|Dallas Town North
 Back In The Old Routine|TTBB|Greg Backwell
 Back In The Old Routine|TTBB|Greg Blackwell
 Back In The Old Routine|TTBB|R. J. Margison
@@ -1617,22 +1981,28 @@ Back In Those Days Gone By|TTBB|Mike Senter
 Back In Those Days Gone By|TTBB|Mike Senter Music
 Back In Those Wonderful Days|TTBB|Einar Pedersen
 Back to Basics|SSAA|Deke Sharon
+Back to the Fifties|SSAA|Lynnell Diamond
 Back To The River|SATB|Dan Wessler
 Back to the River St. John|SSAA|Tom Gentry
 Back to the River St. John|TTBB|Tom Gentry
 Back To You|SATB|Rowena Harper
 Back To You|TTBB|Rowena Harper
+Back When Dad And Mother's Mother And Dad Were Young|TTBB|Mark Goodney
 Back Where I Come From|TTBB|Lance Fisher
 Backwards|TTBB|Greg Mallett
 Backwards|TTBB|Matt Astle
+Bad Bad Leroy Brown|TTBB|Fran Wilson
+Bad Bad Leroy Brown|TTBB|Tony Nasto
 Bad Blood|SATB|Nicholas Wright
 Bad Blood|TTBB|Nicholas Wright
+Bad Bobbie's Baritone Blues|SSAA|Dot Calvin
 Bad Buncha Boys|TTBB|Kirk Roose
 Bad Buncha Boys Singin' Barbershop|TTBB|Kirk Roose
 Bad Day|SATB|Jay Dougherty
 Bad Day|TTBB|Jay Dougherty
 Bad Day|TTBB|Liz Garnett
 Bad Day|TTBB|Steven Armstrong
+Bad Day (You Had A)|TTBB|Steven Armstrong
 Bad Guy|TTBB|Kevin Koehl
 Bad Guys/Down and Out Medley|TTBB|Liz Garnett
 Bad Moon Rising|SATB|Kyle Snook
@@ -1653,12 +2023,14 @@ Ballad of Gilligan's Isle|TTBB|Steve Jamison
 Ballad Of Gilligan's Isle Parody|TTBB|Chris Hebert
 Ballad Of The Green Beret|SSAA|Duane Enders
 Ballad of the Smog|TTBB|Tom Gentry
+Ballin' the Jack|SSAA|Chris Smith
 Ballin' The Jack|SSAA|David Wright
 Ballin' The Jack|SSAA|Mary K. Coffman Music Fund
 Ballin' The Jack|TTBB|David Wright
 Ballin' The Jack|TTBB|Jack Baird
 Ballin' The Jack|TTBB|Jim Shubert
 Ballin' The Jack|TTBB|Kirk Roose
+Banana Man|TTBB|Steve Wolf
 Banana Split For My Baby|SATB|Dan Wessler
 Banana Split For My Baby|SSAA|Dan Wessler
 Banana Split For My Baby|TTBB|Dan Wessler
@@ -1668,6 +2040,7 @@ Bananaphone|TTBB|Kohl Kitzmiller
 Band Parade Medley|TTBB|Joe Mannherz
 Band Played On, The|TTBB|Rob Hopkins
 Bandstand Boogie|SSAA|Jay Giallombardo
+Bandstand Boogie|SSAA|Renee Craig
 Bandstand Boogie|TTBB|Jay Giallombardo
 Bandstand Boogie|TTBB|Jon Nicholas
 Bandstand Boogie|TTBB|Todd Troutman
@@ -1681,6 +2054,7 @@ Bangarang|TTBB|Nicholas Wright
 Banjo Medley|TTBB|Tom Gentry
 Banjo's Back In Town|SSAA|Jay Giallombardo
 Banjo's Back In Town|SSAA|Nancy Bergman
+Banjo's Back In Town|SSAA|Renee Craig
 Banjo's Back In Town|TTBB|Bernie Pitkin
 Banjo's Back In Town|TTBB|Jay Giallombardo
 Banjo's Back In Town|TTBB|Tom Gentry
@@ -1689,7 +2063,11 @@ Barbara Ann|SATB|Jon Nicholas
 Barbara Ann|TTBB|Deke Sharon
 Barbara Ann|TTBB|Jon Nicholas
 Barbara Ann|TTBB|Larry Wright
+Barbara Ann|TTBB|Lars Holmstrom
+BARBERPOLE CAT II Package|TTBB|Barbershop Harmony Society
+BARBERPOLE CAT Package|TTBB|Barbershop Harmony Society
 Barbershop A Song With Me|SSAA|Carolyn Johnson
+Barbershop All Year Round|TTBB|Barbershop Harmony Society
 Barbershop All Year Round (Medley)|TTBB|Smith, Embury, Merrill, & Stevens
 Barbershop Buddies|SSAA|Carolyn Johnson
 Barbershop Girl Of My Dreams|TTBB|Einar Pedersen
@@ -1697,12 +2075,16 @@ Barbershop Harmony Time|SSAA|Dave Stevens
 Barbershop Harmony Time|TTBB|Dave Stevens
 Barbershop in History|TTBB|Brent Graham
 Barbershop In History Medley|TTBB|Brent Graham
+Barbershop Joe|SSAA|Karen Penketh
 Barbershop Memories|TTBB|Kevin Keller
 Barbershop Rag|TTBB|Louis Perry
+Barbershop Song|TTBB|Steve Hall
 Barbershop Time of Your Life|TTBB|Joe Liles
 Barbershopper of Seville|SSAA|Jay Giallombardo
 Barbershopper of Seville|TTBB|Jay Giallombardo
 Barbershoppin Cowgirl|SSAA|Carolyn Johnson
+Barbershoppin' Cowgirl|SSAA|Carolyn E. Johnson
+Barbershoppin' Cowgirl|SSAA|Johnson
 Bare Necessities|SATB|Tom Gentry
 Bare Necessities|SSAA|Carolyn Healey
 Bare Necessities|SSAA|Jay Giallombardo
@@ -1712,6 +2094,7 @@ Bare Necessities|SSAA|Tom Gentry
 Bare Necessities|TTBB|Clay Hine
 Bare Necessities|TTBB|Jay Giallombardo
 Bare Necessities|TTBB|Patrick McAlexander
+Bare Necessities|TTBB|Simon Rylander
 Bare Necessities|TTBB|Thomas Gentry
 Bare Necessities|TTBB|Tom Gentry
 Barefoot Blue Jean Night|TTBB|Deke Sharon
@@ -1720,8 +2103,12 @@ Baritone Blues|SSAA|Lawrence Bean
 Baritone Blues|TTBB|Lawrence Bean
 Barney Google|TTBB|Roy Keys
 Barney Google|TTBB|Walter Latzko
+Barry Manilow Medley|SSAA|Ann Minihane
+Barry Manilow Medley|TTBB|Jay Giallombardo
 Barstool Cowboy|TTBB|Larry Wright
 Bashful Baby|TTBB|Munson Hinman
+Basin Street Blues|SSAA|Ann Minihane
+Basin Street Blues|SSAA|Brian Beck
 Basin Street Blues|SSAA|Dave Briner
 Basin Street Blues|SSAA|David Briner
 Basin Street Blues|SSAA|David Wright
@@ -1731,13 +2118,16 @@ Basin Street Blues|TTBB|Dave Briner
 Basin Street Blues|TTBB|David Briner
 Basin Street Blues|TTBB|David Wright
 Basin Street Blues|TTBB|Tom Gentry
+Basin Street Blues|TTBB|Unspecified
 Basin Street!|SSAA|Joe Mannherz
 Basin Street!|TTBB|Joe Mannherz
 Basin Street!|TTBB|Steve Jamison
+Basin Street/Bye Bye Blues|SSAA|Lorraine Rochefort
 Basketcase|TTBB|Deke Sharon
 Battle Hymn Of The Republic|SATB|Derric Johnson
 Battle Hymn Of The Republic|SSAA|Judy West
 Battle Hymn Of The Republic|TTBB|Barbershop Harmony Society
+Battle Hymn Of The Republic|TTBB|Clay Hine
 Battle Hymn Of The Republic|TTBB|Joe Liles
 Battle Hymn Of The Republic|TTBB|Jon Nicholas
 Battle Hymn Of The Republic|TTBB|Paul Jorg
@@ -1749,6 +2139,8 @@ Be A Clown|TTBB|Joe Mannherz
 Be A Clown|TTBB|Kevin Keller
 Be A Clown / Make 'Em Laugh Medley|SSAA|Jay Giallombardo
 Be A Clown / Make 'Em Laugh Medley|TTBB|Jay Giallombardo
+Be A Clown/Make 'em Laugh|SSAA|Joni Bescos
+Be A Clown/Make Em' Laugh Medley|TTBB|Jay Giallombardo
 Be A Santa|SSAA|Joey Minshall
 Be Anything (But Be Mine)|TTBB|Dick Barrett
 Be Careful What You Eat|TTBB|Deke Sharon
@@ -1773,16 +2165,22 @@ Be Not Afraid|SATB|Robert Rund
 Be Our Guest|SATB|Deke Sharon
 Be Our Guest|SATB|Steve Delehanty
 Be Our Guest|SSAA|Jay Giallombardo
+Be Our Guest|SSAA|Margaret Rochon and Nancy Bergman
 Be Our Guest|SSAA|Nancy Bergman
+Be Our Guest|SSAA|Nancy Bergman/Margaret Rochon
 Be Our Guest|SSAA|Steve Delehanty
 Be Our Guest|SSAA|Susan Kegley
 Be Our Guest|SSAA|Tedda Lippincott
+Be Our Guest|SSAA|Unspecified
 Be Our Guest|TTBB|Greg Volk
+Be Our Guest|TTBB|Greg Volk, Steven Armstrong
 Be Our Guest|TTBB|Jay Giallombardo
+Be Our Guest|TTBB|Russ Foris
 Be Our Guest|TTBB|Steve Delehanty
 Be Our Guest (from Walt Disney's "Beauty and the Beast"|TTBB|Stephen Delehanty
 Be Our Guest (from Walt Disney's "Beauty and the Beast")|SATB|Steve Delehanty
 Be Our Guest (from Walt Disney's "Beauty and the Beast")|SSAA|Stephen Delehanty
+Be Prepared To Play|TTBB|Steve Tramack
 Be Present At Our Table, Lord|TTBB|Greg Mallett
 Be Sweet To Me Kid|TTBB|Frank Leitnaker
 Be The Hero|SATB|David Wright
@@ -1795,24 +2193,34 @@ Be Thou My Vision|TTBB|Paul Jorg
 Be True to Your School|SATB|Deke Sharon
 Be True to Your School|TTBB|Deke Sharon
 Be-bop-a-lula|TTBB|Larry Wright
+Beach Boys Medley|SSAA|Alex Kaiserman
+Beach Boys Medley|SSAA|P. Mauritzen
 Beach Boys Medley|SSAA|Paula Mauritzen
 Beach Boys Medley|SSAA|Tedda Lippincott
+Beach Boys Medley|SSAA|Tom Colville
 Beach Boys Medley|SSAA|Tom Gentry
 Beach Boys Medley|TTBB|Stephen Delehanty
 Beach Boys Medley|TTBB|Steve Delehanty
 Beach Boys Medley|TTBB|Tom Colville
 Beach Boys Medley|TTBB|Tom Gentry
+Beach Boys Medley|TTBB|Unspecified
+Beale Street Blues|TTBB|Steve Delehanty
 Beale Street Mama|TTBB|Edward Boehm
 Beat Goes On|SATB|Joe Mannherz
+Beat Me Daddy Eight to the Bar|SSAA|Jarmela Speta
 Beat Me Daddy, Eight To The Bar|TTBB|Jim Shubert
 Beat Of The Future|TTBB|Steve Jamison
 Beatles Love Medley|SATB|Deke Sharon
 Beatles Love Medley|TTBB|Deke Sharon
 Beatles Medley|SSAA|Dan Naumann
 Beatles Medley|SSAA|Mark Burnip
+Beatles Medley|SSAA|Paula Mauritzen
 Beatles Medley|TTBB|Dan Naumann
 Beatles Medley|TTBB|Mark Burnip
 Beatles Medley|TTBB|Todd Troutman
+Beatles Medley (First Half)|TTBB|Greg Volk
+Beatles Medley (Second Half)|TTBB|Greg Volk
+Beatles Salute|SSAA|Jim Massey
 Beatles Sunshine Medley|SATB|Mark Hale
 Beatles Sunshine Medley|SSAA|Mark Hale
 Beatles Sunshine Medley|TTBB|Mark Hale
@@ -1820,6 +2228,7 @@ Beautiful|SATB|Karen Penketh
 Beautiful|SATB|Kohl Kitzmiller
 Beautiful|SSAA|Kevin Keller
 Beautiful|SSAA|Kohl Kitzmiller
+Beautiful|SSAA|Lorraine Rochefort
 Beautiful Boy|SATB|Kevin Keller
 Beautiful Boy|SSAA|Kevin Keller
 Beautiful Boy|TTBB|Kevin Keller
@@ -1836,6 +2245,7 @@ Beautiful Lady In Blue|TTBB|Chris Arnold
 Beautiful Ohio|TTBB|Lee Crews
 Beautiful Ohio|TTBB|Tom Gentry
 Beautiful Savior|SSAA|Dotty Hougen
+Beautiful Savior|TTBB|J. Spencer Cornwall
 Beautiful Savior|TTBB|Joe Liles
 Beautiful Savior|TTBB|Tom Gentry
 Beautiful Soul|TTBB|Adam Bock
@@ -1844,6 +2254,7 @@ Beautiful Star of Bethlehem|TTBB|John Hale
 Beautiful Thang|TTBB|Melody Hine
 Beautiful Things|SATB|Mark Stevens
 Beautiful Things|TTBB|Mark Stevens
+Beautiful/Just The Way You Are Medley|SSAA|Hari Birtles
 Beauty And The Beast|SSAA|Betty Grant
 Beauty And The Beast|SSAA|Bitsy Bacon
 Beauty And The Beast|SSAA|Carolyn Schmidt
@@ -1851,15 +2262,21 @@ Beauty And The Beast|SSAA|Gayle Rastorfer
 Beauty And The Beast|SSAA|Nina Herdes
 Beauty And The Beast|TTBB|Carol Kingsbury
 Beauty And The Beast|TTBB|Fred and Carol Kingsbury
+Beauty And The Beast|TTBB|Fred Kingsbury
 Beauty School Dropout|SSAA|Eileen Leotta
+Beauty School Dropout|SSAA|Joni Bescos
 Because|SATB|Joe Mannherz
 Because|SATB|Manoj Padki
 Because|SATB|Matt Astle
+Because|SSAA|Derek Hollis
 Because|SSAA|Emily Moriarty
 Because|SSAA|Joey Minshall
 Because|SSAA|Matt Astle
 Because|SSAA|Nancy Bergman
 Because|TTBB|James Henry
+Because|TTBB|Jim Henry
+Because|TTBB|John Hohl
+Because|TTBB|Josh Ehrlich
 Because|TTBB|Mark Stevens
 Because|TTBB|Matt Astle
 Because He Lives|SSAA|Tedda Lippincott
@@ -1871,6 +2288,8 @@ Because My Baby Don't Mean 'Maybe' Now|TTBB|Kevin Keller
 Because of You|SSAA|Don Gray
 Because of You|TTBB|Dennis Driscoll
 Because of You|TTBB|Eric Ruthenberg
+Because Of You|TTBB|Don Gray
+Because We Believe|SSAA|Joe Liles
 Because We're Kids|TTBB|Jeremey Johnson
 Because You Loved Me|SSAA|Elaine Gain
 Because You Loved Me|SSAA|Jean McFadyen
@@ -1885,6 +2304,7 @@ Becky from Babylon|TTBB|Al Baker
 Bedelia|TTBB|Frank Leitnaker
 Beep Beep|SSAA|Carolyn Healey
 Beep Beep|SSAA|Tedda Lippincott
+Beep Beep|TTBB|Don Gray
 Beep Beep|TTBB|Walter Latzko
 Beer Barrel Polka|SSAA|Kay Bromert
 Beer Barrel Polka|TTBB|Barbershop Harmony Society
@@ -1899,12 +2319,15 @@ Before He Cheats|SATB|Nicholas Wright
 Before He Cheats|SSAA|Nicholas Wright
 Before He Cheats|TTBB|Deke Sharon
 Before I Grew Up To Love You|TTBB|Burt Szabo
+Before the Parade Passes By|SSAA|Lorraine Rochefort
 Before The Parade Passes By|SSAA|Aaron Dale
 Before The Parade Passes By|SSAA|Carolyn Schmidt
 Before The Parade Passes By|SSAA|Jay Giallombardo
 Before The Parade Passes By|SSAA|Liz Garnett
 Before The Parade Passes By|TTBB|Aaron Dale
 Before The Parade Passes By|TTBB|Adam Scott
+Before The Parade Passes By|TTBB|Don Gray
+Before The Parade Passes By|TTBB|Jay Giallombardo
 Before The World Began|TTBB|Jack Baird
 Beg, Steal Or Borrow|SATB|Liz Garnett
 Beggin'|TTBB|Emily Moriarty
@@ -1944,6 +2367,8 @@ Believe|TTBB|Kevin Keller
 Believe|TTBB|Mark Goodney
 Believe|TTBB|Walter Latzko
 Believe It Or Not|SSAA|Jay Giallombardo
+Believe It Or Not|SSAA|Mo Rector
+Believe It Or Not|SSAA|Sylvia Alsbury
 Believe It Or Not|TTBB|Jay Giallombardo
 Believe It Or Not|TTBB|Kevin Keller
 Believe It Or Not|TTBB|Tom Gentry
@@ -1962,12 +2387,17 @@ Bells Of Killarney|TTBB|Tom Parker
 Below My Feet|TTBB|Nicholas Wright
 Ben 10 Theme Song|TTBB|Mason Eubank
 Beneath Your Beautiful|SATB|Deke Sharon
+Benediction|TTBB|Gene Grier and Lowell Everson
 Benediction Of Aaron|TTBB|Jim West
 Benny's From Heaven|TTBB|Rob Campbell
+Besame Mucho|SSAA|Ruby Rhea
+Beside an Open Fireplace|SSAA|Michael Gellert
 Beside An Open Fireplace|TTBB|Roy Keys
 Best Day of My Life|SATB|Deke Sharon
 Best Day of My Life|SATB|Nicholas Wright
+Best Day Of My Life|SSAA|Deke Sharon
 Best Day/Good Life Medley|SATB|Deke Sharon
+Best of Doo-Wop|TTBB|Ed Lojeski
 Best Of Me|TTBB|Rasmus Krigström
 Best Of My Love|SSAA|Deke Sharon
 Best Of Times|SSAA|Jo Lund
@@ -1978,6 +2408,7 @@ Best Seat In The House|TTBB|Larry Wright
 Best things happen while you dance/ Dance Medley|SSAA|Joe Mannherz
 Best Things In Life Are Free|TTBB|Marie Johnson
 Bestest Friend|TTBB|Cay Outerbridge
+Betelehemu (TTBB)|TTBB|Olatunji / Whalum
 Beth|TTBB|Kohl Kitzmiller
 Bethlehem Joy|SSAA|Dianne Goldrick
 Bethlehem Joy|TTBB|Dianne Goldrick
@@ -2000,10 +2431,12 @@ Betty|SATB|Greg Mallett
 Betty|SSAA|Greg Mallett
 Betty|TTBB|Greg Mallett
 Betty Co-ed|TTBB|Jack Baird
+Between the Devil and the Deep Blue Sea|SSAA|Nancy Bergman
 Between The Devil And The Deep Blue Sea|SATB|David Wright
 Between The Devil And The Deep Blue Sea|SSAA|Jon Nicholas
 Between The Devil And The Deep Blue Sea|TTBB|David Wright
 Between The Devil And The Deep Blue Sea|TTBB|Jon Nicholas
+Between The Devil And The Deep Blue Sea|TTBB|Pete Rupay
 Between The Lines|SATB|Deke Sharon
 Between You And The Birds And The Bees And Cupid|SSAA|Aaron Dale
 Between You And The Birds And The Bees And Cupid|TTBB|Aaron Dale
@@ -2024,11 +2457,15 @@ Bewitched, Bothered, and Bewildered|TTBB|Steve Jamison
 Beyonce Medley|TTBB|Deke Sharon
 Beyond The Blue Horizon|TTBB|Jeff McKeen
 Beyond The Blue Horizon|TTBB|Walter Latzko
+Beyond the Sea|SSAA|Dave Briner
+Beyond the Sea|SSAA|Elaine Gain
 Beyond the Sea|SSAA|Jay Giallombardo
 Beyond the Sea|SSAA|Takako Fuke
 Beyond the Sea|TTBB|Aaron Dale
 Beyond the Sea|TTBB|Adam Reimnitz
+Beyond the Sea|TTBB|D.Kynaston
 Beyond the Sea|TTBB|Dan Mulligan
+Beyond the Sea|TTBB|David Briner
 Beyond the Sea|TTBB|Deke Sharon
 Beyond the Sea|TTBB|Jay Giallombardo
 Beyond the Sea|TTBB|Mark Goodney
@@ -2044,6 +2481,7 @@ Bidin' My Time|SSAA|Norma Andersen
 Bidin' My Time|SSAA|Walter Latzko
 Bidin' My Time|TTBB|Bill Biffle
 Bidin' My Time|TTBB|Howard Dale
+Big Bad Bill|SSAA|Jim Arns
 Big Bad Bill from Louisville|TTBB|Walter Latzko
 Big Bad Bill Is Sweet William Now|SATB|Kyle Snook
 Big Bad Bill Is Sweet William Now|SSAA|Kyle Snook
@@ -2065,6 +2503,7 @@ Big Girls Don't Cry|SSAA|Marsha Zwicker
 Big Girls Don't Cry|SSAA|Tedda Lippincott
 Big Girls Don't Cry|TTBB|Jay Giallombardo
 Big Hair|SSAA|Larry Wright
+Big Hair|SSAA|Lorraine Rochefort
 Big Rock Candy Mountain|SSAA|Tedda Lippincott
 Big Spender|SSAA|Bev Sellers
 Big Spender|SSAA|Brent Graham
@@ -2072,6 +2511,7 @@ Big Spender|SSAA|Jo Lund
 Big Ten Fight Song Medley|TTBB|Tom Gentry
 Big Yellow Taxi|SATB|Deke Sharon
 Big Yellow Taxi|SSAA|Chris Arnold
+Big, Bad Bill Is Sweet William Now|SSAA|Jim Arns
 Bigger Isn't Better|TTBB|Dennis Driscoll
 Biggest Aspidastra In The World|TTBB|Don Gray
 Bill|SSAA|Nancy Bergman
@@ -2081,6 +2521,7 @@ Bill|TTBB|Tom Gentry
 Bill Bailey Fugue|SSAA|Larry Wright
 Bill Bailey Fugue|TTBB|Larry Wright
 Bill Bailey Instrumental|SSAA|Cris Conerty
+Bill Bailey, Won't You Please Come Home|TTBB|David Harrington
 Bill Bailey, Won't You Please Come Home?|TTBB|Brent Graham
 Bill Bailey, Won't You Please Come Home?|TTBB|David Harrington
 Bill Bailey, Won't You Please Come Home?|TTBB|Don Gray
@@ -2100,6 +2541,8 @@ Billionaire|SSAA|Rob Hopkins
 Billionaire|TTBB|Rob Hopkins
 Billy (I Always Dream of Bill)|SSAA|Jay Giallombardo
 Billy (I Always Dream of Bill)|TTBB|Jay Giallombardo
+Billy-A-Dick|SSAA|Jim Arns
+Billy-A-Dick|SSAA|June Dale
 Billy-A-Dick|TTBB|Dennis Driscoll
 Billy, Don't Be A Hero|TTBB|Deke Sharon
 Bird Dog|TTBB|Larry Wright
@@ -2107,9 +2550,12 @@ Bird In A Gilded Cage|TTBB|Ed Waesche
 Bird In A Gilded Cage|TTBB|Jack Baird
 Birdland|SATB|Anders Lindqvist
 Birdland|SATB|Joe Mannherz
+Birdland|SSAA|Ann Minihane
 Birdland|SSAA|Jim Arns
 Birdland|TTBB|Jay Dougherty
 Birds Medley|TTBB|Tom Gentry
+Birth of the Blues|SSAA|David Wright
+Birth Of the Blues|TTBB|J. Rae Jamieson
 Birth Of The Blues|SSAA|Brian Beck
 Birth Of The Blues|SSAA|Carolyn Schmidt
 Birth Of The Blues|SSAA|Lyle Pilcher
@@ -2121,13 +2567,17 @@ Birth Of The Blues|TTBB|Joe Mannherz
 Birth Of The Blues|TTBB|Roger Payne
 Birth Of The Blues|TTBB|Steve Jamison
 Birth Of The Blues|TTBB|Walter Latzko
+Birthday Of A King|SSAA|Matt Swann
+Birthday Of A King|TTBB|Matt Swann
 Black And Blue|TTBB|Ed Waesche
 Black and Gold|TTBB|Deke Sharon
 Black Coffee|TTBB|Walter Latzko
 Black Eyed Susan Brown|TTBB|Mel Knight
+Black Horse and the Cherry Tree|SSAA|Lorraine Rochefort
 Black Horse And The Cherry Tree|SATB|Deke Sharon
 Black Roses and Black Balloons|SSAA|Cris Conerty
 Black Water|SATB|Deke Sharon
+Black Water|SSAA|Jon Nicholas
 Black Water|TTBB|Derek Hatley
 Black Water|TTBB|Jon Nicholas
 Black-Eyed Blues|TTBB|Dennis Driscoll
@@ -2139,8 +2589,10 @@ Blackbird|SSAA|Dianne Goldrick
 Blackbird|SSAA|Jeremey Johnson
 Blackbird|TTBB|Dianne Goldrick
 Blackbird|TTBB|Gary Thiel
+Blackbird Medley|TTBB|Gary Parker
 Blackbird Parody|SSAA|Tom Gentry
 Blackbird Parody|TTBB|Tom Gentry
+Blah Blah Blah|TTBB|Steven Armstrong
 Blah-Blah-Blah|TTBB|Douglas Beck
 Blame It On My Youth|SSAA|Brent Graham
 Blame It On My Youth|TTBB|Adam Reimnitz
@@ -2169,6 +2621,7 @@ Bless This House|TTBB|David Harrington
 Bless This House|TTBB|Derric Johnson
 Bless This House|TTBB|Harry Mays
 Bless This House|TTBB|Jim West
+Bless Us All|TTBB|Adam Bock
 Bless Us All|TTBB|Tom Gentry
 Bless You Darlin' Mother|TTBB|Dave Marquis
 Bless You For Being An Angel|SSAA|Larry Wright
@@ -2189,11 +2642,14 @@ Blow Gabriel Blow|TTBB|Aaron Dale
 Blow Gabriel Blow|TTBB|Jay Giallombardo
 Blow The Man Down|TTBB|Jim West
 Blow The Winds Southerly|SATB|Matthew Spinner
+Blow, Gabriel Blow|SSAA|Jo Lund
+Blow, Gabriel Blow|SSAA|Renee Craig
 Blow, Gabriel, Blow|TTBB|Rasmus Krigström
 Blowin' In the Wind|SSAA|Kay Bromert
 Blue|SSAA|Jo Lund
 Blue|SSAA|Tedda Lippincott
 Blue|TTBB|Deke Sharon
+Blue & Sentimental/Solitude|TTBB|Wayne Grimmer
 Blue Ain't Your Color|TTBB|David Harrington
 Blue And Sentimental|TTBB|Mark Goodney
 Blue Bayou|SSAA|Bev Sellers
@@ -2207,10 +2663,14 @@ Blue Christmas|SSAA|Dianne Goldrick
 Blue Christmas|SSAA|Jeanne Elmuccio
 Blue Christmas|SSAA|Liz Garnett
 Blue Christmas|SSAA|Tedda Lippincott
+Blue Christmas|TTBB|Don Gray
 Blue Christmas|TTBB|Eric Ruthenberg
+Blue Christmas|TTBB|Jim Clancy
+Blue Christmas|TTBB|Joel T. Rutherford
 Blue Christmas|TTBB|Jon Nicholas
 Blue Christmas|TTBB|M. Gill
 Blue Christmas|TTBB|Todd Troutman
+Blue Christmas (I'll have a)|SSAA|Lynnell Diamond
 Blue Hawaii|SSAA|Jean Kane
 Blue Hawaii|SSAA|Nancy Bergman
 Blue Hawaii|TTBB|Manoj Padki
@@ -2223,6 +2683,7 @@ Blue Moon|SSAA|David Briner
 Blue Moon|SSAA|Jan-Ake Westin
 Blue Moon|TTBB|Aaron Dale
 Blue Moon|TTBB|Andy Isbell
+Blue Moon|TTBB|Dave Briner
 Blue Moon|TTBB|David Briner
 Blue Moon|TTBB|Joe Browne
 Blue Moon|TTBB|Paul Laurenz
@@ -2241,22 +2702,28 @@ Blue Shadows On The Trail|TTBB|Jay Giallombardo
 Blue Skies|SATB|Clay Hine
 Blue Skies|SATB|Deke Sharon
 Blue Skies|SATB|Joe Mannherz
+Blue Skies|SSAA|Clay Hine
 Blue Skies|SSAA|Renee Craig
+Blue Skies|TTBB|Buzz Haeger
 Blue Skies|TTBB|Clay Hine
 Blue Skies|TTBB|Clayton Hine
 Blue Skies|TTBB|Ed Waesche
+Blue Skies|TTBB|Grant Libramento (Palmetto Statesmen)
 Blue Skies|TTBB|Jim Shubert
 Blue Skies|TTBB|Jon Nicholas
 Blue Skies|TTBB|Ken Potter
 Blue Skies|TTBB|Tom Gentry
+Blue Skies (YWIH)|SSAA|Renee Craig
 Blue Smoke|SSAA|Kohl Kitzmiller
 Blue Star|TTBB|John Grant
 Blue Suede Shoes|SSAA|Tom Gentry
 Blue Suede Shoes|TTBB|Tom Gentry
+Blue Velvet|TTBB|Curt Kimbal
 Blue Velvet|TTBB|Curt Kimball
 Blue Velvet|TTBB|Jim McQuiston
 Blue Velvet|TTBB|Jon Nicholas
 Blue Velvet|TTBB|Mark Goodney
+Blue Velvet|TTBB|Ruby Rhea
 Blue Velvet|TTBB|Scott Kitzmiller
 Blue World|TTBB|Todd Troutman
 Blue-Collar Gal|TTBB|Roger Payne
@@ -2270,7 +2737,10 @@ Blues (My Naughty Sweetie Gives To Me)|TTBB|L. M. Coyle
 Blues (My Naughty Sweetie Gives To Me)|TTBB|Robert Rund
 Blues (Stay Away From Me)|SSAA|Walter Latzko
 Blues Brothers Medley|TTBB|Tom Gentry
+Blues in the Night|SSAA|Dave Briner
+Blues In The Night|SSAA|Ann Minihane
 Blues In The Night|SSAA|David Briner
+Blues In The Night|SSAA|Mary Coffman
 Blues In The Night|SSAA|Mary K. Coffman Music Fund
 Blues In The Night|SSAA|Tom Gentry
 Blues In The Night|TTBB|Dan Wessler
@@ -2285,27 +2755,35 @@ Blues In The Night|TTBB|William Behrendt
 Blues Serenade|TTBB|Kirk Roose
 Blues Vamp Warmup|TTBB|Deke Sharon
 Boar's Head Carol|SATB|Marshall Webb
+Boar's Head Carol|TTBB|Jay Giallombardo
+Boar's Head Carol, The (TTBB)|TTBB|Grant Cochran
 Body & Soul|SATB|Joe Mannherz
 Body & Soul|TTBB|Walter Latzko
 Body & Soul|TTBB|Wayne Grimmer
 Bohemian Rhapsody|SATB|Deke Sharon
 Bohemian Rhapsody|SATB|Joe Mannherz
+Bohemian Rhapsody|SATB|Queen
 Bohemian Rhapsody|SSAA|Deke Sharon
+Bohemian Rhapsody|SSAA|Heather Lane
 Bohemian Rhapsody|SSAA|Jay Giallombardo
+Bohemian Rhapsody|SSAA|Lorraine Rochefort
 Bohemian Rhapsody|TTBB|Adam Scott
 Bohemian Rhapsody|TTBB|Deke Sharon
 Bohemian Rhapsody|TTBB|Deke Sharon & Adam Scott
 Bohemian Rhapsody|TTBB|Jay Giallombardo
 Bohemian Rhapsody|TTBB|Steven Armstrong
+Bon jour mon Coeur|TTBB|Orlando di Lasso
 Bon Soir, Herr Kommissar|TTBB|Tom Gentry
 Boogie Down Medley|TTBB|Aaron Dale
 Boogie Woogie Bugle Boy|SSAA|Carolyn Healey
 Boogie Woogie Bugle Boy|SSAA|Connie Kash
 Boogie Woogie Bugle Boy|SSAA|David Wright
+Boogie Woogie Bugle Boy|SSAA|Joni Bescos
 Boogie Woogie Bugle Boy|SSAA|June Dale
 Boogie Woogie Bugle Boy|SSAA|Larry Wright
 Boogie Woogie Bugle Boy|SSAA|Nancy Bergman
 Boogie Woogie Bugle Boy|SSAA|Tom Gentry
+Boogie Woogie Bugle Boy|SSAA|Unspecified
 Boogie Woogie Bugle Boy|TTBB|Anastasio Rossi
 Boogie Woogie Bugle Boy|TTBB|David Wright
 Boogie Woogie Bugle Boy|TTBB|Deke Sharon
@@ -2319,14 +2797,18 @@ Book Of Love|TTBB|Kevin Koehl
 Book Of Love|TTBB|Tom Gentry
 Boondocks|SSAA|Larry Wright
 Boot Scootin' Boogie|SATB|Dan Wessler
+Boot Scootin' Boogie|SSAA|Brian Beck
 Boot Scootin' Boogie|SSAA|Dan Wessler
 Boot Scootin' Boogie|SSAA|Tedda Lippincott
 Boot Scootin' Boogie|TTBB|Dan Wessler
+Bop 'Til You Drop|SSAA|BTM
+Bop Til You Drop|SSAA|Barbara McNeill
 Bop Till You Drop|SSAA|Barbara McNeill
 Border Song|TTBB|Anders Lindqvist
 Born Free|TTBB|Walter Latzko
 Born on a New Day|SATB|Peter Knight
 Born This Way|SSAA|Liz Garnett
+Born to Be Blue|TTBB|Theo Hicks
 Born To Be Blue|TTBB|Melody Hine
 Born To Be Blue|TTBB|Theodore Hicks
 Born To Be Wild|SSAA|Joey Minshall
@@ -2344,6 +2826,7 @@ Both Sides Now|TTBB|Kevin Keller
 Both Sides Now|TTBB|Mark Stevens
 Both Sides Now|TTBB|Robert Rund
 Bottle It Up|SSAA|Deke Sharon
+Bottom of the River|SSAA|Joel Derksen
 Bounce Me Brother With A Solid Four|SSAA|Joyce Stanbery
 Bounce Me Brother With A Solid Four|SSAA|Kyle Snook
 Bound To You|SSAA|Simon Arnott
@@ -2353,13 +2836,16 @@ Boy Band Medley|TTBB|Deke Sharon
 Boy Band Medley|TTBB|Jeremey Johnson
 Boy of Mine|TTBB|Brent Graham
 Boyfriend Medley|SSAA|David Wright
+Boyfriend Medley|SSAA|Jan Meyer
 Boyhood Medley|TTBB|Robert Rund
 Boys in the Bright White Sports Car (Trooper)|SSAA|Joey Minshall
 Brahm's Lullaby|SSAA|Paul Grimm
 Brahms Lullaby|SATB|Joe Mannherz
+Brahms Lullabye|TTBB|Steven Armstrong
 Brain Damage|TTBB|Anders Lindqvist
 Brand New|SATB|Nicholas Wright
 Brand New|TTBB|Melody Hine
+Brand New Day|TTBB|Bob Disney
 Brand New Key|SSAA|Emily Moriarty
 Bravado|SATB|Nicholas Wright
 Brave|SATB|Deke Sharon
@@ -2378,6 +2864,7 @@ Bread And Gravy|TTBB|Wayne Grimmer
 Bread and Roses|SSAA|Fran Carter
 Break Forth, O Beauteous Heavenly Light|TTBB|Walter Latzko
 Break It To Me Gently|SATB|Mark Stevens
+Break It To Me Gently|SSAA|Brian Beck
 Break It To Me Gently|SSAA|Michael Gellert
 Break It To Me Gently|TTBB|Adam Scott
 Break It To Me Gently|TTBB|Robert Rund
@@ -2391,6 +2878,12 @@ Breakfast at Tiffany's|SATB|Deke Sharon
 Breakfast at Tiffany's|TTBB|Alex Morris
 Breakfast at Tiffany's|TTBB|Deke Sharon
 Breakfast In America|TTBB|Anders Lindqvist
+Breakin' Up is Hard to Do|SSAA|Nancy Bergman/Joan D'Agnostino
+Breakin' Up Is Hard to Do|SSAA|Bev Sellers
+Breakin' Up Is Hard To Do|SSAA|Anna Maria Parker
+Breakin' Up Is Hard To Do|TTBB|Tom Gentry
+Breakin' Up Is Hard To Do (YWIH)|SSAA|Anna Maria Parker
+Breakin' Up Is Hard To Do (YWIH)|SSAA|Tedda Lippincott
 Breaking Free|SATB|Soren Detlefsen
 Breaking Free|TTBB|Soren Detlefsen
 Breaking Up Is Hard To Do|SATB|Tom Campbell
@@ -2406,11 +2899,13 @@ Breaking Up Is Hard To Do|SSAA|Nancy Bergman
 Breaking Up Is Hard To Do|SSAA|Tedda Lippincott
 Breaking Up Is Hard To Do|SSAA|Tom Campbell
 Breaking Up Is Hard To Do|SSAA|Tom Gentry
+Breaking Up Is Hard To Do|TTBB|Adam Reimnitz
 Breaking Up Is Hard To Do|TTBB|David Wright
 Breaking Up Is Hard To Do|TTBB|Jay Giallombardo
 Breaking Up Is Hard To Do|TTBB|Kim Brittain
 Breaking Up Is Hard To Do|TTBB|Larry Wright
 Breaking Up Is Hard To Do|TTBB|Tom Campbell
+Breaking Up Is Hard To Do (contest)|SSAA|Tom Gentry
 Breath Of Life|TTBB|Ralph Urquhart
 Breathe Again|SATB|Nicholas Wright
 Breathe Again|TTBB|Nicholas Wright
@@ -2430,22 +2925,28 @@ Brethren, We Have Met To Worship|TTBB|Derric Johnson
 Brians song|SSAA|Joe Mannherz
 Brians song|TTBB|Joe Mannherz
 Brick House|SSAA|Melody Hine
+Bricklayer Song|TTBB|Al Fisk
 Bridal Chorus from Lohengrin|SATB|Deke Sharon
 Bridge Of Light|SSAA|June Berg
 Bridge Over Troubled Water|SATB|Deke Sharon
+Bridge Over Troubled Water|SATB|Kirby Shaw
 Bridge Over Troubled Water|SSAA|Asuka Ichikawa
 Bridge Over Troubled Water|SSAA|Brent Graham
 Bridge Over Troubled Water|SSAA|Cay Outerbridge
 Bridge Over Troubled Water|SSAA|Larry Wright
+Bridge Over Troubled Water|TTBB|A. Nightingale, T. Pearce
 Bridge Over Troubled Water|TTBB|Brent Graham
 Bridge Over Troubled Water|TTBB|Cay Outerbridge
 Bridge Over Troubled Water|TTBB|Dan Wessler
+Bridge Over Troubled Water|TTBB|Greg Volk ed. Gary Lewis
 Bridge Over Troubled Water|TTBB|Jim West
 Bridge Over Troubled Water|TTBB|Larry Wright
 Bridge Over Troubled Water|TTBB|Marilyn Penketh
 Bridge Over Troubled Water|TTBB|Rob Campbell
 Bridge Over Troubled Water|TTBB|Simon Arnott
+Bridge Over Troubled Water|TTBB|Unspecified
 Bridget|TTBB|Walter Latzko
+Brigadoon Medley|TTBB|Jay Giallombardo
 Bright College Days|TTBB|W. Engelke
 Bright Lights and Cityscapes|SATB|Nicholas Wright
 Bright Lights Bigger City/Magic|TTBB|Deke Sharon
@@ -2455,6 +2956,7 @@ Bright Was The Night|TTBB|Inc. SPEBSQSA
 Bright Was The Night|TTBB|SPEBSQSA
 Brighter Than The Sun|SSAA|Carole Prietto
 Brighter Than The Sun|SSAA|Nicholas Wright
+Brighter Than the Sun/We Are Young|SSAA|Carole Prietto
 Bring A Torch, Jeanette, Isabella|SSAA|Carolyn Johnson
 Bring A Torch, Jeanette, Isabella|SSAA|Jay Giallombardo
 Bring A Torch, Jeanette, Isabella|SSAA|Marshall Webb
@@ -2467,11 +2969,17 @@ Bring Back Those Minstrel Days|TTBB|Marie Johnson
 Bring Back Those Vaudeville Days|TTBB|Joe Liles
 Bring Back Those Wonderful Days|SSAA|Tom Gentry
 Bring Back Those Wonderful Days|TTBB|Tom Gentry
+Bring Him Home|SSAA|Dave Briner
 Bring Him Home|SSAA|David Briner
 Bring Him Home|SSAA|Gene Bender
 Bring Him Home|SSAA|Richard Hasty
+Bring Him Home|TTBB|Darin Drown
+Bring Him Home|TTBB|Jay Giallombardo
 Bring Him Home|TTBB|Mark Burnip
+Bring Him Home|TTBB|Pete Rupay
 Bring Him Home|TTBB|Rich Hasty
+Bring Him Home|TTBB|Rob Hopkins
+Bring Him Home (2000 version)|TTBB|Jay Giallombardo
 Bring Me A Letter From My Old Home Town|TTBB|Burt Szabo
 Bring Me Back My Lovin' Honey Boy|SSAA|Marie Johnson
 Bring Me Sunshine|SATB|Dan Wessler
@@ -2488,6 +2996,7 @@ Bring Me Sunshine|TTBB|Eric Ruthenberg
 Bring Me Sunshine|TTBB|Matt Astle
 Bring Me Sunshine|TTBB|Richard Curtis
 Bring Me Sunshine|TTBB|Robert Rund
+Bring Me Sunshine|TTBB|Steve Armstrong
 Bring Me Sunshine|TTBB|Theodore Hicks
 Bring Me To Life|SATB|Deke Sharon
 Bring Me To Life|SSAA|Erica Kelch-Slesnick
@@ -2496,11 +3005,15 @@ Bring On The Beautiful Girls/I'm A Showgirl|SSAA|Nancy Bergman
 Bring On The Men|SSAA|Wayne Grimmer
 Bring On The Pepper|SSAA|Jo Lund
 Bring Us In Good Ale|SATB|Mike Menefee
+Britney Spears Medley|SSAA|Matthew Hodge
 Broadway|SSAA|Brian Beck
 Broadway|TTBB|Ed Waesche
 Broadway Baby|SSAA|Bev Sellers
+Broadway Baby|SSAA|Bev Sellers and Sylvia Alsbury
 Broadway Baby|SSAA|Connie Kash
 Broadway Baby|SSAA|Marge Bailey
+Broadway Baby|SSAA|Sellers Alsbury
+Broadway Baby (From 'Follies')|SSAA|Renee Craig
 Broadway Grandma's Medley|SSAA|Nancy Bergman
 Broadway Medley|SSAA|Brent Graham
 Broadway Medley|SSAA|Jay Giallombardo
@@ -2522,6 +3035,9 @@ Broadway Rose|TTBB|Louis Perry
 Broadway Rose|TTBB|Steve Jamison
 Broadway Rose|TTBB|Tom Gentry
 Broadway Show Opener|TTBB|J Rae Jamieson
+Broadway Show Opener|TTBB|J. Rae Jamieson
+Broadway Star|SSAA|Wydra Joni Bescos
+Broadway Star Medley|SSAA|Joni Bescos / Mary Ann Wydra
 Broadway USA/Razzle Dazzle Medley|SSAA|Jay Giallombardo
 Broadway USA/Razzle Dazzle Medley|TTBB|Jay Giallombardo
 Broken|TTBB|Michael Webber
@@ -2543,9 +3059,13 @@ Brother|TTBB|Nicholas Wright
 Brother Can You Spare A Dime|SSAA|Jo Lund
 Brother Can You Spare A Dime|TTBB|Bob Dowma
 Brother Can You Spare A Dime|TTBB|David Wright
+Brother Can You Spare A Dime|TTBB|Jim Clancy, Bob Shami
 Brother Can You Spare A Dime|TTBB|Joe Mannherz
+Brother Can You Spare A Dime|TTBB|Steven Armstrong
 Brother Loves Travelin' Salvation Show|SSAA|Jean Shook
 Brother Noah Gave Out Checks for Rain|TTBB|Toban Dvoretsky
+Brother, Can You Spare A Dime|TTBB|Nighthawks
+Brother, Can You Spare A Dime?|TTBB|Backwell/Turner
 Brother, Can You Spare A Dime?|TTBB|Steve Armstrong
 Brother, Can You Spare A Dime?|TTBB|Steven Armstrong
 Brother, My Brother|TTBB|Kevin Keller
@@ -2553,6 +3073,7 @@ Brotherhood of Man|SSAA|Jay Giallombardo
 Brotherhood of Man|TTBB|Jay Giallombardo
 Brotherhood of Man|TTBB|Tony Nasto
 Brothers Love Song|TTBB|Steve Delehanty
+Brothers, Sing On!|TTBB|Edvard Grieg
 Brown Eyed Girl|SATB|Deke Sharon
 Brown Eyed Girl|TTBB|Adam Scott
 Brown Eyed Girl|TTBB|Deke Sharon
@@ -2572,9 +3093,13 @@ Buckeye Battle Cry|TTBB|Kevin Keller
 Buckle Down Winsocki|TTBB|Marty Israel
 Budapest|SATB|Nicholas Wright
 Buddy Holly|TTBB|Wayne Grimmer
+Buddy Holly Medley|SSAA|Becky Wilkins
 Buddy's Blues|TTBB|Adam Bock
+Buffalo Bills Uptune Medley|TTBB|Walter Latzko
 Buffalo Gals|TTBB|Todd Troutman
+Bugler's Holiday|TTBB|Jay Giallombardo
 Buglers Holiday|TTBB|Jay Giallombardo
+Bugs Bunny Overture|TTBB|Ed Waesche
 Bugsy Malone|TTBB|Liz Garnett
 Build Me Up Buttercup|SSAA|Melody Hine
 Build Me Up Buttercup|TTBB|Dan Wessler
@@ -2587,6 +3112,7 @@ Bundle Of Old Love Letters|TTBB|Barbershop Harmony Society
 Bundle Of Old Love Letters|TTBB|D. C. Macintyre
 Bundle Of Old Love Letters|TTBB|J. I. Ruehle
 Bundle Of Old Love Letters|TTBB|SPEBSQSA
+Buona Sera|TTBB|Janne Olsson
 Burn|SATB|Nicholas Wright
 Burn|SSAA|Nicholas Wright
 Burnin The Roadhouse Down|SSAA|Aaron Dale
@@ -2596,6 +3122,7 @@ Bury A Friend|TTBB|Melody Hine
 Bury Me Not On The Lone Prairie|SSAA|Kay Bromert
 Bury Me Not On The Lone Prairie|TTBB|Adam Reimnitz
 Bury Me Not On The Lone Prairie|TTBB|Jon Nicholas
+Bury Me Out On The Lone Prairie|TTBB|Jon Nicholas
 Busy Doing Nothing|SSAA|Kohl Kitzmiller
 But After The Ball Was Over|TTBB|Ed Waesche
 But For Now|TTBB|Simon Arnott
@@ -2612,10 +3139,13 @@ Butterfly|SSAA|Linda Samuelsson
 Butterfly Kisses|TTBB|Theodore Hicks
 Butterfly Kisses|TTBB|Tom Gentry
 Butterscotch Castle|TTBB|Jay Giallombardo
+Button Up Your Overcoat|SSAA|Nancy Bergman
 Button Up Your Overcoat|SSAA|Rebecca J. Wood
 Button Up Your Overcoat|SSAA|Tom Gentry
 Button Up Your Overcoat|TTBB|Bill Gard
 Button Up Your Overcoat|TTBB|Tom Gentry
+Button Up Your Overcoat (Senior Men's Version)|TTBB|Tom Gentry
+Button Up Your Overcoat (Seniors' Version)|TTBB|Tom Gentry
 Button Up Your Overcoat / You Were Meant for Me Medley|TTBB|Ed Waesche
 Buttons And Bows|SSAA|Charlene Yazurlo
 Buttons And Bows|SSAA|Walter Latzko
@@ -2628,6 +3158,7 @@ By The Beautiful Sea|SSAA|Dot Calvin
 By The Beautiful Sea|TTBB|Dennis Driscoll
 By The Beautiful Sea|TTBB|Dot Calvin
 By The Beautiful Sea|TTBB|Val Hicks
+By The Beautiful Sea (YWIH)|SSAA|Dot Calvin
 By The Light Of The Silvery Moon|SSAA|Joni Bescos
 By The Light Of The Silvery Moon|SSAA|Walter Latzko
 By The Light Of The Silvery Moon|TTBB|Jim Shubert
@@ -2640,9 +3171,11 @@ By The Sea / In The Good Old Summertime Medley|TTBB|Brent Graham
 By The Sea / In The Good Old Summertime Medley|TTBB|J. I. Ruehle
 By The Sea / In The Good Old Summertime Medley|TTBB|Mike Sotiriou
 By The Sea / In The Good Old Summertime Medley|TTBB|Renee Craig
+By the Sea Medley|SSAA|Nancy Bergman
 By The Sea/Minnie The Mermaid Medley|SATB|Jay Giallombardo
 By The Sea/Minnie The Mermaid Medley|TTBB|Jay Giallombardo
 By The Sea/Row Row Row|SSAA|Nancy Bergman
+By the Time I Get to Phoenix|SSAA|Nancy Bergman
 By The Time I Get To Phoenix|SSAA|Larry Wright
 By The Time I Get To Phoenix|TTBB|David Zimmerman
 By The Time I Get To Phoenix|TTBB|Dennis Driscoll
@@ -2652,9 +3185,11 @@ Bye Bye Baby|SSAA|Dot Calvin
 Bye Bye Baby/Baby Won't You Please Come Home Medley|SSAA|Carolyn Schmidt
 Bye Bye Baby/Baby Won't You Please Come Home Medley|SSAA|Larry Wright
 Bye Bye Baby/Baby Won't You Please Come Home Medley|TTBB|Larry Wright
+Bye Bye Baby/Won't You Please Come Home|SSAA|Chari Pernert
 Bye Bye Blackbird|SSAA|Carolyn Schmidt
 Bye Bye Blackbird|SSAA|David Wright
 Bye Bye Blackbird|SSAA|Larry Wright
+Bye Bye Blackbird|SSAA|Mike Senter
 Bye Bye Blackbird|TTBB|Brian Beck
 Bye Bye Blackbird|TTBB|Brian Kotval
 Bye Bye Blackbird|TTBB|Jon Nicholas
@@ -2663,7 +3198,10 @@ Bye Bye Blackbird|TTBB|Rob Hopkins
 Bye Bye Blackbird|TTBB|Walter Latzko
 Bye Bye Blackbird/Bye Bye Baby Medley|SSAA|Larry Wright
 Bye Bye Blackbird/Bye Bye Baby Medley|TTBB|Larry Wright
+Bye Bye Blues|SSAA|Fred Hamm/Dave Bennett
+Bye Bye Blues|SSAA|The Barbertones
 Bye Bye Blues|TTBB|BHS
+Bye Bye Blues|TTBB|Greg Volk
 Bye Bye Blues|TTBB|SPEBSQSA
 Bye Bye Blues|TTBB|SPEBSQSA, Inc.
 Bye Bye Blues|TTBB|Val Hicks
@@ -2676,6 +3214,8 @@ Bye Bye Love|SSAA|Tom Gentry
 Bye Bye Love|TTBB|Barbershop Harmony Society
 Bye Bye Love|TTBB|Larry Wright
 Bye Bye Love|TTBB|Tom Gentry
+Bye Bye, Love|TTBB|Barbershop Harmony Society
+Bye, Bye Blackbird|TTBB|Brian Beck
 Bye, Bye My Love|TTBB|Tom Gentry
 Bygone Memories|TTBB|Brent Graham
 C-H-R-I-S-T-M-A-S|TTBB|Derric Johnson
@@ -2692,6 +3232,7 @@ Cabaret|SSAA|Nancy Bergman
 Cabaret|SSAA|Sam Hubbard
 Cabaret|TTBB|Adam Bock
 Cabaret|TTBB|Barbershop Harmony Society
+Cabaret|TTBB|Buzz Haeger
 Cabaret|TTBB|Einar Pedersen
 Cabaret|TTBB|Greg Mallett
 Cabaret|TTBB|Jim Dillett
@@ -2701,7 +3242,9 @@ Cabaret|TTBB|Liz Garnett
 Cabaret|TTBB|Robert Standley
 Cabaret|TTBB|Sam Hubbard
 Cabaret|TTBB|Steve Delehanty
+Cabaret|TTBB|Unspecified
 Cabaret|TTBB|Warren 'Buzz' Haeger
+Caissons Medley|SSAA|June Dale
 Cake By The Ocean|TTBB|Nicholas Wright
 Calendar Girl|SSAA|Marge Bailey
 Calendar Girl|SSAA|Tedda Lippincott
@@ -2714,6 +3257,7 @@ California Dreamin'|SATB|Joe Mannherz
 California Dreamin'|SSAA|Debbie Keretz
 California Dreamin'|SSAA|Glenda Lloyd
 California Dreamin'|SSAA|Jay Giallombardo
+California Dreamin'|SSAA|Lynnell Diamond
 California Dreamin'|SSAA|Michael Gellert
 California Dreamin'|SSAA|Mike Taylor
 California Dreamin'|SSAA|Tedda Lippincott
@@ -2721,6 +3265,8 @@ California Dreamin'|TTBB|Anders Lindqvist
 California Dreamin'|TTBB|Deke Sharon
 California Dreamin'|TTBB|Jay Giallombardo
 California Dreamin'|TTBB|Joe Johnson
+California Dreaming|SSAA|Lynnell Diamond
+California Dreaming|TTBB|Mike Taylor
 California Girls|TTBB|Jon Nicholas
 California Here I Come|SSAA|Joe Mannherz
 California Here I Come|SSAA|Nancy Bergman
@@ -2730,8 +3276,12 @@ California Here I Come|TTBB|Jim Gay
 California Here I Come|TTBB|Joe Mannherz
 California Here I Come|TTBB|Rob Campbell
 California Here I Come (Dealer's Choice version)|TTBB|Dave Stevens
+California Medley|SSAA|Nancy Bergman
 California Medley|TTBB|Burt Szabo
+California, Here I Come|SSAA|Nancy Bergman
+California, Here I Come|TTBB|Dave Stevens/Dealer?s Choice
 Californication|SATB|Adam Bock
+Call It Nostalgia|TTBB|Charles Stahl
 Call It Nostalgia|TTBB|Sam Stahl
 Call It Nostalgia|TTBB|Stahl
 Call Me|SATB|Deke Sharon
@@ -2746,6 +3296,7 @@ Call Me Back Pal O' Mine|TTBB|Jerry Koskela
 Call Me Back Pal O' Mine|TTBB|Larry Wright
 Call Me Back Pal O' Mine|TTBB|Lee Sutter
 Call Me Back Pal O' Mine|TTBB|Rob Campbell
+Call Me Back, Pal O Mine|TTBB|Ed Gentry
 Call Me Irresponsible|SSAA|Tom Gentry
 Call Me Irresponsible|TTBB|Adam Scott
 Call Me Irresponsible|TTBB|Tom Gentry
@@ -2756,6 +3307,8 @@ Call Me Maybe|TTBB|Nicholas Wright
 Call Upon The Lord|TTBB|Derric Johnson
 Call Your Girlfriend|SSAA|Nicholas Wright
 Callin' Baton Rouge|TTBB|Don Staffin
+Calypso Clapping Carol|SSAA|Farris Collins
+Calypso Clapping Carol|TTBB|Farris Collins
 Calypso Medley|SSAA|Jay Giallombardo
 Calypso Medley|TTBB|Jay Giallombardo
 Calypso Noel|TTBB|Derric Johnson
@@ -2763,6 +3316,7 @@ Camelot|TTBB|Dick Stuart
 Camptown Races Medley|SATB|Jay Giallombardo
 Camptown Races Medley|SSAA|Jay Giallombardo
 Camptown Races Medley|TTBB|Jay Giallombardo
+Camptown Racetrack|TTBB|Joe Liles
 Can He, Could He, Would He|SATB|Kevin Keller
 Can He, Could He, Would He|SSAA|Kevin Keller
 Can He, Could He, Would He|TTBB|Kevin Keller
@@ -2770,6 +3324,11 @@ Can He, Could He, Would He|TTBB|Paul Jorg
 Can I Interest You In Hannukah?|TTBB|Dom Finetti
 Can I Steal A Little Love|TTBB|Wayne Grimmer
 Can You Bring Back The Heart I Gave You|TTBB|Burt Szabo
+Can You Feel the Love Tonight|SSAA|June Dale
+Can You Feel the Love Tonight|SSAA|Tedda Lippincott
+Can You Feel The Love Tonight|SSAA|Marge Bailey
+Can You Feel The Love Tonight|TTBB|June Dale
+Can You Feel The Love Tonight (YWIH)|SSAA|Marge Bailey
 Can You Feel The Love Tonight?|SATB|June Dale
 Can You Feel The Love Tonight?|SATB|Kevin Koehl
 Can You Feel The Love Tonight?|SSAA|June Berg
@@ -2785,7 +3344,9 @@ Can You Tame Wild Wimmen|TTBB|Bob Benson
 Can You Tame Wild Wimmen|TTBB|David Briner
 Can You Tame Wild Wimmen|TTBB|Jim Shubert
 Can You Tame Wild Wimmen|TTBB|Tom Gentry
+Can You Tame Wild Wimmen?|TTBB|Bob Benson
 Can You Tame Wild Women?|TTBB|Jim West
+Can-Can|SSAA|Clay Hine
 Can-Can Parody|SSAA|Tedda Lippincott
 Can't Buy Me Love|SATB|Kohl Kitzmiller
 Can't Buy Me Love|SSAA|Kohl Kitzmiller
@@ -2798,6 +3359,7 @@ Can't Fight This Feeling|TTBB|Andrew Wittenberg
 Can't Fight This Feeling|TTBB|Nicholas Wright
 Can't Get Over You|TTBB|Norma Andersen
 Can't Have any Fun without You|SSAA|Jo Lund
+Can't Help Falling In Love|SATB|Henrik Rosenberg
 Can't Help Falling In Love|SATB|Kevin Koehl
 Can't Help Falling In Love|SATB|Kohl Kitzmiller
 Can't Help Falling In Love|SATB|Simon Lubkowski
@@ -2820,12 +3382,15 @@ Can't Help Falling In Love|TTBB|Kevin Keller
 Can't Help Falling In Love|TTBB|Kevin Koehl
 Can't Help Falling In Love|TTBB|Luke Stevenson
 Can't Help Falling In Love|TTBB|Tom Gentry
+Can'T Help Falling In Love Love Me Tender|SSAA|Joanne Dockrell
 Can't Help Lovin' Dat Man|SSAA|Anna Maria Parker
 Can't Help Lovin' Dat Man|SSAA|Carolyn Butler
 Can't Help Lovin' Dat Man|SSAA|David Wright
 Can't Help Lovin' Dat Man|SSAA|Patrick McAlexander
 Can't Help Lovin' Dat Man|SSAA|Sam Hubbard
 Can't Help Lovin' Dat Man|TTBB|Sam Hubbard
+Can't Help Lovin' That Man of Mine|SSAA|Anna Maria Parker
+Can't Help Lovin' That Man Of Mine|SSAA|Brian Beck
 Can't Smile Without You|SSAA|Chris Arnold
 Can't Smile Without You|SSAA|Larry Wright
 Can't Smile Without You|TTBB|Chris Arnold
@@ -2841,6 +3406,7 @@ Can't Take My Eyes Off Of You|SATB|Alex Morris
 Can't Take My Eyes Off Of You|SATB|Anders Lindqvist
 Can't Take My Eyes Off Of You|SATB|Deke Sharon
 Can't Take My Eyes Off Of You|SATB|Kevin Keller
+Can't Take My Eyes Off Of You|SATB|Mason Kaye
 Can't Take My Eyes Off Of You|SSAA|Alex Morris
 Can't Take My Eyes Off Of You|SSAA|Elaine Gain
 Can't Take My Eyes Off Of You|SSAA|Kay Bromert
@@ -2857,6 +3423,7 @@ Can't Take My Eyes Off Of You|TTBB|Mark Burnip
 Can't Take My Eyes Off Of You|TTBB|Mike Menefee
 Can't Take My Eyes Off Of You|TTBB|Richard Curtis
 Can't Take My Eyes Off Of You|TTBB|Walter Latzko
+Can't Take My Eyes Off Of You|TTBB|Zac Booles
 Can't We Talk It Over|SSAA|Jay Giallombardo
 Can't We Talk It Over|TTBB|Jay Giallombardo
 Can't You Hear Me Callin' Caroline|TTBB|David Wright
@@ -2883,6 +3450,7 @@ Candle On The Water|SSAA|June Dale
 Candle On The Water|SSAA|Larry Wright
 Candle On The Water|SSAA|Tom Gentry
 Candle On The Water|TTBB|Tom Gentry
+Candle on the Water (YWIH)|SSAA|Anna Maria Parker
 Candleglow|TTBB|Jim West
 Candlelight And Gold|TTBB|Joe Liles
 Candlelight And Gold|TTBB|Tom Gentry
@@ -2902,13 +3470,16 @@ Candy Man|SSAA|Nancy Bergman
 Candy Man|SSAA|Staffan Paulson
 Candy Man|TTBB|Harold Ulring
 Candy Man|TTBB|Kevin Keller
+Candyman Medley|SSAA|Alex Kaiserman
 Canticle of the Sun|SSAA|David Wright
 Capri Fischer|TTBB|Tom Gentry
+Captain Of The Toy Brigade|TTBB|Jay Giallombardo
 Car Wash|SSAA|Joey Minshall
 Car Wash|TTBB|Todd Troutman
 Caravan|SATB|Deke Sharon
 Caravan|TTBB|Scott Kitzmiller
 Carefully Taught Medley|TTBB|Robert Rund
+Careless|TTBB|Platinum
 Careless|TTBB|Warren 'Buzz' Haeger
 Caribbean Amphibian|SSAA|Carolyn Schmidt
 Carmen Ohio|SATB|Kevin Keller
@@ -2917,10 +3488,15 @@ Carmen Ohio|SSAA|Patricia Godfrey
 Carmen Ohio|TTBB|Kevin Keller
 Carol Classics Medley|TTBB|Jay Giallombardo
 Carol From An Irish Cabin|SATB|Jon Nicholas
+Carol From An Irish Cabin|TTBB|Dale Wood
 Carol From An Irish Cabin|TTBB|Joe Grimme
 Carol Me|SSAA|Kay Bromert
+Carol Medley|SSAA|Floyd Connett
 Carol Medley|SSAA|Larry Wright
 Carol Medley|TTBB|Larry Wright
+Carol of the Bells|SSAA|Avis Fellows
+Carol of the Bells|SSAA|Kirby Shaw
+Carol of the Bells|TTBB|Peter Wilhousky/Greg Lyne
 Carol Of The Bells|SATB|Brian Doepke
 Carol Of The Bells|SATB|Deke Sharon
 Carol Of The Bells|SATB|Joe Mannherz
@@ -2930,8 +3506,11 @@ Carol Of The Bells|SSAA|Liz Garnett
 Carol Of The Bells|SSAA|Takako Fuke
 Carol Of The Bells|TTBB|David Wright
 Carol Of The Bells|TTBB|Derric Johnson
+Carol Of The Bells|TTBB|Greg Lyne
 Carol Of The Bells|TTBB|Nicholas Wright
 Carol Of The Bells|TTBB|Steve Jamison
+Carol of the Bells (SATB)|SATB|Unspecified
+Carol Of The Bells/What Child Is This Medley(Joe Spie|SSAA|Joe Spiecker
 Carol Of The Russian Children|SATB|Derric Johnson
 Carolina Blues|TTBB|Robert Rund
 Carolina In My Mind|TTBB|David Naddor
@@ -2950,18 +3529,28 @@ Carolina Moon|TTBB|Gene Cokeroft
 Carolina Moon|TTBB|John Stefero
 Carolina Moon|TTBB|Scott Kitzmiller
 Carolina Moon|TTBB|Todd Troutman
+Carolina Parody|TTBB|Ed Wasche - Lyrics John Werth
 Carolina Rolling Stone|TTBB|Burt Szabo
 Carolina Rolling Stone|TTBB|Walter Latzko
 Carolina Sunshine|TTBB|Burt Szabo
+Caroline|TTBB|Larry Cole/Wally Cluett
+Caroline|TTBB|Larry Cole/Wally Cluett/Boston Common
 Caroline|TTBB|Rob Hopkins
+Caroline|TTBB|Rudy Newman
+Caroline|TTBB|Wally Cluett
 Caroline (TTBB) (as sung by the Boston Common)|TTBB|Cole, Cluett, and the Boston Common
 Caroline, I'm Coming Back To You|TTBB|Rob Hopkins
+Caroling Caroling|TTBB|David Wright
 Caroling, Caroling|SATB|Joe Mannherz
+Caroling, Caroling|SSAA|Brian Beck
+Caroling, Caroling|SSAA|David Wright
 Caroling, Caroling|SSAA|Larry Wright
 Caroling, Caroling|SSAA|Norma Andersen
+Caroling, Caroling|TTBB|Dave Briner
 Caroling, Caroling|TTBB|Larry Wright
 Carols of the Angels Medley|SSAA|Jay Giallombardo
 Carols of the Angels Medley|TTBB|Jay Giallombardo
+Carrickfergus|SSAA|Chris MacMartin
 Carry Me Back To Old Virginny|SSAA|Walter Latzko
 Carry On|SATB|Nicholas Wright
 Carry On Wayward Son|SSAA|Carole Prietto
@@ -2973,23 +3562,32 @@ Casey Jones|TTBB|J Rae Jamieson
 Casey's Odyssey|TTBB|Robert Rund
 Casper The Friendly Ghost|TTBB|Larry Wright
 Cassiopeia|SATB|Grant Goulding
+Catch a Falling Star|TTBB|Steve Hall
 Catch A Wave|TTBB|Steve Jamison
 Cattle Call|TTBB|Steve Jamison
 Caught A Touch Of Your Love|SSAA|Kohl Kitzmiller
+Cause I'm A Blond|SSAA|Debbie Connelly
 Cause I'm A Blonde|SSAA|Debbie Cleveland
 Cavatina|SSAA|Jenny Mills
 Cecilia|TTBB|Adam Bock
 Cecilia|TTBB|Deke Sharon
+Cecilia|TTBB|Interstate Rivals
 Cecilia|TTBB|Larry Wright
+Cecilia|TTBB|Unspecified
 Cecilia|TTBB|Val Hicks
 Celebrate|SATB|Alex Morris
 Celebrate Diversity|SSAA|Julie Starr
+Celebrate Harmony|TTBB|Joe Liles
 Celebrate Harmony (Show Opener / Closer)|TTBB|Joe Liles
 Celebrate The Music|SSAA|Renee Craig
 Celebrate/Goody Goodbye|SSAA|Larry Wright
 Celebrate/Goody Goodbye|TTBB|Larry Wright
 Celebrate/Happy Birthday|SSAA|Larry Wright
 Celebrate/Happy Birthday|TTBB|Larry Wright
+Celebration|SATB|Renee Craig
+Celebration|SSAA|Connie Kash
+Celebration|SSAA|Renee Craig
+Celebration Medley|SSAA|Nancy Faddegon
 Celebrity|SSAA|Avis Fellows
 Celestial|TTBB|Dan Wessler
 Cell Block Tango|SSAA|Kevin Keller
@@ -3001,8 +3599,12 @@ Champion's Knack|SSAA|Tom Gentry
 Champion's Knack|TTBB|Tom Gentry
 Chances Are|SSAA|Carolyn Healey
 Chances Are|SSAA|Carolyn Schmidt
+Chances Are|SSAA|Greg Volk
 Chances Are|SSAA|Sharon Holmes
 Chances Are|SSAA|Tedda Lippincott
+Chances Are|TTBB|Don Gray
+Chances Are|TTBB|Greg Volk
+Chances Ares|TTBB|Greg Volk
 Chandelier|SATB|Nicholas Wright
 Chandelier|SSAA|Emily Moriarty
 Chandelier|SSAA|Nicholas Wright
@@ -3011,6 +3613,7 @@ Change My Heart, Oh God|SSAA|Tom Gentry
 Change My Heart, Oh God|TTBB|Tom Gentry
 Change the World|SATB|Deke Sharon & David Wright
 Change the World|SSAA|Deke Sharon & David Wright
+Change the World|SSAA|Mac Huff
 Change the World|TTBB|Deke Sharon & David Wright
 Change The World|SATB|Deke Sharon
 Change The World|SSAA|David Wright
@@ -3019,10 +3622,19 @@ Change The World|SSAA|Kay Bromert
 Change The World|SSAA|Tedda Lippincott
 Change The World|TTBB|David Wright
 Change The World|TTBB|Deke Sharon
+Changes Medley|SSAA|Bev Sellers
+Changes Medley|SSAA|Jim Arns
+Changes Medley|SSAA|Nancy Bergman
+Changes Medley|SSAA|Renee Craig
 Changes/I Used To Love You|SSAA|Carolyn Schmidt
+Changes/I Used to Love You Medley|SSAA|Carolyn Schmidt
 Channel Surfin'|SSAA|Tedda Lippincott
+Chanson D'Amour|SSAA|Bob O'Connell
 Chantez, Chantez|TTBB|Ken Bastien
 Chantez, Chantez|TTBB|Walter Latzko
+Chanukah Is Here|TTBB|Alan Josephson
+Chapel of Love|SSAA|Charlene Yazurlo
+Chapel of Love|SSAA|Dotty Hougen
 Chapel Of Love|SATB|Joe Mannherz
 Chapel Of Love|SSAA|Anna Maria Parker
 Chapel Of Love|TTBB|Adam Bock
@@ -3031,6 +3643,7 @@ Chapters Of Life|TTBB|Walter Latzko
 Charade|TTBB|Curt Kimball
 Charade|TTBB|Matthew Gallagher
 Chargog-gagoog-manchaug-gagogg|TTBB|Walter Latzko
+Charleston|SSAA|Brian Beck
 Charleston|SSAA|Connie Nickel
 Charleston|SSAA|David Wallace
 Charleston|SSAA|Jeanne Elmuccio
@@ -3043,6 +3656,7 @@ Charleston, Flappers And Razz-A-Ma-Tazz|TTBB|Dennis Driscoll
 Charleston, Flappers And Razz-A-Ma-Tazz|TTBB|Merrill Miller
 Charley, My Boy|SSAA|Jan Meyer
 Charley, My Boy|SSAA|Nancy Bergman
+Charlie and the MTA|SSAA|Lorraine Rochefort
 Charlie Brown|SSAA|Larry Wright
 Charlie Brown|TTBB|Larry Wright
 Charlie Brown Christmas|SSAA|Carole Prietto
@@ -3052,6 +3666,7 @@ Charmaine|TTBB|John Stefero
 Charmaine|TTBB|Toban Dvoretsky
 Charmaine|TTBB|Walter Latzko
 Charmed Life|SSAA|Chris Moyer
+Chase the Rain Away|SSAA|Lynnell Diamond
 Chasin' the Blues|SSAA|Kevin Keller
 Chasin' the Blues|TTBB|Kevin Keller
 Chasing Cars|SATB|Karen Penketh
@@ -3059,9 +3674,12 @@ Chasing Cars|TTBB|Deke Sharon
 Chasing Cars|TTBB|Jon Nicholas
 Chattanooga Choo Choo|SATB|Joe Mannherz
 Chattanooga Choo Choo|SSAA|Jon Nicholas
+Chattanooga Choo Choo|SSAA|Joni Bescos
+Chattanooga Choo Choo|SSAA|Renee Craig
 Chattanooga Choo Choo|TTBB|Joe Mannherz
 Chattanooga Choo Choo|TTBB|Jon Nicholas
 Chattanooga Choo Choo|TTBB|Kirk Young
+Chattanooga Choo Choo|TTBB|Renee Craig
 Chattanooga Choo Choo|TTBB|Walter Latzko
 Chattanooga Choo Choo/Pennsylvania, Goodbye Medley|SSAA|Jon Nicholas
 Chattanooga Choo Choo/Pennsylvania, Goodbye Medley|TTBB|Jon Nicholas
@@ -3073,14 +3691,19 @@ Chattanoogie Shoe Shine Boy|TTBB|Jeremey Johnson
 Cheap Thrills|SSAA|Deke Sharon
 Cheap Thrills|SSAA|Emily Moriarty
 Cheatin, On Me|TTBB|Dennis Driscoll
+Cheek to Cheek|SSAA|Ruby Rhea
 Cheek to Cheek|TTBB|Ed Waesche
+Cheek To Cheek|SSAA|Brian Beck
 Cheek To Cheek|SSAA|Carolyn Johnson
 Cheek To Cheek|SSAA|Ed Waesche
 Cheek To Cheek|SSAA|Elaine Gain
 Cheek To Cheek|SSAA|Walter Latzko
 Cheek To Cheek|TTBB|Mark Goodney
+Cheek To Cheek-My Blue Heaven Medley|TTBB|John Brockman
+Cheer Up Charlie|SSAA|Sharon Holmes
 Cheer Up, Charlie|SSAA|Brent Graham
 Cheer Up, Charlie|SSAA|James Henry
+Cheer Up, Charlie|SSAA|Jim Henry
 Cheer Up, Charlie|SSAA|Kevin Keller
 Cheer Up, Charlie|SSAA|Sharon Holmes
 Cheer Up, Charlie|TTBB|Brent Graham
@@ -3089,17 +3712,21 @@ Cheer Up, Charlie|TTBB|Jim Henry
 Cheer Up, Charlie|TTBB|Kevin Keller
 Cheeseburger In Paradise|TTBB|Eric Ruthenberg
 Chega De Saudade (No More Blues)|TTBB|Melody Hine
+Chemistry|TTBB|Patrick McAlexander
 Cherish|SATB|Kevin Keller
 Cherish|SSAA|Kevin Keller
 Cherish|TTBB|Adam Bock
 Cherish|TTBB|Kevin Keller
 Cherish|TTBB|Larry Wright
 Cherish That Name|TTBB|Derric Johnson
+Cherry Pink and Apple Blossom White|SSAA|Ruby Rhea
 Chesapeake Bay / Old Dominion Line Medley|TTBB|Rob Campbell
 Chicago|SATB|Deke Sharon
+Chicago - My Kind of Town Medley|TTBB|Jack Baird
 Chicago / My Kind Of Town Medley|TTBB|Jack Baird
 Chicago Medley|SSAA|Ed Waesche
 Chicago Medley|SSAA|Jay Giallombardo
+Chicago Medley|SSAA|Jo Lund
 Chicago Medley|TTBB|Don Hewey
 Chicago Medley|TTBB|Ed Waesche
 Chicago Medley|TTBB|Jay Giallombardo
@@ -3118,6 +3745,8 @@ Children Go Where I Send Thee|TTBB|Jon Nicholas
 Children Of The Heavenly Father|TTBB|Paul Jorg
 Children Run Joyfully|SSAA|Kay Bromert
 Children Will Listen|SSAA|Melody Hine
+Children's Medley (Jolly Old St. Nicholas/Up on the Housetop)|TTBB|Barbershop Harmony Society
+Chili con Carne|SSAA|Anders Edenroth
 Chili Con Carne|SATB|Joe Mannherz
 Chill or Be Chilled|SATB|Deke Sharon
 Chim Chim Cher-ee|SSAA|June Dale
@@ -3130,6 +3759,7 @@ Chipmunks Christmas Song|TTBB|Roger Payne
 Chiquita Banana|SSAA|Connie Kash
 Chiquita Banana|TTBB|Dave Mohr
 Chitty Car Medley|SSAA|Tom Gentry
+Chitty Chitty Bang Bang|SSAA|Joni Bescos
 Chitty Chitty Bang Bang|SSAA|Tom Gentry
 Chitty Chitty Bang Bang|TTBB|Mark Goodney
 Chitty Chitty Bang Bang|TTBB|Nick Bryant
@@ -3137,31 +3767,49 @@ Chitty Chitty Bang Bang|TTBB|Tom Gentry
 Chloe|TTBB|Ed Waesche
 Cho Superstar|TTBB|Adam Scott
 Choc'late in My Stocking|TTBB|Aaron Dale
+Choc'late In My Stocking|SSAA|Aaron Dale
+Choc'late In My Stocking|SSAA|Lynnell Diamond
 Chocolate|SSAA|Jan Meyer
 Chocolate|SSAA|Marge Bailey
 Chocolate Ice Cream Cone|TTBB|Tom Gentry
 Chocolate In My Stocking|SSAA|Aaron Dale
 Chocolate In My Stocking|TTBB|Aaron Dale
+Choo Choo Ch' Boogie|TTBB|Walter Latzko
 Choo Choo Ch'Boogie|SSAA|Becky Wilkins
 Choo Choo Ch'Boogie|SSAA|Cheryl Suhr
 Choo Choo Ch'Boogie|SSAA|LaVeda Redfield
+Choo Choo Train|SSAA|Joan Adler
 Choose Your Fighter|TTBB|Gabriel Lawson
+Chordbuster March|SSAA|Joe Liles
+Chordbuster March|SSAA|WA Wyatt
+Chordbuster's March|SSAA|A. A. Wyatt
+Chordbuster's March|TTBB|WA Wyatt
+Chordbusters March|SSAA|WA Wyatt
 Chosen Family|SSAA|Melody Hine
 Christ Child Carols Medley|TTBB|Jay Giallombardo
+Christ-Mas|SSAA|Greta Somers
 CHRISTmas|SSAA|Greta Somers
+CHRISTMAS|SSAA|Tedda Lippincott
 Christmas (Baby Please Come Home)|SATB|Deke Sharon
 Christmas (Baby Please Come Home)|SSAA|Simon Arnott
 Christmas Back Home|TTBB|Walter Latzko
 Christmas Canon|SSAA|Carole Prietto
+Christmas Canon (with Children's Choir)|SATB|Shaun Agnew
+Christmas Carol Medley|SSAA|Marie Johnson
+Christmas Carol Medley|TTBB|Barbershop Harmony Society
 Christmas Carol Medley Singalong|TTBB|Carl Taylor
 Christmas Children|SSAA|Kay Bromert
 Christmas Children|SSAA|Larry Wright
+Christmas Chopstick|SSAA|Traditional
 Christmas Chopsticks|SSAA|Anastasio Rossi
 Christmas Chopsticks|SSAA|Earl Moon
 Christmas Chopsticks|SSAA|Larry Wright
+Christmas Chopsticks|SSAA|Unspecified
 Christmas Chopsticks|TTBB|Earl Moon
 Christmas Chopsticks|TTBB|Jim West
 Christmas Chopsticks|TTBB|Larry Wright
+Christmas Chopstix|SSAA|Sweet Adelines International
+Christmas Chopstix|SSAA|Unspecified
 Christmas Cookie|TTBB|Jon Nicholas
 Christmas Day (The North Wind)|SSAA|Glenda Lloyd
 Christmas Dinner|TTBB|Tom Gentry
@@ -3169,21 +3817,28 @@ Christmas Dreams Song|SSAA|Mary K. Coffman Music Fund
 Christmas Eve In My Home Town|TTBB|Joe Colon
 Christmas Eve In My Home Town|TTBB|Mark Hale
 Christmas Eve In My Home Town|TTBB|Roy Keys
+Christmas Eve In My Hometown|TTBB|Hal Maples
+Christmas Eve In My Hometown|TTBB|Mark Hale
+Christmas Eve in Washington|SSAA|Ann Minihane
 Christmas Folly|SSAA|Jay Giallombardo
 Christmas Folly|TTBB|Jay Giallombardo
 Christmas Fun Medley|TTBB|Tom Gentry
 Christmas Holiday|TTBB|Gabriel Lawson
 Christmas Holidays Medley|SSAA|Jo Lund
+Christmas In Dixie|SSAA|Joe Liles
 Christmas in Kentucky|SATB|Jon Nicholas
 Christmas in Kentucky|SSAA|Jon Nicholas
 Christmas in Kentucky|TTBB|Jon Nicholas
 Christmas In Kilarney|SSAA|Larry Wright
 Christmas In Kilarney|TTBB|Larry Wright
 Christmas In New Orleans|SSAA|Jo Lund
+Christmas in San Francisco|SSAA|Lynnell Diamond
 Christmas In The Air|TTBB|Derric Johnson
 Christmas in Three Minutes|TTBB|Tom Gentry
 Christmas Is|SSAA|Patricia Godfrey
 Christmas Is A Feeling|SSAA|Tedda Lippincott
+Christmas Is Meant For Children|SSAA|Renee Craig
+Christmas Is The Best Time Of The Year|SSAA|Judy Vidal
 Christmas Island|SSAA|Dianne Goldrick
 Christmas Island|SSAA|Jean Shook
 Christmas Island|SSAA|Walter Latzko
@@ -3196,12 +3851,19 @@ Christmas Lights|SSAA|Kay Bromert
 Christmas Lullaby|SATB|Joe Mannherz
 Christmas Lullaby|SSAA|Jeanne Elmuccio
 Christmas Magic|SSAA|Patricia Godfrey
+Christmas Means|TTBB|Joe Johnson
+Christmas Medley|SSAA|Tedda Lippincott
 Christmas Medley|TTBB|Bud Arberg
 Christmas Medley|TTBB|Tom Gentry
+Christmas Medley|TTBB|Unspecified
+Christmas Medley for Kids|SSAA|Marsha Zwicker
 Christmas Needs Love to Be Christmas|SSAA|Jo Lund
 Christmas Of Love|SATB|Chris Arnold
 Christmas On The Beach At Waikiki|TTBB|T. W. De Crow
+Christmas Overture|TTBB|Kenny Ray Hatton and Joe Johnson
 Christmas Sludge|SATB|Anders Lindqvist
+Christmas Stays the Same|SSAA|Joe Johnson
+Christmas Stays The Same|TTBB|Joe Johnson
 Christmas Through Your Eyes|SATB|Larry Triplett
 Christmas Through Your Eyes|SSAA|Larry Triplett
 Christmas Through Your Eyes|TTBB|Larry Triplett
@@ -3209,15 +3871,19 @@ Christmas Time|TTBB|Mark Stevens
 Christmas Time (Don't Let The Bells End)|TTBB|Simon Arnott
 Christmas Time Is Here|SATB|Kirk Young
 Christmas Time Is Here|SATB|Kohl Kitzmiller
+Christmas Time Is Here|SSAA|Adam Bock
+Christmas Time Is Here|SSAA|Carole Prietto
 Christmas Time Is Here|SSAA|Jan Olson
 Christmas Time Is Here|SSAA|Kohl Kitzmiller
 Christmas Time Is Here|SSAA|Patsee Parker
 Christmas Time Is Here|SSAA|Sharon Holmes
 Christmas Time Is Here|TTBB|Adam Bock
 Christmas Time Is Here|TTBB|Al Fisk
+Christmas Time Is Here|TTBB|Brian Beck
 Christmas Time Is Here|TTBB|Deke Sharon
 Christmas Time Is Here|TTBB|Derric Johnson
 Christmas Time Is Here|TTBB|Gabriel Lawson
+Christmas Time Is Here|TTBB|Jay Giallombardo
 Christmas Time Is Here|TTBB|Jim Shubert
 Christmas Time Is Here|TTBB|Jon Nicholas
 Christmas Time Is Here|TTBB|Ken Potter
@@ -3235,7 +3901,9 @@ Christmas Waltz|TTBB|Gabriel Lawson
 Christmas Waltz|TTBB|Jim Shubert
 Christmas Waltz|TTBB|Mark Goodney
 Christmas Waltz / Silver Bells|SSAA|Tedda Lippincott
+Christmas Waltz/Silver Bells Medley|SSAA|Tedda Lippincott
 Christmas Was Meant For Children|SSAA|Brent Graham
+Christmas Was Meant For Children|SSAA|Renee Craig
 Christmas Why Can't I Find You|TTBB|Gabriel Lawson
 Christmastime is here|SATB|Bryan W. Pulver
 Christmastime is here|SATB|Joe Mannherz
@@ -3245,6 +3913,9 @@ Christmastime is here|TTBB|Brent Graham
 Christmastime is here|TTBB|Carole Prietto
 Chuck E's In Love|SATB|Deke Sharon
 Chugwater|TTBB|Todd Troutman
+Church Bells|SSAA|Clay Hine
+Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
+Church Bells Parody|TTBB|Clay Hine
 Cielito Lindo|SATB|Deke Sharon
 Cinderella|TTBB|Adam Bock
 Cinderella|TTBB|Adam Scott
@@ -3252,15 +3923,24 @@ Cinderella|TTBB|Gene Cokeroft
 Cinderella Girl|TTBB|Mark Jennings
 Circle Of Friends|SSAA|Gloria Eddy
 Circle Of Friends|SSAA|Kay Bromert
+Circle of Life|SSAA|Lorraine Rochefort
 Circle Of Life|TTBB|Jake Jacobson
+Circle Of Life|TTBB|Jay Giallombardo
+Circle Of Life|TTBB|R. Soderlund
+Circle of Life (Chorus Parts Only)|TTBB|R. Soderlund
+Circle of Life (chorus with 4-part overlay)|SSAA|Lorraine Rochefort
+Circle Of Life All|SATB|R. Soderlund, Chris Arnold
+Circle Of Life Men|TTBB|R. Soderlund, Chris Arnold
 Circle of Life/He Lives In You Medley|SATB|Deke Sharon
 Circus Day In Dixie|TTBB|Ed Waesche
 Circus Medley|TTBB|Rob Campbell
+Circus Medley|TTBB|Steve Tramack
 Cities Medley|TTBB|Jay Giallombardo
 City Lights|SSAA|Jo Lund
 City Of New Orleans|TTBB|Jordan Johnson
 City Of New Orleans|TTBB|Mike Menefee
 City of Stars|SSAA|Liz Garnett
+Civil War Medley|TTBB|Barbershop Harmony Society
 Civil War Medley|TTBB|Jay Giallombardo
 Civil War Medley|TTBB|SPEBSQSA
 Civil War Medley|TTBB|Tom Gentry
@@ -3268,6 +3948,7 @@ Clampdown|TTBB|Deke Sharon
 Clancy Lowered The Boom|SSAA|Larry Wright
 Clancy Lowered The Boom|TTBB|Larry Wright
 Clancy Lowered The Boom|TTBB|Paul Bowman
+Clap Hands|TTBB|Will Hamblet
 Clap Yo Hands|SSAA|Walter Latzko
 Clap Yo Hands|TTBB|Steve Jamison
 Clarity|SATB|Nicholas Wright
@@ -3277,6 +3958,7 @@ Classical Gas|SATB|Aaron Dale
 Clean|SATB|Nicholas Wright
 Cleanin' Up The Town|TTBB|Dom Finetti
 Cleanin' Up The Town|TTBB|Theodore Hicks
+Clear-Day|TTBB|Unspecified
 Cleopatra, Queen of Denial|SSAA|Dan Wessler
 Climb Ev'ry Mountain|SSAA|Adam Bock
 Climb Ev'ry Mountain|SSAA|Jay Giallombardo
@@ -3293,6 +3975,13 @@ Climb Ev'ry Mountain|TTBB|Scott Kitzmiller
 Climb Ev'ry Mountain|TTBB|Steve Delehanty
 Climb Ev'ry Mountain|TTBB|Tom Gentry
 Climb Ev'ry Mountain|TTBB|Walter Latzko
+Climb Every Mountain|SSAA|Joe Liles
+Climb Every Mountain|SSAA|Nancy Bergman
+Climb Every Mountain|SSAA|Unspecified
+Climb Every Mountain|TTBB|Don Gray
+Climb Every Mountain|TTBB|Frank Bloebaum
+Climb Every Mountain|TTBB|Jay Giallombardo
+Climb Every Mountain|TTBB|Steve Delehanty
 Climbin' Up The Mountain|SSAA|Marie Johnson
 Clocks|SATB|Deke Sharon
 Clocks|TTBB|Deke Sharon
@@ -3306,49 +3995,62 @@ Close To You|TTBB|Jeremey Johnson
 Close Your Eyes|SSAA|Kyle Snook
 Closer To Fine|SATB|Jay Dougherty
 Closer To Fine|SSAA|Jay Dougherty
+Closest Thing To Crazy (Katie Melua)|SSAA|Linda Corcoran
 Cloud|SSAA|Nicholas Wright
 Cloudburst|SATB|Joe Mannherz
 Cloudburst|TTBB|Larry Triplett
 Clouds|SATB|Deke Sharon
+Clown (Emile Sande)|SSAA|Lisa Hannant
 Clown Medley|SSAA|Jay Giallombardo
 Clown Medley|TTBB|Jay Giallombardo
 Clown Medley|TTBB|Tom Gentry
 Club At The End of the Street|SATB|Deke Sharon
+Cocktails for Two|SSAA|Joni Bescos
 Cocktails For Two|TTBB|Barbershop Harmony Society
 Cocktails For Two|TTBB|Merrill Miller
 Cocktails For Two|TTBB|Richard Lengel
 Cocktails For Two|TTBB|SPEBSQSA
 Cocktails For Two|TTBB|Steve Tramack
 Cocktails For Two|TTBB|Todd Troutman
+Coconut|SSAA|Joe Liles
 Coconut Nut, The (Coconut Song)|SSAA|Jay Dougherty
 Coffee calls for a Cigarette|SATB|Joe Mannherz
 Coffee In A Cardboard Cup|SSAA|Tedda Lippincott
 Coffee In A Cardboard Cup|TTBB|Michael Webber
 Coffee In A Cardboard Cup|TTBB|Steve Tramack
+Cohan Medley|SSAA|Aileen Nightingale
+Cohan Medley|SSAA|Bergman/Nightingale
 Cohan Medley|SSAA|Nancy Bergman
 Cohan Medley|TTBB|Jack Baird
+Cold & Fugue|SSAA|Foncannon/Jones
 Cold Jordan|TTBB|Jim West
 Cold Water|TTBB|Nicholas Wright
 Cold-Hearted|SSAA|Julie Starr
 Cold-Hearted Man|SATB|Hannah Briggs
 Cole Porter Love Songs Medley|TTBB|John Hohl
 Colleen My Own|TTBB|George Hulst
+College Days Medley|TTBB|Tom Gentry
 College Medley|TTBB|George Davidson
 College Medley|TTBB|Val Hicks
 College Years|TTBB|Tom Gentry
+Collegiate|TTBB|Chuck Brooks
 Collegiate Love|TTBB|Dennis Driscoll
 Collegiate Love|TTBB|Jay Giallombardo
 Collegiate Sam|SSAA|Jay Giallombardo
 Collegiate Sam|TTBB|Jay Giallombardo
 Color The Children|SSAA|June Berg
 Colorado Christmas|TTBB|Jay Giallombardo
+Colorado My Home|TTBB|Darin Drown
 Colorado Trail|TTBB|Todd Troutman
 Colorado, My Home|SSAA|Sylvia Alsbury
+Colors of the Wind|SSAA|Tedda Lippincott
+Colors of the Wind|TTBB|Chris MacMartin
 Colors Of The Wind|SATB|Anders Lindqvist
 Colors Of The Wind|SATB|Melody Hine
 Colors Of The Wind|SSAA|Katie Taylor
 Colors Of The Wind|SSAA|Melody Hine
 Colors Of The Wind|TTBB|Melody Hine
+Colours of the Wind|SSAA|Liz Garnett
 Columbia, The Gem of the Ocean Medley|TTBB|Paul Jorg
 Columbus '92|TTBB|Jim West
 Come Alive|TTBB|Aaron Dale
@@ -3357,6 +4059,7 @@ Come Along My Mandy|TTBB|Burt Szabo
 Come and Get Your Love|SATB|Sheryl Neal
 Come and Get Your Love|TTBB|Gabriel Lawson
 Come and Get Your Love|TTBB|Nicholas Wright
+Come And See What's Hap'nin' In The Barn|TTBB|Jay Giallombardo
 Come Back And See Us|SSAA|Larry Wright
 Come Back And See Us|TTBB|Larry Wright
 Come Back To Me|SSAA|Aaron Dale
@@ -3373,20 +4076,27 @@ Come Dance With Me|TTBB|Larry Wright
 Come Dance With Me|TTBB|Patrick McAlexander
 Come Dance With Me / Come Fly With Me Medley|TTBB|Kevin Keller
 Come Dance with Me with Come Fly with Me|TTBB|Kevin Keller
+Come Dance With Me/Come Fly With Me Medley|TTBB|Kevin Keller
 Come Fly With Me|SATB|Deke Sharon
 Come Fly With Me|SATB|Kevin Keller
 Come Fly With Me|SSAA|Carolyn Schmidt
 Come Fly With Me|SSAA|Kevin Keller
 Come Fly With Me|TTBB|Kevin Keller
+Come Fly With Me|TTBB|Unspecified
+Come Fly With Me/Fly Me To The Moon Medley(Joel T. Ruther|SATB|Joel T. Rutherford
+Come Follow The Band|SSAA|Ann Minihane
 Come Follow The Band|TTBB|Steve Tramack
 Come Go With Me|SATB|Tom Gentry
 Come Go With Me|SSAA|Tom Gentry
+Come Go With Me|TTBB|Daniel Goldschmidt
 Come Go With Me|TTBB|Tom Gentry
 Come Home|SATB|Nicholas Wright
 Come Home Medley|TTBB|Eric Ruthenberg
 Come In From The Cold|TTBB|Kyle Snook
+Come In From the Rain|SSAA|Betty Oliver
 Come In From The Rain|SSAA|David Wright
 Come In From The Rain|SSAA|Jo Lund
+Come Josephine In My Flying Machine|TTBB|Burt Szabo
 Come Live with Me|SSAA|Jay Giallombardo
 Come Live with Me|TTBB|Jay Giallombardo
 Come On And Sing!|SSAA|June Dale
@@ -3398,6 +4108,7 @@ Come On Home|SSAA|Kay Bromert
 Come On-A My House|SSAA|Walter Latzko
 Come On, Ring Those Bells|SSAA|Joey Minshall
 Come On, Ring Those Bells|TTBB|Paul Jorg
+Come Rain or Come Shine|SSAA|Ardeth Fullmer
 Come Rain Or Come Shine|SSAA|Jo Lund
 Come Rain Or Come Shine|SSAA|Scott Kitzmiller
 Come Rain Or Come Shine|SSAA|Steve Tramack
@@ -3412,6 +4123,8 @@ Come See What's Happenin' in the Barn|SSAA|Jay Giallombardo
 Come See What's Happenin' in the Barn|SSAA|Jeremey Johnson
 Come See What's Happenin' in the Barn|TTBB|Jay Giallombardo
 Come See What's Happenin' in the Barn|TTBB|Jeremey Johnson
+Come See What's Happening In The Barn|TTBB|Jeremey Johnson
+Come Share His Life With Me|TTBB|Richard Loebakka
 Come Softly To Me|TTBB|Deke Sharon
 Come Softly To Me|TTBB|Michael Holmes
 Come Take Your Place in My Heart|SSAA|Jim Clancy
@@ -3439,9 +4152,16 @@ Come, Thou Almighty King|SSAA|Walter Latzko
 Come, Thou Almighty King|TTBB|Jon Nicholas
 Come, Thou Almighty King|TTBB|Walter Latzko
 Come, Ye Thankful People, Come|TTBB|Jon Nicholas
+Comedy (Harmony) Tonight|SSAA|Sharon Holmes
+Comedy Tonight|SSAA|Betty Steele
 Comedy Tonight|TTBB|Dennis Burnett
 Comedy Tonight|TTBB|Don Gray
+Comedy Tonight|TTBB|Hal Maples
+Comedy Tonight|TTBB|Roger Payne
 Comedy Tonight|TTBB|Vincent Zito
+Comelet Us Sing Of Christmas Day|SSAA|Renee Craig
+Comes Love|SSAA|Adam Reimnitz
+Comes Love|TTBB|Adam Reimnitz
 Comfortable|TTBB|Dan Wessler
 Comfortable|TTBB|Dom Finetti
 Comfortably Numb|TTBB|Anders Lindqvist
@@ -3459,23 +4179,28 @@ Commerical Medley|TTBB|Jay Giallombardo
 Communion Song|TTBB|Ken Potter
 Company|SSAA|Glenda Lloyd
 Completely|SSAA|Liz Garnett
+Coney Island Baby|TTBB|Barbershop Harmony Society
 Coney Island Baby / Baby Face Medley|TTBB|Steve Jamison
 Coney Island Baby / We All Fall Medley|TTBB|Barbershop Harmony Society
 Coney Island Baby / We All Fall Medley|TTBB|SPEBSQSA
 Coney Island Medley|SSAA|Jay Giallombardo
 Coney Island Medley|TTBB|Jay Giallombardo
 Coney Island Washboard|SSAA|Ardeth Fullmer
+Coney Island Washboard|SSAA|Clay Hine
 Coney Island Washboard|TTBB|Barbershop Harmony Society
 Coney Island Washboard Roundelay|TTBB|Clay Hine
+Conga/Rhythm Medley|SSAA|Brian Beck
 Congratulate Me|SSAA|Jo Lund
 Congratulate Me|TTBB|Dennis Driscoll
 Congratulations|SATB|Karen Penketh
 Connecticut|SSAA|Adam Bock
+Connie Francis Medley: Lipstick Collar, Who'S Sorry Now|SSAA|Unspecified
 Consider Yourself|SSAA|Dot Calvin
 Consider Yourself|SSAA|Jay Giallombardo
 Consider Yourself|SSAA|Tom Gentry
 Consider Yourself|TTBB|Dennis Driscoll
 Consider Yourself|TTBB|Derric Johnson
+Consider Yourself|TTBB|Don Gray
 Consider Yourself|TTBB|Ed Waesche
 Consider Yourself|TTBB|Jay Giallombardo
 Consider Yourself|TTBB|Joe Mannherz
@@ -3483,13 +4208,18 @@ Consider Yourself|TTBB|John Muir
 Consider Yourself|TTBB|Mark Goodney
 Consider Yourself|TTBB|Tom Gentry
 Consider Yourself (from "Oliver!")|TTBB|Tom Gentry
+Consider Yourself At Home (YWIH)|SSAA|Dot Calvin
+Convoy|TTBB|Bryan Ziegler
+Cool Water|TTBB|Don Gray
 Cool Water|TTBB|Jon Nicholas
 Cool Water|TTBB|Todd Troutman
 Cool Yule|SSAA|June Berg
 Cool Yule|SSAA|Susan Kegley
 Cool Yule|TTBB|Aaron Dale
 Cool Yule|TTBB|Mark Goodney
+Cop On The Beat|TTBB|Fred King
 Copacabana|SATB|Matt Astle
+Copacabana|SSAA|Greg Volk
 Copacabana|SSAA|Jean McFadyen
 Copacabana|SSAA|Tom Gentry
 Copacabana|TTBB|Matt Astle
@@ -3510,14 +4240,18 @@ Cottage For Sale|TTBB|Brent Graham
 Cottage For Sale|TTBB|Theodore Hicks
 Cotton Candy And A Toy Balloon|TTBB|Norm Benson
 Cotton Club Medley|TTBB|Tom Gentry
+Cotton Fields (Them Old...)|TTBB|Peter Mumford
 Could 'Ja?|TTBB|Wayne Grimmer
 Could I Have This Dance|SSAA|Charlene Yazurlo
+Could I Have This Dance|SSAA|Joni Bescos
 Could I Have This Dance|SSAA|June Berg
 Could It Be Magic|SSAA|Sam Hubbard
 Could It Be Magic|TTBB|Sam Hubbard
+Could It Be Magic?|SSAA|Renee Craig
 Count On Me|SATB|Chris Arnold
 Count On Me|SATB|Dianne Goldrick
 Count On Me|SSAA|Dianne Goldrick
+Count On Me|SSAA|Elaine Gain
 Count On Me|SSAA|Jen Squires
 Count On Me|SSAA|Jeremey Johnson
 Count On Me|SSAA|Joey Minshall
@@ -3531,6 +4265,8 @@ Count your blessings|TTBB|Brent Graham
 Count your blessings|TTBB|Joe Mannherz
 Count your blessings|TTBB|Paul Jorg
 Count your blessings|TTBB|Todd Troutman
+Count Your Blessings|SSAA|Sharon Holmes
+Count Your Blessings|TTBB|Jim Massey
 Count Your Blessings Instead Of Sheep|SATB|Adam Bock
 Count Your Blessings Instead Of Sheep|SSAA|Jeanne Elmuccio
 Count Your Blessings Instead Of Sheep|SSAA|Wayne Grimmer
@@ -3541,9 +4277,18 @@ Counting Stars|SATB|Nicholas Wright
 Counting Stars|TTBB|Nicholas Wright
 Country Boy|SSAA|Aaron Dale
 Country Boy|TTBB|Aaron Dale
+Country Dances|SATB|Ward Swingle
+Country Girl|SSAA|Aaron Dale
+Country Girl (Country Boy)|SSAA|Aaron Dale
+Country Roads|SSAA|Nancy Bergman
+Country Roads|TTBB|Steve Jamison
+Country Roads Take Me Home|TTBB|Steve Jamison
 Country Roads with Sunshine On My Shoulders (Medley)|SSAA|Steve Jamison
 Country Roads with Sunshine On My Shoulders (Medley)|TTBB|Steve Jamison
+Country Roads, Take Me Home|SSAA|Nancy Bergman
+Country Roads/Sunshine On My Shoulders Medley|TTBB|Steve Jamison
 Country Rock Medley|TTBB|Dick Rode
+County Fair|TTBB|Russ Foris
 Cousin Dupree|SATB|Joe Mannherz
 Cousin Dupree|TTBB|Joe Mannherz
 Coventry Carol|SSAA|Carole Prietto
@@ -3551,12 +4296,15 @@ Coventry Carol|SSAA|Dianne Goldrick
 Coventry Carol|SSAA|Liz Garnett
 Coventry Carol|SSAA|Renee Craig
 Coventry Carol|TTBB|Anders Lindqvist
+Coventry Carol|TTBB|Barbershop Harmony Society
 Coventry Carol|TTBB|Dianne Goldrick
 Coventry Carol|TTBB|Gabriel Lawson
 Coventry Carol|TTBB|Inc. SPEBSQSA
 Coventry Carol|TTBB|Matt Astle
+Coventry Carol|TTBB|Renee Craig
 Coventry Carol|TTBB|SPEBSQSA
 Cover Me In Sunshine|SSAA|Corinna Garriock
+Cow Patti|TTBB|Don Gray
 Cow-cow Boogie|SSAA|Dianne Goldrick
 Cowboy Casanova|SATB|Deke Sharon
 Cowboys and Angels|TTBB|Kohl Kitzmiller
@@ -3572,8 +4320,10 @@ Crazy|SATB|Deke Sharon
 Crazy|SSAA|Avis Fellows
 Crazy|SSAA|Barbara Huffman
 Crazy|SSAA|Carolyn Schmidt
+Crazy|SSAA|Clay Hine
 Crazy|SSAA|Jean Shook
 Crazy|SSAA|Larry Wright
+Crazy|SSAA|Lorraine Rochefort
 Crazy|SSAA|Nancy Bergman
 Crazy|SSAA|Scott Kitzmiller
 Crazy|SSAA|Sylvia Alsbury
@@ -3586,23 +4336,29 @@ Crazy|TTBB|Todd Troutman
 Crazy|TTBB|Walter Latzko
 Crazy 'Bout Ya Baby|TTBB|Don Gillespie
 Crazy 'Bout Ya Baby|TTBB|Don Gray
+Crazy 'Bout Ya Baby|TTBB|Larry Wright
 Crazy 'Bout Ya Baby|TTBB|Rob Campbell
+Crazy 'Bout Ya, Baby|TTBB|Rob Campbell
 Crazy Amazing|SATB|Deke Sharon
 Crazy Dreams|SSAA|Jen Squires
 Crazy Dreams|SSAA|Joey Minshall
 Crazy for You|SSAA|Liz Garnett
+Crazy For You (Madonna)|SSAA|Liz Garnett
 Crazy Little Thing Called Love|SATB|Deke Sharon
 Crazy Little Thing Called Love|SSAA|Aaron Dale
 Crazy Little Thing Called Love|SSAA|Jay Giallombardo
 Crazy Little Thing Called Love|SSAA|Kohl Kitzmiller
 Crazy Little Thing Called Love|TTBB|Aaron Dale
+Crazy Little Thing Called Love|TTBB|Chris Peterson
 Crazy Little Thing Called Love|TTBB|Deke Sharon
 Crazy Little Thing Called Love|TTBB|Jay Giallombardo
 Crazy Little Thing Called Love|TTBB|Kohl Kitzmiller
 Crazy Little Thing Called Love|TTBB|Nicholas Wright
+Crazy Man Medley|TTBB|Greg Lapp, Rich Hasty
 Crazy People|TTBB|Jeremey Johnson
 Crazy She Calls Me|TTBB|Brian Mastrull
 Crazy Train|TTBB|Deke Sharon
+Crazy Words, Crazy Tune|TTBB|139th Street Quartet
 Crazy World|SSAA|Brent Graham
 Crazy World|TTBB|Brent Graham
 Creep|SATB|Melody Hine
@@ -3616,15 +4372,19 @@ Creep|TTBB|Rowena Harper
 Creole Cutie|SATB|Nancy Bergman
 Creole Cutie|SSAA|Nancy Bergman
 Creole Cutie|TTBB|Bill Busby
+Creole Cutie|TTBB|Unspecified
 Crinoline Days|TTBB|Tom Gentry
 Crocodile Rock|SSAA|Rowena Harper
 Cross Over The Bridge|TTBB|Jim Shubert
+Cross That Mason Dixon Line|TTBB|David Wright
 Cross That Mason-Dixon Line|TTBB|Earl Moon
 Crossing The Bar|TTBB|Burt Szabo
 Crossing The Bar|TTBB|Jack Baird
+Crown Him with Many Crowns|TTBB|Heather Sorenson
 Crown Him With Many Crowns|TTBB|Jon Nicholas
 Cruel Summer|SATB|Nicholas Wright
 Cruella De Vil|SSAA|David Wright
+Cruella De Vil|SSAA|Lynnell Diamond
 Cruella De Vil|SSAA|Melody Hine
 Cruella De Vil|TTBB|David Wright
 Cruella De Vil|TTBB|Tom Wheeler
@@ -3635,6 +4395,7 @@ Cruisin' Down The River|TTBB|Leif Erickson
 Cruisin' Down The River|TTBB|Mo Rector
 Cruisin' Down The River|TTBB|Steve Jamison
 Cruisin' Down The River|TTBB|Walter Latzko
+Cruising Down The River|TTBB|Mo Rector
 Cry|SSAA|Walter Latzko
 Cry|TTBB|Adam Scott
 Cry|TTBB|Don Gray
@@ -3643,11 +4404,14 @@ Cry|TTBB|Walter Latzko
 Cry Baby|SSAA|Nancy Bergman
 Cry Baby Blues|SSAA|Charlotte Pernert
 Cry Baby Blues|SSAA|Marsha Zwicker
+Cry Baby/So Long Dearie|SSAA|Nancy Bergman
 Cry Me A River|SATB|Deke Sharon
 Cry Me A River|SSAA|Brent Graham
 Cry Me A River|SSAA|Carolyn Healey
 Cry Me A River|SSAA|Jo Lund
 Cry Me A River|SSAA|Liz Garnett
+Cry Me A River|SSAA|Peter W Godfrey
+Cry Me A River|SSAA|Unspecified
 Cry Me A River|TTBB|Brent Graham
 Cry Me A River|TTBB|Mark Burnip
 Cry Today, Smile Tomorrow|SSAA|Rowena Harper
@@ -3657,6 +4421,7 @@ Cryin' for The Carolines|TTBB|Roy Keys
 Crying|SSAA|Tom Gentry
 Crying|TTBB|David Wright
 Crying|TTBB|Tom Gentry
+Crying|TTBB|Unspecified
 Crying for You|TTBB|Fred King
 Crying in the Rain|SSAA|Tom Gentry
 Crying in the Rain|TTBB|Tom Gentry
@@ -3665,14 +4430,18 @@ Crying Myself To Sleep|SSAA|Nancy Bergman
 Cuando Calienta El Sol|SSAA|Carol Lord
 Cuando Nos Volvamos A Encontrar|SATB|Dan Wessler
 Cuanto Le Gusta|SSAA|Zona Snyder
+Cuddle Up|TTBB|Clay Hine
 Cuddle Up A Little Closer|SSAA|Ed Hinkley
 Cuddle Up A Little Closer|SSAA|Molly Rowland
 Cuddle Up A Little Closer|SSAA|Nancy Bergman
 Cuddle Up A Little Closer|TTBB|Burt Szabo
+Cuddle Up A Little Closer|TTBB|Clay Hine
 Cuddle Up A Little Closer|TTBB|Walter Latzko
 Cuddle Up A Little Closer, Lovey Mine|TTBB|Burt Szabo
 Cup Of Coffee, A Sandwich and You|TTBB|Walter Latzko
+Cup Song|SSAA|J. Mariano
 Cupid Shuffle|TTBB|Kyle Kitzmiller
+Cups (Pitch Perfect)|SSAA|Kirby Shaw
 Cups (When I'm Gone)|SATB|Kirby Shaw
 Cups (When I'm Gone)|SSAA|Deke Sharon
 Cups (When I'm Gone)|SSAA|Jenna Kellas
@@ -3691,15 +4460,21 @@ Daddy (You oughta get the best for me...)|SSAA|Nancy Bergman
 Daddy Get Your Baby Out Of Jail|TTBB|Rob Hopkins
 Daddy Sang Bass|SATB|Jim Shubert
 Daddy Sang Bass|SSAA|Jay Giallombardo
+Daddy Sang Bass|SSAA|Larry Wright
 Daddy Sang Bass|TTBB|Barbershop Harmony Society
+Daddy Sang Bass|TTBB|Carl Perkins
 Daddy Sang Bass|TTBB|Chris Arnold
 Daddy Sang Bass|TTBB|Jay Giallombardo
+Daddy Sang Bass Baseball Parody|TTBB|Unspecified
 Daddy Sang Bass/Will The Circle Be Unbroken|SSAA|Larry Wright
 Daddy Sang Bass/Will The Circle Be Unbroken|TTBB|Larry Wright
+Daddy You've Been a Mother to Me|TTBB|Jack Baird
 Daddy, You've Been a Mother To Me|SSAA|Jay Giallombardo
 Daddy, You've Been a Mother To Me|TTBB|Jack Baird
 Daddy, You've Been a Mother To Me|TTBB|Jay Giallombardo
 Daddy, You've Been a Mother To Me|TTBB|Tom Gentry
+Daddy's Little Girl|SSAA|Don Gray
+Daddy's Little Girl|SSAA|Nancy Bergman
 Daddy's Little Girl|TTBB|David Wright
 Daddy's Little Girl|TTBB|Don Gray
 Daddy's Little Girl|TTBB|J Rae Jamieson
@@ -3711,6 +4486,8 @@ Daddy's Little Girl|TTBB|Roy Keys
 Daddy's Little Girl|TTBB|Walter Latzko
 Daisies|SATB|Mark Stevens
 Daisy Bell|TTBB|Jon Nicholas
+Daisy Bell (A Bicycle Built For Two)|TTBB|Jon Nicholas
+Daisy Bell (Bicycle Built For Two)|TTBB|Jon Nicholas
 Daisy/Summer Time Medley|SSAA|Jay Giallombardo
 Daisy/Summer Time Medley|TTBB|Jay Giallombardo
 Dakota|TTBB|Bob Dowma
@@ -3729,12 +4506,17 @@ Dance With Me Tonight|TTBB|Nicholas Wright
 Dance With My Father|TTBB|Cay Outerbridge
 Dance With My Father|TTBB|Theo Hicks
 Dance With My Father|TTBB|Theodore Hicks
+Dancin (Darktown Strutters Ball Adaptation)|SSAA|Judy Vidal
 Dancin' Dan|TTBB|Dennis Driscoll
 Dancin' In The Moonlight|TTBB|Deke Sharon
 Dancin' In The Moonlight|TTBB|Kohl Kitzmiller
+Dancin' in the Streets|TTBB|Jay Giallombardo
+Dancin' in the Streets of New Orleans|SSAA|Bergman/Hill
+Dancin' in the Streets of New Orleans/Mardis Gras March|SSAA|Marsha Hill/Nancy Bergman
 Dancing At The Moving Picture Ball|TTBB|Rob Hopkins
 Dancing Frankie Medley|TTBB|Tom Gentry
 Dancing In The Dark|SATB|Hannah Briggs
+Dancing in the Dark Medley|SSAA|Nancy Bergman
 Dancing In The Street|SATB|Alexander Ronneburg
 Dancing In The Street|SATB|Deke Sharon
 Dancing In The Street|SATB|Patrick McAlexander
@@ -3749,6 +4531,7 @@ Dancing In The Street|TTBB|Jay Giallombardo
 Dancing In The Street|TTBB|Larry Wright
 Dancing In The Street|TTBB|Steve Tramack
 Dancing In The Streets of New Orleans|SSAA|Nancy Bergman
+Dancing Medley|SSAA|Joe Mannherz
 Dancing On My Own|SATB|Nicholas Wright
 Dancing On My Own|TTBB|Cay Outerbridge
 Dancing On The Ceiling|TTBB|Walter Latzko
@@ -3756,14 +4539,19 @@ Dancing Our Worries Away|TTBB|Burt Szabo
 Dancing Queen|SATB|Deke Sharon
 Dancing Queen|SSAA|Ã…se Hagerman
 Dancing Queen|SSAA|Deke Sharon
+Dancing Queen|SSAA|Elaine Gain
 Dancing Queen|SSAA|Takako Fuke
+Dancing Queen|TTBB|Steven Armstrong
 Dancing Queen|TTBB|Todd Troutman
+Dancing Queen (Gain)|SSAA|Elaine Gain
 Dancing Through Life|TTBB|Greg Mallett
 Dancing Through Life|TTBB|Simon Arnott
 Danger Zone|SSAA|Emily Moriarty
 Danger Zone|TTBB|Adam Bock
 Danger Zone|TTBB|Nicholas Wright
+Dangerous Dan|TTBB|Sidewinders
 Dangerous Dan McGrew|TTBB|Carole Prietto
+Dangerous Dan McGrew|TTBB|The Sidewinders
 Dangerous Dan McGrew|TTBB|Tom Gentry
 Dangerous Woman|SATB|Deke Sharon
 Dangerous Woman|SSAA|Deke Sharon
@@ -3771,8 +4559,12 @@ Daniel Saw The Stone|TTBB|Paul Jorg
 Danke Schoen|SSAA|Kohl Kitzmiller
 Danny Boy|SATB|Deke Sharon
 Danny Boy|SATB|Peter Knight
+Danny Boy|SATB|Steve Wolf
 Danny Boy|SSAA|Anna Maria Parker
 Danny Boy|SSAA|Jay Giallombardo
+Danny Boy|SSAA|Lynnell Diamond
+Danny Boy|SSAA|Renee Craig
+Danny Boy|TTBB|Barbershop Harmony Society
 Danny Boy|TTBB|Bob Hofstetter
 Danny Boy|TTBB|Burt Szabo
 Danny Boy|TTBB|Ed Waesche
@@ -3784,6 +4576,9 @@ Danny Boy|TTBB|Jon Nicholas
 Danny Boy|TTBB|Mike Sotiriou
 Danny Boy|TTBB|Nick Bryant
 Danny Boy|TTBB|Renee Craig
+Danny Boy|TTBB|Simon Arnott
+Danny Boy|TTBB|Steve Bishop / Patrick Rose
+Danny Boy (SSAA)|SSAA|Dede Duson
 Danny's Arrival Song|TTBB|Aaron Dale
 Dapper Dan|TTBB|Toban Dvoretsky
 Dapper Dan/Two-Time Dan|TTBB|Tom Gentry
@@ -3791,10 +4586,16 @@ Dare To Dream|SSAA|Marge Bailey
 Dark Eyes|TTBB|Kirk Roose
 Dark Horse|SSAA|Nicholas Wright
 Darkness Falls Across The Land|TTBB|Wayne Grimmer
+Darkness on the Delta|TTBB|Bluegrass Student Union
 Darkness On The Delta|SATB|Barbershop Harmony Society
 Darkness On The Delta|SSAA|Walter Latzko
+Darkness On The Delta|TTBB|Barbershop Harmony Society
+Darkness On The Delta|TTBB|Rob Hopkins
 Darkness On The Delta|TTBB|SPEBSQSA
 Darkness On The Delta|TTBB|Walter Latzko
+Darkness On the Delta (Parody)|TTBB|Chordiac Arrest
+Darktown Strutter's Ball|TTBB|Don Gray
+Darktown Strutter's Ball|TTBB|Ed Waesche
 Darktown Strutters' Ball|SSAA|Don Gray
 Darktown Strutters' Ball|SSAA|Walter Latzko
 Darktown Strutters' Ball|TTBB|Don Gray
@@ -3814,16 +4615,19 @@ Darn That Dream|SSAA|Michael Gellert
 Darn That Dream|TTBB|Robert Rund
 Das Sound Machine Finale|SATB|Deke Sharon
 David And Goliath|TTBB|Derric Johnson
+Day By Day|SSAA|Ruby Rhea
 Day By Day|TTBB|Jim Shubert
 Day By Day|TTBB|Jon Nicholas
 Day By Day|TTBB|Robert Rund
 Day By Day|TTBB|Walter Latzko
 Day By Day (from Day By Day)|TTBB|John Brockman
 Day Dreamin'|TTBB|Louis Perry
+Day In Day Out|TTBB|Jeremey Johnson
 Day In, Day Out|SSAA|Adam Scott
 Day In, Day Out|TTBB|Jeremey Johnson
 Day In, Day Out|TTBB|Rasmus Krigström
 Daybreak|SSAA|Michael Gellert
+Daybreak|SSAA|Norma Andersen
 Daybreak|TTBB|Jay Giallombardo
 Daydream|SATB|Kevin Keller
 Daydream|SATB|Mel Knight
@@ -3839,21 +4643,27 @@ Daydream|TTBB|Tom Gentry
 Daydream Believer|SSAA|Brian Mastrull
 Daydream Believer|TTBB|Brian Mastrull
 Daydream Believer|TTBB|David Harrington
+Daydream Medley|TTBB|Joe Johnson
 Daydreams From The Memories|SSAA|Tedda Lippincott
 Days|TTBB|Hilary Allen
 Days of Wine and Roses|SSAA|Jon Nicholas
 Days of Wine and Roses|TTBB|Adam Bock
 Days of Wine and Roses|TTBB|Jon Nicholas
 Days of Wine and Roses|TTBB|Kohl Kitzmiller
+Dayton Ohio|TTBB|King's Singers
 Dayton, Ohio 1903|TTBB|Jay Giallombardo
 Dayton, Ohio 1903|TTBB|Jim West
 De Colores|TTBB|Tom Gentry
+De King Is Born Today|TTBB|Morgan Ames
+Dean Martin Medley|TTBB|Jay Giallombardo
 Dear Heart|TTBB|Dennis Driscoll
 Dear Heart|TTBB|Nancy Bergman
 Dear Heart|TTBB|Paul Jorg
 Dear Hearts And Gentle People|TTBB|Jim West
 Dear Hearts And Gentle People|TTBB|Rob Campbell
 Dear Hearts And Gentle People|TTBB|SPEBSQSA
+Dear Little Boy / Soldier Medley|SSAA|Dave Briner
+Dear Little Boy Of Mine|SSAA|Joe Liles and Floyd Connett
 Dear Little Boy Of Mine|TTBB|Barbershop Harmony Society
 Dear Little Boy Of Mine|TTBB|Burt Szabo
 Dear Little Boy Of Mine|TTBB|Inc. SPEBSQSA
@@ -3872,9 +4682,11 @@ Dear Old Girl|SSAA|Jay Giallombardo
 Dear Old Girl|TTBB|Barbershop Harmony Society
 Dear Old Girl|TTBB|Burt Szabo
 Dear Old Girl|TTBB|David Wright
+Dear Old Girl|TTBB|Fred King
 Dear Old Girl|TTBB|Inc. SPEBSQSA
 Dear Old Girl|TTBB|Jack Baird
 Dear Old Girl|TTBB|Jay Giallombardo
+Dear Old Girl|TTBB|Rob Hopkins
 Dear Old Girl|TTBB|SPEBSQSA
 Dear Old Pal Of Mine|TTBB|Burt Szabo
 Dear Old Pal Of Mine|TTBB|Joe Mannherz
@@ -3891,6 +4703,8 @@ Death Of A Bachelor|TTBB|David Harrington
 Death Of A Bachelor|TTBB|Nicholas Wright
 December 1963 (Oh, What A Night)|TTBB|Grant Goulding
 December 1963 (Oh, What A Night)|TTBB|Jay Giallombardo
+Deck the Hall|TTBB|Mark Patterson
+Deck the Halls|SATB|Burt Szabo
 Deck The Halls|SATB|Bryan W. Pulver
 Deck The Halls|SATB|Deke Sharon
 Deck The Halls|SATB|Derric Johnson
@@ -3901,20 +4715,28 @@ Deck The Halls|SSAA|Linda Samuelsson
 Deck The Halls|SSAA|Liz Garnett
 Deck The Halls|SSAA|Mark Rusch
 Deck The Halls|SSAA|Nancy Bergman
+Deck The Halls|SSAA|Renee Craig
 Deck The Halls|TTBB|Adam Scott
+Deck The Halls|TTBB|Andreas Weiland
 Deck The Halls|TTBB|Burt Szabo
 Deck The Halls|TTBB|Jay Giallombardo
 Deck The Halls|TTBB|Jon Nicholas
 Deck The Halls|TTBB|Mark Rusch
 Deck The Halls|TTBB|Nick Bryant
+Deck The Halls|TTBB|Robert Shaw
 Dedicated To You|TTBB|Jon Nicholas
 Deed I Do|SSAA|Aaron Dale
 Deed I Do|SSAA|Connie Kash
+Deed I Do|SSAA|Joni Bescos
 Deed I Do|SSAA|Larry Wright
+Deed I Do|SSAA|Lynnell Diamond
 Deed I Do|TTBB|Aaron Dale
 Deed I Do|TTBB|Larry Wright
+Deed I Do Medley|SSAA|Joni Bescos
+Deed I Do/Yes Sir, That's My Baby|SSAA|Bev Sellers
 Deep Beneath/Not There Yet|SATB|Deke Sharon
 Deep Henderson|TTBB|Jon Nicholas
+Deep in a Dream|TTBB|Chris MacMartin
 Deep In My Heart, Dear|SSAA|Jay Giallombardo
 Deep In My Heart, Dear|TTBB|Don Gray
 Deep In My Heart, Dear|TTBB|Jay Giallombardo
@@ -3956,18 +4778,23 @@ Defying Gravity|TTBB|Richard Curtis
 Delilah|SSAA|Diane Butler
 Delilah|SSAA|Mark Burnip
 Delilah|TTBB|Mark Burnip
+Delta Dawn|SSAA|Joni Bescos
 Delta Dawn|TTBB|Dave Mohr
 Delta Dawn|TTBB|Jim Clancy
 Delta Dawn|TTBB|R. B. Easterlin
 Demon Kitty Rag|SSAA|Melody Hine
 Demon Kitty Rag|TTBB|Melody Hine
 Demons|SATB|Nicholas Wright
+Demons|SSAA|Jonathan Sparks
 Demons|TTBB|Nicholas Wright
 Dentist Medley|TTBB|Tom Gentry
+Dentist!|TTBB|Roger Payne
 Descendants Medley|TTBB|Deke Sharon
+Desert Song|TTBB|Jon Nicholas
 Desire|SSAA|Carole Prietto
 Despacito|SSAA|Carole Prietto
 Desperado|SATB|Tom Gentry
+Desperado|SSAA|Brian Hogan
 Desperado|SSAA|Jeremey Johnson
 Desperado|SSAA|Richard Hubbard
 Desperado|SSAA|Sylvia Posso
@@ -3978,7 +4805,10 @@ Desperado|TTBB|Thomas Degan
 Desperado|TTBB|Tom Gentry
 Despondency|SATB|Jay Dougherty
 Destination Moon|SSAA|Kevin Keller
+Destination Moon|SSAA|Siegal-Seirup
 Destination Moon|SSAA|Sonny Steffan
+Destination Moon|TTBB|Adam Reimnitz
+Destination Moon|TTBB|Anthony Nasto
 Destination Moon|TTBB|Matthew Gallagher
 Destination Moon|TTBB|Mike Louque and Sam Dabrusin
 Destination Moon|TTBB|Sam Dobrusin/Richmond/Wong
@@ -3993,6 +4823,8 @@ Devoted to You|TTBB|Tom Gentry
 Diamond's Are A Girls Best Friend|SSAA|Jarmela Speta
 Diamond's Are A Girls Best Friend|SSAA|Larry Wright
 Diamond's Are A Girls Best Friend|SSAA|Liz Garnett
+Diamonds Are A Girl's Best Friend|SSAA|Jarmela Speta
+Diamonds Are A Girl's Best Friends|SSAA|Tedda Lippincott
 Diamonds Are A Girls Best Friend|SSAA|Deke Sharon
 Diamonds Are A Girls Best Friend|SSAA|Tedda Lippincott
 Diamonds are Forever|SATB|Julianne Kallman
@@ -4000,26 +4832,32 @@ Diamonds are Forever|SSAA|Larry Wright
 Diamonds are Forever|SSAA|Liz Garnett
 Diamonds are Forever|TTBB|Liz Garnett
 Diamonds Are Medley|SSAA|Carolyn Schmidt
+Diamonds Medley|SSAA|Carolyn Schmidt
 Diane (I'm In Heaven When I See You Smile)|TTBB|Kevin Keller
 Dick Van Dyke Celebration|SSAA|Mark Burnip
 Dick Van Dyke Celebration|TTBB|Mark Burnip
 Did I Remember?|SSAA|Joe Mannherz
 Did I Remember?|TTBB|Joe Mannherz
+Diddly Squat|TTBB|Tom Gentry
 Diddly Squat (You Ain't Gettin')|SSAA|Tom Gentry
 Diddly Squat (You Ain't Gettin')|TTBB|Ken Potter
 Diddly Squat (You Ain't Gettin')|TTBB|Tom Gentry
 Didn't Leave Nobody But the Baby|SSAA|Sheryl Neal
+Didn't My Lord Deliver Daniel|TTBB|Aaron Dale
 Didn't My Lord Deliver Daniel?|SATB|Aaron Dale
 Didn't My Lord Deliver Daniel?|SSAA|Aaron Dale
 Didn't My Lord Deliver Daniel?|TTBB|Aaron Dale
+Didn't We|SSAA|George Avener
 Didn't We|SSAA|Larry Wright
 Didn't We|TTBB|Fred King
 Didn't We|TTBB|Jay Giallombardo
 Didn't We|TTBB|Larry Wright
+Didn't We / MacArthur Park Medley|TTBB|Jim Clancy, Larry Wright, Rich Hasty
 Die A Happy Man|TTBB|Theodore Hicks
 Die For You|SATB|Mark Stevens
 Die Lorelei|SSAA|Kevin Keller
 Die Lorelei|TTBB|Kevin Keller
+Diet Riot|SSAA|Lynnell Diamond
 Dig A Little Deeper|SATB|Tony Nasto
 Dig A Little Deeper In Gods (His) Love|TTBB|David Wallace
 Dig A Little Deeper In The Well|SSAA|Larry Wright
@@ -4030,6 +4868,8 @@ Ding Dong Merrily On High|SATB|Deke Sharon
 Ding Dong Merrily On High|SSAA|Jan-Ake Westin
 Ding Dong Merrily On High|TTBB|Gabriel Lawson
 Ding Dong Merrily On High|TTBB|Jay Giallombardo
+Ding Dong The Witch Is Dead|SSAA|Clay Hine
+Ding Dong The Witch Is Dead|TTBB|Clay Hine
 Ding-Dong! The Witch Is Dead|SATB|Kevin Keller
 Ding-Dong! The Witch Is Dead|SSAA|Kevin Keller
 Ding-Dong! The Witch Is Dead|TTBB|Kevin Keller
@@ -4039,6 +4879,8 @@ Direct Our Harmony|SSAA|Carolyn Johnson
 Dirty Hands! Dirty Face!|TTBB|Jay Giallombardo
 Disappear|SATB|Deke Sharon
 Disco Inferno|SATB|Deke Sharon
+Disco Medley|SSAA|Brian Beck
+Disco Medley|SSAA|Janne Olsson
 Disco Medley|TTBB|Deke Sharon
 Disney 'Jungle Lion' Medley|TTBB|Deke Sharon
 Disney 2020 Grammys Medley|TTBB|Deke Sharon
@@ -4056,7 +4898,13 @@ Disneyland Medley|TTBB|Deke Sharon
 Distant Sun|SATB|Rowena Harper
 Disturbia|SATB|Deke Sharon
 Diversity|TTBB|Deke Sharon
+Dixie|TTBB|Mo Rector
 Dixie Chicken|SATB|Deke Sharon
+Dixie Down Broadway|SSAA|Frank Marzocco
+Dixie Medley|TTBB|Ed Waesche
+Dixie Sunshine|SSAA|Nancy Bergman
+Dixie/Battle Hymn Medley|SSAA|Sharon Holmes
+Dixieland Delight|SSAA|Brian Beck
 Dixieland Delight|TTBB|Mark Stevens
 Do - Re - Mi|SSAA|Larry Wright
 Do - Re - Mi|SSAA|Nancy Bergman
@@ -4076,19 +4924,25 @@ Do I Love You?|TTBB|Brent Graham
 Do I Love You?|TTBB|David Zimmerman
 Do I Worry?|TTBB|Walter Latzko
 Do Lord|SSAA|Dorothy Short
+Do Lord|SSAA|Dot Short
 Do Lord|TTBB|Roy Keys
 Do Not Say Goodbye|TTBB|Jack Baird
 Do Nothing Til You Hear From Me|TTBB|Jay Giallombardo
 Do Wah Ditty Ditty|SSAA|Marsha Zwicker
+Do You Believe in Magic|SSAA|Joan D'Agostino
 Do You Believe In Magic|SSAA|Joan D 'Agostino
 Do You Believe In Magic|TTBB|Ken Potter
+Do You Ever Think Of Me?|SSAA|June Dale
 Do You Ever Think Of Me?|TTBB|Walter Latzko
+Do You Hear The People Sing|TTBB|Tom Gentry
 Do You Hear The People Sing?|SATB|Tom Gentry
 Do You Hear The People Sing?|SSAA|Gene Bender
 Do You Hear The People Sing?|SSAA|Tom Gentry
+Do You Hear The People Sing?|TTBB|Jay Giallombardo
 Do You Hear The People Sing?|TTBB|Tom Gentry
 Do You Hear What I Hear|SSAA|Brian Doepke
 Do You Hear What I Hear|SSAA|Carolyn Schmidt
+Do You Hear What I Hear|SSAA|Gas House Gang
 Do You Hear What I Hear|SSAA|Judy Vidal
 Do You Hear What I Hear|SSAA|Kim Andrews
 Do You Hear What I Hear|SSAA|Larry Wright
@@ -4100,30 +4954,43 @@ Do You Hear What I Hear|TTBB|Jay Giallombardo
 Do You Hear What I Hear|TTBB|Joe Liles
 Do You Hear What I Hear|TTBB|Jon Nicholas
 Do You Hear What I Hear|TTBB|Larry Wright
+Do You Hear What I Hear|TTBB|Phil Ordaz
+Do You Hear What I Hear|TTBB|Unspecified
 Do You Hear What I Hear?|SSAA|Joe Liles
+Do You Hear What I Hear?|SSAA|Judy Vidal
+Do You Hear What I Hear?|SSAA|Tedda Lippincott
+Do You Hear What I Hear?|TTBB|Gas House Gang, Jay Giallombardo
+Do You Hear What I Hear?|TTBB|Jon Nicholas
 Do You Know The Muffin Man?|TTBB|Adam Scott
 Do You Know The Way To San Jose|SATB|Deke Sharon
 Do You Know The Way To San Jose|SSAA|Erica Kelch-Slesnick
 Do You Know The Way To San Jose|SSAA|Larry Wright
 Do You Know The Way To San Jose|TTBB|Larry Wright
 Do You Know The Way To San Jose|TTBB|Todd Troutman
+Do You Know What It Means|SSAA|Sylvia Alsbury
+Do You Know What It Means to Miss New Orleans|SSAA|Tom Campbell
 Do You Know What It Means To Miss New Orleans|SSAA|Sylvia Alsbury
 Do You Know What It Means To Miss New Orleans|TTBB|BHS
 Do You Know What It Means To Miss New Orleans|TTBB|Deke Sharon
 Do You Know What It Means To Miss New Orleans|TTBB|Joe Mannherz
 Do You Know What It Means To Miss New Orleans|TTBB|Tom Campbell
+Do You Know What It Means To Miss New Orleans?|TTBB|Don Gray
+Do You Know What It Means To Miss New Orleans?|TTBB|Val Hicks
+Do You Know What It Means To Miss New Orleans(Barbershop Harmony Soc|TTBB|Barbershop Harmony Society
 Do You Know You Are My Sunshine|TTBB|David Wallace
 Do You Know You Are My Sunshine|TTBB|Paul Jorg
 Do You Love Me|TTBB|Theodore Hicks
 Do you really love me|SSAA|Joe Mannherz
 Do you really love me|TTBB|Ken Potter
 Do you really love me|TTBB|Ruby Rhea
+Do You Really Love Me?|SSAA|Ruby Rhea
 Do You Remember|SSAA|Joe Mannherz
 Do You Remember|TTBB|Joe Mannherz
 Do You Remember These?|TTBB|Tom Gentry
 Do You Remember When?|TTBB|1964 Harmony Education Program (HEP) Advanced Arrangers Class
 Do You Remember When?|TTBB|Barbershop Harmony Society
 Do You See What I See?|SSAA|Nancy Bergman
+Do You See What I See?|SSAA|Nancy Bergman/Aileen Nightingale
 Do You Take This Woman for Your Lawful Wife|TTBB|Joe Simone
 Do You Want To Know a Secret!|SSAA|Jan-Ake Westin
 Do You Want To Know a Secret!|TTBB|Steve Jamison
@@ -4132,6 +4999,7 @@ Dock Of The Bay, The (Sittin On)|SSAA|Charlene Yazurlo
 Dock Of The Bay, The (Sittin On)|TTBB|Aaron Dale
 Dock Of The Bay, The (Sittin On)|TTBB|Deke Sharon
 Dock Of The Bay, The (Sittin On)|TTBB|Jon Nicholas
+Doctor Jazz Medley|SSAA|Mary Coffman
 Doctor, My Eyes|TTBB|Mark Stevens
 Does Anybody Really Know What Time It Is?|SATB|Deke Sharon
 Does He Love You?|SSAA|Joan D 'Agostino
@@ -4154,18 +5022,22 @@ Doin' What Comes Natur'lly|SSAA|Nancy Bergman
 Dolce Far Niente|TTBB|Walter Latzko
 Doll On A Music Box|SATB|Mark Goodney
 Dominick, The Donkey|TTBB|Mark Goodney
+Dominion / Chesapeake Medley|TTBB|Don Gray
 Don Juan|SSAA|Carolyn Schmidt
 Don't|SSAA|Dawn Haggerty
 Don't|SSAA|Nicholas Wright
 Don't Ask Me Why|SATB|Joe Mannherz
 Don't Ask Me Why|SSAA|Joe Mannherz
 Don't Ask Me Why|TTBB|Darin Drown
+Don't Be a Baby, Baby|TTBB|Boston Common
 Don't Be a Baby, Baby|TTBB|Gas House Gang & Boston Common
 Don't Be A Baby, Baby|SSAA|Kay Bromert
 Don't Be A Baby, Baby|SSAA|Sonny Steffan
 Don't Be A Baby, Baby|TTBB|Aaron Dale
+Don't Be A Baby, Baby|TTBB|Barbershop Harmony Society
 Don't Be A Do-Badder|TTBB|Mark Goodney
 Don't Be Anybodys Soldier Boy But Mine|SSAA|Bitsy Bacon
+Don't Be Cruel (To A Heart That's True)|TTBB|Greg Gilpin
 Don't Be Cruel (To A Heart That's True)|TTBB|Tom Gentry
 Don't Be So Mean To Baby|SSAA|Ig Jakovac
 Don't Blame Me|SATB|Nicholas Wright
@@ -4177,16 +5049,20 @@ Don't Blame Me|SSAA|Nancy Bergman
 Don't Blame Me|SSAA|Peg Millard
 Don't Blame Me|TTBB|Joe Mannherz
 Don't Blame Me|TTBB|Larry Wright
+Don't Blame Me|TTBB|Lou Perry
 Don't Blame Me|TTBB|Louis Perry
 Don't Blame Me|TTBB|Walter Latzko
 Don't Blame Me For What Happens In The Moonlight|TTBB|Burt Szabo
 Don't Break My Heart With Goodbye|TTBB|Burt Szabo
+Don't Break the Heart that Loves You|TTBB|Greg Volk
+Don't Break the Heart That Loves You|SSAA|Unspecified
 Don't Break The Heart That Loves You|SSAA|Greg Volk
 Don't Break the Rules|TTBB|Aaron Dale
 Don't Break the Rules|TTBB|Dan Wessler
 Don't Bring Lulu|SSAA|Jo Lund
 Don't Bring Lulu|TTBB|Burt Szabo
 Don't Bring Lulu|TTBB|DUPLICATE see 509971 Senter
+Don't Bring Lulu|TTBB|Fraser Brown
 Don't Bring Lulu|TTBB|Mike Senter Music
 Don't Bring Lulu|TTBB|Walter Latzko
 Don't Call Me Sweetie 'Cause I'm Bitter|SSAA|Nancy Bergman
@@ -4194,7 +5070,9 @@ Don't Cry for me Argentina|TTBB|Jon Nicholas
 Don't Cry Joe|TTBB|Val Hicks
 Don't Cry Little Girl|SSAA|Jay Giallombardo
 Don't Cry Little Girl|TTBB|Tom Gentry
+Don't Cry Out Loud|SSAA|Joni Bescos
 Don't Cry Out Loud|TTBB|Hal Snyder
+Don't Cry, Little Girl|SSAA|Nancy Bergman
 Don't Cry, Little Girl, Don't Cry|SSAA|Carolyn Johnson
 Don't Cry, Little Girl, Don't Cry|SSAA|Nancy Bergman
 Don't Cry, Little Girl, Don't Cry|TTBB|Earl Moon
@@ -4203,8 +5081,10 @@ Don't Dream It's Over|SSAA|Glenda Lloyd
 Don't Dream It's Over|SSAA|Rowena Harper
 Don't Dream It's Over|TTBB|Alex Morris
 Don't Ever Leave Me|SSAA|Walter Latzko
+Don't Ever Make Fun of an Egg|TTBB|Unspecified
 Don't Fence Me In|SSAA|Frank Marzocco
 Don't Fence Me In|TTBB|Burt Szabo
+Don't Fence Me In|TTBB|Darin Drown
 Don't Fence Me In|TTBB|David Wright
 Don't Fence Me In|TTBB|Don Gray
 Don't Fence Me In|TTBB|Fred King
@@ -4240,6 +5120,7 @@ Don't Know Why|SSAA|Staffan Paulson
 Don't Know Why|TTBB|Alex Morris
 Don't Know Why|TTBB|Dan Wessler
 Don't Know Why|TTBB|Kohl Kitzmiller
+Don't Laugh at Me|TTBB|Jake Kynaston
 Don't Let Go|TTBB|Robert Rund
 Don't Let It Show|TTBB|Anders Lindqvist
 Don't Let Me Be Lonely Tonight|TTBB|Joe Grimme
@@ -4247,6 +5128,7 @@ Don't Let Me Go|TTBB|Cay Outerbridge
 Don't Let That Moon Get Away|SATB|Kevin Keller
 Don't Let That Moon Get Away|SSAA|Kevin Keller
 Don't Let That Moon Get Away|TTBB|Kevin Keller
+Don't Let The Rain Come Down|SSAA|Don Rose
 Don't Let The Sun Go Down On Me|SATB|Deke Sharon
 Don't Let The Sun Go Down On Me|SSAA|Mark Burnip
 Don't Let The Sun Go Down On Me|TTBB|Anders Lindqvist
@@ -4265,6 +5147,7 @@ Don't Nobody Bring Me No Bad News|SSAA|Carolyn Healey
 Don't Nobody Bring Me No Bad News|SSAA|Rowena Harper
 Don't Pay The Ferryman|SATB|Don Staffin
 Don't Pay The Ferryman|TTBB|Don Staffin
+Don't Put a Tax On My Barbershop Chords|TTBB|Tom Gentry
 Don't Put A Tax On The Beautiful Girls|TTBB|Burt Szabo
 Don't Put A Tax On The Beautiful Girls|TTBB|Kevin Keller
 Don't Put A Tax On The Beautiful Girls|TTBB|Tom Gentry
@@ -4280,6 +5163,11 @@ Don't Sit under The Apple Tree|SSAA|David Harrington
 Don't Sit under The Apple Tree|SSAA|Larry Wright
 Don't Sit under The Apple Tree|SSAA|Walter Latzko
 Don't Sit under The Apple Tree|TTBB|David Harrington
+Don't Sit Under the Apple Tree|SSAA|Dot Short
+Don't Sit Under the Apple Tree|SSAA|Marie Johnson
+Don't Sit Under the Apple Tree|SSAA|Nancy Bergman
+Don't Sit Under the Apple Tree|TTBB|Dick Rode
+Don't Sit Under the Apple Tree|TTBB|Unspecified
 Don't Speak|SATB|Deke Sharon
 Don't Speak|SSAA|Kohl Kitzmiller
 Don't Speak|TTBB|Matthew Gallagher
@@ -4288,7 +5176,9 @@ Don't Start Now|SATB|Nicholas Wright
 Don't Stop|SSAA|Larry Wright
 Don't Stop Believin'|SATB|Deke Sharon
 Don't Stop Believin'|SSAA|Deke Sharon
+Don't Stop Believin'|SSAA|Lorraine Rochefort
 Don't Stop Believin'|TTBB|Deke Sharon
+Don't Stop Believing|SSAA|Lorraine Rochefort
 Don't Stop Me Now|SATB|Deke Sharon
 Don't Stop Me Now|SATB|Melody Hine
 Don't Stop Me Now|SSAA|Adam Scott
@@ -4309,7 +5199,11 @@ Don't Stop The Music|TTBB|Deke Sharon
 Don't Take The Girl|TTBB|Kevin Keller
 Don't Take Your Lines From Dimestore Novels|TTBB|Larry Wright
 Don't Take Your Love From Me|SSAA|Sharon Holmes
+Don'T Tell Me The Same Things Lies Medley|SSAA|Joni Bescos Judy Vidal intro
 Don't Tell Me The Same Things Over Again|TTBB|Louis Perry
+Don't Tell Me the Same Things/I Used to Love You|SSAA|Bescos/Alsbury
+Don't Tell Me the Same Things/It's the Last Time|SSAA|Jim Arns
+Don't Tell Me the Same Things/Lies Medley|SSAA|Joni Bescos
 Don't Think You'll Be Missed|TTBB|Dennis Driscoll
 Don't U Wait No More|SATB|Nicholas Wright
 Don't Wait on Me|TTBB|Walter Latzko
@@ -4333,6 +5227,7 @@ Dona Nobis Pacem|SSAA|Dianne Goldrick
 Done|SSAA|Nicholas Wright
 Done In Black And White|TTBB|Paul Jorg
 Donna Medley|TTBB|Tom Gentry
+Dont Break The Heart That Loves You|SSAA|Unspecified
 Doo Wacka Doo|TTBB|Tom Gentry
 Doo Wop Medley|SSAA|Anna Maria Parker
 Doodle Doo Doo|SSAA|Linda Edmondson
@@ -4345,6 +5240,7 @@ Down And Out|TTBB|Deke Sharon
 Down and Out Blues|SSAA|Nancy Bergman
 Down At The Barbecue|SSAA|Marie Johnson
 Down At The Long Branch Saloon|SSAA|Nancy Bergman
+Down At The Twist & Shout|SSAA|Barbara McNeill
 Down At The Twist And Shout|SSAA|Barbara McNeill
 Down At The Twist And Shout|SSAA|June Dale
 Down By The Erie Canal|TTBB|Burt Szabo
@@ -4352,10 +5248,12 @@ Down By The Lazy River|SATB|Anders Lindqvist
 Down By The Lazy River|TTBB|Anders Lindqvist
 Down By The O-hi-o|TTBB|Dennis Driscoll
 Down By The O-hi-o|TTBB|Tom Gentry
+Down By the Old Mill Stream|TTBB|Tell Taylor
 Down By The Old Mill Stream|SSAA|Jan Meyer
 Down By The Old Mill Stream|SSAA|Marie Johnson
 Down By The Old Mill Stream|SSAA|Nancy Bergman
 Down By The Old Mill Stream|SSAA|Walter Latzko
+Down By The Old Mill Stream|TTBB|Barbershop Harmony Society
 Down By The Old Mill Stream|TTBB|Burt Szabo
 Down By The Old Mill Stream|TTBB|Derric Johnson
 Down By The Old Mill Stream|TTBB|Douglas Smith
@@ -4382,20 +5280,29 @@ Down in the Glen|TTBB|Jay Giallombardo
 Down In The Lane|TTBB|Burt Szabo
 Down In The Old Neighborhood|TTBB|Lou Perry
 Down In The Old Neighborhood|TTBB|Louis Perry
+Down In The Valley|TTBB|George Mead
 Down On 33rd And 3rd|TTBB|Joe Samuel
 Down on the Corner|TTBB|Greg Lyne
 Down On The Corner|TTBB|Gregory Lyne
+Down On The Farm|TTBB|Joe Colon
 Down On The Farm|TTBB|John Mulkin
 Down Our Way|TTBB|Floyd Connett
 Down South|TTBB|Dave Stevens
 Down the Lane and Home Again|SSAA|Jay Giallombardo
 Down the Lane and Home Again|TTBB|Jay Giallombardo
 Down The Old Ox Road|TTBB|Dennis Driscoll
+Down The River To Pray|SSAA|Sharon Holmes
 Down The Trail To Home Sweet Home|TTBB|Barbershop Harmony Society
+Down to the River to Pray|SSAA|Sharon Holmes
 Down To The River To Pray|SSAA|Marge Bailey
 Down To The River To Pray|TTBB|Jim West
+Down To The River To Pray|TTBB|Joe Johnson
 Down To The River To Pray|TTBB|Paul Jorg
 Down Under|TTBB|Nicholas Wright
+Down Under Medley|SSAA|Brian Beck
+Down Where The South Begins|TTBB|Bill Busby
+Down Where The South Begins|TTBB|Renee Craig
+Down Where the Swanee River Flows|TTBB|Clay Hine
 Down Where The Swanee River Flows|TTBB|Larry Autenreith
 Down With Love|SSAA|Kevin Keller
 Down With Love|SSAA|Steve Tramack
@@ -4407,6 +5314,9 @@ Downtown|TTBB|Dan Mulligan
 Doxology|SATB|Kevin Keller
 Doxology|SSAA|Kevin Keller
 Doxology|TTBB|Kevin Keller
+Dr Jazz Jazz Holiday Medley|SSAA|Sellers Alsbury
+Dr Jazz Medley|SSAA|Mary Coffman
+Dr. Jazz/Holiday Medley|SSAA|Mary Coffman
 Dr. Jazz/Jazz Holiday Medley|SSAA|Bev Sellers
 Dr. Jazz/Jazz Holiday Medley|SSAA|Sharon Carlson
 Dr. Who Theme|SATB|Adam Bock
@@ -4422,7 +5332,10 @@ Dream|TTBB|Bud Arberg
 Dream|TTBB|Gerald Hooper
 Dream|TTBB|Jim Shubert
 Dream|TTBB|Walter Latzko
+Dream a Little Dream of Me|SSAA|Gentry/Ramsson
+Dream a Little Dream of Me|SSAA|Tom Gentry/Beth Ramsson
 Dream a Little Dream of Me|TTBB|Thomas Gentry
+Dream A Little Dream of Me|SSAA|Don Gray
 Dream A Little Dream Of Me|SATB|Joe Mannherz
 Dream A Little Dream Of Me|SATB|Kohl Kitzmiller
 Dream A Little Dream Of Me|SATB|Rob Campbell
@@ -4435,11 +5348,13 @@ Dream A Little Dream Of Me|TTBB|Brent Graham
 Dream A Little Dream Of Me|TTBB|Clay Hine
 Dream A Little Dream Of Me|TTBB|Dennis Driscoll
 Dream A Little Dream Of Me|TTBB|Jack Bridges
+Dream A Little Dream Of Me|TTBB|Joe Johnson
 Dream A Little Dream Of Me|TTBB|Jon Nicholas
 Dream A Little Dream Of Me|TTBB|Kohl Kitzmiller
 Dream A Little Dream Of Me|TTBB|Marilyn Penketh
 Dream A Little Dream Of Me|TTBB|Tom Gentry
 Dream A Little Dream Of Me|TTBB|Walter Latzko
+Dream a Little Dream of Me/Penthouse Serenade|TTBB|Webb Comfort
 Dream Along With Me|TTBB|Todd Troutman
 Dream Angus|SSAA|Jo Lund
 Dream Baby|SSAA|Tedda Lippincott
@@ -4447,6 +5362,7 @@ Dream Days (Take Me Back to Those)|SSAA|Jay Giallombardo
 Dream Days (Take Me Back to Those)|TTBB|Jay Giallombardo
 Dream Is A Wish Your Heart Makes|SSAA|Tony Nasto
 Dream Is A Wish Your Heart Makes|TTBB|David Wright
+Dream Is A Wish, A (YWIH)|SSAA|Lorraine Rochefort
 Dream Lover|SATB|Kohl Kitzmiller
 Dream Lover|SSAA|Kohl Kitzmiller
 Dream Lover|SSAA|Larry Wright
@@ -4492,18 +5408,23 @@ Drifting and Dreaming|SSAA|Walter Latzko
 Drink To Me Only With Thine Eyes|SATB|Derric Johnson
 Drink To Me Only With Thine Eyes|SSAA|Diane Clark
 Drink To Me Only With Thine Eyes|TTBB|Roy Keys
+Drinking Song|TTBB|Don Gray
 Drive|SATB|Deke Sharon
 Drive|TTBB|Deke Sharon
 Drive|TTBB|Jon Nicholas
+Drive By|TTBB|The Blenders
 Drive My Car|SATB|Deke Sharon
 Drive My Car|SSAA|Jay Giallombardo
 Drive My Car|SSAA|Michael Gellert
 Drive My Car|SSAA|Staffan Paulson
 Drive My Car|TTBB|James Henry
 Drive My Car|TTBB|Jay Giallombardo
+Drive My Car|TTBB|Jim Henry
 Drive My Car|TTBB|Staffan Paulson
 Drive The Cold Winter Away|TTBB|Matt Astle
 Drivers License|SATB|Nicholas Wright
+Drivin Me Crazy|SSAA|Bob Disney
+Drivin' Me Crazy|SSAA|Bob Diz Disney
 Drivin' Me Crazy|SSAA|Robert Disney
 Drivin' Me Crazy|TTBB|Bob Disney
 Drivin' Me Crazy|TTBB|Robert Disney
@@ -4516,6 +5437,7 @@ Drops of Jupiter|SSAA|Nicholas Wright
 Drown In My Own Tears|TTBB|Mark Hale
 Drumming Song|SATB|Nicholas Wright
 Drunken Sailor|SSAA|June Dale
+Drunken Sailor|TTBB|Alice Parker, Robert Shaw, Pippa Goodall
 Drunken Sailor|TTBB|Jim West
 Dry Bones|SSAA|David Harrington
 Dry Bones|SSAA|Nancy Bergman
@@ -4523,7 +5445,9 @@ Dry Bones|TTBB|David Harrington
 Du Gamla, Du Fria|TTBB|Tom Gentry
 Dueling Banjos|TTBB|Jay Giallombardo
 Duetto Buffo Di Due Gatti|SSAA|Dede Nibler
+Duetto Buffo di Quatro Gatti|SSAA|Dede Nibler
 Duke Ellington Medley|TTBB|Derric Johnson
+Duke Ellington's Swingtime|SSAA|Renee Craig
 Dumas Walker|TTBB|Jon Nicholas
 Dumb Ways To Die|SSAA|Kristina Roper
 Dumb Ways To Die|TTBB|Nicholas Wright
@@ -4534,11 +5458,17 @@ Dunk-Dunk-Dunk|SSAA|Zona Snyder
 Dust In The Wind|SSAA|David Zimmerman
 Dust In The Wind|SSAA|Kay Bromert
 Dust In The Wind|TTBB|David Zimmerman
+Dust Off That Old Pianna|TTBB|David Wright
+Each Time I Fall in Love|SSAA|SK Grundy
 Each Time I Fall In Love|SSAA|Larry Wright
 Each Time I Fall In Love|SSAA|S. K. Grundy
+Each Time I Fall In Love|SSAA|Suzy Lobaugh
 Each Time I Fall In Love|TTBB|Larry Wright
 Each Time I Fall In Love|TTBB|S. K. Grundy
+Each Time I Fall In Love|TTBB|SK Grundy
+Each Time I Fall In Love|TTBB|Unspecified
 Eagle When She Flies|SSAA|Jo Lund
+Early American 'Uptempo' Medley|TTBB|Jay Giallombardo
 Early American Medley|SSAA|Jay Giallombardo
 Early American Medley|TTBB|Barbershop Harmony Society
 Early American Medley|TTBB|Jay Giallombardo
@@ -4548,6 +5478,7 @@ Earth Angel|TTBB|Eric Ruthenberg
 Earth Angel|TTBB|Scott Anderson
 Earth Wind and Fire Medley|SSAA|Aaron Dale
 Earth's Answer|SATB|David Avshalomov
+Ease on Down the Road|SSAA|Dede Nibler
 Ease On Down The Road|SSAA|Joey Minshall
 Ease On Down The Road|SSAA|Larry Wright
 Ease On Down The Road|TTBB|Patrick McAlexander
@@ -4559,6 +5490,7 @@ East To West|SATB|Deke Sharon
 Easter Parade|SSAA|Nancy Bergman
 Easter Parade|TTBB|Ed Waesche
 Easy|TTBB|Rowena Harper
+Easy Goin?|TTBB|David Wallace
 Easy Goin'|TTBB|Walter Latzko
 Easy Living|SATB|Joe Mannherz
 Easy Living|SSAA|Joe Mannherz
@@ -4574,6 +5506,7 @@ Easy Street|TTBB|Joe Mannherz
 Easy Street|TTBB|Warren 'Buzz' Haeger
 Ebb Tide|SSAA|Fred King
 Ebb Tide|TTBB|Fred King
+Ebb Tide|TTBB|Freddie King
 Ebony And Ivory|SSAA|Takako Fuke
 Eclipse|TTBB|Anders Lindqvist
 Edelweis/Climb E'vry Mountain Medley|TTBB|Jeremey Johnson
@@ -4588,6 +5521,7 @@ Edelweiss|TTBB|Brent Graham
 Edelweiss|TTBB|Hilary Allen
 Edelweiss|TTBB|Jim West
 Edelweiss|TTBB|Joe Mannherz
+Edelweiss|TTBB|Johan Wikstrom
 Edelweiss|TTBB|Mac Huff
 Edelweiss|TTBB|Marilyn Penketh
 Edelweiss|TTBB|Rob Campbell
@@ -4601,14 +5535,18 @@ Eight Days a Week|SSAA|David Harrington
 Eight Days a Week|TTBB|David Harrington
 Eight Days a Week|TTBB|Deke Sharon
 Eight Days a Week|TTBB|Jon Nicholas
+Eight Days A Week mini|SSAA|David Harrington
+Eight Days A Week mini|TTBB|David Harrington
 Eight More Miles to Louisville|SSAA|Walter Latzko
 Eight Street Association|SSAA|Jim Arns
 Eighteen Holes|TTBB|Larry Wright
 Eighteen Wheels On A Big Rig|TTBB|Tom Gentry
 Eine Kleine Nachtmusik|SATB|Anders Lindqvist
+Eine Kleine NOT Musik|TTBB|Jim Henry
 Either Way|SSAA|Deke Sharon
 El Shaddai|SSAA|Dianne Goldrick
 El Shaddai|TTBB|Dianne Goldrick
+El Yivneh Hagalil|TTBB|Peter Sozio
 Elastic Heart|SATB|Nicholas Wright
 Elastic Heart|TTBB|Nicholas Wright
 Eleanor Rigby|SATB|Joe Mannherz
@@ -4618,10 +5556,15 @@ Eleanor Rigby|TTBB|Jon Nicholas
 Eleanor Rigby|TTBB|Thomas Degan
 Eleanor Rigby|TTBB|Tom Gentry
 Electricity|TTBB|Simon Arnott
+Elegance (From Hello, Dolly !)|SSAA|J Speta
+Eli's Comin'|SSAA|Brian Beck
+Elijah Rock|SATB|Moses Hogan
 Elijah Rock|TTBB|David Wright
 Eliza|SSAA|Jay Giallombardo
 Eliza|TTBB|Burt Szabo
 Eliza|TTBB|Jay Giallombardo
+Elmer Fudd Medley|TTBB|Scott Turnbull
+Elmer's Tune|SSAA|Joni Bescos
 Elmer's Tune|TTBB|Frank Leitnaker
 Elmer's Tune|TTBB|Jim Shubert
 Eloise|TTBB|Walter Latzko
@@ -4629,10 +5572,13 @@ Elvis Medley|SATB|Deke Sharon
 Elvis Medley|SSAA|Kathleen Ramos
 Elvis Medley|TTBB|John Hohl
 Elvis Medley|TTBB|Tom Gentry
+Elvis Medley; Can'T Help Fall Love Love Me Tender|SSAA|Joanne Dockrell
 Emaline|TTBB|Earl Moon
 Emaline|TTBB|Walter Latzko
 Embraceable You|SATB|Joe Mannherz
+Embraceable You|SATB|Steven Armstrong
 Embraceable You|SSAA|Carolyn Healey
+Embraceable You|SSAA|Dave Briner
 Embraceable You|SSAA|David Briner
 Embraceable You|SSAA|Ed Waesche
 Embraceable You|SSAA|Jay Giallombardo
@@ -4648,23 +5594,30 @@ Embraceable You|TTBB|Rob Hopkins
 Embraceable You|TTBB|Steve Jamison
 Embraceable You|TTBB|Steven Armstrong
 Embraceable You / You Do Something To Me|SSAA|Ed Hinkley
+Embraceable You/You Do Something to Me|SSAA|Ed Hinkley
+Emily|TTBB|Bob Pyper
 Emily|TTBB|Jon Nicholas
 Emily I'm Sorry|SATB|Nicholas Wright
 Emily Remembers|SSAA|Joan D 'Agostino
 Empire State Of Mind|SSAA|Larry Wright
+Empire State Of Mind (Alicia Keys)|SSAA|H Zimmerman
 Empire State of Mind (part II) Broken Dawn|SSAA|Nicholas Wright
+Empty Chairs At Empty Tables|TTBB|Steve Tramack
+Encore|SSAA|Steve Delehanty / Roger Payne
 Encore|TTBB|Roger Payne
 End of a Love Affair|TTBB|Walter Latzko
 End Of The Way|TTBB|Jim West
 End Of Time|SATB|Deke Sharon
 Endless Love|SATB|Jo Lund
 Enjoy The Ride|TTBB|Kirk Young
+Enjoy The Ride|TTBB|Steve Tramack
 Enjoy Yourself (It's Later Than You Think)|TTBB|Jim Shubert
 Entangled|TTBB|Anders Lindqvist
 Enter Sandman|SSAA|Tom Gentry
 Enter Sandman|TTBB|Tom Gentry
 Enterprise Theme (where My Heart Will Take Me)|TTBB|Chris Arnold
 Entrance Of The Gladiators|SSAA|Joey Minshall
+Entrance of the Gladiators - March of Triumph|SSAA|Joey Minshall
 EPCOT Medley|TTBB|Deke Sharon
 Epic Knight Medley|TTBB|Various
 Eres Tu/Touch The Wind|SSAA|Doris Twardosky
@@ -4672,6 +5625,8 @@ Eres Tu/Touch The Wind|SSAA|Judith Riley
 Erie Canal|TTBB|Keith Clark
 Erie Canal|TTBB|Walter Latzko
 Escape|TTBB|Kevin Koehl
+Eternal Father|TTBB|Dan Tice
+Eternal Father, Strong To Save|TTBB|Joe Johnson
 Eternal Flame|SSAA|Dawn Haggerty
 Eternal Flame|SSAA|Wayne Grimmer
 Eternity|SATB|Anders Lindqvist
@@ -4683,12 +5638,15 @@ Ev'ry Day Of My Life|TTBB|Robert Mattes
 Ev'ry Day Of My Life|TTBB|Ron Bergenstock
 Ev'ry Morning She Makes Me Late|TTBB|Steve Hardy
 Ev'ry Night I Cry Myself to Sleep Over You|TTBB|Walter Latzko
+Ev'ry Street's a Boulevard|SSAA|Jarmela Speta
+Ev'ry Time We Say Goodbye|SATB|Henrik Rosenberg
 Ev'ry Time We Say Goodbye|SATB|Joe Mannherz
 Ev'ry Time We Say Goodbye|SSAA|Joe Mannherz
 Ev'ry Time We Say Goodbye|TTBB|Joe Mannherz
 Ev'rybody Wants To Be A Cat|SATB|Deke Sharon
 Ev'rybody Wants To Be A Cat|SSAA|Melody Hine
 Ev'rybody Wants To Be A Cat|SSAA|Tedda Lippincott
+Eve Wasn't Modest Till She Ate That Apple|TTBB|Ig Jakovac
 Even Now|SSAA|Jay Giallombardo
 Even Now|TTBB|Jay Giallombardo
 Evening Sun Descended|TTBB|James Trapp
@@ -4713,8 +5671,12 @@ Every Breath You Take|SSAA|Aaron Dale
 Every Breath You Take|TTBB|Aaron Dale
 Every Breath You Take|TTBB|Alex Morris
 Every Breath You Take|TTBB|Nicholas Wright
+Every Day of My Life|SSAA|Lynnell Diamond
+Every Day of My Life|TTBB|Bob Mattes
 Every Day Of My Life|SSAA|Jay Giallombardo
+Every Day Of My Life|SSAA|Unspecified
 Every Day Of My Life|TTBB|Jay Giallombardo
+Every Day Of My Life|TTBB|Unspecified
 Every Little Thing She Does Is Magic|SATB|Simon Lubkowski
 Every Little Thing She Does Is Magic|TTBB|Adam Scott
 Every Night|TTBB|Walter Latzko
@@ -4726,12 +5688,15 @@ Every Tear Is A Smile|TTBB|Burt Szabo
 Every Time I Feel The Spririt|SATB|Derric Johnson
 Every Time I Join My Sister In A Song|SSAA|Paul C. Olguin
 Every Time I See You, I Cry|TTBB|Mac Huff
+Every Time We Say Goodbye|TTBB|Dave Briner
 Every Time We Say Goodbye|TTBB|Rob Hopkins
 Every Time We Say Goodbye|TTBB|Steve Jamison
 Every Which-a-way|SATB|David Wright
 Every Woman's Song|SSAA|Joey Minshall
 Everybody (backstreet's Back)|TTBB|Nicholas Wright
 Everybody Eats When They Come to My House|TTBB|Melody Hine
+Everybody Loves a Hero|TTBB|Drayton Justus
+Everybody Loves a Lover|TTBB|Unspecified
 Everybody Loves A Lover|SSAA|Anna Maria Parker
 Everybody Loves A Lover|SSAA|Joey Minshall
 Everybody Loves A Lover|TTBB|Drayton Justus
@@ -4744,11 +5709,13 @@ Everybody Loves Somebody|SSAA|Joey Minshall
 Everybody Loves Somebody|SSAA|Kohl Kitzmiller
 Everybody Loves Somebody|SSAA|Larry Triplett
 Everybody Loves Somebody|SSAA|Tedda Lippincott
+Everybody Loves Somebody|TTBB|John Hohl
 Everybody Loves Somebody|TTBB|Jon Nicholas
 Everybody Loves Somebody|TTBB|Kevin Keller
 Everybody Loves Somebody|TTBB|Kohl Kitzmiller
 Everybody Loves Somebody|TTBB|Larry Triplett
 Everybody Loves Somebody|TTBB|Todd Troutman
+Everybody Loves Somebody Sometime|SSAA|Tedda Lippincott
 Everybody Needs a Best Friend|SATB|Jeremey Johnson
 Everybody Needs a Best Friend|TTBB|Aaron Dale
 Everybody Needs Somebody To Love|SSAA|Jim Arns
@@ -4758,12 +5725,15 @@ Everybody Step|SSAA|Linda Edmondson
 Everybody Step|TTBB|Carole Prietto
 Everybody Step|TTBB|Dennis Driscoll
 Everybody Step|TTBB|Jim Shubert
+Everybody Step/Alexander's Ragtime Band Medley|TTBB|Greg Volk
 Everybody Talks|SATB|Deke Sharon
 Everybody Talks|SATB|Nicholas Wright
 Everybody Wants To Be A Cat (from The Aristocats)|TTBB|Jason Dyer
 Everybody Wants To Go To Heaven|SSAA|Louis Perry
 Everybody Wants To Go To Heaven|TTBB|Louis Perry
 Everybody's Buddy|TTBB|Jay Giallombardo
+Everybody's Changing|TTBB|Henrik Rosenberg
+Everybody's Crazy Over Dixie|TTBB|Steve Taylor
 Everybody's Doin' It Now|SSAA|Charlotte Pernert
 Everybody's Doin' It Now|TTBB|Walter Latzko
 Everybody's Walkin' Down in New Orleans|TTBB|Robert Rund
@@ -4773,10 +5743,12 @@ Everyone's Wrong But Me|TTBB|Kevin Keller
 Everything|SSAA|Aaron Dale
 Everything|SSAA|Carolyn Healey
 Everything|SSAA|Larry Wright
+Everything|SSAA|Lynnell Diamond
 Everything|SSAA|Takako Fuke
 Everything|TTBB|Aaron Dale
 Everything|TTBB|Adam Scott
 Everything|TTBB|Larry Wright
+Everything (Michael Buble)|SSAA|Aaron Dale
 Everything Changes|TTBB|Adam Bock
 Everything Happens To Me|SSAA|Dianne Goldrick
 Everything Happens To Me|TTBB|Dianne Goldrick
@@ -4787,8 +5759,10 @@ Everything Is Awesome|SATB|Liz Garnett
 Everything Is Beautiful|TTBB|Jim Stenson
 Everything Is Peaches Down In Georgia|TTBB|Burt Szabo
 Everything Old Is New Again|SSAA|Ann Minihane
+Everything Old Is New Again|SSAA|Bev Sellers
 Everything Old Is New Again|SSAA|Joe Mannherz
 Everything Old Is New Again|TTBB|Ed Waesche
+Everything Old Is New Again|TTBB|Hank Shuster
 Everything Old Is New Again|TTBB|Henry Shuster
 Everything Old Is New Again|TTBB|Joe Mannherz
 Everything's All Right|SSAA|June Berg
@@ -4799,8 +5773,14 @@ Everything's Comin' Up Roses|SSAA|Tom Gentry
 Everything's Comin' Up Roses|TTBB|Adam Reimnitz
 Everything's Comin' Up Roses|TTBB|David Wright
 Everything's Comin' Up Roses|TTBB|Dennis Driscoll
+Everything's Comin' Up Roses|TTBB|Greg Volk
 Everything's Comin' Up Roses|TTBB|Tom Gentry
+Everything's Coming Up Roses|SSAA|Carolyn Schmidt
+Everything's Coming Up Roses|SSAA|Joey Minshall
 Everything's Coming Up Roses|TTBB|David Wright
+Everything's Coming Up Roses|TTBB|Unspecified
+Everything's Coming Up Roses/There's No Business Like Show Business Medley(Brian|TTBB|Brian Beck
+Everything's Up To Date In Kansas City|TTBB|Jay Giallombardo
 Everywhere|SSAA|Lauren Kahn
 Everywhere|TTBB|Mark Stevens
 Everywhere I Go|TTBB|Deke Sharon
@@ -4811,10 +5791,12 @@ Evil Like Me|SATB|Dan Wessler
 Evolution Of Dance Medley|TTBB|Clay Hine
 Ex's & Oh's|SSAA|Rowena Harper
 Exactly Like Me!|SSAA|Jo Lund
+Exactly Like You|SSAA|Elaine Gain
 Exactly Like You|SSAA|Joe Mannherz
 Exactly Like You|SSAA|Scott Kitzmiller
 Exactly Like You|TTBB|Luke Stevenson
 Exactly Like You|TTBB|Scott Kitzmiller
+Exodus|SATB|Nancy Bergman
 Exodus|TTBB|Jim West
 Express Yourself|SSAA|Jay Dougherty
 Extraordinary|SSAA|Jeremey Johnson
@@ -4826,11 +5808,15 @@ Eye Of The Tiger|SATB|Deke Sharon
 Eye Of The Tiger|SSAA|Jay Giallombardo
 Eye Of The Tiger|TTBB|Jay Giallombardo
 Eye Of The Tiger|TTBB|Nicholas Wright
+Eyes Medley|SSAA|Brent Graham
+Eyes Medley|SSAA|Clay Hine
 Eyes Medley|SSAA|Jay Giallombardo
 Eyes Medley|TTBB|Jay Giallombardo
+Ezekiel Saw da Wheel|SSAA|Breath of Life Quartet
 Ezekiel Saw The Wheel|TTBB|David Wright
 Ezekiel Saw The Wheel|TTBB|Derric Johnson
 F Sharp|TTBB|Wayne Grimmer
+Fa La La|TTBB|Tom Gentry
 Fa-La-La|SSAA|Tedda Lippincott
 Fa-La-La|TTBB|Tom Gentry
 Fabricating Frankie Medley|TTBB|Tom Gentry
@@ -4851,6 +5837,7 @@ Faith|TTBB|Kohl Kitzmiller
 Faith of our Fathers|TTBB|Walter Latzko
 Faithfully|TTBB|Mark Stevens
 Fallen Angel|TTBB|Theodore Hicks
+Fallen for Somebody New|TTBB|Larry Wright
 Fallin'|SATB|Nicholas Wright
 Fallin'|SSAA|Nicholas Wright
 Fallin'|TTBB|Deke Sharon
@@ -4858,8 +5845,11 @@ Falling In Love Again (Can't Help It)|SSAA|Becky Cartine
 Falling In Love With You|TTBB|Eric Ruthenberg
 Fallingwater|SATB|Nicholas Wright
 Fame|SSAA|Debbie Keretz
+Fame|SSAA|Debbie Keretz/Jo Kraut
+Fame|SSAA|Jarmela Speta
 Fame|SSAA|Joey Minshall
 Fame|SSAA|Mike Taylor
+Fame|SSAA|Paula Mauritzen
 Family Guy Theme Song|TTBB|Brent Graham
 Family Guy Theme Song|TTBB|Kevin Koehl
 Family Man|TTBB|Walter Latzko
@@ -4869,11 +5859,16 @@ Far Away Places Medley|SSAA|Carolyn Schmidt
 Far From The Home I Love|SSAA|Charlene Yazurlo
 Far From The Home I Love|TTBB|Gabriel Lawson
 Far Side Banks of Jordan|SSAA|Kay Bromert
+Fare The Well Love|TTBB|Jay Giallombardo
 Fare Thee Well|SSAA|Joey Minshall
 Fare Thee Well|TTBB|Jay Giallombardo
 Fare Thee Well Annabelle|TTBB|Ed Waesche
 Fare Thee Well Love|TTBB|David Wright
+Fare Thee Well, Love|SSAA|Joey Minshall
+Fare Thee Well, Love|TTBB|David Wright, Chris Arnold
 Farmer Tan|TTBB|Dan Wessler
+Farmer Tan|TTBB|Jayson Ryner
+Fascinatin' Rhythm|TTBB|Jay Giallombardo
 Fascinating Rhythm|SSAA|Jay Giallombardo
 Fascinating Rhythm|SSAA|Walter Latzko
 Fascinating Rhythm|TTBB|Archie Steen
@@ -4881,14 +5876,21 @@ Fascinating Rhythm|TTBB|Jay Giallombardo
 Fascinating Rhythm|TTBB|Steve Jamison
 Fascinating Rhythm|TTBB|Walter Latzko
 Fast Car|TTBB|Nicholas Wright
+Fat Bottomed Girls|TTBB|Mason Kaye
+Fat Bottomed Girls|TTBB|Simon Hunt
+Fat Bottomed Girls (Queen)|TTBB|Simon Hunt
 Father The Tree|SATB|David Avshalomov
 Fats Waller Medley|TTBB|J Rae Jamieson
+Fattig Bonddrang|TTBB|Johan Wikstrom
 Favourite Pair of Pants|TTBB|Dom Finetti
+Feast Of Lights|SSAA|Greg Lyne
+Feast of Lights Medley|TTBB|Barbershop Harmony Society
 Feast Of Lights Medley|SSAA|Gregory Lyne
 Feast Of Lights Medley|TTBB|Gregory Lyne
 Feed The Birds|SATB|Kevin Keller
 Feed The Birds|SATB|Larry Triplett
 Feed The Birds|SSAA|Diana DeBruycker
+Feed The Birds|SSAA|Joe Spiecker
 Feed The Birds|SSAA|June Dale
 Feed The Birds|SSAA|Kevin Keller
 Feed The Birds|SSAA|Larry Triplett
@@ -4903,6 +5905,9 @@ Feel It Still|TTBB|Kohl Kitzmiller
 Feelin' Alright|SATB|Deke Sharon
 Feelin' Fine|TTBB|Todd Troutman
 Feelin' Good|TTBB|John Brockman
+Feelin' Groovy|SSAA|YWIH
+Feelin' Groovy|TTBB|Aidan Brand
+Feelin' Groovy (The 59th Street Bridge Song) (YWIH)|SSAA|Marge Bailey
 Feelin' Stronger Every Day|TTBB|Anders Lindqvist
 Feeling Blue|TTBB|Jud Finley
 Feeling Good|SATB|Joe Mannherz
@@ -4910,6 +5915,8 @@ Feeling Good|SSAA|David Harrington
 Feeling Good|SSAA|Liz Garnett
 Feeling Good|TTBB|David Harrington
 Feeling Good|TTBB|Patrick McAlexander
+Feeling Good 4-part|SSAA|David Harrington
+Feeling Good 5-part|SSAA|David Harrington
 Feelings|SSAA|Jo Lund
 Feels Like Home|SATB|Melody Hine
 Feels Like Home|SSAA|Carole Prietto
@@ -4918,33 +5925,45 @@ Feels Like Home|SSAA|Nancy Bergman
 Feels Like Home|TTBB|Mark Burnip
 Feels Like Home|TTBB|Walter Latzko
 Feliz Navidad|SATB|Deke Sharon
+Feliz Navidad|SATB|Mel Knight
 Feliz Navidad|SSAA|Dianne Goldrick
 Feliz Navidad|SSAA|Julie Starr
 Feliz Navidad|SSAA|June Berg
 Feliz Navidad|SSAA|Kathleen Ramos
+Feliz Navidad|SSAA|Marge Bailey
+Feliz Navidad|SSAA|Marge Bailey/Kathy Ramos
 Feliz Navidad|SSAA|Nancy Bergman
 Feliz Navidad|SSAA|Tom Gentry
 Feliz Navidad|SSAA|Valerie Hoy
+Feliz Navidad|TTBB|Brian Beck
 Feliz Navidad|TTBB|Dave Briner and Tom Gentry
+Feliz Navidad|TTBB|Dave Briner/ Tom Gentry
 Feliz Navidad|TTBB|David Briner
 Feliz Navidad|TTBB|Mark Goodney
 Feliz Navidad|TTBB|Nancy Bergman
+Feliz Navidad|TTBB|Roger Payne
 Feliz Navidad|TTBB|Tom Gentry
 Feliz Navidad|TTBB|Walter Kaestner
+Feliz Navidad|TTBB|Will Hamblet
 Ferry Cross the Mersey|SATB|Liz Garnett
 Ferry Cross the Mersey|TTBB|Dan Mulligan
 Festival Of Lights|SSAA|Carolyn Johnson
+Festival Of Lights|TTBB|Alan Josephson
 Festive Carol Medley|SSAA|Jay Giallombardo
 Festive Carol Medley|TTBB|Jay Giallombardo
 Feudin' And Fightin'|TTBB|George Hulst
 Fever|SATB|Deke Sharon
+Fever|SSAA|Greg Volk
 Fever|SSAA|Jen Squires
 Fever|SSAA|Jim Arns
 Fever|SSAA|Tedda Lippincott
+Fiddle in the Band|SSAA|Tedda Lippincott
+Fiddler on the Roof Medley|TTBB|Walter Latzko
 Fidelity|SATB|Deke Sharon
 Fido Is A Hot Dog Now|TTBB|Dennis Morrissey
 Fields of Athenry|TTBB|Neil Watkins
 Fields of Athenry|TTBB|Reed Sampson
+Fields of Gold|SSAA|Anna-Marie Nystrom
 Fields Of Gold|SSAA|Anna-Maria Nystrom
 Fields Of Gold|SSAA|Deke Sharon
 Fields Of Gold|SSAA|June Dale
@@ -4955,6 +5974,7 @@ Fifteen Minute Intermission|SSAA|Nancy Bergman
 Fifteen Minute Intermission|SSAA|Norma Holzmeier
 Fifties Medley|SSAA|Jay Giallombardo
 Fifties Medley|SSAA|Jo Lund
+Fifties Medley|SSAA|Sonny Steffan
 Fifties Medley|TTBB|Jay Giallombardo
 Fifty Nifty|TTBB|Derric Johnson
 Fight Song|SATB|Melody Hine
@@ -4978,8 +5998,10 @@ Find My Way|TTBB|Nicholas Wright
 Find Out What They Like And How They Like It|SSAA|David Wright
 Fine and Dandy|TTBB|Jim West
 Fine By Me|TTBB|Nicholas Wright
+Fine Fine Line|TTBB|Ben Brown
 Finger Prints|TTBB|Dennis Driscoll
 Finian's Rainbow Medley|SSAA|Paul Grimm
+Finian's Rainbow Medley|TTBB|Gene Cokeroft
 Fire And Rain|SATB|Deke Sharon
 Fire And Rain|SATB|Melody Hine
 Fire And Rain|SSAA|Melody Hine
@@ -4988,6 +6010,7 @@ Fire And Rain|TTBB|Deke Sharon
 Fire Away|TTBB|Jackson Pinder
 Fire N Gold|SSAA|Nicholas Wright
 Firecracker|SATB|Deke Sharon
+Fireflies|SATB|E.C. Schirmer Publishing
 Fireflies|TTBB|Nicholas Wright
 Firefly|SSAA|Jon Nicholas
 Firefly|SSAA|Marge Bailey
@@ -4997,6 +6020,8 @@ Firefly|TTBB|BHS
 Firefly|TTBB|Ed Waesche
 Firefly|TTBB|Jon Nicholas
 Firefly|TTBB|SPEBSQSA
+Firefly|TTBB|Unspecified
+Firefly / Glow Worm Medley|TTBB|Don Gray
 Fireman, Save My Child|TTBB|Marie Johnson
 Firework|SATB|Deke Sharon
 Firework|SSAA|Carole Prietto
@@ -5006,6 +6031,7 @@ First Cousin|TTBB|Austin Shortes
 First Day In Heaven|TTBB|Brent Graham
 Fishy Medley|TTBB|Tom Gentry
 Fit As A Fiddle|SSAA|Arline Cardoso
+Fit As A Fiddle|SSAA|Brian Beck
 Fit As A Fiddle|SSAA|Clay Hine
 Fit As A Fiddle|SSAA|David Wright
 Fit As A Fiddle|SSAA|Walter Latzko
@@ -5013,12 +6039,15 @@ Fit As A Fiddle|TTBB|Clay Hine
 Fit As A Fiddle|TTBB|David Wright
 Fit As A Fiddle|TTBB|Todd Troutman
 Fit As A Fiddle|TTBB|Walter Latzko
+Fit As A Fiddle/The Bells Are Ringing (Medley)|SSAA|Clay Hine
 Fitzpleasure|TTBB|Nicholas Wright
+Five Foot Two|SATB|Clay Hine
 Five Foot Two|SSAA|Emily Moriarty
 Five Foot Two|SSAA|Nancy Bergman
 Five Foot Two|TTBB|Clay Hine
 Five Foot Two|TTBB|Joe Liles
 Five Foot Two|TTBB|Jon Nicholas
+Five Foot Two (Parody)|TTBB|Joe Liles
 Five Foot Two Parody|TTBB|Rob Hopkins
 Five Foot Two, Eyes Of Blue|TTBB|Clay Hine
 Five Foot Two, Eyes Of Blue|TTBB|Joe Liles
@@ -5033,6 +6062,7 @@ Five Minutes More|TTBB|Jim Shubert
 Five Minutes More|TTBB|Jon Nicholas
 Five Minutes More|TTBB|Patrick McAlexander
 Five Minutes More|TTBB|Tom Gentry
+Five Minutes More / It All Depends on You|SSAA|Doris Twardosky / D.Dolan
 Five O'Clock World|TTBB|Dan Naumann
 Five Pennies Medley|TTBB|Jeremey Johnson
 Fix You|SATB|Deke Sharon
@@ -5043,19 +6073,29 @@ Fixer Upper|SATB|Melody Hine
 Fixing A Hole|TTBB|Jon Nicholas
 Flag Waver (America The Beautiful / God Bless America)|SSAA|Nancy Bergman
 Flag Waver (America The Beautiful / God Bless America)|TTBB|Nancy Bergman
+Flag Waver Medley|SSAA|Nancy Bergman
 Flaggin' The Train To Tuscaloosa|TTBB|Patrick McAlexander
+Flamin' Agnes|TTBB|Bryan Ziegler
 Flaming Agnes|SSAA|Bryan Ziegler
 Flaming Agnes|TTBB|Bryan Ziegler
+Flashdance (What A Feeling)|SSAA|D Keretz
 Flat Foot Floogie|TTBB|Jim Shubert
 Flight|SSAA|Greg Mallett
 Flight|TTBB|Greg Mallett
+Flim Flam Man|SSAA|Frank Marzocco
 Flintstones|SSAA|Jen Squires
 Flintstones|TTBB|Andrew Tepe
 Flip Flop Fly|TTBB|Deke Sharon
 Flip top|SATB|Joe Mannherz
+Flirty Eyes|SSAA|Marcia Hill/Nancy Bergman
 Flirty Eyes|SSAA|Nancy Bergman
+Flirty Eyes|SSAA|Nancy Bergman/Marcia Hill
+Flirty Eyes|TTBB|Tony Nasto
 Flirty Eyes/Jeepers Creepers Medley|SSAA|Jeanne Elmuccio
 Floatin' Along|TTBB|Dan Wessler
+Floatin' Down The River Medley|TTBB|Ed Waesche
+Floatin' Down to Cotton Town|SSAA|David Wright
+Floatin' Down to Cotton Town|SSAA|Renee Craig
 Floatin' Down To Cotton Town|SSAA|Walter Latzko
 Floatin' Down To Cotton Town|TTBB|Rob Campbell
 Floatin' Down To Cotton Town|TTBB|Walter Latzko
@@ -5071,6 +6111,8 @@ Fly|SATB|Deke Sharon
 Fly Away|SATB|Deke Sharon
 Fly Like An Eagle|SATB|Deke Sharon
 Fly Like An Eagle|TTBB|Deke Sharon
+Fly Me to the Moon|SSAA|Mo Field
+Fly Me to the Moon|SSAA|Zona Snyder
 Fly Me To The Moon|SATB|Kohl Kitzmiller
 Fly Me To The Moon|SATB|Nicholas Wright
 Fly Me To The Moon|SSAA|Aaron Dale
@@ -5090,8 +6132,13 @@ Fly me to the Moon/Come fly with me Medley|SATB|Joe Mannherz
 Fly me to the Moon/Come fly with me Medley|SSAA|Joe Mannherz
 Fly me to the Moon/Come fly with me Medley|TTBB|Joe Mannherz
 Fly To Heaven Medley|TTBB|David Harrington
+Fly To Heaven Medley: I'll Fly Away, I Surrender All, Down In The River To Pray, When We All Get to Heaven|TTBB|David Harrington
 Fly's Eyes|TTBB|Tom Gentry
+Flyin' High Medley|SSAA|June Dale
+Flying High Medley|SSAA|June Dale
+Flying Sinatra Medley|SSAA|Roger Payne
 Flying Sinatra Medley|TTBB|Roger Payne
+Flying Sinatra Medley|TTBB|Roger Payne, Ed Waesche
 Folk Medley|TTBB|Derric Johnson
 Folks Who Live On The Hill|SATB|Joe Mannherz
 Folks Who Live On The Hill|SSAA|Joe Mannherz
@@ -5103,16 +6150,20 @@ Follow Me|SATB|Kohl Kitzmiller
 Follow Me|SSAA|Kevin Koehl
 Follow Me|SSAA|Kohl Kitzmiller
 Follow Me|SSAA|Mark Rusch
+Follow Me|TTBB|Johan Wikstrom
 Follow Me|TTBB|Kevin Koehl
 Follow Me|TTBB|Kohl Kitzmiller
 Follow Me|TTBB|Mark Goodney
 Follow Me|TTBB|Nicholas Wright
 Follow Me|TTBB|Todd Troutman
 Follow The Crowd|SSAA|Joan D 'Agostino
+Follow The Drinking Gourd|SSAA|Bob Jones
 Follow The Flag|TTBB|Doug Nichol
 Follow the Fold|TTBB|Walter Latzko
+Follow The Fold|SATB|Don Gray
 Follow You|TTBB|Kevin Koehl
 Follow Your Heart|TTBB|Louis Perry
+Follow Your Star|TTBB|Douglas E. Wagner
 Folsom Prison Blues|TTBB|Mark Stevens
 Folsom Prison Blues|TTBB|Tom Gentry
 Food Blooz|SSAA|Carolyn Schmidt
@@ -5123,11 +6174,13 @@ Fool On The Hill|TTBB|Anders Lindqvist
 Fool On The Hill|TTBB|Jay Giallombardo
 Fool On The Hill|TTBB|Jon Nicholas
 Fools Fall In Love|TTBB|Kohl Kitzmiller
+Fools Rush In|TTBB|Joe Johnson
 Football Hero Medley|SSAA|Jay Giallombardo
 Football Hero Medley|TTBB|Jay Giallombardo
 Football Medley|SSAA|Tom Gentry
 Football Medley|TTBB|Tom Gentry
 Footloose|SSAA|Aaron Dale
+Footloose|SSAA|Brian Beck
 Footloose|SSAA|Kay Bromert
 Footloose|SSAA|Kohl Kitzmiller
 Footloose|TTBB|Aaron Dale
@@ -5136,13 +6189,18 @@ Footsteps Of Jesus|TTBB|Derric Johnson
 For (S)He's a Jolly Good Fellow|SATB|Deke Sharon
 For All The World|SSAA|David Briner
 For All We Know|SATB|Mark Stevens
+For All We Know|SSAA|Avis Fellows
 For All We Know|SSAA|Becky Cartine
 For All We Know|SSAA|Clay Hine
+For All We Know|SSAA|Dave Briner
 For All We Know|SSAA|David Briner
 For All We Know|SSAA|Diane Clark
+For All We Know|SSAA|June Dale
+For All We Know|SSAA|Renee Craig
 For All We Know|TTBB|David Briner
 For All We Know|TTBB|Joe Mannherz
 For All We Know|TTBB|Liz Garnett
+For All We Know|TTBB|Lou Perry
 For All We Know|TTBB|Rob Hopkins
 For All Your Miracles|SSAA|Jay Giallombardo
 For All Your Miracles|TTBB|Jay Giallombardo
@@ -5155,16 +6213,19 @@ For Forever|TTBB|Dan Wessler
 For Forever|TTBB|Theodore Hicks
 For Good|SATB|Deke Sharon
 For Good|SSAA|Carole Prietto
+For Good|SSAA|Carolyn Healey
 For Good|SSAA|Carolyn Schmidt
 For Good|SSAA|Joan D 'Agostino
 For Good|SSAA|June Berg
 For Good|SSAA|Larry Wright
+For Good|SSAA|Lynnell Diamond
 For Good|SSAA|Melody Hine
 For Good|SSAA|Michael Gellert
 For Good|SSAA|Steve Tramack
 For Good|SSAA|Tom Gentry
 For Good|TTBB|Aaron Dale
 For Good|TTBB|Steve Tramack
+For Good|TTBB|Steven Armstrong
 For Good|TTBB|Tom Gentry
 For Good (from Wicked)|TTBB|Steve Tramack
 For Her|TTBB|Dan Wessler
@@ -5191,6 +6252,7 @@ For Once In My Life|SSAA|Tom Gentry
 For Once In My Life|TTBB|Aaron Dale
 For Once In My Life|TTBB|Adam Reimnitz
 For Once In My Life|TTBB|Joe Mannherz
+For Once In My Life|TTBB|John Hohl
 For Once In My Life|TTBB|Mark Goodney
 For Once In My Life|TTBB|Steve Tramack
 For Once In My Life|TTBB|Tom Gentry
@@ -5207,10 +6269,17 @@ For Sentimental Reasons|TTBB|Mark Goodney
 For The Beauty of the Earth|SSAA|Carolyn Johnson
 For The Beauty of the Earth|TTBB|Jon Nicholas
 For the Good Times|TTBB|Tom Gentry
+For the Longest Time|SSAA|Lorraine Rochefort
+For the Longest Time|SSAA|Tom Gentry
+For the Longest Time|TTBB|Roger Emerson
+For the Sake of Auld Lang Syne|SSAA|Joni Bescos
+For the Sake of Auld Lang Syne|SSAA|Renee Craig
 For The Sake Of Auld Lang Syne|SSAA|Mark Rusch
 For The Sake Of Auld Lang Syne|TTBB|Don Hewey
 For The Sake Of Auld Lang Syne|TTBB|Ed Waesche
 For The Sake Of Auld Lang Syne|TTBB|Jay Giallombardo
+For The Sake Of Auld Lang Syne|TTBB|Jim Clancy
+For The Sake Of Auld Lang Syne|TTBB|John Hohl, Ed Waesche
 For The Sake Of Auld Lang Syne|TTBB|Mark Rusch
 For The Sake Of Auld Lang Syne|TTBB|Rob Campbell
 For the Want of a Kiss|SATB|Joe Mannherz
@@ -5219,6 +6288,7 @@ For the Want of a Kiss|TTBB|Joe Mannherz
 For You|SSAA|Eileen Leotta
 For You|TTBB|Kohl Kitzmiller
 For Your Love|SATB|Deke Sharon
+Forest Lawn|SSAA|Bev Sellers
 Forest Lawn|SSAA|Tedda Lippincott
 Forest Lawn|SSAA|Tom Gentry
 Forest Lawn|TTBB|Dennis Driscoll
@@ -5253,15 +6323,18 @@ Forgetting|SSAA|Jan Meyer
 Forgetting You|TTBB|James Bongard
 Forgive Me|SSAA|Earl Moon
 Forgive Me|SSAA|Jay Giallombardo
+Forgive Me|SSAA|Tom Gentil
 Forgive Me|TTBB|Don Gray
 Forgive Me|TTBB|Earl Moon
 Forgive Me|TTBB|Jay Giallombardo
 Forgive Me|TTBB|Rob Hopkins
+Forgive Me (Parody)|TTBB|Unspecified
 Forgiven Says It All|TTBB|Brent Graham
 Forgotten Dreams/Long Ago Medley|SATB|Joe Mannherz
 Forgotten Dreams/Long Ago Medley|SSAA|Joe Mannherz
 Forties Medley|SSAA|Jay Giallombardo
 Forties Medley|TTBB|Jay Giallombardo
+Forties Tune|SSAA|Joe Liles
 Fortune In Dreams|SSAA|Earl Moon
 Fortune In Dreams|TTBB|Clay Hine
 Fortune In Dreams|TTBB|Earl Moon
@@ -5270,6 +6343,8 @@ Fortuosity|SSAA|Dan Wessler
 Fortuosity|TTBB|Kohl Kitzmiller
 Fortuosity|TTBB|Russ Foris
 Fortuosity (from Disney's "The Happiest Millionaire")|TTBB|Russ Foris
+Forty Second Street|SSAA|Dot Calvin
+Forty Second Street|TTBB|Greg Volk
 Forty-Five Minutes from Broadway|TTBB|Gregory Lyne
 Forty-Five Minutes from Broadway|TTBB|Walter Latzko
 Forty-Second Street|SSAA|Walter Latzko
@@ -5280,6 +6355,8 @@ Found/Tonight|TTBB|Greg Mallett
 Four Brothers (Four Sisters)|SSAA|Kirsten Bridges
 Four Foot Two|SSAA|Tom Gentry
 Four Foot Two|TTBB|Tom Gentry
+Four Leaf Clover|TTBB|Barbershop Harmony Society
+Four Leaf Clover/Yes Sir Medley|SSAA|Joe Spiecker
 Four Seasons In One Day|TTBB|Rowena Harper
 Four Seasons Medley|SSAA|Tom Gentry
 Four Seasons Medley|TTBB|Rob Campbell
@@ -5296,8 +6373,10 @@ Freckles|TTBB|Jack Baird
 Freckles|TTBB|Toban Dvoretsky
 Freckles / Peck's Bad Boy Medley|SSAA|Tom Gentry
 Freddie Feelgood|SATB|Jay Giallombardo
+Freddie Feelgood|SSAA|Jay Giallombardo
 Freddie Feelgood|TTBB|Dave Briner
 Freddie Feelgood|TTBB|David Briner
+Freddie Feelgood [And His Funky Little Four Piece Band](Dave Br|TTBB|Dave Briner
 Free Fallin'|TTBB|Aaron Dale
 Free For All|TTBB|Dennis Driscoll
 Freedom|SATB|Nicholas Wright
@@ -5323,6 +6402,7 @@ Friendly Giant Theme|TTBB|Ed Howard
 Friends|SSAA|David Wright
 Friends|SSAA|Jo Lund
 Friends|SSAA|Sam Hubbard
+Friends|SSAA|Tedda Lippincott
 Friends|TTBB|David Wright
 Friends|TTBB|Sam Hubbard
 Friends in Low Places|SSAA|Kathy Barnett
@@ -5330,17 +6410,24 @@ Friends in Low Places|TTBB|Tom Gentry
 Friends Medley|SSAA|David Wright
 Friends Medley|TTBB|David Wright
 Friendship|SATB|Bryan Ziegler
+Friendship|SSAA|Jean Shook
 Friendship|SSAA|Jo Lund
 Friendship|TTBB|Richard Floersheimer
+Frim Fram Sauce|SSAA|Betty Grant
 Frim Fram Sauce|TTBB|Aaron Dale
+Frog Kissin'|SSAA|Marie Johnson
 Frog Kissin'|SSAA|Nancy Bergman
 Frog Kissin'|TTBB|Bob Jones
+Frog Kissin'|TTBB|Bob Jones, John Hohl
 Frog Kissin'|TTBB|Dan Wilson
 Frog Kissin'|TTBB|John Hohl
 Frog Kissin'|TTBB|Tom Gentry
+Frog Kissin' (YWIH)|SSAA|Marie Johnson
 From A Distance|SSAA|Kay Bromert
+From A Distance|SSAA|Lorraine Rochefort
 From A Distance|SSAA|Tedda Lippincott
 From A Distance|TTBB|Kim Brittain
+From A Distance (SSAA)|SSAA|Mac Huff
 From Me To You|SSAA|Emily Moriarty
 From Me To You|TTBB|Patrick McAlexander
 From Now On|SATB|Anders Lindqvist
@@ -5351,13 +6438,17 @@ From Now On|TTBB|Sheryl Neal
 From Now On/Come Alive|TTBB|Aaron Dale
 From Now On/Come Alive (from The Greatest Showman)|TTBB|Aaron Dale
 From Sunrise to Sunset|SSAA|Joan D 'Agostino
+From the First Hello|TTBB|Lou Perry
+From The First Hello|TTBB|Ed Waesche
 From The First Hello (To The Last Goodbye)|TTBB|Lou Perry
 From The First Hello To The Last Goodbye|SSAA|Brent Graham
 From The First Hello To The Last Goodbye|SSAA|Jim Arns
 From The First Hello To The Last Goodbye|TTBB|Brent Graham
+From The First Hello To The Last Goodbye|TTBB|Lou Perry
 From The First Hello To The Last Goodbye|TTBB|Louis Perry
 From The Ground Up|SSAA|Melody Hine
 From The Land Of Sky Blue Water|TTBB|Howard Dale
+From the Sniff Hello|SSAA|Lou Perry
 From The Start|SATB|Jay Dougherty
 From The Start|SATB|Steve Tramack
 From The Time You Say Goodbye|TTBB|Marilyn Penketh
@@ -5372,6 +6463,9 @@ From This Moment On|TTBB|Jim Emery
 From This Moment On|TTBB|Joe Mannherz
 From This Moment On|TTBB|John Hohl
 From This Moment On|TTBB|Steve Tramack
+Frosty / Santa Medley|TTBB|Roger Payne
+Frosty the Snowman|SSAA|Donna Shorkey
+Frosty the Snowman|SSAA|Sandy Sharpe
 Frosty The Snowman|SATB|Rob Campbell
 Frosty The Snowman|SSAA|Carolyn Schmidt
 Frosty The Snowman|SSAA|Rob Campbell
@@ -5404,6 +6498,7 @@ Fun In Just One Lifetime|TTBB|Joe Liles
 Fun Medley|SATB|Deke Sharon
 Funk Medley|TTBB|Aaron Dale
 Funk Medley – Uptown Funk|TTBB|Aaron Dale
+Funky Rudolph|SSAA|Ann Minihane
 Funniest Clown In The Big Top|SSAA|Carolyn Schmidt
 Funniest Clown In The Big Top|TTBB|Michael McCord
 Funny But I Still Love You|TTBB|Michael Webber
@@ -5411,6 +6506,7 @@ Funny face|SATB|Joe Mannherz
 Funny How Time Slips Away|TTBB|Jon Nicholas
 Future Days|TTBB|Larry Wright
 Gabriela|SATB|Mark Stevens
+Gaither Vocal Band Medley|SSAA|Steve Tramack
 Galileo|SSAA|Deke Sharon
 Galway Bay|SSAA|Larry Wright
 Galway Bay|TTBB|Dennis Driscoll
@@ -5440,9 +6536,12 @@ Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Burt Szabo
 Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Jack Baird
 Gee But There's Class To A Girl Like You|TTBB|Dennis Driscoll
 Gee But There's Class To A Girl Like You|TTBB|Jack Baird
+Gee I'm Glad It's Raining|TTBB|Jeremey Johnson
 Gee What A Wonderful Day|TTBB|Ed Gentry
+Gee, But It's Good To Be Here|SSAA|Joey Minshall
 Gee, I Wish I Was Back in the Army|TTBB|Jay Giallombardo
 Gee, I Wish I Was Back in the Army|TTBB|Tom Gentry
+Gee, I Wish I Was Back In The Army|SSAA|Tom Gentry
 Gee, I'm Glad It's Rainin'|TTBB|Jeremey Johnson
 Gee! But I Hate To Go Home Alone|TTBB|Dennis Driscoll
 Gentle Annie|SSAA|Diane Clark
@@ -5454,29 +6553,42 @@ George M. Cohan Medley|TTBB|Paul Engel
 George M. Cohan Medley|TTBB|SPEBSQSA
 George M. Cohan Medley|TTBB|Steve Delehanty
 George M. Cohan Medley|TTBB|Val Hicks
+George M. Cohan Medley|TTBB|Val Hicks/Greg Lyne
 George Michael Medley|TTBB|Jeremey Johnson
 Georgia Cabin Door|SSAA|Carolyn Healey
 Georgia Camp Meeting|SSAA|Larry Wright
 Georgia Camp Meeting|TTBB|Larry Wright
 Georgia Land|TTBB|Chuck Olson
+Georgia Lullaby|SSAA|Joey Minshall
 Georgia May|SSAA|Aaron Dale
 Georgia May|TTBB|Aaron Dale
 Georgia Medley|TTBB|Tom Gentry
+Georgia on my Mind|SSAA|Brian Beck
 Georgia On My Mind|SATB|Jay Giallombardo
 Georgia On My Mind|SATB|Kevin Keller
 Georgia On My Mind|SATB|Steve Jamison
 Georgia On My Mind|SATB|Walter Latzko
 Georgia On My Mind|SSAA|David Harrington
+Georgia On My Mind|SSAA|Jim Massey
+Georgia On My Mind|SSAA|Joni Bescos
+Georgia On My Mind|SSAA|Mary Coffman
 Georgia On My Mind|SSAA|Mary K. Coffman Music Fund
 Georgia On My Mind|SSAA|Sheryl Neal
 Georgia On My Mind|SSAA|Steve Jamison
+Georgia On My Mind|SSAA|Susan Lamb
 Georgia On My Mind|TTBB|David Harrington
+Georgia On My Mind|TTBB|Jim Clancy
 Georgia On My Mind|TTBB|Scott Kitzmiller
 Georgia On My Mind|TTBB|Steve Jamison
+Geronimo|SSAA|Thomas J. West
+Gershwin Love Song Medley|TTBB|Jay Giallombardo
 Gershwin Medley|SATB|Jay Giallombardo
 Gershwin Medley|TTBB|Derric Johnson
 Gershwin Montage|TTBB|Jay Giallombardo
 Gesu Bambino|SATB|Derric Johnson
+Gesu Bambino|SATB|Joe Liles
+Gesu Bambino|SSAA|Jarmela Speta
+Gesu Bambino|SSAA|Joe Liles
 Gesu Bambino|TTBB|Gabriel Lawson
 Get A Job|SATB|Manoj Padki
 Get A Job|SSAA|Charlene Yazurlo
@@ -5486,6 +6598,7 @@ Get Happy|SATB|Roland Sharette
 Get Happy|SSAA|Ann Minihane
 Get Happy|SSAA|Kohl Kitzmiller
 Get Happy|SSAA|Nancy Bergman
+Get Happy|TTBB|Ann Minihane
 Get Happy|TTBB|Jim Shubert
 Get Happy|TTBB|Kevin Keller
 Get Happy|TTBB|Kohl Kitzmiller
@@ -5493,33 +6606,40 @@ Get Happy/Hallelujah|TTBB|Kevin Keller
 Get Home|SATB|Nicholas Wright
 Get Lost|SATB|Richard Curtis
 Get Lucky|TTBB|Nicholas Wright
+Get Me to the Church on Time|SSAA|Nancy Bergman
 Get Me To The Church On Time|SSAA|Aaron Dale
 Get Me To The Church On Time|SSAA|Carolyn Schmidt
 Get Me To The Church On Time|SSAA|Jay Giallombardo
 Get Me To The Church On Time|SSAA|Tom Gentry
 Get Me To The Church On Time|TTBB|Aaron Dale
+Get Me To The Church On Time|TTBB|Don Gray
 Get Me To The Church On Time|TTBB|Gary Lewis
 Get Me To The Church On Time|TTBB|Jay Giallombardo
 Get Me To The Church On Time|TTBB|Kohl Kitzmiller
 Get Me To The Church On Time|TTBB|Tom Gentry
+Get Me To The Church On Time Medley|TTBB|David Wright
 Get Me To The Church On Time/The Joint is Jumpin|TTBB|David Wright
 Get Me to the Girl Medley|TTBB|Tom Gentry
 Get On Board (The Gospel Train)|TTBB|Michael Webber
 Get On Your Feet|SSAA|Aaron Dale
 Get Out And Get Under The Moon|TTBB|Aaron Dale
 Get Out And Get Under The Moon|TTBB|Ed Waesche
+Get Out And Shop|SSAA|Nancy Bergman
 Get Out And Shop!|SSAA|Nancy Bergman
 Get Out And Vote!|SSAA|Nancy Bergman
 Get Out Those Old Records|SSAA|Walter Latzko
 Get Out Those Old Records|TTBB|Barbershop Harmony Society
+Get Out Those Old Records|TTBB|HEP
 Get Out Those Old Records|TTBB|SPEBSQSA
 Get Out Those Old Records Medley|TTBB|Mo Rector
+Get Ready|SSAA|Kevin McMahon
 Get Ready|TTBB|James Henry
 Get Together|SSAA|Lauren Kahn
 Get Up And Go|SSAA|Kevin Keller
 Get Up And Go|TTBB|Kevin Keller
 Get Your Happy Days On Medley|TTBB|Aaron Dale
 Get Your Happy Days On!|TTBB|Aaron Dale
+Get Your Happy Days On! Medley|TTBB|Aaron Dale
 Get'cha Head in the Game|SATB|Deke Sharon
 Getting Some Fun Out Of Life|SSAA|David Briner
 Getting Some Fun Out Of Life|TTBB|Kyle Snook
@@ -5530,18 +6650,24 @@ Getting To Know You|SSAA|Tedda Lippincott
 Getting To Know You|SSAA|Walter Latzko
 Getting To Know You|TTBB|Larry Wright
 Ghost|SSAA|Joey Minshall
+Ghost Riders|TTBB|Unspecified
+Ghost Riders in the Sky|TTBB|Unspecified
+Ghost Riders In the Sky|TTBB|Larry Wright
 Ghost Story|TTBB|Deke Sharon
 Ghostbusters|TTBB|Brian Doepke
 Ghosts (How Can I Move On)|SSAA|Liz Garnett
 Gilligan's Island Theme Song|SSAA|Larry Wright
 Gilligan's Island Theme Song|TTBB|Larry Wright
 Gimme A Little Kiss Will Ya Huh|SATB|Mel Knight
+Gimme A Man After Midnite|SSAA|Ase Hagerman
 Gimme Gimme|SSAA|Adam Bock
 Gimme Gimme|SSAA|Greg Mallett
 Gimme Gimme|SSAA|Melody Hine
 Gimme Gimme|TTBB|Greg Mallett
+Gimme Gimme Gimme (Abba)|SSAA|Alison Jack
 Gimme Some Lovin'|TTBB|Theodore Hicks
 Gimme That Wine|TTBB|Dan Wessler
+Gimme! Gimme! Gimme! (A Man After Midnight)|SSAA|Ase Hagerman
 Girl|SATB|Anders Lindqvist
 Girl|SATB|Deke Sharon
 Girl|TTBB|Deke Sharon
@@ -5557,6 +6683,7 @@ Girl Of My Dreams|TTBB|Jim West
 Girl Of My Dreams|TTBB|Lloyd McClure
 Girl Of My Dreams|TTBB|Phil Embury
 Girl Of My Dreams|TTBB|Renee Craig
+Girl Of My Dreams|TTBB|Roy Keys
 Girl on Fire|SSAA|Aaron Dale
 Girl on Fire|SSAA|Joey Minshall
 Girl on Fire|SSAA|Melody Hine
@@ -5570,15 +6697,21 @@ Girls Just Wanna Have Fun|SSAA|Carolyn Schmidt
 Girls Just Wanna Have Fun|SSAA|Deke Sharon
 Girls Just Wanna Have Fun|SSAA|Liz Garnett
 Girls Medley|TTBB|Ed Waesche
+Girls Night Out|SSAA|Brian Beck
 Girls Night Out|SSAA|Charlene Yazurlo
+Girls Night Out|SSAA|Moses Hogan
 Girls, Girls|TTBB|Dave Stevens
+Give 'Em A Show They'll Never Forget|SSAA|Lynnell Diamond
 Give A Little Love|SSAA|Carolyn Healey
+Give A Little Whistle|TTBB|Joe Liles
 Give A Little Whistle|TTBB|Lance Fisher
 Give It Away|SSAA|Avis Fellows
 Give It Away|TTBB|Dennis Driscoll
 Give Me A Band and My Baby|SSAA|Janice Wheeler
 Give Me A Band and My Baby|TTBB|Alexander Ronneburg
+Give Me a Barbershop Song|SSAA|Roy Dawson and Steve Hall
 Give Me A Barbershop Song|SSAA|Steve Hall
+Give Me A Barbershop Song|TTBB|Roy Dawson
 Give Me A Barbershop Song|TTBB|Steve Hall
 Give Me a Basketball|TTBB|Paul Olguin
 Give Me A Basketball|TTBB|Paul Olquin
@@ -5597,6 +6730,7 @@ Give Me That Barbershop Style|TTBB|Einar Pedersen
 Give Me That Smile|TTBB|Adam Scott
 Give Me The Circus Life|SSAA|Joey Minshall
 Give Me The Moonlight, Give Me The Girl|TTBB|Dennis Driscoll
+Give Me the Simple Life|TTBB|Walter Latzko
 Give Me The Simple Life|SATB|Aaron Dale
 Give Me The Simple Life|SSAA|Aaron Dale
 Give Me The Simple Life|SSAA|Connie Kash
@@ -5610,11 +6744,14 @@ Give Me Wings|SSAA|Joan D 'Agostino
 Give Me Your Tired, Your Poor|SSAA|Donna Stewart
 Give Me Your Tired, Your Poor|SSAA|Jay Giallombardo
 Give Me Your Tired, Your Poor|SSAA|Norma Andersen
+Give Me Your Tired, Your Poor|TTBB|Barbershop Harmony Society
 Give Me Your Tired, Your Poor|TTBB|Derric Johnson
 Give Me Your Tired, Your Poor|TTBB|Jay Giallombardo
 Give Me Your Tired, Your Poor|TTBB|Jim West
 Give Me Your Tired, Your Poor|TTBB|SPEBSQSA
+Give My Regards To Broadway|SSAA|Betty Owens
 Give My Regards To Broadway|SSAA|Jay Giallombardo
+Give My Regards To Broadway|TTBB|Al Baker, Steve Tramack
 Give My Regards To Broadway|TTBB|Burt Szabo
 Give My Regards To Broadway|TTBB|Jay Giallombardo
 Give My Regards To Broadway|TTBB|Toban Dvoretsky
@@ -5623,8 +6760,11 @@ Give Us This Day|SSAA|Doris Twardosky
 Give Us This Day|SSAA|Tedda Lippincott
 Give Us Your Blessing, Lord|SSAA|Muriel Berg
 Glad Rag Doll|SSAA|Dawn Haggerty
+Glad Rag Doll|TTBB|Dennis Driscoll
 Glad Rag Doll|TTBB|Jim Shubert
 Glad Tidings All To You|SSAA|Carolyn Johnson
+Glenn Miller Medley|TTBB|Dick Rode
+Glenn Miller Medley|TTBB|Unspecified
 Glimpse Of Us|SSAA|Sheryl Neal
 Glitter In The Air|SSAA|Joey Minshall
 Gloria|SSAA|Jay Giallombardo
@@ -5652,26 +6792,33 @@ Glow Worm|SSAA|Jim Massey
 Glow Worm|TTBB|Dan Wessler
 Glow Worm|TTBB|Mark Vile
 Glow Worm|TTBB|Walter Latzko
+Glow Worm / Cab Driver Medley|TTBB|Waesche/Martinez
 Glue|TTBB|Jay Giallombardo
 Gnome Travelogue Medley|TTBB|Kevin Keller
 Go|SATB|Deke Sharon
 Go Ahead and Rejoice|SATB|David Avshalomov
+Go Away Little Girl|TTBB|Unspecified
 Go Down Moses|TTBB|David Wright
 Go Down Moses|TTBB|Derric Johnson
+Go Down, Mose|TTBB|Moses Hogan
+Go Home, Little Girl, Go Home|SSAA|Marie Johnson
 Go Rest High on that Mountain|SATB|Jon Nicholas
 Go Rest High on that Mountain|SSAA|Jon Nicholas
 Go Rest High on that Mountain|SSAA|Kohl Kitzmiller
 Go Rest High on that Mountain|TTBB|Jon Nicholas
 Go Rest High on that Mountain|TTBB|Kevin Keller
+Go Tell It On the Mountain|SSAA|Joe Liles
 Go Tell It On The Mountain|SATB|Aaron Dale
 Go Tell It On The Mountain|SATB|Deke Sharon
 Go Tell It On The Mountain|SATB|Joe Mannherz
 Go Tell It On The Mountain|SSAA|David Wright
+Go Tell It On The Mountain|SSAA|Judy Vidal
 Go Tell It On The Mountain|SSAA|June Berg
 Go Tell It On The Mountain|TTBB|Aaron Dale
 Go Tell It On The Mountain|TTBB|David Wright
 Go Tell It On The Mountain|TTBB|Deke Sharon
 Go Tell It On The Mountain|TTBB|Derric Johnson
+Go Tell It On The Mountain|TTBB|Joe Johnson
 Go Tell It On The Mountain|TTBB|Joe Liles
 Go Tell It On The Mountain|TTBB|Jon Nicholas
 Go Tell It On The Mountain|TTBB|Roger Payne
@@ -5682,12 +6829,16 @@ Go The Distance|SSAA|Joey Minshall
 Go The Distance|SSAA|Larry Wright
 Go The Distance|TTBB|Aaron Dale
 Go The Distance|TTBB|Larry Wright
+Go The Distance (Disney)|SSAA|Aaron Dale
 Go Where I Send Thee|SATB|Vince Peterson
 Go Where I Send Thee|TTBB|Derric Johnson
 Go With A Song In Your Heart|TTBB|Dennis Driscoll
+God Be In My Head|TTBB|John Rutter
 God Be With You 'til We Meet Again|TTBB|Jim Clancy
 God Be With You 'til We Meet Again|TTBB|Walter Latzko
+God Be With You Till We Meet Again|TTBB|Joe Johnson
 God Bless America|SATB|Deke Sharon
+God Bless America|SATB|Derric Johnson
 God Bless America|SATB|Gregory Lyne
 God Bless America|SSAA|Carolyn Johnson
 God Bless America|SSAA|Dianne Goldrick
@@ -5696,12 +6847,15 @@ God Bless America|SSAA|Jarmela Speta
 God Bless America|SSAA|Jay Giallombardo
 God Bless America|SSAA|Joan Smith
 God Bless America|SSAA|Nancy Bergman
+God Bless America|SSAA|Renee Craig/Nancy Bergman
 God Bless America|SSAA|Tedda Lippincott
 God Bless America|TTBB|Derric Johnson
+God Bless America|TTBB|Greg Lyne
 God Bless America|TTBB|Gregory Lyne
 God Bless America|TTBB|Jay Giallombardo
 God Bless America|TTBB|Jon Nicholas
 God Bless America|TTBB|Larry Wright
+God Bless America Greg Lyne|TTBB|Unspecified
 God Bless My Family|SSAA|Jo Lund
 God Bless Our Senior Citizens|SSAA|Tom Gentry
 God Bless Our Senior Citizens|TTBB|Tom Gentry
@@ -5723,17 +6877,25 @@ God Bless The U.S.A.|SSAA|Tedda Lippincott
 God Bless The U.S.A.|TTBB|Brian Beck
 God Bless The U.S.A.|TTBB|Derric Johnson
 God Bless The U.S.A.|TTBB|Larry Wright
+God Bless the U.S.A. Medley|SSAA|Jarmela Speta
+God Bless the USA|SSAA|Brian Beck
+God Bless the USA|SSAA|Charlene Yazurlo
+God Bless the USA|SSAA|Tedda Lippincott
+God Bless The USA|SSAA|Carolyn Healey
+God Bless The USA|TTBB|Brian Beck
 God Bless Us Everyone|TTBB|Patrick McAlexander
 God Defend New Zealand|TTBB|Steven Armstrong
 God Didn't Make Little Green Apples|SSAA|Larry Wright
 God Didn't Make Little Green Apples|TTBB|Larry Wright
 God Help The Outcasts|SSAA|Jo Lund
 God Help The Outcasts|SSAA|Marsha Zwicker
+God Only Knows|SATB|A Mighty Wind
 God Only Knows|SATB|Joe Mannherz
 God Only Knows|SSAA|Dawn Haggerty
 God Only Knows|SSAA|Deke Sharon
 God Only Knows|SSAA|Liz Garnett
 God Only Knows|TTBB|Clay Hine
+God Only Knows|TTBB|Clive Chase
 God Only Knows|TTBB|David Wright
 God Only Knows|TTBB|Deke Sharon
 God Only Knows|TTBB|Jay Giallombardo
@@ -5743,6 +6905,9 @@ God Only Knows|TTBB|Steve Tramack
 God Only Knows (6 part - TTTBBB)|TTBB|David Wright
 God Put a Rainbow|TTBB|Tom Gentry
 God Rest Ye Frugal Shoppers|SSAA|Carolyn Johnson
+God Rest Ye Merry Gentlemen|SSAA|Renee Craig
+God Rest Ye Merry Gentlemen|TTBB|Barbershop Harmony Society
+God Rest Ye Merry Gentlemen|TTBB|Greg Volk
 God Rest Ye Merry, Gentlemen|SATB|Anders Lindqvist
 God Rest Ye Merry, Gentlemen|SATB|David Harrington
 God Rest Ye Merry, Gentlemen|SATB|Nick Bryant
@@ -5765,22 +6930,28 @@ God's Healing Love|SSAA|Diane Clark
 God's Healing Love|TTBB|Diane Clark
 GodSpeed|TTBB|Jay Giallombardo
 Goin to the Dance with You|TTBB|Aaron Dale
+Goin' Home|TTBB|Joe Liles
 Goin' Out Of My Head|SSAA|Larry Wright
 Goin' Out Of My Head|SSAA|Nancy Bergman
 Goin' Out Of My Head|TTBB|Larry Wright
+Going Away|SSAA|Russ Foris
 Going Bananas|SATB|Joe Mannherz
 Going Bananas|SSAA|Joe Mannherz
 Going Home|SSAA|Tom Gentry
 Going Home|TTBB|David Wright
 Going Home|TTBB|Mike Menefee
 Going Home|TTBB|Tom Gentry
+Going, Going, Gone Medley|SSAA|Sylvia Alsbury
 Gold|SATB|Nicholas Wright
+Gold|SSAA|Joe Liles
+Gold|TTBB|Jay Giallombardo
 Gold Can Turn To Sand|TTBB|Patrick McAlexander
 Gold Mine|TTBB|Adam Bock
 Golden|SSAA|Simon Arnott
 Golden Barefoot Days|TTBB|Dennis Driscoll
 Golden Dream|TTBB|Derric Johnson
 Golden Dreams|TTBB|Jay Giallombardo
+Golden Dreams|TTBB|Phil Ordaz
 Golden Earrings|TTBB|George Booth
 Golden Hour|SATB|Nicholas Wright
 Goldfinger|SSAA|Simon Arnott
@@ -5802,6 +6973,8 @@ Gone, Gone, Gone|SATB|Melody Hine
 Gone, Gone, Gone|SATB|Nicholas Wright
 Gone, Gone, Gone|TTBB|Deke Sharon
 Gone, Gone, Gone|TTBB|Melody Hine
+Gonna Build A Mountain|SSAA|A. Nightingale
+Gonna Build A Mountain|SSAA|Aileen Nightingale
 Gonna Build A Mountain|SSAA|Aileen Nightingale Music
 Gonna Build A Mountain|SSAA|Michael Gellert
 Gonna Build A Mountain|TTBB|Ed Waesche
@@ -5811,6 +6984,7 @@ Gonna Get a Girl|TTBB|Tom Gentry
 Gonna Get Along Without You Now|SSAA|Nancy Bergman
 Gonna Get Over You|SSAA|Melody Hine
 Gonna Make You Happy Tonight|TTBB|Kohl Kitzmiller
+Gonna Rise Up Singin'|TTBB|Ray Danley
 Goober Peas|TTBB|Larry Wright
 Good 4 U|SATB|Nicholas Wright
 Good Bye, My Lady Love|TTBB|Burt Szabo
@@ -5820,6 +6994,8 @@ Good Day Opener|TTBB|Jay Giallombardo
 Good Day Sunshine|SSAA|Emily Moriarty
 Good Day Sunshine|SSAA|Steve Tramack
 Good Day Sunshine|TTBB|David Wright
+Good Day Sunshine|TTBB|Tony Nasto
+Good Day-Wonderful Day Medley|TTBB|Jay Giallombardo
 Good Enough for Now|SATB|Matt Astle
 Good Enough for Now|SSAA|Matt Astle
 Good Enough for Now|SSAA|Tom Gentry
@@ -5827,6 +7003,7 @@ Good Enough for Now|TTBB|Ken Potter
 Good Enough for Now|TTBB|Matt Astle
 Good Enough for Now|TTBB|Steven Armstrong
 Good Enough for Now|TTBB|Tom Gentry
+Good Enough For Now|SSAA|Hasty-Lapp
 Good Enough For Now|TTBB|Rob Hopkins
 Good Job|SSAA|Melody Hine
 Good King Wenceslas|SATB|Deke Sharon
@@ -5855,15 +7032,18 @@ Good Morning Heartache|SSAA|Joe Mannherz
 Good Morning Heartache|TTBB|Joe Mannherz
 Good Morning Life|SSAA|Kevin Keller
 Good Morning Life|TTBB|Kevin Keller
+Good Morning Starshine|SSAA|Lorraine Rochefort
 Good Morning Theme|SSAA|Marie Johnson
 Good News|SATB|Mark Stevens
 Good News|SSAA|Sharon Holmes
 Good News|TTBB|Mark Stevens
 Good News|TTBB|Michael Webber
+Good News!|TTBB|Jay Althouse
 Good Nght My Someone|TTBB|S. K. Grundy
 Good Night|SSAA|Adam Bock
 Good Night|SSAA|Dede Nibler
 Good Night|SSAA|Donna Stewart
+Good Night Ladies|TTBB|Barbershop Harmony Society
 Good Night Ladies|TTBB|SPEBSQSA
 Good Night Little Girl|TTBB|Burt Szabo
 Good Night Little Soldier|TTBB|R. J. Margison
@@ -5876,6 +7056,9 @@ Good Night Sweetheart|TTBB|Todd Troutman
 Good Night Theme|SSAA|Marie Johnson
 Good Night, Little Boy Of Mine|SSAA|Val Hicks
 Good Night, Little Boy Of Mine|TTBB|Val Hicks
+Good Ol' A Cappella|TTBB|Linda Reed
+Good Old A Capella|SSAA|Chris Moyer
+Good Old A Capella|SSAA|David Wright
 Good Old A Cappella|SATB|Deke Sharon
 Good Old A Cappella|SSAA|Chris Moyer
 Good Old A Cappella|SSAA|David Wright
@@ -5883,10 +7066,13 @@ Good Old A Cappella|SSAA|Deke Sharon
 Good Old A Cappella|SSAA|Tedda Lippincott
 Good Old A Cappella|TTBB|David Wright
 Good Old A Cappella|TTBB|Deke Sharon
+Good Old Acapella|SSAA|Tedda Lippincott
+Good Old Acappella|SSAA|Chris Moyer
 Good Old Days|SSAA|Larry Wright
 Good Old Days|TTBB|Larry Wright
 Good Old-fashioned Lover Boy|SSAA|David Wright
 Good Old-fashioned Lover Boy|TTBB|Tom Gentry
+Good Ole Barbershop Style|SSAA|Jo Lund
 Good Thing Going|TTBB|Rob Hopkins
 Good Time Tavern|SATB|Kohl Kitzmiller
 Good Time Tavern|SSAA|Kohl Kitzmiller
@@ -5903,6 +7089,7 @@ Good Vibrations|TTBB|Larry Wright
 Good Vibrations|TTBB|Staffan Paulson
 Good-Bye Boys|TTBB|Unknown
 Good-Bye My Honey Love|SSAA|Carolyn Johnson
+Good-bye My Lady Love|TTBB|Renee Craig, Joe Liles
 Good-Bye My Treasure Chest|SSAA|Carolyn Johnson
 Good-Bye Rose|TTBB|Inc. SPEBSQSA
 Good/Wonderful Day Medley|SSAA|Jay Giallombardo
@@ -5921,13 +7108,19 @@ Goodbye Dear Old Friend|TTBB|Andy Wolf
 Goodbye Dear, I'll Be Back in a Year|SATB|Jay Giallombardo
 Goodbye Dear, I'll Be Back in a Year|SSAA|Jay Giallombardo
 Goodbye Dear, I'll Be Back in a Year|TTBB|Jay Giallombardo
+Goodbye Dixie Goodbye/Going Back To Caroline Medley|TTBB|Chris Slacke
+Goodbye Dixie, Goodbye|TTBB|Aaron Dale
+Goodbye Dixie, Goodbye|TTBB|Gary Parker
 Goodbye Earl|SSAA|Deke Sharon
 Goodbye In Her Eyes|TTBB|Nicholas Wright
+Goodbye Means the End of My World|SSAA|Joe Liles
 Goodbye Means The End Of My World|TTBB|Joe Liles
+Goodbye Medley|SSAA|Mary Coffman
 Goodbye Medley|SSAA|Mary K. Coffman Music Fund
 Goodbye Medley|SSAA|Tom Gentry
 Goodbye Medley|TTBB|Tom Gentry
 Goodbye Mr. A|TTBB|Nick Bryant
+Goodbye My Goodtime Friend|SSAA|Sylvia Alsbury
 Goodbye My Lady Love|TTBB|Burt Szabo
 Goodbye My Lady Love|TTBB|Kevin Keller
 Goodbye People|TTBB|Jim West
@@ -5936,6 +7129,7 @@ Goodbye Rose|TTBB|SPEBSQSA
 Goodbye Rose|TTBB|Tom Gentry
 Goodbye To Yesterday|SSAA|Kevin Koehl
 Goodbye Wild Women Goodbye|TTBB|Dennis Morrissey
+Goodbye World Goodbye|SSAA|Dave Briner
 Goodbye World Goodbye|SSAA|David Wright
 Goodbye World Goodbye|SSAA|Jay Giallombardo
 Goodbye World Goodbye|TTBB|David Wright
@@ -5944,6 +7138,7 @@ Goodbye Yellow Brick Road|SATB|Dan Wessler
 Goodbye Yellow Brick Road|SSAA|Dan Wessler
 Goodbye Yellow Brick Road|SSAA|Lauren Kahn
 Goodbye Yellow Brick Road|TTBB|Anders Lindqvist
+Goodbye Yellow Brick Road|TTBB|Joe Johnson
 Goodbye Yellow Brick Road|TTBB|Rasmus Krigstrom
 Goodbye Yellow Brick Road|TTBB|Simon Arnott
 Goodbye Yellowbrick Road|TTBB|Simon Arnott
@@ -5954,21 +7149,28 @@ Goodbye, Rose|TTBB|Burt Szabo
 Goodbye, You Phony Lyin' Baby|SSAA|Nancy Bergman
 Goodnight Angeline|TTBB|David Briner
 Goodnight Little Soldier|SSAA|Jean Shook
+Goodnight Little Soldier|SSAA|Shook, Breidert and Twaredosky
 Goodnight My Angel|SATB|Dan Naumann
 Goodnight My Angel|SATB|Ken Potter
 Goodnight My Angel|SSAA|Dan Naumann
 Goodnight My Angel|SSAA|Lyndal Thorburn
 Goodnight My Angel|SSAA|Mike Menefee
 Goodnight My Angel|TTBB|Dan Naumann
+Goodnight My Angel|TTBB|David Wright
 Goodnight My Angel|TTBB|Mike Menefee
+Goodnight My Someone|TTBB|SK Grundy
 Goodnight Saigon|TTBB|Tom Gentry
+Goodnight Sweetheart|SSAA|June Berg
 Goodnight Sweetheart|TTBB|Willis Diekema
+Goodnight Sweetheart Goodnight|SSAA|Becky Wilkins
+Goodnight Sweetheart, Goodnight|TTBB|Mel Knight
 Goodnight, Irene|TTBB|Jack Hale
 Goodnight, Ladies (from "The Music Man")|TTBB|SPEBSQSA
 Goodnight, Little Boy Of Mine|TTBB|Val Hicks
 Goodnight, Little Girl Of My Dreams|TTBB|Steve Hardy
 Goodnight, My Love|SSAA|Melody Hine
 Goodnight, My Someone (from "The Music Man")|TTBB|S. K. Grundy
+Goodnight, Saigon|TTBB|Tom Gentry
 Goodnight, Sweetheart, Goodnight|SATB|Deke Sharon
 Goodnight, Sweetheart, Goodnight|SATB|Kevin Koehl
 Goodnight, Sweetheart, Goodnight|SATB|Manoj Padki
@@ -5989,12 +7191,17 @@ Goodnight, Sweetheart, Goodnight|TTBB|Tom Gentry
 Goodnight, Sweetheart, Goodnight (Goodnight, It's Time to Go)|TTBB|Webb Comfort
 Goodnight, Well Its Time To Go|SSAA|Charlene Yazurlo
 Goodtime Barbershop & Variety Show|SSAA|Nancy Bergman
+Goodtime Barbershop and Variety Show|SSAA|Nancy Bergman
+Goodtime Strutter's Ball|SSAA|Nancy Bergman
 Goodtime Strutters' Ball|SSAA|Nancy Bergman
+Goody Goodbye|SSAA|George Avener
+Goody Goody|SSAA|Joni Bescos
 Goody Goody|SSAA|Nancy Bergman
 Goody Goody|SSAA|Rob Hopkins
 Goody Goody|TTBB|Dennis Driscoll
 Goody Goody|TTBB|Milton Teitel
 Goody Goody|TTBB|Rob Hopkins
+Goody Goody (version 2)|TTBB|Rob Hopkins
 Goofus|SSAA|Douglas Smith
 Goofus|TTBB|Dennis Driscoll
 Goofus|TTBB|Douglas Smith
@@ -6004,10 +7211,15 @@ Gorgeous|TTBB|Gabriel Lawson
 Gorilla|TTBB|Nicholas Wright
 Gortnamona|SSAA|Liz Garnett
 Gospel Home Medley|TTBB|Tom Gentry
+Gospel Medley|SSAA|Ed Waesche
+Gospel Medley|SSAA|Jay Giallombardo
+Gospel Medley|TTBB|Bluegrass Student Union
+Gospel Medley|TTBB|Ed Waesche
 Gospel Medley|TTBB|J Rae Jamieson
 Gospel Medley|TTBB|Jay Giallombardo
 Gospel Ship|TTBB|Roy Ringwald
 Got My Thumb Out|TTBB|Joe Liles
+Gotta Be On My Way|SSAA|Mike Senter
 Gotta Be On My Way|TTBB|Mike Senter Music
 Gotta Be This Or That|SSAA|Becky Cartine
 Gotta Be This Or That|SSAA|Joe Mannherz
@@ -6025,6 +7237,7 @@ Grace Kelly|SSAA|Liz Garnett
 Grace Kelly|TTBB|Kevin Koehl
 Grace Kelly|TTBB|Kohl Kitzmiller
 Graceland|SATB|Deke Sharon
+Graduation Day|SATB|EdLojeski
 Graduation Day|SSAA|Thomas Gentry
 Graduation Day|SSAA|Tom Gentry
 Graduation Day|TTBB|Thomas Gentry
@@ -6033,6 +7246,7 @@ Grampa Loves Rock And Roll|TTBB|Norma Andersen
 Gran Torino|TTBB|Theodore Hicks
 Granada|TTBB|Tom Gentry
 Grand Knowing You|TTBB|J Rae Jamieson
+Grand Old Flag This Is My Country Medley|SSAA|Judy Vidal
 Grandma Got Run Over By A Reindeer|SATB|Joe Mannherz
 Grandma Got Run Over By A Reindeer|SSAA|Carolyn Healey
 Grandma Got Run Over By A Reindeer|SSAA|Joe Mannherz
@@ -6044,13 +7258,18 @@ Grandma Got Run Over By A Reindeer|TTBB|Larry Wright
 Grandma Got Run Over By A Reindeer|TTBB|Todd Troutman
 Grandma's Boy|SSAA|Jay Giallombardo
 Grandma's Boy|TTBB|Jay Giallombardo
+Grandma's Feather Bed|SSAA|Joni Bescos
+Grandma's Feather Bed|TTBB|Tom Gentry
+Grandma's Feather Bed (YWIH)|SSAA|Joni Bescos
 Grandmas Feather Bed|SSAA|Joni Bescos
 Grandmas Feather Bed|TTBB|Jim West
 Grandmas Feather Bed|TTBB|Mark Goodney
 Grandmas Feather Bed|TTBB|Tom Gentry
+Grandmother's Love Letters|SSAA|Lois Whitney
 Grandmother's Love Letters|TTBB|Burt Szabo
 Grandmother's Love Letters|TTBB|Toban Dvoretsky
 Grandpa (Tell Me `Bout The Good Old Days)|SSAA|Tedda Lippincott
+Grapefruit Diet|SSAA|Dave Briner
 Gravity|SATB|Adam Bock
 Gravity|SATB|Kohl Kitzmiller
 Gravity|SATB|Matt Astle
@@ -6060,6 +7279,7 @@ Gravity|TTBB|Matt Astle
 Gravity Blues|SSAA|Tom Gentry
 Gravity Blues|TTBB|Tom Gentry
 Grease Medley|SSAA|Jen Squires
+Grease Medley|SSAA|Linda Masterson
 Grease Medley|TTBB|Tom Gentry
 Greased Lightning|SATB|Melody Hine
 Greased Lightning|SSAA|Jen Squires
@@ -6068,6 +7288,7 @@ Great Adventure|SATB|Nick Bryant
 Great Atomic Power|SATB|Kevin Keller
 Great Atomic Power|SSAA|Kevin Keller
 Great Atomic Power|TTBB|Kevin Keller
+Great Balls of Fire|SSAA|Larry Wright
 Great Big Blue-Eyed Baby, You're A|SSAA|Jay Giallombardo
 Great Big Blue-Eyed Baby, You're A|TTBB|Jay Giallombardo
 Great Big U.S.A.|TTBB|Deke Sharon
@@ -6075,6 +7296,7 @@ Great Day|SSAA|David Harrington
 Great Day|SSAA|David Wright
 Great Day|SSAA|Joe Mannherz
 Great Day|SSAA|Larry Wright
+Great Day|SSAA|Nancy Bergman
 Great Day|TTBB|Bob Weiss
 Great Day|TTBB|Brian Beck
 Great Day|TTBB|David Harrington
@@ -6093,8 +7315,10 @@ Great Is Thy Faithfulness|TTBB|Hal Snyder
 Great Is Thy Faithfulness|TTBB|Kevin Keller
 Great Is Thy Faithfulness|TTBB|Ray Buntaine
 Great Lakes Song|TTBB|Tom Gentry
+Great Race|SSAA|Joni Bescos
 Greatest Day|SSAA|Rosalind Johnson
 Greatest Day|TTBB|Simon Lubkowski
+Greatest Love of All|SSAA|Jo Lund
 Greatest Mistake Of My Life|TTBB|Roy Keys
 Greedy|SATB|Nicholas Wright
 Green Acres Theme|SSAA|Doris Twardosky
@@ -6111,6 +7335,7 @@ Greensleeves|SSAA|Walter Latzko
 Grenade|SATB|Nicholas Wright
 Grim Grinning Ghosts|SATB|Larry Triplett
 Grim Grinning Ghosts|TTBB|Brent Graham
+Grim Grinning Ghosts|TTBB|Kyle Williamson
 Grim Grinning Ghosts|TTBB|Larry Wright
 Grinch Medley|SSAA|Nancy Bergman
 Grizzly Bear|TTBB|Todd Troutman
@@ -6124,15 +7349,19 @@ Grouch Anthem|SSAA|Dianne Goldrick
 Grouch Anthem|TTBB|Dianne Goldrick
 Grow As We Go|SATB|Justin Miller
 Grow Old With Me|SATB|John Cowlishaw
+Grow Old With Me|TTBB|Aaron Dale
 Grow Old With Me|TTBB|Andrew Carolan
 Grow Old With You|SSAA|Aaron Dale
 Grow Old With You|TTBB|Aaron Dale
 Grow Old With You|TTBB|Larry Wright
+Growin' Old|TTBB|Unspecified
 Growin' Old Can Be Fun|TTBB|Dennis Driscoll
+Grown Up Christmas List|SSAA|Brian Beck
 Grown-Up Christmas List|SATB|Joe Mannherz
 Grown-Up Christmas List|SATB|Tom Gentry
 Grown-Up Christmas List|SSAA|Debbie Keretz
 Grown-Up Christmas List|SSAA|Elaine Gain
+Grown-Up Christmas List|SSAA|Jean Crockett Kane
 Grown-Up Christmas List|SSAA|Joe Mannherz
 Grown-Up Christmas List|SSAA|June Berg
 Grown-Up Christmas List|TTBB|Gabriel Lawson
@@ -6151,12 +7380,16 @@ Guilty|TTBB|Kevin Keller
 Guilty|TTBB|Scott Kitzmiller
 Guinnevere|SATB|Joe Mannherz
 Gulf Coast Blues|TTBB|Jim Shubert
+Guys and Dolls|TTBB|Theo Hicks
+Guys And Dolls|SATB|Don Gray
 Guys And Dolls|TTBB|Dennis Driscoll
 Guys And Dolls|TTBB|Larry Wright
 Guys And Dolls|TTBB|Theodore Hicks
 Guys and Dolls Medley|SSAA|Jo Lund
 Gypsy in my Soul|TTBB|Walter Latzko
+Gypsy Love Song|TTBB|Jay Giallombardo
 Gypsy Love Song|TTBB|Walter Latzko
+Gypsy Medley|SSAA|Lorraine Rochefort
 Hab'n Sie nicht 'ne Frau ('nen Mann) fuer mich|TTBB|Tom Gentry
 Hail Holy Queen|SSAA|Cynthia Becker
 Hail Holy Queen|SSAA|Sharon Vitkovsky
@@ -6166,8 +7399,11 @@ Hail to the Chief|TTBB|Kevin Keller
 Hair|SSAA|Emily Moriarty
 Hair|TTBB|Wayne Woodward
 Hairspray|SSAA|Michael Gellert
+Hakuna Matata|TTBB|David Wright
 Hakunah Matata|SATB|Melody Hine
+Hakunah Matata|SSAA|Lorraine Rochefort
 Hakunah Matata|TTBB|David Wright
+Hakunah Matatah|SSAA|Lorraine Rochefort
 Half Of The Way|TTBB|Thomas Degan
 Half-Way To Heaven|TTBB|Dennis Driscoll
 Hall Of Fame|SATB|Deke Sharon
@@ -6182,27 +7418,37 @@ Hallelujah|SSAA|Jay Giallombardo
 Hallelujah|SSAA|Jordan Travis
 Hallelujah|SSAA|June Dale
 Hallelujah|SSAA|Kay Bromert
+Hallelujah|SSAA|Linda Corcoran
 Hallelujah|SSAA|Sherry Berkley
+Hallelujah|SSAA|Tedda Lippincott
 Hallelujah|TTBB|Adam Scott
+Hallelujah|TTBB|Brent Graham
 Hallelujah|TTBB|Deke Sharon
 Hallelujah|TTBB|Gary Thiel
 Hallelujah|TTBB|Greg Mallett
 Hallelujah|TTBB|Jay Giallombardo
+Hallelujah|TTBB|Jim Clancy
 Hallelujah|TTBB|Jordan Travis
+Hallelujah|TTBB|Mark Hale
 Hallelujah|TTBB|Walter Latzko
 Hallelujah (Cohen)|SSAA|Adam Scott
 Hallelujah (Cohen)|TTBB|Adam Scott
+Hallelujah (Gain)|SSAA|Elaine Gain
 Hallelujah (SATB) (Cohen)|SATB|Adam Scott
+Hallelujah (Sharon)|SSAA|Deke Sharon
+Hallelujah Chorus|SATB|George Frideric Handel
 Hallelujah Chorus|SSAA|Jay Giallombardo
 Hallelujah Chorus|TTBB|David Wright
 Hallelujah Chorus|TTBB|Derric Johnson
 Hallelujah Chorus|TTBB|Jay Giallombardo
 Hallelujah Chorus|TTBB|Mark Goodney
+Hallelujah Chorus (Parody)|SSAA|Jim Arns
 Hallelujah Christmas|SSAA|Kay Bromert
 Hallelujah, I Love Her So|TTBB|Aaron Dale
 Hallelujah, I Love Her So|TTBB|Jay Giallombardo
 Hallelujah, I Love Her So|TTBB|Kohl Kitzmiller
 Hallelujah, I Love Her So|TTBB|Tom Gentry
+Halloween Medley|SSAA|M. Penketh
 Halls Of Ivy|SSAA|Jay Giallombardo
 Halls Of Ivy|TTBB|Don Gray
 Halls Of Ivy|TTBB|Jay Giallombardo
@@ -6211,6 +7457,7 @@ Hand In Hand|TTBB|Matt Astle
 Hand Medley|TTBB|Dennis Driscoll
 Handclap|SATB|Nicholas Wright
 Handful Of Keys|SSAA|David Wright
+Handful Of Keys|TTBB|Walter Latzko
 Hands|SATB|Deke Sharon
 Hang Fire|SATB|Don Staffin
 Hang Fire|TTBB|Don Staffin
@@ -6221,17 +7468,22 @@ Hang On Sloopy|TTBB|Tom Gentry
 Hang On The Bell, Nellie|TTBB|Barbershop Harmony Society
 Hang On The Bell, Nellie|TTBB|SPEBSQSA
 Hang On The Bell, Nellie|TTBB|Unknown
+Hang With Me|SSAA|Henrik Rosenberg
 Hanginaround|SATB|Deke Sharon
+Hannuka Medley|TTBB|James Shubert
 Hannukah Song|TTBB|Deke Sharon
 Hannukah, Oh Hannukah|SATB|Deke Sharon
+Hanukah Medley|SSAA|Lorraine Rochefort
 Hanukkah|SATB|Derric Johnson
 Hanukkah|SSAA|Kathleen Ramos
 Hanukkah In Santa Monica|SATB|Jake Bavarsky
 Hanukkah In Santa Monica|TTBB|Jake Bavarsky
+Hanukkah In Santa Monica|TTBB|John Hohl
 Hanukkah In Santa Monica|TTBB|Mark Goodney
 Hanukkah Medley|SSAA|Erica Kelch-Slesnick
 Hanukkah Medley|SSAA|Jim Arns
 Hanukkah Medley|TTBB|Jim Arns
+Hanukkah, Songs For|SSAA|Anna Maria Parker
 Happier Than Ever|TTBB|Allyson Lotz
 Happiness|SSAA|Fran Carter
 Happiness|SSAA|Nicholas Wright
@@ -6247,6 +7499,7 @@ Happy|SSAA|Elaine Gain
 Happy|SSAA|Hari Birtles
 Happy|SSAA|Larry Wright
 Happy|SSAA|Lauren Kahn
+Happy|SSAA|Mo Field
 Happy|SSAA|Sheryl Neal
 Happy|TTBB|Adam Scott
 Happy|TTBB|Jeremey Johnson
@@ -6255,21 +7508,32 @@ Happy|TTBB|Tom Gentry
 Happy (from "Despicable Me 2")|SATB|Adam Scott
 Happy (from "Despicable Me 2")|SSAA|Adam Scott
 Happy (from "Despicable Me 2")|TTBB|Adam Scott
+Happy (Pharrell Williams)|SSAA|Elaine Gain
+Happy (Wright)|SSAA|Nick Wright
 Happy Anniversary|SATB|David Avshalomov
 Happy Anniversary|SSAA|David Avshalomov
 Happy Anniversary|TTBB|David Avshalomov
 Happy Anniversary|TTBB|Dennis Driscoll
 Happy As The Sun|TTBB|Justin Miller
+Happy Birthday|SSAA|David Harrington
 Happy Birthday|SSAA|Jen Squires
 Happy Birthday|SSAA|Jess Curtiss
+Happy Birthday|SSAA|Larry Wright
+Happy Birthday|SSAA|Nancy Bergman/Renee Craig
+Happy Birthday|SSAA|Traditional
+Happy Birthday|TTBB|David Harrington
+Happy Birthday|TTBB|Not Specified
 Happy Birthday - Beautiful Baby|TTBB|Jim West
 Happy Birthday (Keep a Song In Your Heart)|SSAA|Cris Conerty
 Happy Birthday (non Traditional)|SSAA|Larry Wright
+Happy Birthday Baby|TTBB|Aaron Dale
+Happy Birthday Doo Wop|SSAA|Joey Minshall
 Happy Birthday To You|SATB|Brian Doepke
 Happy Birthday To You|SATB|Deke Sharon
 Happy Birthday To You|SATB|Derric Johnson
 Happy Birthday To You|SATB|Dianne Goldrick
 Happy Birthday To You|SATB|Joe Mannherz
+Happy Birthday To You|SATB|Peter Nugent
 Happy Birthday To You|SSAA|Brent Graham
 Happy Birthday To You|SSAA|David Harrington
 Happy Birthday To You|SSAA|Dianne Goldrick
@@ -6288,7 +7552,10 @@ Happy Birthday To You|TTBB|Robert Clark
 Happy Birthday To You|TTBB|Tom Gentry
 Happy Days|TTBB|Joshua Matisoff
 Happy Days|TTBB|Joshua Matisoff and Joseph Redgate
+Happy Days and Lonely Nights|SSAA|Carolyn Healey
 Happy Days And Lonely Nights|TTBB|Earl Moon
+Happy Days are Here Again|SSAA|Jim Arns
+Happy Days are Here Again|TTBB|Bob Robson
 Happy Days Are Here Again|SSAA|Michael Gellert
 Happy Days Are Here Again|SSAA|Sheryl Neal
 Happy Days Are Here Again|TTBB|David Wright
@@ -6301,12 +7568,15 @@ Happy Days Are Here Again|TTBB|Robert Robson
 Happy Days Are Here Again|TTBB|Walter Latzko
 Happy Days Are Here/Get Happy Medley|SSAA|Jay Giallombardo
 Happy Days Are Here/Get Happy Medley|TTBB|Jay Giallombardo
+Happy Days Lonely Nights|SSAA|Pam Basinski
+Happy Days Theme|TTBB|J. Matisoft and J. Redgate
 Happy Ending|SATB|Deke Sharon
 Happy Ending|TTBB|Matt Astle
 Happy Feet|SSAA|Jim Arns
 Happy Feet Medley|TTBB|Ed Waesche
 Happy Go Lucky Lane|TTBB|Jay Giallombardo
 Happy Go Lucky Lane|TTBB|Jay Giallombardo/Greg Volk
+Happy Hanukkah My Friend|SSAA|Nancy Bergman
 Happy Hanukkah, My Friend|SSAA|Jeanne Elmuccio
 Happy Hanukkah, My Friend|SSAA|Nancy Bergman
 Happy Happy Birthday Baby|TTBB|Aaron Dale
@@ -6318,9 +7588,12 @@ Happy Holiday|SSAA|June Berg
 Happy Holiday|TTBB|Jay Giallombardo
 Happy Holiday Medley|SATB|Joe Mannherz
 Happy Holiday Medley|TTBB|Jay Giallombardo
+Happy Holiday/It's The Holiday Season Medley|SSAA|Mark Hale
 Happy Holiday/The Holiday Season|SATB|Adam Scott
 Happy Holiday/The Holiday Season|SSAA|Adam Scott
 Happy Holiday/The Holiday Season|TTBB|Adam Scott
+Happy Holidays/It's The Holiday Season|SSAA|Mark Hale
+Happy Holidays/It's The Holiday Season|TTBB|Mark Hale
 Happy Joyous Hanuka|TTBB|Jake Bavarsky
 Happy Man|TTBB|Jim West
 Happy Rhythm|SSAA|Joey Minshall
@@ -6331,17 +7604,22 @@ Happy Times|SSAA|Becky Cartine
 Happy Together|SATB|Carolyn Schmidt
 Happy Together|SATB|Joey Minshall
 Happy Together|SATB|Liz Garnett
+Happy Together|SSAA|Carolyn Schmidt
 Happy Together|SSAA|David Wright
 Happy Together|SSAA|Joey Minshall
+Happy Together|SSAA|Krista Carlson/David Wright
 Happy Together|SSAA|Larry Wright
 Happy Together|SSAA|Liz Garnett
+Happy Together|SSAA|Marie Hampton
 Happy Together|SSAA|Takako Fuke
 Happy Together|SSAA|Walter Latzko
 Happy Together|TTBB|Chris Arnold
 Happy Together|TTBB|David Wright
 Happy Together|TTBB|Ed Howard
+Happy Together|TTBB|Krista Carlson, David Wright
 Happy Together|TTBB|Larry Wright
 Happy Together|TTBB|Liz Garnett
+Happy Together|TTBB|Nylons
 Happy Trails|SSAA|June Berg
 Happy Trails|SSAA|Tom Gentry
 Happy Trails|TTBB|Brent Graham
@@ -6354,13 +7632,19 @@ Happy Trails|TTBB|Steve Delehanty
 Happy Trails|TTBB|Todd Troutman
 Happy Trails|TTBB|Tom Gentry
 Happy Trails|TTBB|Tom Parker
+Happy Trails (4 Part Mens, 2 Part Womens)|SATB|Steve Delehanty
+Happy Trails To You/Route 66 Medley|TTBB|Brent Graham
 Happy Working Song|SSAA|Hilary Allen
+Happy Xmas War Is Over (Give Peace A Chance)|SSAA|Lynnell Diamond
 Happy/All About That Bass Medley|SSAA|Larry Wright
 Happy/Sad|TTBB|Adam Reimnitz
+Harbor Lights|SSAA|Mary Coffman
 Harbor Lights|SSAA|Mary K. Coffman Music Fund
 Harbor Lights|TTBB|Paul Jorg
+Harbour Lights|TTBB|Chris MacMartin
 Hard Boiled Rose|TTBB|Marty Israel
 Hard Candy Christmas|SSAA|Melody Hine
+Hard Hearted Hanna|TTBB|Clay Hine
 Hard Hearted Hannah|SSAA|Betty Oliver
 Hard Hearted Hannah|SSAA|Dave Stevens
 Hard Hearted Hannah|SSAA|Jo Lund
@@ -6372,20 +7656,31 @@ Hard Hearted Hannah|SSAA|Michael Gellert
 Hard Hearted Hannah|TTBB|Clay Hine
 Hard Hearted Hannah|TTBB|Dennis Driscoll
 Hard Hearted Hannah|TTBB|Howard Jones Jr.
+Hard Hearted Hannah|TTBB|Jeff Taylor
 Hard Hearted Hannah|TTBB|Larry Wright
 Hard Hearted Hannah|TTBB|Todd Troutman
+Hard Hearted Hannah|TTBB|Val Hicks
 Hard Hearted Hannah|TTBB|Walter Latzko
 Hard Times (No One Knows Better Than I)|TTBB|Kevin Keller
 Hard Times (No One Knows Better Than I)|TTBB|Theo Hicks
 Hard Times Come Again No More|SATB|Thomas Degan
 Hard Times Come Again No More|TTBB|David Wright
+Hard Times Come Again No More|TTBB|Patrick Rose
+Hard Times, Come Again No More|TTBB|David Wright
 Hard To Get Gertie|TTBB|Ed Waesche
 Hard To Say I'm Sorry|SATB|Deke Sharon
 Hard To Say I'm Sorry|SSAA|Brian Mastrull
 Hard To Say I'm Sorry|TTBB|Brian Mastrull
 Hard To Say I'm Sorry|TTBB|Deke Sharon
 Hard To Say I'm Sorry (from Summer Lovers)|TTBB|David Mastrull
+Hard-Hearted Hannah|SSAA|Lorraine Rochefort
+Hard-Hearted Hannah|SSAA|Marge Bailey
+Hard-Hearted Hannah|SSAA|Michael Gellert
 Harder To Breathe|TTBB|Deke Sharon
+Hark The Angels Sing Gloria|SSAA|Judy Vidal Renee Craig
+Hark the Herald Angels Sing|TTBB|Barbershop Harmony Society
+Hark The Herald Angels Sing|SSAA|Renee Craig
+Hark The Herald Angels Sing|TTBB|David Harrington
 Hark the Herald Angels Sing/Angels We Have Heard on High|TTBB|Jay Giallombardo
 Hark! The Herald Angels Sing|SATB|David Harrington
 Hark! The Herald Angels Sing|SSAA|David Harrington
@@ -6398,10 +7693,13 @@ Hark! The Herald Angels Sing|TTBB|Dianne Goldrick
 Hark! The Herald Angels Sing|TTBB|Gabriel Lawson
 Hark! The Herald Angels Sing|TTBB|Walter Latzko
 Harlem Sandman / Mr. Sandman Medley|SSAA|Jo Lund
+Harley Davidson Medley|SSAA|Gene Cokeroft
 Harmonisch im Abgang|TTBB|Tom Gentry
 Harmonize The World|SSAA|Nancy Bergman
+Harmony|SATB|Doug Miller
 Harmony|SATB|Douglas Miller
 Harmony|SSAA|David Wright
+Harmony|SSAA|Susan Lamb
 Harmony|TTBB|David Wright
 Harmony|TTBB|Douglas Miller
 Harmony|TTBB|Jim West
@@ -6411,7 +7709,9 @@ Harmony Collage|TTBB|Joe Liles
 Harmony Explosion Tags|TTBB|
 Harmony Hall|SATB|Nicholas Wright
 Harmony Joe|SSAA|Tom Gentry
+Harmony Joe|TTBB|Joe Johnson
 Harmony Joe|TTBB|Tom Gentry
+Harmony Leads the Way|SSAA|Joe Liles
 Harmony Leads The Way|TTBB|Joe Liles
 Harmony Rag|TTBB|Mel Knight
 Harrigan / Mulligan Medley|TTBB|Burt Szabo
@@ -6429,28 +7729,38 @@ Havana|SSAA|Nicholas Wright
 Have A Good Time|SATB|Deke Sharon
 Have A Good Time|SSAA|Becky Cartine
 Have A Happy Day|TTBB|Mac Huff
+Have a Holly Jolly Christmas|SSAA|Sandy Sharpe
 Have A Little Talk With Jesus|TTBB|Derric Johnson
+Have A Little Talk With Myself|SSAA|Aileen Nightingale
 Have A Little Talk With Myself|TTBB|Gary Parker
+Have a Nice Day|SSAA|Beth Rothwell
 Have A Nice Day|TTBB|Tom Gentry
 Have A Smile|TTBB|Steve Sutherland
 Have A Smile|TTBB|T. W. De Crow
+Have I Stayed Too Long At The Fair|SSAA|Renee Craig
 Have I Told You Lately|SSAA|Dianne Goldrick
 Have I Told You Lately|SSAA|Jeremey Johnson
 Have I Told You Lately|TTBB|Jeremey Johnson
 Have I Told You Lately|TTBB|Todd Troutman
+Have I Told You Lately That I Love You?|SSAA|Henrik Rosenberg
 Have It All|TTBB|Dan Wessler
 Have to Say I Love You in a Song, I'll|SATB|Jay Giallombardo
 Have You Even Been In Heaven?|TTBB|Dennis Driscoll
+Have you Ever Been Lonely|SSAA|Aileen Nightingale
+Have You Ever Been Lonely|TTBB|Unspecified
 Have You Ever Been Lonely?|SSAA|Aileen Nightingale Music
 Have You Ever Been Lonely?|TTBB|Roger Craig
 Have You Ever Been Lonely? (Have You Ever Been Blue?)|TTBB|Roger Craig
+Have you Ever Heard the Swanee River Cry|SSAA|Dot Calvin
 Have You Ever Seen The Rain?|SSAA|Kay Bromert
 Have You Got Any Castles, Baby?|SSAA|June Berg
 Have You Met Miss Jones|SSAA|Jo Lund
 Have You Met Miss Jones|TTBB|Dan Wessler
 Have You Met Miss Jones|TTBB|Rasmus Krigstrom
 Have You Met Miss Jones|TTBB|Walter Latzko
+Have You Met Miss Jones?|SSAA|Jo Lund
 Have You Met Miss Jones?|TTBB|Rasmus Krigström
+Have You See the Child?|TTBB|Jay Giallombardo
 Have You Seen The Child|TTBB|Jay Giallombardo
 Have Yourself a Mary Little Christmas|TTBB|M. Gill
 Have Yourself A Merry Little Christmas|SATB|Chris Arnold
@@ -6479,11 +7789,13 @@ Have Yourself A Merry Little Christmas|TTBB|David Harrington
 Have Yourself A Merry Little Christmas|TTBB|Derric Johnson
 Have Yourself A Merry Little Christmas|TTBB|Greg Mallett
 Have Yourself A Merry Little Christmas|TTBB|Jay Giallombardo
+Have Yourself A Merry Little Christmas|TTBB|Jim Clancy
 Have Yourself A Merry Little Christmas|TTBB|Joe Grimme
 Have Yourself A Merry Little Christmas|TTBB|Kohl Kitzmiller
 Have Yourself A Merry Little Christmas|TTBB|Larry Merriman
 Have Yourself A Merry Little Christmas|TTBB|Larry Wright
 Have Yourself A Merry Little Christmas|TTBB|Steve Delehanty
+Have Yourself A Merry Little Christmas|TTBB|Unspecified
 Have Yourself A Merry Little Christmas|TTBB|Walter Latzko
 Haven't Met You Yet|SATB|Deke Sharon
 Haven't Met You Yet|SATB|Matt Astle
@@ -6508,6 +7820,7 @@ He|TTBB|Tom Gentry
 He Ain't Heavy, He's My Brother|SSAA|Jay Giallombardo
 He Ain't Heavy, He's My Brother|TTBB|Deke Sharon
 He Ain't Heavy, He's My Brother|TTBB|Jay Giallombardo
+He Ain't Heavy, He's My Brother|TTBB|Jim Clancy
 He Ain't Heavy, He's My Brother|TTBB|Mark Burnip
 He ain't heavy/Air that I breathe|SSAA|Mark Burnip
 He ain't heavy/Air that I breathe|TTBB|Mark Burnip
@@ -6518,6 +7831,7 @@ He May Be Old, But He's Got Young Ideas|SSAA|Marie Johnson
 He May Be Old, But He's Got Young Ideas|TTBB|Don King
 He May Be Old, But He's Got Young Ideas|TTBB|Harry Buerer
 He Never Failed Me Yet|SSAA|David Wallace
+He Never Failed Me Yet|TTBB|Robert Ray
 He Never Said A Mumblin' Word|TTBB|Derric Johnson
 He Never Sleeps|TTBB|Derric Johnson
 He Started The Whole World Singing|SSAA|Margaret Swift
@@ -6525,6 +7839,8 @@ He Touched Me|SSAA|Kay Bromert
 He Touched Me|SSAA|Larry Wright
 He Touched Me|TTBB|Jack Tyne
 He Touched Me|TTBB|Walter Latzko
+He Was Really Saying Something/Needle In A Haystack Medley|SSAA|Zac Booles
+He Was There|SSAA|Nancy Bergman
 He Was There (at the Mardi Gras)|SSAA|Nancy Bergman
 He Will Carry You|SATB|Larry Triplett
 He Will Carry You|SSAA|Larry Triplett
@@ -6532,6 +7848,7 @@ He Will Carry You|TTBB|Larry Triplett
 He Will Set Your Fields On Fire|TTBB|John Hale
 He'd Have To Get Under - Get Out And Get Under|TTBB|Burt Szabo
 He'd Keep On Saying Good Night|TTBB|Steve Jamison
+He'll Be Coming Down the Chimney|SSAA|Nancy Bergman
 He'll Be Coming Down The Chimney (When He Comes)|SSAA|Nancy Bergman
 He's A Cousin Of Mine|SSAA|Connie Nickel
 He's A Cousin Of Mine|TTBB|Don Gray
@@ -6540,16 +7857,23 @@ He's a Runner|SATB|Joe Mannherz
 He's Gone|TTBB|Derric Johnson
 He's Got The Whole World|TTBB|Fred King
 He's Got The Whole World|TTBB|Jon Nicholas
+He's Got The Whole World In His Hand|TTBB|Jon Nicholas
+He's Got The Whole World In His Hands|TTBB|Fred King
 He's My Rock, My Sword, My Shield|SSAA|Tedda Lippincott
+He's the Good Man That Was so Hard to Find|SSAA|Burt Szabo
 Head Over Heels|SSAA|Lauren Kahn
 Head Over Heels|TTBB|Mark Stevens
+Headless Horseman|TTBB|Aaron Dale
 Heal The World|SSAA|Takako Fuke
 Hear Me Out|SSAA|Deke Sharon
+Hear That Swanee River Cry|SSAA|Mary Coffman
 Hear That Swanee River Cry|TTBB|Mac Huff
 Hear the Voice of the Bard|SATB|David Avshalomov
 Hear Them Bells|TTBB|Jon Nicholas
 Hear Us Now, Oh God, Our Father|TTBB|Einar Pedersen
+Heard It Through The Grapevine|TTBB|Alex Kaiserman
 Heart|SSAA|Jim Massey
+Heart|SSAA|Massey
 Heart|TTBB|Ed Waesche
 Heart|TTBB|Einar Pedersen
 Heart|TTBB|Roger Payne
@@ -6557,6 +7881,8 @@ Heart (from "Damn Yankees")|TTBB|Ed Waesche
 Heart (You Gotta Have)|SSAA|Larry Wright
 Heart (You Gotta Have)|TTBB|Larry Wright
 Heart (You Gotta Have)|TTBB|Walter Latzko
+Heart (You've Gotta Have)|SSAA|Barbara McNeill
+Heart (You've Gotta Have)|SSAA|Larry Wright
 Heart And Soul|SATB|Bryan Ziegler
 Heart And Soul|SATB|Kohl Kitzmiller
 Heart And Soul|SSAA|Bryan Ziegler
@@ -6565,6 +7891,7 @@ Heart And Soul|SSAA|Marsha Zwicker
 Heart And Soul|TTBB|Bryan Ziegler
 Heart And Soul|TTBB|Simon Arnott
 Heart Attack|SATB|Nicholas Wright
+Heart Of a Clown|SSAA|Joni Bescos
 Heart Of A Clown|SSAA|Lloyd Steinkamp
 Heart Of A Clown|TTBB|Bruce Cannon
 Heart Of A Clown|TTBB|Duane Enders
@@ -6578,18 +7905,27 @@ Heart of Glass|SATB|Deke Sharon
 Heart of Glass|SSAA|Deke Sharon
 Heart Of Gold|SSAA|Claudia Westland
 Heart Of Gold|SSAA|Cris Conerty
+Heart of My Heart|SSAA|Barbershop Harmony Society
 Heart of My Heart|SSAA|LaVeda Redfield
 Heart of My Heart|SSAA|Nancy Bergman
+Heart of My Heart|SSAA|Unspecified
 Heart of My Heart|TTBB|Brent Graham
+Heart of My Heart|TTBB|Traditional
+Heart Of My Heart|TTBB|Barbershop Harmony Society
+Heart of My Heart (The Story of the Rose)|TTBB|Barbershop Harmony Society
+Heart Of My Heart [Story Of The Rose]|TTBB|Barbershop Harmony Society
 Heart Of My Heart Medley|TTBB|Fred King
 Heart Of My Heart, Story Of The Rose|TTBB|Burt Szabo
 Heart Of Stone|SSAA|Jen Squires
 Heart-breaking Baby Doll|TTBB|Burt Szabo
+Heartache Tonight|SSAA|Jim Arns
 Heartache Tonight|TTBB|Aaron Dale
 Heartache Tonight|TTBB|Deke Sharon
 Heartache Tonight|TTBB|Rasmus Krigström
+Heartaches|SSAA|Brian Beck
 Heartaches|SSAA|Marsha Zwicker
 Heartaches|TTBB|John Eby
+Heartaches/Lies Medley|SSAA|Joni Bescos
 Heartbeat Song|SATB|Nicholas Wright
 Heartbreak Hotel|TTBB|Deke Sharon
 Heartbreaker|SATB|Deke Sharon
@@ -6601,6 +7937,8 @@ Heat Wave|SSAA|David Wright
 Heat Wave|SSAA|Joey Minshall
 Heat Wave|SSAA|Kevin Keller
 Heat Wave|TTBB|Dan Wessler
+Heat Wave (Love is Like a Heat Wave)|SSAA|Joey Minshall
+Heatwave|SSAA|Kevin Keller
 Heave Away|TTBB|Greg Mallett
 Heaven|SATB|Deke Sharon
 Heaven|SATB|Nicholas Wright
@@ -6608,6 +7946,7 @@ Heaven|TTBB|Joe Grimme
 Heaven Can Wait|SATB|Don Staffin
 Heaven Can Wait|TTBB|Don Staffin
 Heaven Medley (Cheek To Cheek/My Blue Heaven)|TTBB|John Brockman
+Heaven on My Mind|TTBB|Unspecified
 Heaven Will Protect The Working Girl|TTBB|Burt Szabo
 Heaven Will Protect The Working Girl|TTBB|Jack Baird
 Heaven's Light|TTBB|Adam Bock
@@ -6627,6 +7966,7 @@ Hello Dolly|SSAA|Carolyn Schmidt
 Hello Dolly|TTBB|Dick Barrett
 Hello Dolly|TTBB|Don Gray
 Hello Dolly|TTBB|Ed Waesche
+Hello Hollywood Hello|SSAA|Nancy Bergman
 Hello Ma Baby|SSAA|Jay Giallombardo
 Hello Ma Baby|TTBB|Bill Diekema
 Hello Ma Baby|TTBB|Burt Szabo
@@ -6635,6 +7975,7 @@ Hello Mary Lou|SSAA|Tedda Lippincott
 Hello Mary Lou|TTBB|David Wright
 Hello Mary Lou|TTBB|Tom Gentry
 Hello Mary Lou (Goodbye Heart)|TTBB|David Wright
+Hello Muddah, Hello Faddah|SSAA|Tedda Lippincott
 Hello Muddah, Hello Faddah|SSAA|Tom Gentry
 Hello Muddah, Hello Faddah|TTBB|Tom Gentry
 Hello My Baby|SSAA|Betty Oliver
@@ -6647,17 +7988,22 @@ Hello My Baby|TTBB|Kevin Keller
 Hello My Baby|TTBB|Val Hicks
 Hello My Baby|TTBB|Walter Latzko
 Hello My Baby|TTBB|Willis Diekema
+Hello My Baby Through the Years|SSAA|Clay Hine
+Hello My Baby, Won't You Please Come Home|TTBB|Steven Armstrong, Jan-Ake Westin
 Hello Young Lovers|SSAA|Anna Maria Parker
 Hello Young Lovers|SSAA|David Briner
 Hello Young Lovers|SSAA|Tom Gentry
 Hello Young Lovers|TTBB|Tom Gentry
 Hello, Detective Joe|TTBB|Tom Gentry
 Hello, Hollywood, Hello|SSAA|Nancy Bergman
+Hello, Young Lovers|SSAA|Anna Maria Parker
+Hello! My Baby|TTBB|Burt Szabo
 Help Is On The Way|SSAA|Michael Gellert
 Help Me Rhonda|SSAA|Deke Sharon
 Help Me Rhonda|TTBB|Deke Sharon
 Help Me Rhonda|TTBB|Jon Nicholas
 Help Me To Help My Neighbor|TTBB|Burt Szabo
+Help Me, Rhonda|TTBB|Jon Nicholas
 Help, I'm Turning Into My Parents|SSAA|Jim Massey
 Help, I'm Turning Into My Parents|SSAA|Nancy Shumard
 Help!|SATB|Clay Hine
@@ -6666,6 +8012,7 @@ Help!|SATB|Manoj Padki
 Help!|SSAA|Glenda Lloyd
 Help!|SSAA|Jon Nicholas
 Help!|TTBB|Jon Nicholas
+Help! I'm Turning Into My Parents!|SSAA|Nancy Shumard
 Helplessly Hoping|SATB|Adam Bock
 Helplessly Hoping|SATB|Deke Sharon
 Helplessly Hoping|SATB|Joe Mannherz
@@ -6701,6 +8048,7 @@ Here Comes Santa Claus / Up On The Housetop Medley|SSAA|Nancy Bergman
 Here Comes Santa Claus / Up On The Housetop Medley|TTBB|Nancy Bergman
 Here Comes That Rainy Day Feeling|TTBB|Mark Stevens
 Here Comes The Flood|SATB|Anders Lindqvist
+Here Comes The Show Boat|TTBB|Barbershop Harmony Society
 Here Comes The Showboat|SSAA|David Briner
 Here Comes The Showboat|TTBB|David Wright
 Here Comes The Sun|SATB|Deke Sharon
@@ -6710,6 +8058,7 @@ Here Comes The Sun|SSAA|Glenda Lloyd
 Here Comes The Sun|SSAA|Jay Giallombardo
 Here Comes The Sun|SSAA|Joan D 'Agostino
 Here Comes The Sun|SSAA|Liz Garnett
+Here Comes The Sun|TTBB|Bob Shami
 Here Comes The Sun|TTBB|Cay Outerbridge
 Here Comes The Sun|TTBB|Deke Sharon
 Here Comes The Sun|TTBB|Gary Thiel
@@ -6739,8 +8088,11 @@ Here, There And Everywhere|TTBB|Alex Kaiserman
 Here, There And Everywhere|TTBB|Jay Giallombardo
 Here, There And Everywhere|TTBB|Rob Campbell
 Here, There And Everywhere|TTBB|Tom Gentry
+Here, There, and Everywhere|SSAA|June Berg
+Here's that Rainy Day|TTBB|Tony Pelling
 Here's That Rainy Day|SSAA|Jay Giallombardo
 Here's That Rainy Day|SSAA|Joe Mannherz
+Here's That Rainy Day|SSAA|Joni Bescos
 Here's That Rainy Day|TTBB|Dennis Driscoll
 Here's That Rainy Day|TTBB|Jay Giallombardo
 Here's To Adventure|SATB|Larry Triplett
@@ -6753,6 +8105,7 @@ Here's To The Heroes|SSAA|Doris Twardosky
 Here's To The Heroes|SSAA|Jay Giallombardo
 Here's To The Heroes|TTBB|Jay Giallombardo
 Here's To The Winners|SSAA|Joni Bescos
+Here's To The Winners|TTBB|Renee Craig
 Heritage Medley|TTBB|Barbershop Harmony Society
 Heritage Medley|TTBB|SPEBSQSA
 Hernando's Hideaway|SSAA|Bev Sellers
@@ -6765,9 +8118,12 @@ Hero|TTBB|Jay Giallombardo
 Hero|TTBB|Kevin Keller
 Hero|TTBB|Kyle Kitzmiller
 Hero|TTBB|Walter Latzko
+Hero (And Then A Hero Comes Along)|SSAA|Tedda Lippincott
 Hero Of The Game Medley|TTBB|Dan Wilson
 Heroes (we could be)|SATB|Nicholas Wright
 Heroes (we could be)|SSAA|Nicholas Wright
+Hey Daddy|SSAA|Nancy Bergman
+Hey Daddy (You Oughta Get the Best For Me)|SSAA|Nancy Bergman
 Hey Good Lookin'|SSAA|David Wright
 Hey Good Lookin'|SSAA|Tom Gentry
 Hey Good Lookin'|TTBB|David Wright
@@ -6782,6 +8138,7 @@ Hey Jude|TTBB|Deke Sharon
 Hey Jude|TTBB|Jay Dougherty
 Hey Jude|TTBB|Jay Giallombardo
 Hey Little Baby O' Mine|TTBB|Joe Liles
+Hey Little Baby of Mine|SSAA|Joe Liles
 Hey Look Ma, I Made It|SATB|Nicholas Wright
 Hey Look Me Over|SSAA|Jay Giallombardo
 Hey Look Me Over|SSAA|Nancy Bergman
@@ -6794,9 +8151,11 @@ Hey Look Me Over|TTBB|Jay Giallombardo
 Hey Look Me Over|TTBB|John Hohl
 Hey Look Me Over|TTBB|Tom Gentry
 Hey Look Me Over / If My Friends Could See Me Now Medley|TTBB|Tom Gentry
+Hey Look me Over / If They Could See Me Now (Medley)|TTBB|Tom Gentry
 Hey Mister! Stay!|SSAA|Joey Minshall
 Hey Pretty Moon|TTBB|Kyle Snook
 Hey Santa|SATB|Joe Mannherz
+Hey Soul Sister|SSAA|Elaine Gain
 Hey There|SSAA|David Wright
 Hey There|SSAA|Joan D 'Agostino
 Hey There|SSAA|Joe Mannherz
@@ -6804,16 +8163,28 @@ Hey There|TTBB|David Wright
 Hey There|TTBB|Joe Mannherz
 Hey There|TTBB|Walter Latzko
 Hey There Delilah|TTBB|Gabriel Lawson
+Hey, Good Lookin'|SSAA|David Wright
+Hey, Good Lookin'|SSAA|Nancy Bergman
+Hey, Good Lookin'|SSAA|Tom Gentry
 Hey, Good Lookin'|TTBB|Jim West
+Hey, Good Lookin'|TTBB|Jon Nicholas
 Hey, Good Lookin'|TTBB|Thomas Gentry
+Hey, Good Lookin'|TTBB|Tom Gentry
+Hey, Look Me Over|TTBB|David Wright
+Hey, Look Me Over|TTBB|Ells Morey
+Hey, Look Me Over|TTBB|Tom Gentry
+Hey, Look Me Over|TTBB|Willis Diekema, John Hohl
 Hey, Look Me Over (from WILDCAT) -|TTBB|BHS
+Hey, Look Me Over / If My Friends Could See Me Now|TTBB|Tom Gentry
 Hey, Soul Sister|SATB|Nicholas Wright
 Hey, Soul Sister|SSAA|Elaine Gain
 Hey, Soul Sister|TTBB|Deke Sharon
 Hey, Soul Sister|TTBB|Jon Nicholas
+Hey, Won't You Play Another Somebody|SSAA|Tedda Lippincott
 Hey!|TTBB|Tom Gentry
 Hey! Baby!|TTBB|Jim Shubert
 Hey! Baby!|TTBB|Jon Nicholas
+Hey! Look Me Over|SSAA|Nancy Bergman
 Hi Ho|SATB|Deke Sharon
 Hi Neighbor|SSAA|Marge Bailey
 Hi Neighbor|TTBB|Fred King
@@ -6825,11 +8196,15 @@ Hi Neighbor|TTBB|Joe Mannherz
 Hi Neighbor|TTBB|Mike Sotiriou
 Hi Neighbor|TTBB|Richard Gray
 Hi Neighbor|TTBB|Rob Ozman
+Hi Neighbor|TTBB|Walter Latzko
+Hi Neighbor / One Of Those Songs|TTBB|Walter Latzko
+Hi Neighbor/Consider Yourself Medley|TTBB|Joe Simone
 Hi-De-Ho (That Old Sweet Roll)|TTBB|Joe Mannherz
 Hibernate With Me|TTBB|Mason Eubank
 Hickey|SSAA|Tom Gentry
 Hickey|TTBB|Tom Gentry
 Hide and Seek|SATB|Andrew Carolan
+Hide And Seek|SATB|Joseph Bates
 High Cost Of Lovin'|SSAA|Kay Bromert
 High Cost Of Lovin'|TTBB|Dennis Driscoll
 High Cost Of Lovin'|TTBB|Richard Gallagher
@@ -6843,6 +8218,7 @@ High Hopes|TTBB|Dennis Driscoll
 High Hopes|TTBB|Jim Shubert
 High Hopes|TTBB|Tom Gentry
 High Middle Low|SSAA|Sally Summey
+High Time|TTBB|Roy Dawson
 Higher And Higher|SATB|David Wright
 Higher And Higher|SSAA|David Wright
 Higher And Higher|TTBB|David Wright
@@ -6869,8 +8245,11 @@ Hit Me With a Hot Note/Too Darn Hot Medley|SSAA|Liz Garnett
 Hit Me With Your Best Shot|SATB|Deke Sharon
 Hit Me With Your Best Shot|SSAA|Deke Sharon
 Hit That Jive Jack|SATB|Joe Mannherz
+Hit That Jive Jack|SSAA|Greg Volk
 Hit That Jive Jack|TTBB|Aaron Dale
 Hit That Jive Jack|TTBB|Dan Wessler
+Hit That Jive Jack|TTBB|Greg Volk
+Hit That Jive, Jack|TTBB|Aaron Dale
 Hit The Road Jack|SATB|Joe Mannherz
 Hit The Road Jack|SATB|Tom Gentry
 Hit The Road Jack|SSAA|Tom Gentry
@@ -6879,6 +8258,8 @@ Hit The Road Jack|TTBB|Tom Gentry
 Hit The Road To Dreamland|SSAA|Michael Gellert
 Ho Hey|TTBB|Nicholas Wright
 Hoagy Medley|TTBB|Rob Campbell
+Hockey Song, The (aka The Good Old Hockey Game)|TTBB|Steven Armstrong
+Hocus Pocus Medley|SSAA|Liz Garnett
 Hoedown|TTBB|Michael Webber
 Hokey Pokey|SSAA|Larry Wright
 Hokey Pokey|TTBB|Larry Wright
@@ -6901,6 +8282,7 @@ Hold On|SSAA|Kevin Keller
 Hold On|TTBB|Aaron Dale
 Hold On|TTBB|David Wright
 Hold On|TTBB|Jeremey Johnson
+Hold On|TTBB|Joe Pickin
 Hold On|TTBB|Kevin Keller
 Hold On Tight|SSAA|Elaine Gain
 Hold On Tight|SSAA|Kevin Keller
@@ -6915,7 +8297,10 @@ Hold You a Little Too Long|TTBB|Theo Hicks
 Hold You A Little Too Long|SATB|Theodore Hicks
 Hold You A Little Too Long|SSAA|Theodore Hicks
 Hold You A Little Too Long|TTBB|Theodore Hicks
+Holdin On For A Hero|SSAA|Jim Arns
+Holdin' Out for a Hero|SSAA|Jim Arns
 Holding On To You|SATB|Nicholas Wright
+Holding Out for a Hero|SSAA|Paul Ayres
 Holding Out For A Hero|SSAA|Deke Sharon
 Holding Out For A Hero|SSAA|Jen Squires
 Holding Out For A Hero|SSAA|Jim Arns
@@ -6937,9 +8322,11 @@ Holiday Season/Happy Holiday Medley|TTBB|Adam Scott
 Holiday Season/Happy Holiday Medley|TTBB|Scott Turnbull
 Holiday Show Opener/Closer|SSAA|Larry Wright
 Holiday Show Opener/Closer|TTBB|Larry Wright
+Holland Road|TTBB|Nathan Peplinski
 Holly Jolly Christmas|SATB|Deke Sharon
 Holly Jolly Christmas|SATB|Joe Mannherz
 Holly Jolly Christmas|SATB|Kevin Keller
+Holly Jolly Christmas|SSAA|Betty Oliver
 Holly Jolly Christmas|SSAA|Carolyn Johnson
 Holly Jolly Christmas|SSAA|Dianne Goldrick
 Holly Jolly Christmas|SSAA|Jan Meyer
@@ -6961,6 +8348,7 @@ Holy Ground|TTBB|Derric Johnson
 Holy Ground Medley|TTBB|Tom Parker
 Holy Highway|TTBB|Paul Jorg
 Holy Thursday|SATB|David Avshalomov
+Holy, Holy, Holy|TTBB|Joe Johnson
 Holy, Holy, Holy|TTBB|Walter Latzko
 Home|SSAA|Elaine Gain
 Home|SSAA|Joey Minshall
@@ -6975,11 +8363,13 @@ Home|TTBB|Walter Latzko
 Home (from Beauty And The Beast)|TTBB|Cay Outerbridge
 Home Again|SSAA|Kay Bromert
 Home Among The Gumtrees|SSAA|Emily Moriarty
+Home Christmas Medley|SSAA|Carmen Youra
 Home For The Holidays|SATB|Burt Szabo
 Home For The Holidays|SATB|Kay Bromert
 Home For The Holidays|SATB|Russ Foris
 Home For The Holidays|SSAA|Burt Szabo
 Home For The Holidays|SSAA|Carolyn Schmidt
+Home For The Holidays|SSAA|Carolyn Schmidt Tedda Lippincott
 Home For The Holidays|SSAA|Debbie Porter
 Home For The Holidays|SSAA|Jay Giallombardo
 Home For The Holidays|SSAA|Russ Foris
@@ -6989,6 +8379,8 @@ Home For The Holidays|TTBB|Jay Giallombardo
 Home For The Holidays|TTBB|Jon Nicholas
 Home For The Holidays|TTBB|Mark Goodney
 Home For The Holidays|TTBB|Russ Foris
+Home on the Range|SSAA|Brian Beck
+Home on the Range|TTBB|Don Gray
 Home On The Range|SSAA|Jay Giallombardo
 Home On The Range|SSAA|Nancy Bergman
 Home On The Range|TTBB|Jack Baird
@@ -7005,7 +8397,9 @@ Homesick|SATB|Nicholas Wright
 Hometown Band|SSAA|LaVeda Redfield
 Hometown Band|SSAA|Sonny Steffan
 Hometown Band|TTBB|Jim Hickman
+Hometown in Dixieland|TTBB|Jay Giallombardo
 Homeward Bound|SATB|Kevin Keller
+Homeward Bound|SSAA|Janice Wheeler
 Homeward Bound|SSAA|Kevin Keller
 Homeward Bound|TTBB|Deke Sharon
 Homeward Bound|TTBB|Jon Nicholas
@@ -7013,13 +8407,17 @@ Homeward Bound|TTBB|Kevin Keller
 Homeward Bound|TTBB|Steve Tramack
 Homeward Bound|TTBB|Todd Troutman
 Honesty|TTBB|Kohl Kitzmiller
+Honey (Open That Door)/Hey Good Lookin'|TTBB|Aaron Dale
 Honey / Little 'Lize Medley|TTBB|Floyd Connett
 Honey Boy|SSAA|Walter Latzko
 Honey Bun|TTBB|Dennis Driscoll
+Honey I'm Home|SSAA|Corinna Garriock
+Honey Medley|SSAA|David Harrington
 Honey Medley|TTBB|David Harrington
 Honey Medley|TTBB|Tom Gentry
 Honey of Mine|TTBB|Aaron Dale
 Honey Pie|TTBB|Todd Troutman
+Honey Pie (Beatles)|SATB|Paul Hart
 Honey That I Love So Well / My Honey's Lovin' Arms Medley|SSAA|David Harrington
 Honey That I Love So Well / My Honey's Lovin' Arms Medley|TTBB|David Harrington
 Honey Won't You Open That Door/Hey Good Lookin' Medley|TTBB|Aaron Dale
@@ -7030,6 +8428,8 @@ Honey, I'm Home|SSAA|Tedda Lippincott
 Honey, That I Love So Well|TTBB|Tom Gentry
 Honey's Arms Medley|TTBB|Al Leroy
 Honey's Arms Medley|TTBB|Dennis Driscoll
+Honey/Little 'Lize Medley|TTBB|Barbershop Harmony Society
+Honey/Little 'Lize Medley|TTBB|Floyd Connett
 Honeycomb|TTBB|Paul Jorg
 Honeymoon|TTBB|Walter Latzko
 Honeysuckle Rose|TTBB|Aaron Dale
@@ -7039,10 +8439,12 @@ Honky Tonk Moon|SSAA|Anna Maria Parker
 Honky Tonkin'|TTBB|Aaron Dale
 Honneur A Toi|SATB|Deke Sharon
 Honneur A Toi|TTBB|Deke Sharon
+Honolulu City Lights|SSAA|Brian Beck
 Hooch|TTBB|Deke Sharon
 Hooey|TTBB|Tom Gentry
 Hooked On A Feeling|SATB|Jon Nicholas
 Hooked On A Feeling|SSAA|Corinna Garriock
+Hooked On A Feeling|SSAA|Jim Arns
 Hooked On A Feeling|SSAA|Jon Nicholas
 Hooked On A Feeling|SSAA|Tedda Lippincott
 Hooked On A Feeling|TTBB|Deke Sharon
@@ -7060,6 +8462,7 @@ Hooray For Hollywood|SSAA|Joni Bescos
 Hooray For Hollywood|TTBB|Dennis Driscoll
 Hooray For Hollywood|TTBB|Edward Boehm
 Hooray For Hollywood|TTBB|Jay Giallombardo
+Hooray For Hollywood/That's Entertainment Medley(Jay Giallomb|TTBB|Jay Giallombardo
 Hooray For Love|SSAA|Aaron Dale
 Hooray For Love|SSAA|Larry Wright
 Hooray For Love|TTBB|Alan Gordon
@@ -7068,6 +8471,7 @@ Hooray For Love|TTBB|Walter Latzko
 Hooray For Love/Glory Of Love|SSAA|Marsha Zwicker
 Hooray for Tom|SSAA|Lauren Kahn
 Hope of Israel|TTBB|Aaron Dale
+Hopelessly Devoted to You|SSAA|Carolyn Healey
 Hopelessly Devoted To You|SATB|Melody Hine
 Hopelessly Devoted To You|SSAA|Dianne Goldrick
 Hopelessly Devoted To You|SSAA|Joy McGregor
@@ -7079,7 +8483,10 @@ Hortense|TTBB|Walter Latzko
 Hospitality|TTBB|Gene Cokeroft
 Hot Diggity (Dog Ziggity Boom)|SSAA|Marge Bailey
 Hot Diggity (Dog Ziggity Boom)|SSAA|Muriel Berg
+Hot Diggity (YWIH)|SSAA|Muriel Berg
+Hot Diggity Dog (Dog Ziggity Boom)|SSAA|Muriel Berg
 Hot Dogs Or Legs|TTBB|Melody Hine
+Hot Stuff|SSAA|Sylvia Alsbury
 Hot Time In The Old Town|TTBB|Jean Boardman
 Hot! Hot! Hot!|SATB|Jan-Ake Westin
 Hot! Hot! Hot!|SSAA|Jan-Ake Westin
@@ -7090,6 +8497,7 @@ Hour-Day-Month Medley|TTBB|Dennis Driscoll
 Hour-Month-Day Medley|TTBB|Dennis Driscoll
 House At Pooh Corner|SATB|Deke Sharon
 House At Pooh Corner|SSAA|Carolyn Schmidt
+House At Pooh Corner|TTBB|Anthony Nasto
 House At Pooh Corner|TTBB|Jeremey Johnson
 House I Live In|SSAA|Jay Giallombardo
 House I Live In|SSAA|Tedda Lippincott
@@ -7101,6 +8509,7 @@ House I Live In|TTBB|Walter Latzko
 House of Blue Lights|SSAA|Jo Lund
 House Of The Rising Sun|TTBB|Deke Sharon
 How 'Ya Gonna Keep 'Em Down On The Farm|TTBB|Inc. SPEBSQSA
+How 'Ya Gonna Keep 'Em Down On The Farm?|TTBB|Barbershop Harmony Society
 How 'Ya Gonna Keep Em Down|SSAA|Unknown
 How About Me?|SSAA|Charlotte Pernert
 How About Me?|SSAA|David Briner
@@ -7113,6 +8522,8 @@ How Are Things In Glocca Morra|SATB|Kevin Keller
 How Are Things In Glocca Morra|TTBB|Don Gray
 How Are Things In Glocca Morra|TTBB|Joe Mannherz
 How Are Things In Glocca Morra|TTBB|Mark Goodney
+How Are Things in Glocca Morra?|TTBB|Don Gray
+How Are Ya Fixed For Love|SATB|Shawn York
 How Are You Goin' To Wet Your Whistle|TTBB|Tom Gentry
 How Blue The Night|TTBB|Manoj Padki
 How Bout A Dance?|SATB|Greg Mallett
@@ -7120,6 +8531,7 @@ How Bout A Dance?|SSAA|Greg Mallett
 How Bout A Dance?|TTBB|Greg Mallett
 How Can I Keep From Singing|SATB|Larry Triplett
 How Can I Keep From Singing|SATB|Mike Menefee
+How Can I Keep From Singing|SSAA|Joe Liles
 How Can I Keep From Singing|SSAA|Larry Triplett
 How Can I Keep From Singing|SSAA|Mark Rusch
 How Can I Keep From Singing|TTBB|Carole Prietto
@@ -7128,13 +8540,17 @@ How Can I Keep From Singing|TTBB|Jon Nicholas
 How Can I Keep From Singing|TTBB|Larry Triplett
 How Can I Keep From Singing|TTBB|Mark Rusch
 How Can I Keep From Singing Your Praise|TTBB|Larry Triplett
+How Can I Miss You If You Won't Go Away|SSAA|Unspecified
+How Can I Miss You If You Won'T Go Away|SSAA|Tedda Lippincott
 How Can I Miss You If You Won't Go Away?|SSAA|Louis Perry
 How Can I Miss You If You Won't Go Away?|SSAA|Tedda Lippincott
+How Can I Miss You If You Won't Go Away?|TTBB|Lou Perry
 How Can I Miss You If You Won't Go Away?|TTBB|Louis Perry
 How Can You Buy Killarney|TTBB|Jay Giallombardo
 How Can You Buy Killarney|TTBB|Renee Craig
 How Can You Mend a Broken Heart|SSAA|Kevin Keller
 How Can You Mend a Broken Heart|TTBB|Ruby Rhea
+How Can You Mend A Broken Heart|TTBB|Henrik Rosenberg
 How Come I Can't Get The Girls|TTBB|Larry Wright
 How Come I Can't Get The Guys|SSAA|Larry Wright
 How Could I Ever Know?|SATB|Theodore Hicks
@@ -7144,14 +8560,18 @@ How Could I Ever Know?|TTBB|Theodore Hicks
 How Could I Ever Know? (from The Secret Garden)|TTBB|Matt Gallagher
 How Could I Ever Know? (from The Secret Garden)|TTBB|Theo Hicks
 How Could You Believe Me|SATB|Nancy Bergman
+How Could You Believe Me|SSAA|Brian Beck
 How Could You Believe Me|SSAA|Sylvia Alsbury
 How Could You Believe Me|TTBB|Mark Goodney
 How Could You Believe Me ?/It's A Sin To Tell A Lie (Medley)|TTBB|Renee Craig
+How Could You Believe Me?|SSAA|Renee Craig
 How D'Ya Like Your Eggs in the Morning|SSAA|Emily Moriarty
 How D'Ya Like Your Eggs in the Morning|SSAA|Joey Minshall
 How D'Ya Like Your Eggs in the Morning|SSAA|Tom Gentry
 How D'Ya Like Your Eggs in the Morning|TTBB|Michael Webber
 How D'Ya Like Your Eggs in the Morning|TTBB|Tom Gentry
+How Deep is the Ocean|SSAA|Ed Waesche
+How Deep Is the Ocean|SSAA|Lynn McCord
 How Deep Is The Ocean|SATB|Anders Lindqvist
 How Deep Is The Ocean|SATB|Rob Hopkins
 How Deep Is The Ocean|SSAA|Kevin Keller
@@ -7166,14 +8586,20 @@ How Deep Is the Ocean (How High Is the Sky)|TTBB|Ed Waesche
 How Deep Is The Ocean (How High Is The Sky)|SSAA|Rob Hopkins
 How Deep Is The Ocean (How High Is The Sky)|TTBB|Rob Hopkins
 How Deep Is The Ocean (How High Is The Sky) (Parody)|TTBB|Ed Waesche
+How Deep is the Ocean?|TTBB|Jim Clancy
 How Deep Is The Ocean/Remember|TTBB|Walter Latzko
+How Deep Is Your Love|SSAA|Ruby Rhea
+How Deep Is Your Love|TTBB|Henrik Rosenberg
+How Deep Is Your Love|TTBB|John Palmer
 How Deep Is Your Love?|SSAA|Larry Wright
 How Deep Is Your Love?|TTBB|Aaron Dale
 How Deep Is Your Love?|TTBB|Larry Wright
 How Did We Come To This?|SSAA|Ed Schubel
 How Did We Come To This?|TTBB|Simon Arnott
+How Do I Love Thee|SSAA|Nathan Christensen
 How Do You Do It Mable On|TTBB|Jack Baird
 How Do You Keep The Music Playing?|SATB|David Wright
+How Do You Like Your Eggs in the Morning|SSAA|Tom Gentry
 How Do You Open A Show|SSAA|Avis Fellows
 How Do You Open A Show|TTBB|Ed Waesche
 How Far I'll Go|SATB|Anders Lindqvist
@@ -7189,14 +8615,19 @@ How Far I'll Go (from Moana)(Parody)|TTBB|Ira Allen (tag)/Matt Astle
 How Far Is It To Bethlehem|SATB|Larry Triplett
 How Far Is It To Bethlehem|SSAA|Larry Triplett
 How Far Is It To Bethlehem|TTBB|Larry Triplett
+How Far Is It to Betlehem|TTBB|Larry Triplett
+How Great Thou Art|SATB|Joe Johnson
 How Great Thou Art|SSAA|Amanda Sandroni, Katie Gillis, Ali Hauger, Katie Macdonald
 How Great Thou Art|SSAA|Mark Burnip
 How Great Thou Art|SSAA|Nancy Bergman
+How Great Thou Art|TTBB|Clay Hine
 How Great Thou Art|TTBB|Derric Johnson
+How Great Thou Art|TTBB|Fred King
 How Great Thou Art|TTBB|Jim West
 How Great Thou Art|TTBB|Mark Burnip
 How Great Thou Art|TTBB|Paul Jorg
 How Great Thou Art|TTBB|Walter Latzko
+How High the Moon|SSAA|Cheryl Suhr
 How High The Moon|SATB|Joe Mannherz
 How High The Moon|SSAA|Mark Hale
 How High The Moon|SSAA|Melody Hine
@@ -7211,6 +8642,7 @@ How Long|SSAA|Adam Bock
 How Long Has This Been Going On?|SSAA|Jo Lund
 How Long Has This Been Going On?|SSAA|Kevin Keller
 How Long Has This Been Going On?|TTBB|Kevin Keller
+How Lucky Can You Get/Luck Be a Lady|SSAA|Brian Beck
 How Lucky You Are|SATB|Patrick McAlexander
 How Lucky You Are|SSAA|Dan Wessler
 How Lucky You Are|SSAA|Dianne Goldrick
@@ -7220,12 +8652,16 @@ How Lucky You Are|TTBB|Dan Wessler
 How Lucky You Are|TTBB|Katie Farrell
 How Lucky You Are|TTBB|Patrick McAlexander
 How Lucky You Are (from Seussical)|TTBB|Dan Wessler
+How Many Hearts Have You Broken|SSAA|Jim Arns
 How Many Hearts Have You Broken?|SSAA|Jim Arns
 How Many Hearts Have You Broken?|SSAA|Marie Johnson
+How Many Hearts Have You Broken?|SSAA|Steve Jamison
 How Many Hearts Have You Broken?|TTBB|Dennis Driscoll
 How Many Hearts Have You Broken?|TTBB|Steve Jamison
+How Many Hearts Have You Broken?|TTBB|Unspecified
 How Many Hearts Have You Broken? / Them There Eyes Medley|SSAA|Brent Graham
 How Many Hearts Have You Broken? / Them There Eyes Medley|TTBB|Brent Graham
+How Many Hearts/ Them There Eyes|SSAA|Brent Graham
 How Many Times|SSAA|Joe Mannherz
 How Many Times|TTBB|Joe Mannherz
 How Soon|SSAA|Joan D 'Agostino
@@ -7238,6 +8674,8 @@ How Sweet It Is To Be Loved By You|TTBB|Jeremey Johnson
 How Sweet It Is To Be Loved By You|TTBB|Larry Wright
 How To Build A Chorus|TTBB|Val Hicks
 How To Stay Married|TTBB|Louis Perry
+How We Sang Today|SSAA|Unspecified
+How We Sang Today|SSAA|Vicki Uhr
 How We Sang Today!|SSAA|Vicki Uhr
 How Wonderful to Know|SSAA|Tom Gentry
 How Wonderful to Know|TTBB|Tom Gentry
@@ -7247,10 +8685,14 @@ How Ya Gonna Keep 'Em Down On The Farm|TTBB|Ken Bastien
 How Ya Gonna Keep 'Em Down On The Farm|TTBB|SPEBSQSA
 How Ya Gonna Keep 'Em Down On The Farm|TTBB|Tom Gentry
 How Ya Gonna Keep 'Em Down On The Farm|TTBB|Walter Latzko
+How Ya Gonna Keep 'Em Down On The Farm Medley|SSAA|Nancy Bergman
+How Ya Gonna Keep 'Em Down On the Farm?|TTBB|Mike Senter
 How Ya Gonna Keep 'Em/Johnny's In Town|SSAA|Nancy Bergman
 How'd You Like to Spoon With Me?|TTBB|Walter Latzko
 How'dja Like to Love Me|SSAA|David Wright
 How'dja Like to Love Me|TTBB|David Wright
+How's Every Little Thing In Dixie|TTBB|Al Rekhop
+How's Every Little Thing in Dixie?|TTBB|David Wright
 Howl|SSAA|Deke Sharon
 Huckleberry Finn|TTBB|Jack Baird
 Huckleberry Finn|TTBB|Jim Stahly
@@ -7268,11 +8710,14 @@ Hunting Song|TTBB|John Coffin
 Hunting Song|TTBB|Marie Johnson
 Hunting Song|TTBB|Marvin Skupski
 Hunting Song|TTBB|Thomas Degan
+Huron Carol|SSAA|Corinna Garriock
+Huron Carol|TTBB|Steven Armstrong
 Hurricane|SATB|Nicholas Wright
 Hurts So Good|SSAA|Nicholas Wright
 Hush|SSAA|Dick Kneeland
 Hush|TTBB|Dick Kneeland
 Hush, Little Baby|SSAA|Dianne Goldrick
+Hushabye Mountain|TTBB|Bill Mitchell
 Hushabye Mountain|TTBB|Nick Bryant
 Hushabye Mountain|TTBB|William Mitchell
 Hymn For A Sunday Evening|SSAA|Cynthia Becker
@@ -7283,6 +8728,7 @@ Hymn Of Promise|TTBB|Douglas Russell
 Hymn to Freedom|SATB|Jim Clancy
 Hymn to Freedom|SSAA|Jim Clancy
 Hymn to Freedom|TTBB|Jim Clancy
+Hymns of Christmas Medley|TTBB|Shaun Agnew
 Hymns of the Cross Medley|TTBB|Jim Clancy
 I (Who Have Nothing)|SATB|Gabriel Spector
 I (Who Have Nothing)|SATB|Kohl Kitzmiller
@@ -7292,6 +8738,7 @@ I (Who Have Nothing)|TTBB|Kohl Kitzmiller
 I 2 I|SATB|Deke Sharon
 I Adore Mi Amore|TTBB|Wayne Grimmer
 I Ain't Down Yet|SSAA|Jo Anne Ingels
+I Ain't Down Yet|SSAA|JoAnne Ingels
 I Ain't Down Yet|TTBB|Andy Maddox
 I Ain't Down Yet|TTBB|Walter Latzko
 I Ain't Gonna Be Nobody's Fool|TTBB|Burt Szabo
@@ -7313,26 +8760,34 @@ I Always Knew The Girl I'd Love Would Be A Girl Like You|TTBB|Toban Dvoretsky
 I am A Child of God/I wonder When He Comes Again Medley|SSAA|Aaron Dale
 I am A Child of God/I wonder When He Comes Again Medley|TTBB|Aaron Dale
 I Am A Man of Constant Sorrow|TTBB|Aaron Dale
+I am Australian|TTBB|Unspecified
 I Am Changing|SSAA|Simon Arnott
+I Am Not American|TTBB|Steven Armstrong
+I Am Sailing|SSAA|Unspecified
 I Am The Man|SSAA|Jay Giallombardo
 I Am The Man|TTBB|Jay Giallombardo
 I Am the Very Model of a Mommy of a Toddler|SSAA|Joey Minshall
 I Am The Walrus|SATB|Anders Lindqvist
 I Am What I Am|SSAA|Michael Gellert
 I Am What I Am/I Will Survive Medley|SSAA|Liz Garnett
+I Am What I Am/My Way (Medley)|TTBB|Steve Tramack
 I Am Woman|SSAA|Glenda Lloyd
 I Am Woman|SSAA|Judith Dixon
+I Am Woman|SSAA|Judy Dixon
 I Am Woman|SSAA|Tony Nasto
 I Am Woman|TTBB|Judith Dixon
 I Apologize|TTBB|Walter Latzko
 I Asked The Lord|SSAA|Diana Franceschi
 I Asked The Lord|SSAA|Kay Bromert
+I Asked The Lord|TTBB|Buzz Haeger
 I Asked The Lord|TTBB|Jim West
 I Asked The Lord|TTBB|Warren 'Buzz' Haeger
+I Been Workin' On The Railroad|TTBB|Roger Payne
 I Believe|SSAA|Adam Bock
 I Believe|SSAA|Dianne Goldrick
 I Believe|SSAA|Joey Minshall
 I Believe|SSAA|Tom Gentry
+I Believe|TTBB|Barbershop Harmony Society
 I Believe|TTBB|David Harrington
 I Believe|TTBB|Dianne Goldrick
 I Believe|TTBB|Earl Moon
@@ -7342,6 +8797,8 @@ I Believe|TTBB|SPEBSQSA
 I Believe|TTBB|Tom Gentry
 I Believe (2010 Olympic Theme Song)|SSAA|June Dale
 I Believe (TTBB) (arr. BHS) - US Orders Only|TTBB|Inc. SPEBSQSA
+I Believe I Can Fly|SSAA|Joey Minshall
+I Believe in Father Christmas|TTBB|Shaun Agnew
 I Believe In Miracles|TTBB|Paul Jorg
 I Believe In Music|SSAA|Jo Lund
 I Believe In Music|SSAA|Joe Liles
@@ -7350,6 +8807,7 @@ I Believe In Santa Claus|TTBB|Andrew Wittenberg
 I Believe In You|SSAA|Tom Gentry
 I Believe In You|TTBB|Jon Nicholas
 I Believe In You|TTBB|Kevin Keller
+I Believe/You'll Never Walk Alone|SSAA|Fred King
 I Believed It All|SSAA|Ardeth Fullmer
 I Bend the Knee of My Heart|TTBB|David Avshalomov
 I Bet My Life|SATB|Nicholas Wright
@@ -7358,8 +8816,10 @@ I Called You My Sweetheart|TTBB|Ed Waesche
 I Called You My Sweetheart|TTBB|Unknown
 I Can Always Find A Little Sunshine At The Ymca|TTBB|Walter Latzko
 I Can Cook Too|SSAA|Joey Minshall
+I Can Cook Too|SSAA|Lorraine Rochefort
 I Can Do That|SATB|Deke Sharon
 I Can Dream About You|TTBB|Mark Stevens
+I Can Dream, Can't I?|SSAA|Brad Rees
 I Can Dream, Can't I?|SSAA|Dede Nibler
 I Can Dream, Can't I?|SSAA|Don Gray
 I Can Dream, Can't I?|SSAA|Jo Lund
@@ -7371,6 +8831,7 @@ I Can Dream, Can't I?|TTBB|Ed Waesche
 I Can Never Get Over A Girl Like You|TTBB|Keith Clark
 I Can Only Imagine|SSAA|Larry Wright
 I Can See Clearly Now|SATB|Deke Sharon
+I Can See Clearly Now|SSAA|Charlene Yazurlo
 I Can See Clearly Now|SSAA|Jay Giallombardo
 I Can See Clearly Now|SSAA|Kay Bromert
 I Can See Clearly Now|SSAA|Melody Hine
@@ -7385,6 +8846,8 @@ I Can't Begin To Tell You|SSAA|Burt Szabo
 I Can't Begin To Tell You|SSAA|Carolyn Schmidt
 I Can't Begin To Tell You|TTBB|Duane Enders
 I Can't Begin To Tell You|TTBB|Joe Liles
+I Can't Believe I'm Losing You|SSAA|Joni Bescos
+I Can't Believe I'm Not A Millionaire|SSAA|Julia Cope
 I Can't Believe Im Losing You|SSAA|LaVeda Redfield
 I Can't Believe That You're In Love With Me|SSAA|Joe Mannherz
 I Can't Believe That You're In Love With Me|SSAA|Kevin Keller
@@ -7398,6 +8861,8 @@ I Can't Get Off-a My Horse|SSAA|Nancy Bergman
 I Can't Get Started with You|SSAA|Dianne Goldrick
 I Can't Get Started with You|TTBB|Joe Mannherz
 I Can't Get Started with You|TTBB|Walter Latzko
+I Can't Give Anything But Love/I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I Can't Give You Anything But Love|SATB|Mason Kaye
 I Can't Give You Anything But Love|SATB|Rob Campbell
 I Can't Give You Anything But Love|SSAA|David Harrington
 I Can't Give You Anything But Love|SSAA|Joe Mannherz
@@ -7405,15 +8870,27 @@ I Can't Give You Anything But Love|SSAA|Nancy Bergman
 I Can't Give You Anything But Love|SSAA|Tom Gentry
 I Can't Give You Anything But Love|TTBB|Clay Hine
 I Can't Give You Anything But Love|TTBB|David Harrington
+I Can't Give You Anything But Love|TTBB|Ed Waesche
 I Can't Give You Anything But Love|TTBB|Jay Giallombardo
 I Can't Give You Anything But Love|TTBB|Joe Mannherz
 I Can't Give You Anything But Love|TTBB|Mark Goodney
 I Can't Give You Anything But Love|TTBB|Walter Latzko
 I Can't Give You Anything But Love / L-O-V-E|SSAA|Nancy Bergman
+I Can't Give You Anything But Love & Steppin' Out With My Baby Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love-L.O.V.E.|SSAA|Nancy Bergman
+I Can't Give You Anything But Love-LOVE|SSAA|Nancy Bergman
+I Can't Give You Anything But Love, Baby|TTBB|David Harrington
 I Can't Give You Anything but Love/Cuddle Up a Little Closer|TTBB|Tom Gentry
+I Can't Give You Anything But Love/L-O-V-E Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/LOVE Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/Steppin' Out Medley|SSAA|Nancy Bergman
 I Can't Give You Anything But Love/Steppin' Out With My Baby|SSAA|Nancy Bergman
 I Can't Give You Anything/I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I Can't Give You/Steppin' Out With My Baby|SSAA|Nancy Bergman
+I Can't Help Falling In Love|TTBB|Will Hamblet
 I Can't Help Falling in Love with You|TTBB|Kevin Keller
+I Can't Help Falling In Love With You|TTBB|Johan Wikstrom
+I Can't Help Falling In Love With You|TTBB|Jon Nicholas
 I Can't Let You Throw Yourself Away|TTBB|Adam Scott
 I Can't Make You Love Me|SATB|Deke Sharon
 I Can't Make You Love Me|SSAA|Cris Conerty
@@ -7436,6 +8913,7 @@ I Could Have Danced All Night|SSAA|Jay Giallombardo
 I Could Have Danced All Night|TTBB|Brent Graham
 I Could Have Danced All Night|TTBB|Jay Giallombardo
 I Could Have Told You|SSAA|Sonny Steffan
+I Could Have Told You|TTBB|Henrik Rosenberg
 I Could Write a Book|SATB|Deke Sharon
 I Could Write a Book|SSAA|Joe Mannherz
 I Could Write a Book|TTBB|Joe Mannherz
@@ -7443,6 +8921,7 @@ I Could Write a Book|TTBB|Melody Hine
 I Couldn't Be Happier|SSAA|Carole Prietto
 I Couldn't Live Without Your Love|SSAA|Fran Carter
 I Couldn't Sleep a Wink Last Night|SSAA|Joey Minshall
+I Cover the Waterfront|TTBB|Webb Comfort
 I Cried For You|SSAA|Jo Lund
 I Cried For You|TTBB|Ed Waesche
 I Cried For You|TTBB|Walter Latzko
@@ -7453,8 +8932,10 @@ I Did It My Way|TTBB|Larry Wright
 I Didn't Raise My Boy To Be A Soldier|SSAA|Nancy Bergman
 I Didn't Raise My Boy To Be A Soldier|SSAA|Tom Gentry
 I Didn't Raise My Boy To Be A Soldier|TTBB|Tom Gentry
+I Didn't Wanna Fall|SSAA|Joe Liles
 I Didn't Want To Fall|SSAA|Joe Liles
 I Didn't Want To Fall|TTBB|Joe Liles
+I Didn't Want to Fall - modified words|SSAA|Joe Liles
 I Dig Rock And Roll Music|SSAA|Kevin Keller
 I Dig Rock And Roll Music|TTBB|Kevin Keller
 I Do Wanna Know|SATB|Don Staffin
@@ -7467,6 +8948,7 @@ I Don't Care If The Sun Don't Shine|SSAA|Michael Gellert
 I Don't Care If The Sun Don't Shine|SSAA|Nancy Bergman
 I Don't Care If The Sun Don't Shine|SSAA|Steve Tramack
 I Don't Care If The Sun Don't Shine|TTBB|Steve Tramack
+I Don't Care/Steppin Out|SSAA|Nancy Bergman
 I Don't Dance|SSAA|Kohl Kitzmiller
 I Don't Know Enough About You|SSAA|Chris Arnold
 I Don't Know Enough About You|SSAA|Larry Wright
@@ -7477,6 +8959,8 @@ I Don't Know Enough About You|TTBB|Chris Arnold
 I Don't Know Enough About You|TTBB|Joe Mannherz
 I Don't Know Enough About You|TTBB|Larry Wright
 I Don't Know Enough About You|TTBB|Walter Latzko
+I Don't Know Enough About You/ I Don't Know Why Medley(Tom Ge|SSAA|Tom Gentry
+I Don't Know Enough About You/ I Don't Know Why Medley(Tom Ge|TTBB|Tom Gentry
 I Don't Know Enough About You/I Don't Know Why|SSAA|Tom Gentry
 I Don't Know Enough About You/I Don't Know Why|TTBB|Tom Gentry
 I Don't Know How To Say Goodbye|SATB|Joe Mannherz
@@ -7490,7 +8974,10 @@ I Don't Know How To Say Goodbye|TTBB|Joe Mannherz
 I Don't Know How To Say Goodbye|TTBB|Theo Hicks
 I Don't Know How To Say Goodbye|TTBB|Theodore Hicks
 I Don't Know If I Should Call Her|TTBB|Jon Nicholas
+I Don't Know Medley|TTBB|Tom Gentry
+I Don't Know Medley (I Know a Little Bit/I Don't Know Why I Love You Like I Do)|SSAA|Unspecified
 I Don't Know Where I'm Going But I'm On My Way|SSAA|Carolyn Johnson
+I Don't Know Why|SSAA|Buzz Haeger
 I Don't Know Why|SSAA|Dianne Goldrick
 I Don't Know Why|SSAA|Walter Latzko
 I Don't Know Why|SSAA|Warren 'Buzz' Haeger
@@ -7499,18 +8986,28 @@ I Don't Know Why|TTBB|Dianne Goldrick
 I Don't Know Why|TTBB|Jim West
 I Don't Know Why|TTBB|Jud Finley
 I Don't Know Why|TTBB|Mel Knight
+I Don't Know Why|TTBB|Webb Comfort
+I Don't Know Why (I Just Do)|SSAA|Haeger
+I Don't Know Why (I Love You Like I Do)|SSAA|Buzz Haeger
+I Don't Know Why Medley|SSAA|Mary Coffman
+I Don't Know Why, I Just Do|SSAA|Buzz Haeger
+I Don't Know Why/You Made Me Love You|SSAA|Mary Coffman
 I Don't Know Why/You Made Me Medley|SSAA|Mary K. Coffman Music Fund
 I Don't Mind Being All Alone|SSAA|Barbershop Harmony Society
 I Don't Mind Being All Alone|SSAA|BHS
 I Don't Mind Being All Alone|TTBB|Barbershop Harmony Society
 I Don't Mind Being All Alone|TTBB|George Hulst
 I Don't Remember Her Name|TTBB|Paul Olguin
+I Don't Stand A Ghost of a Chance|SSAA|Cheryl Suhr
 I Don't Stand A Ghost Of A Chance|TTBB|Jim Shubert
 I Don't Understand The Poor|TTBB|Greg Mallett
 I don't wanna be the one|SSAA|Joe Mannherz
 I don't wanna be the one|TTBB|Joe Mannherz
+I Don't Wanna Get Married/When You're Married|SSAA|Avis Fellows/Marie Johnson
 I Don't Wanna Go Home|SSAA|Sonny Steffan
 I Don't Wanna Wake Up When I'm Dreaming|TTBB|Walter Ingram
+I Don't Wanna Walk Without You|SSAA|Nancy Bergman
+I Don't Wanna Walk Without You|SSAA|Renee Craig
 I Don't Want A Doctor, All I Want Is A Beautiful Girl|TTBB|John Muir
 I Don't Want Him To Love You When I'm Gone Medley|SSAA|David Wright
 I Don't Want Him To Love You When I'm Gone Medley|TTBB|David Wright
@@ -7531,8 +9028,12 @@ I Don't Want To Set The World On Fire|SATB|Jay Dougherty
 I Don't Want To Set The World On Fire|SSAA|Jay Dougherty
 I Don't Want To Set The World On Fire|SSAA|Marge Bailey
 I Don't Want To Set The World On Fire|TTBB|Jay Dougherty
+I Don't Want To Set The World On Fire|TTBB|Joe Johnson
+I Don't Want To Set The World On Fire|TTBB|Lloyd McClur
 I Don't Want To Set The World On Fire|TTBB|Melody Hine
 I Don't Want To Set The World On Fire|TTBB|Tom Gentry
+I Don't Want to Walk Without You|TTBB|Joe Johnson
+I Don't Want to Walk Without You|TTBB|Tom Gentry
 I Don't Want To Walk Without You|SSAA|Nancy Bergman
 I Don't Want To Walk Without You|SSAA|Renee Craig
 I Don't Want To Walk Without You|TTBB|Dennis Driscoll
@@ -7546,7 +9047,10 @@ I Double Dare You|SSAA|Tom Gentil
 I Double Dare You|TTBB|Kevin Keller
 I Dream Of You|TTBB|Ed Waesche
 I Dreamed A Dream|SSAA|David Wright
+I Dreamed A Dream|SSAA|June Dale
+I Dreamed A Dream (Les Miserable)|SATB|Philip Lawson
 I Enjoy Being A Girl|SSAA|Jean Kane
+I Enjoy Being A Girl (YWIH)|SSAA|Jean Kane
 I Fall In Love Too Easily|TTBB|Manoj Padki
 I Fall In Love With You Every Day|TTBB|Ray Buntaine
 I Fall To Pieces|SSAA|Kevin Keller
@@ -7555,6 +9059,8 @@ I Fall To Pieces|TTBB|Kevin Keller
 I Fall To Pieces|TTBB|Tom Gentry
 I Fall To Pieces/Crazy Medley|TTBB|Kevin Keller
 I Feel A Sin Comin' On|SATB|Tamra Perez
+I Feel A Song / Hallelujah!|TTBB|Ed Waesche
+I Feel A Song Comin On|SSAA|Nancy Bergman
 I Feel A Song Comin' On|SATB|Lance Fisher
 I Feel A Song Comin' On|SATB|Larry Triplett
 I Feel A Song Comin' On|SSAA|Dennis Morrissey
@@ -7564,10 +9070,14 @@ I Feel A Song Comin' On|TTBB|Dennis Morrissey
 I Feel A Song Comin' On|TTBB|John Fortino
 I Feel A Song Comin' On|TTBB|Larry Triplett
 I Feel A Song Comin' On|TTBB|Louis Perry
+I Feel A Song Comin' On|TTBB|Pete Rupay
 I Feel A Song Comin' On|TTBB|Rob Hopkins
 I Feel A Song Comin' On|TTBB|Roger Tarpy
+I Feel A Song Comin' On|TTBB|Unspecified
 I Feel A Song Comin' On / Hallelujah Medley|TTBB|Ed Waesche
+I Feel A Song Coming On|SSAA|Jarmela Speta
 I Feel Pretty|SSAA|Carolyn Schmidt
+I Feel the Earth Move|SSAA|Ase Hagerman
 I Feel The Earth Move|SSAA|Deke Sharon
 I Feel The Earth Move|SSAA|Glenda Lloyd
 I Feel The Earth Move|SSAA|Larry Wright
@@ -7576,9 +9086,11 @@ I Finally Found Someone|SSAA|Tedda Lippincott
 I Finally Found Someone|TTBB|Steve Tramack
 I Find Your Love|SSAA|Liz Garnett
 I Followed Her Around|SATB|Deke Sharon
+I Found a Million Dollar Baby|TTBB|Bill Mitchell, Ed Wasche and Rob Hopkins
 I Found A Million Dollar Baby|SSAA|Carolyn Schmidt
 I Found A Million Dollar Baby|SSAA|Jo Anne Ingels
 I Found A Million Dollar Baby|SSAA|William Mitchell
+I Found A Million Dollar Baby|TTBB|Ed Waesche, Rob Hopkins, Bill Mitchell
 I Found A Million Dollar Baby|TTBB|Rob Hopkins
 I Found A Million Dollar Baby|TTBB|Walter Latzko
 I Found A Million Dollar Baby|TTBB|William Mitchell
@@ -7590,6 +9102,7 @@ I Found The End Of The Rainbow|TTBB|Jay Giallombardo
 I Found You Out When I Found You In|SSAA|June Berg
 I Get A Kick Out Of You|SATB|Deke Sharon
 I Get A Kick Out Of You|SSAA|Carolyn Johnson
+I Get A Kick Out Of You|SSAA|Joni Bescos
 I Get A Kick Out Of You|SSAA|Tom Gentry
 I Get A Kick Out Of You|TTBB|Adam Bock
 I Get A Kick Out Of You|TTBB|Tom Gentry
@@ -7599,13 +9112,17 @@ I Get Along Without You Very Well|SSAA|Sonny Steffan
 I Get Along Without You Very Well|TTBB|Adam Reimnitz
 I Get Along Without You Very Well|TTBB|Andrew Carolan
 I Get Along Without You Very Well|TTBB|David Zimmerman
+I Get Along Without You Very Well|TTBB|Janne Olsson
 I Get Along Without You Very Well|TTBB|Joe Mannherz
 I Get Along Without You Very Well|TTBB|Matthew Gallagher
+I Get Along Without You Very Well|TTBB|Ruby Rhea
 I Get Along Without You Very Well (Except Sometimes)|TTBB|Adam Reimnitz
 I Get Around|SSAA|Larry Wright
 I Get Around|TTBB|Jeremey Johnson
 I Get Around|TTBB|Larry Wright
+I Get Around|TTBB|Larry Wright, Doug Anderson
 I Get Around|TTBB|Sam Hubbard
+I Get By With a Little Help From My Friends|SSAA|Rich Hasty
 I Get The Blues When It Rains|SSAA|Anita Barzilla
 I Get The Blues When It Rains|SSAA|Anna Maria Parker
 I Get The Blues When It Rains|SSAA|David Harrington
@@ -7619,6 +9136,9 @@ I Go Crazy|TTBB|Michael Webber
 I Go For That|SSAA|Joan D 'Agostino
 I Go To Pieces|TTBB|Mark Stevens
 I Go To Rio|SSAA|Rowena Harper
+I Go to the Rock|SSAA|Don Gray
+I Got a Crush On You|SSAA|Marge Bailey
+I Got a Feelin' I'm Fallin'|SSAA|Nancy Bergman
 I Got Better|SATB|Mark Stevens
 I Got Lost In His Arms|SSAA|Jo Lund
 I Got Lost In His Arms|SSAA|Larry Wright
@@ -7628,19 +9148,25 @@ I Got Out Of Bed On The Right Side|SSAA|Marsha Zwicker
 I Got Out Of Bed On The Right Side|TTBB|Walter Latzko
 I Got Plenty O' Nuttin'|SSAA|Kohl Kitzmiller
 I Got Plenty O' Nuttin'|SSAA|Steve Jamison
+I Got Plenty of Nothin'|TTBB|Jay Giallombardo
 I Got Plenty Of Nothing|TTBB|Jay Giallombardo
 I Got Rhythm|SATB|Joe Mannherz
+I Got Rhythm|SSAA|Ann Minihane
 I Got Rhythm|SSAA|David Wright
 I Got Rhythm|SSAA|Jay Giallombardo
 I Got Rhythm|SSAA|Jon Nicholas
 I Got Rhythm|SSAA|Tom Gentry
+I Got Rhythm|TTBB|Bill Biffle
+I Got Rhythm|TTBB|Clay Hine
 I Got Rhythm|TTBB|David Wright
 I Got Rhythm|TTBB|Dennis Driscoll
+I Got Rhythm|TTBB|Ed Waesche
 I Got Rhythm|TTBB|Jay Giallombardo
 I Got Rhythm|TTBB|Tom Gentry
 I Got Rhythm|TTBB|Walter Latzko
 I Got Rhythm Medley|SSAA|Nancy Bergman
 I Got Rhythm Medley|TTBB|Carole Prietto
+I Got Rhythm-Farewell To Love|TTBB|Steven Armstrong
 I Got The Music In Me|SATB|Deke Sharon
 I Got The Music In Me|SSAA|Adam Bock
 I Got The Sun In The Morning|SSAA|Joan D 'Agostino
@@ -7650,6 +9176,8 @@ I Got You (I Feel Good)|SATB|Deke Sharon
 I Got You (I Feel Good)|SSAA|Erica Kelch-Slesnick
 I Got You (I Feel Good)|SSAA|Mike Menefee
 I Got You (I Feel Good)|TTBB|Kohl Kitzmiller
+I Got You, Babe|SSAA|Brian Beck
+I Gotta Dance|SSAA|Brian Beck
 I Gotta Feeling|SATB|Deke Sharon
 I Gotta Feeling|SSAA|Carole Prietto
 I Gotta Right To Sing The Blues|TTBB|Ed Waesche
@@ -7662,6 +9190,7 @@ I Guess It Must Be True|SSAA|Brian Beck
 I Guess That's Why They Call It The Blues|TTBB|Mark Stevens
 I Had A Dream, Dear Montage|TTBB|Jay Giallombardo
 I Had Some Help|TTBB|Mark Stevens
+I Had Someone Before I Had You|SSAA|Avis Fellows
 I Had Someone Else Before I Had You|SSAA|Avis Fellows
 I Had Someone Else Before I Had You|SSAA|David Briner
 I Had Someone Else Before I Had You / Who's Sorry Now Medley|SSAA|Tom Gentry
@@ -7672,6 +9201,7 @@ I Had The Craziest Dream|SSAA|Cheryl Suhr
 I Happen To Love You|SSAA|Walter Latzko
 I Hate Kids|TTBB|Dick Stuart
 I Hate To Get Up In The Morning|TTBB|Robert Turner
+I Hate to Lose You|TTBB|Unspecified
 I Hate To Lose You|TTBB|Walter Latzko
 I Have A Dream|TTBB|Marilyn Penketh
 I Have A Feeling For You|SSAA|David Harrington
@@ -7686,11 +9216,13 @@ I Have Dreamed|SSAA|David Briner
 I Have Dreamed|SSAA|David Wright
 I Have Dreamed|TTBB|David Wright
 I Have Dreamed|TTBB|Walter Latzko
+I Have Had Singing|TTBB|Ron Jeffers
 I Have Nothing|SSAA|Kay Bromert
 I Have Nothing|TTBB|Aaron Dale
 I Have Nothing|TTBB|Theodore Hicks
 I Have Nothing (from The Bodyguard)|TTBB|Theo Hicks
 I Have Seen The Light|TTBB|Jay Giallombardo
+I Have Seen The Light (chorus parts only)|TTBB|Jay Giallombardo
 I Hear Music|TTBB|Dennis Driscoll
 I Hear Music|TTBB|Walter Latzko
 I Heard It Through The Grapevine|SATB|Deke Sharon
@@ -7751,6 +9283,7 @@ I Know What It Means To Be Lonesome|TTBB|Rob Campbell
 I Know Where I've Been|TTBB|Kyle Kitzmiller
 I Know Where I've Been|TTBB|Theo Hicks
 I Know Where I've Been|TTBB|Theodore Hicks
+I Know Why (And So Do You)|TTBB|Kevin Keller
 I Know Why And So Do You|SSAA|Ig Jakovac
 I Know Why And So Do You|SSAA|Joe Mannherz
 I Know Why And So Do You|SSAA|Kevin Keller
@@ -7759,6 +9292,7 @@ I Know Why And So Do You|TTBB|Kevin Keller
 I Know Why And So Do You|TTBB|Walter Latzko
 I Left My Heart At The Stage Door Canteen|TTBB|Brent Graham
 I Left My Heart In San Francisco|SSAA|Larry Wright
+I Left My Heart In San Francisco|TTBB|Jay Wright
 I Left My Heart In San Francisco|TTBB|Larry Wright
 I Left My Heart In San Francisco|TTBB|Scott Kitzmiller
 I Left My Heart In San Francisco|TTBB|Ted Byrne
@@ -7776,10 +9310,13 @@ I Lived|SATB|Deke Sharon
 I Lived|SATB|Nicholas Wright
 I Lost The Best Pal That I Had|TTBB|Louis Perry
 I Love a Banjo|SSAA|Jo Lund
+I Love A Barbershop Song|TTBB|Duane Enders
 I Love A Jolson Song|TTBB|Joe Liles
 I Love A Parade|TTBB|H. R. Skinner
 I Love A Parade / Strike Up The Band Medley|TTBB|Tom Gentry
+I Love a Piano|SSAA|Jim Massey
 I Love A Piano|SSAA|Brian Beck
+I Love A Piano|SSAA|Greg Volk
 I Love A Piano|SSAA|Jay Giallombardo
 I Love A Piano|SSAA|Marge Bailey
 I Love A Piano|SSAA|Takako Fuke
@@ -7819,6 +9356,7 @@ I Love My Baby|TTBB|John Hohl
 I Love My Baby|TTBB|Tom Gentry
 I Love My Baby|TTBB|Walter Latzko
 I Love Paris|TTBB|Einar Pedersen
+I Love That Old Barbershop Style|TTBB|Val Hicks
 I Love That We're Old Fashioned|SSAA|Kevin Keller
 I Love That We're Old Fashioned|TTBB|Kevin Keller
 I Love The Ladies|TTBB|Steve Delehanty
@@ -7829,6 +9367,8 @@ I Love The Whole United States Medley|TTBB|Toban Dvoretsky
 I Love To Go Swimmin' With Wimmen|TTBB|Dennis Driscoll
 I Love To Have The Boys Around Me|SSAA|Dawn Haggerty
 I Love To Have The Boys Around Me|SSAA|Mark Rusch
+I Love to Hear That Good Old Barbershop Style|SSAA|Jo Lund
+I Love to Hear That Old Barbershop Style|SSAA|Jo Lund/Val Hicks
 I Love To Hear That Old Barbershop Style|SSAA|Jo Lund
 I Love To Hear That Old Barbershop Style|SSAA|Val Hicks
 I Love To Hear That Old Barbershop Style|TTBB|Val Hicks
@@ -7846,6 +9386,7 @@ I Love You|TTBB|Greg Mallett
 I Love You Always Forever|SATB|Nicholas Wright
 I Love You Best Of All|TTBB|Unknown
 I Love You California|TTBB|Paul Engel
+I Love You for Sentimental Reasons|SSAA|Joan Adler
 I Love You Just The Same Sweet Adeline|TTBB|David Wallace
 I Love You Just The Same Sweet Adeline|TTBB|Dennis Driscoll
 I Love You Just The Same Sweet Adeline|TTBB|Jack Baird
@@ -7854,6 +9395,7 @@ I Love You Just The Same Sweet Adeline|TTBB|Kirk Roose
 I Love You The Best Of All|TTBB|Barbershop Harmony Society
 I Love You The Best Of All|TTBB|SPEBSQSA
 I Love You Truly|SSAA|June Berg
+I Love You Truly|TTBB|Barbershop Harmony Society
 I Love You Truly|TTBB|Roger Payne
 I Love You Truly|TTBB|Walter Latzko
 I Loved Her First|TTBB|Robert Rund
@@ -7861,11 +9403,13 @@ I May Be Gone For A Long Long Time|TTBB|Burt Szabo
 I May Be Gone For A Long Long Time|TTBB|Jack Baird
 I May Be Gone For A Long Long Time|TTBB|Louis Perry
 I May Be Gone For A Long Long Time|TTBB|Warren 'Buzz' Haeger
+I May Be Gone for a Long, Long Time|TTBB|Unspecified
 I May Be Gone For A Long, Long Time/Yankee Boy|TTBB|Kevin Keller
 I May Never Pass This Way Again|SSAA|Joe Mannherz
 I May Never Pass This Way Again|SSAA|Tedda Lippincott
 I May Never Pass This Way Again|TTBB|Joe Mannherz
 I May Wander|SSAA|Joey Minshall
+I Miss Mother Most of All|SSAA|Joe Liles
 I Miss Mother Most Of All|TTBB|Joe Liles
 I Miss That Mississippi Miss That Misses Me|TTBB|Dennis Driscoll
 I Miss the Good Ol' Days|TTBB|David Naddor
@@ -7901,9 +9445,14 @@ I Never Knew / Somebody Loves Me|TTBB|Frank Marzocco
 I Never Knew / You Were Meant for Me Medley|TTBB|Rob Hopkins
 I Never Knew I Could Love Anybody|SSAA|David Wright
 I Never Knew I Could Love Anybody|TTBB|David Wright
+I Never Knew I Could Love Anybody (Like I'm Loving You)|SSAA|David Wright
+I Never Knew Medley|TTBB|Renee Craig
 I Never Knew the Love I Was Missin'|SSAA|Jan Meyer
 I Never Knew What I Was Missin'|SSAA|Brent Graham
 I Never Knew What I Was Missin'|TTBB|Brent Graham
+I Never Knew You Were Meant for Me|SSAA|Rob Hopkins
+I Never Knew/Get Me To The Church On Time Medley(Clay|TTBB|Clay Hine
+I Never Knew/You Were Meant for Me|SSAA|Renee Craig
 I Never Like It When You Leave|TTBB|Dan Wessler
 I Never Meant To Fall In Love|SSAA|Joe Liles
 I Never Meant To Fall In Love|TTBB|Joe Liles
@@ -7914,14 +9463,20 @@ I Never Thought It Would End This Way|TTBB|Robert Rund
 I Never Walk Alone|SATB|Jon Nicholas
 I Never Walk Alone|SSAA|Jon Nicholas
 I Only Have Eyes For You|SATB|Tom Gentry
+I Only Have Eyes For You|SSAA|Greg Volk
 I Only Have Eyes For You|SSAA|Joe Mannherz
+I Only Have Eyes For You|SSAA|Tedda Lippincott
 I Only Have Eyes For You|SSAA|Tom Gentry
+I Only Have Eyes For You|SSAA|Unspecified
 I Only Have Eyes For You|SSAA|Walter Latzko
 I Only Have Eyes For You|TTBB|Bob Weiss
+I Only Have Eyes For You|TTBB|Bobby Gray
 I Only Have Eyes For You|TTBB|Deke Sharon
 I Only Have Eyes For You|TTBB|Dennis Driscoll
+I Only Have Eyes For You|TTBB|Greg Volk, Bobby Gray
 I Only Have Eyes For You|TTBB|Jim Shubert
 I Only Have Eyes For You|TTBB|Joe Mannherz
+I Only Have Eyes For You|TTBB|R. Weiss
 I Only Have Eyes For You|TTBB|Steve Jamison
 I Only Have Eyes For You|TTBB|Tom Gentry
 I Only Wanna Laugh|TTBB|Jeremey Johnson
@@ -7955,6 +9510,7 @@ I Remember You|TTBB|Joe Mannherz
 I Remember You|TTBB|Walter Latzko
 I Said My Pajamas|TTBB|Fran Wilson
 I Saw Her Again|TTBB|Jeremey Johnson
+I Saw Her Standing There|TTBB|Brian Wollman
 I Saw Her Standing There|TTBB|Jon Nicholas
 I Saw Mommy Kissing Santa Claus|SSAA|Hilary Allen
 I Saw Mommy Kissing Santa Claus|TTBB|Burt Szabo
@@ -7987,19 +9543,23 @@ I See The Light (from Walt Disney Pictures' TANGLED)|TTBB|Kevin Keller
 I See Your Face Before Me|SATB|Kevin Keller
 I See Your Face Before Me|SSAA|Kevin Keller
 I See Your Face Before Me|TTBB|Kevin Keller
+I Shot the Sheriff|TTBB|Steve Wolf
 I Sing|SATB|Joe Mannherz
 I Sing Because I'm Happy|SSAA|Dianne Goldrick
 I Sing Because I'm Happy|TTBB|Dianne Goldrick
+I Sing the Mighty Power of God|TTBB|Andrew Ball
 I Sing You Sing|TTBB|Kevin Keller
 I Stayed Too Long At The Fair|TTBB|Russ Foris
 I Still Believe In Me|SSAA|Jo Lund
 I Still Call Australia Home|SSAA|Glenda Lloyd
+I Still Call Australia Home|SSAA|Unspecified
 I Still Can See Your Face|SSAA|David Wright
 I Still Can't Say Goodbye|TTBB|James Henry
 I Still Have Faith In You|TTBB|Mark Burnip
 I Still Haven't Found What I'm Looking For|SATB|Deke Sharon
 I Swear|SSAA|Charlene Yazurlo
 I Swear|TTBB|Deke Sharon
+I Talk To The Trees|SSAA|D.C. DeBruycker
 I Talk To The Trees|SSAA|Joe Mannherz
 I Talk To The Trees|TTBB|Joe Mannherz
 I Tell Me Ma|SSAA|Liz Garnett
@@ -8012,18 +9572,24 @@ I Think You're Wonderful|TTBB|Tom Gentry
 I Think, I Love|TTBB|Theodore Hicks
 I Thought About You|SSAA|Jay Giallombardo
 I Thought About You|TTBB|Jay Giallombardo
+I Thought About You|TTBB|Ruby Rhea
 I Thought About You|TTBB|Steve Hardy
+I Thought About You|TTBB|Webb Comfort
 I Thought She Knew|SSAA|Theodore Hicks
 I Thought She Knew|TTBB|Theo Hicks
 I Thought She Knew|TTBB|Theodore Hicks
 I Thought She Knew|TTBB|Walter Latzko
 I Thrill When They Mention Your Name|TTBB|Jim Franklin
+I Told 'em All About You/You Dear|SSAA|Four Harmonizers
+I Told Them All About You|SSAA|Jim Arns
 I Told Them All About You|TTBB|Tom Gentry
 I Told Them All About You / You Dear|SSAA|Ed Waesche
 I Told Them All About You / You Dear|SSAA|Jim Arns
 I Told Them All About You / You Dear|TTBB|Ed Waesche
 I Told Them All About You / You Dear Medley|SSAA|Unknown
 I Told Them All About You / You Dear Medley|TTBB|The Four Harmonizers
+I Told Them All About You/You Dear Medley|SSAA|Joe Liles
+I Told Them All About You/You Dear Medley(Four Harmoni|TTBB|Four Harmonizers
 I Told You So|TTBB|Robert Rund
 I Tore Up Your Picture When You Said Goodbye|SSAA|Avis Fellows
 I Tore Up Your Picture When You Said Goodbye|TTBB|Ed Waesche
@@ -8035,8 +9601,11 @@ I Used To Be Color Blind|TTBB|Adam Reimnitz
 I Used To Call Her Baby|TTBB|John Muir
 I Used To Call Her Baby|TTBB|Rob Hopkins
 I Used To Call Her Baby|TTBB|Tom Gentry
+I Used To Call Her Baby|TTBB|Tom Gentry, Don Gray
 I Used to Call Her/Him Baby Medley|SSAA|Jay Giallombardo
 I Used to Call Her/Him Baby Medley|TTBB|Jay Giallombardo
+I Used to Call Him Baby asb Showtime|SSAA|Jay Giallombardo
+I Used to Call Him Baby Medley|SSAA|Jay Giallombardo
 I Used To Love You But It's All Over|SSAA|Nancy Bergman
 I Used To Love You But It's All Over|SSAA|Tedda Lippincott
 I Used To Love You But It's All Over|TTBB|Jim Shubert
@@ -8052,14 +9621,18 @@ I Walked Today Where Jesus Walked|TTBB|Derric Johnson
 I Walked Today Where Jesus Walked|TTBB|Walter Latzko
 I Wan'na Be Like You (The Monkey Song)|TTBB|David Wright
 I Wanna Be A Front Row Man|TTBB|Jim Hickman
+I Wanna Be A Producer|TTBB|Nick Schurmann
 I Wanna Be Around|SSAA|Carolyn Healey
 I Wanna Be Around|SSAA|Dorothy Short
 I Wanna Be Around|SSAA|Jay Giallombardo
 I Wanna Be Around|SSAA|Nancy Bergman
 I Wanna Be Around|TTBB|Jay Giallombardo
 I Wanna Be Around|TTBB|Mark Goodney
+I Wanna Be Around|TTBB|Mo Rector
 I Wanna Be Around|TTBB|Scott Kitzmiller
 I Wanna Be Like You|SATB|Deke Sharon
+I Wanna Be Like You|SATB|Philip Lawson
+I Wanna Be Like You|SSAA|Unspecified
 I Wanna Be Like You|TTBB|David Wright
 I Wanna Be Like You|TTBB|Tom Gentry
 I Wanna Be Loved|SATB|Mark Jennings
@@ -8067,6 +9640,7 @@ I Wanna Be Loved By You|SSAA|Anne Clarke
 I Wanna Be Loved By You|SSAA|Jarmela Speta
 I Wanna Be Loved By You|TTBB|Dick Barrett
 I Wanna Be Loved By You|TTBB|Walter Latzko
+I Wanna Come Back As A Man|SSAA|Jim Arns
 I Wanna Dance With Somebody|SATB|Kohl Kitzmiller
 I Wanna Dance With Somebody|SATB|Nicholas Wright
 I Wanna Dance With Somebody|SATB|Patrick McAlexander
@@ -8076,17 +9650,22 @@ I Wanna Dance With Somebody|SSAA|Nicholas Wright
 I Wanna Go Back to Ohio State|TTBB|Tom Gentry
 I Wanna Go Back to West Virginia|TTBB|Tom Gentry
 I Wanna Hear a Barbershop Song|TTBB|Tom Gentry
+I Wanna Hippopotamus for Christmas|SSAA|Tedda Lippincott
+I Wanna Hold Your Hand|SSAA|David Harrington
+I Wanna Hold Your Hand|TTBB|David Harrington
 I Wanna Marry Harry|SSAA|Tom Gentry
 I Wanna Marry Mary|TTBB|Tom Gentry
 I Wanna Say Hello|TTBB|Michael Webber
 I Wanna Sing Barbershop|SSAA|Jan Meyer
 I Wanna Sing Not Dance|TTBB|Joe Liles
 I Wanna Talk About Me|SSAA|Jim Arns
+I Want a Girl|TTBB|Barbershop Harmony Society
 I Want A Girl|TTBB|SPEBSQSA
 I Want A Girl (Just Like The Girl That Married Dear Old Dad)|TTBB|SPEBSQSA, INC.
 I Want A Girl Medley|SSAA|Avis Fellows
 I Want A Girl Medley|SSAA|Barbara Bianchi
 I Want A Girl Medley|TTBB|Wayne Woodward
+I Want a Hippopotamus for Christmas|TTBB|Tony Searle
 I Want A Hippopotamus For Christmas|SATB|Deke Sharon
 I Want A Hippopotamus For Christmas|SATB|Manoj Padki
 I Want A Hippopotamus For Christmas|SSAA|David Wallace
@@ -8123,7 +9702,9 @@ I Want To Dream By The Old Mill Stream|TTBB|Munson Hinman
 I Want To Go Back To Dixieland|TTBB|Walter Latzko
 I Want To Hold Your Hand|SSAA|David Harrington
 I Want To Hold Your Hand|SSAA|Steve Jamison
+I Want To Hold Your Hand|TTBB|Adam Bock
 I Want To Hold Your Hand|TTBB|David Harrington
+I Want To Hold Your Hand|TTBB|Steve Jamison
 I Want To Stare At My Phone With You|SSAA|Dianne Goldrick
 I Want To Wish You A Merry Christmas|TTBB|SPEBSQSA
 I Want To Wish You A Merry Christmas|TTBB|Unknown
@@ -8133,6 +9714,7 @@ I Want You Back|SSAA|Deke Sharon
 I Want You Back|SSAA|Elaine Gain
 I Want You Back|TTBB|Theodore Hicks
 I Want You For My Sweetheart (but I Don't Want You For My Wife)|TTBB|Nancy Bergman
+I Want You to be My Sweetheart|TTBB|Lou Perry
 I Want You To Be My Sweetheart|TTBB|Louis Perry
 I Want You to Want Me|TTBB|Aaron Dale
 I Want You, I Need You, I Love You|SSAA|Aaron Dale
@@ -8167,6 +9749,7 @@ I Will|TTBB|Jay Giallombardo
 I Will|TTBB|Melody Hine
 I Will|TTBB|Tom Gentry
 I Will Always Love You|SATB|Deke Sharon
+I Will Be There|TTBB|Steve Delehanty
 I Will Follow Him|SSAA|Jeanette Perry
 I Will Follow Him|SSAA|Karen McCarville
 I Will Follow Him|SSAA|Larry Wright
@@ -8174,11 +9757,16 @@ I Will Follow Him|SSAA|Tedda Lippincott
 I Will Follow You|TTBB|David Wright
 I Will Go Sailing No More|SATB|Richard Hasty
 I Will Go Sailing No More|SSAA|Richard Hasty
+I Will Go Sailing No More|TTBB|Rich Hasty
 I Will Go Sailing No More|TTBB|Richard Hasty
+I Will Love Again|SSAA|Vicki Uhr
+I Will Love You 'Til the End of Time|SSAA|Alan Baker
+I Will Love You Til The End of Time|SSAA|Al Baker
 I Will Never Leave You|SSAA|Sharon Holmes
 I Will Never Pass This Way Again|SSAA|Bev Sellers
 I Will Never Pass This Way Again|SSAA|Tom Gentry
 I Will Never Pass This Way Again|TTBB|Clay Hine
+I Will Never Pass This Way Again|TTBB|Don Gray
 I Will Never Pass This Way Again|TTBB|Tom Gentry
 I Will Play a Rhapsody|TTBB|Mark Stevens
 I Will Sing Hallelujah|SSAA|Tom Gentry
@@ -8232,6 +9820,7 @@ I Wish That I Could Hide Inside This Letter|TTBB|Kevin Keller
 I Wish That I'd Been Satisfied With Mary|TTBB|Archie Steen
 I Wish That I'd Been Satisfied With Mary|TTBB|Tom Gentry
 I Wish You Love|SATB|Larry Triplett
+I Wish You Love|SSAA|Dave Briner
 I Wish You Love|SSAA|David Wright
 I Wish You Love|SSAA|Jay Giallombardo
 I Wish You Love|SSAA|Larry Triplett
@@ -8275,9 +9864,11 @@ I Won't Send Roses (from Mack And Mabel)|TTBB|Theo Hicks
 I Won't Tell A Soul|TTBB|George Hulst
 I Wonder as I Wander|TTBB|John Wernega
 I Wonder As I Wander|SSAA|Joey Minshall
+I Wonder As I Wander|TTBB|Darin Drown
 I Wonder As I Wander|TTBB|Derric Johnson
 I Wonder As I Wander|TTBB|Jay Giallombardo
 I Wonder As I Wander|TTBB|Jon Nicholas
+I Wonder as I Wander (Bass feature)|SSAA|Joey Minshall
 I Wonder If You Miss Me Just As Much As I Miss You|TTBB|Jack Baird
 I Wonder What Became Of Sally|TTBB|Burt Szabo
 I Wonder What The King Is Doing Tonight|TTBB|Dick Stuart
@@ -8298,16 +9889,19 @@ I Wonder Who's Kissing Her Now|SSAA|Earl Moon
 I Wonder Who's Kissing Her Now|SSAA|Walter Latzko
 I Wonder Who's Kissing Her Now|TTBB|Jack Baird
 I Wonder Who's Kissing Her Now|TTBB|Louis Perry
+I Wonder Who's Kissing Her Now?|TTBB|Lou Perry
 I Wonder Why|TTBB|Walter Latzko
 I Work 8 Hours I Sleep 8 Hours (8 Hours for Love)|SSAA|Jay Giallombardo
 I Work 8 Hours I Sleep 8 Hours (8 Hours for Love)|TTBB|Jay Giallombardo
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Brent Graham
+I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Ed Waesche
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jack Baird
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jay Giallombardo
 I Write The Songs|SATB|David Wright
 I Write The Songs|SSAA|Jay Giallombardo
 I Write The Songs|SSAA|Melody Hine
 I Write The Songs|SSAA|Takako Fuke
+I Write The Songs|TTBB|Buzz Haeger
 I Write The Songs|TTBB|Douglas Smith
 I Write The Songs|TTBB|Jay Giallombardo
 I Write The Songs|TTBB|Steve Tramack
@@ -8331,6 +9925,7 @@ I'd Give A Million Tomorrows|TTBB|Tom Gentry
 I'd Give The World To Be In My Home Town|SSAA|Mary K. Coffman Music Fund
 I'd Give The World To Be In My Home Town|TTBB|Einar Pedersen
 I'd Give The World To Be In My Hometown|TTBB|Einar Pedersen
+I'd Give The World To Hear Alexanders Band Again|TTBB|Unspecified
 I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Emily Moriarty
 I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Marsha Zwicker
 I'd Like To Buy The World A Coke|TTBB|Mason Eubank
@@ -8340,12 +9935,17 @@ I'd Like To Teach The World To Sing|SSAA|Nancy Bergman
 I'd Like To Teach The World To Sing|TTBB|Dave Stevens
 I'd Like To Teach The World To Sing|TTBB|Ken Bastien
 I'd Like To Teach The World To Sing|TTBB|Rob Hopkins
+I'd Like To Teach The World To Sing (In Perfect Harmony)|TTBB|Dave Stevens
+I'd Like To Teach The World To Sing (In Perfect Harmony)|TTBB|Rob Hopkins
 I'd Love To Be A Baby Again|TTBB|Kim Brittain
 I'd Love to Be in Chicago on Good Ol' St. Valentine's Day|TTBB|Jay Giallombardo
 I'd Love To Live In Loveland|SSAA|Walter Latzko
 I'd Love To Live In Loveland|TTBB|Aaron Dale
+I'd Love To Live In Loveland|TTBB|Barbershop Harmony Society
+I'd Love To Live In Loveland|TTBB|Heritage of Harmony
 I'd Love To Live In Loveland|TTBB|Steve Jamison
 I'd Love To Live In Loveland|TTBB|Val Hicks
+I'd Love To Live In Loveland With A Girl Like You|TTBB|Aaron Dale
 I'd Love To Meet That Old Sweetheart of Mine|TTBB|Lou Perry
 I'd Love To Meet That Old Sweetheart Of Mine|TTBB|Louis Perry
 I'd Love to Play the Palace Once Again|SSAA|Jay Giallombardo
@@ -8361,6 +9961,7 @@ I'd Really Love To Spend This Time With You|TTBB|Jim Shubert
 I'll Always Be In Love With You|SSAA|Joanne Dockrell
 I'll Always Be In Love With You|TTBB|Joe Liles
 I'll Always Be Mother's Boy|TTBB|Rick Spencer
+I'll Always Love You (Smiling Face)|TTBB|Ruby Rhea
 I'll Always Remember You|SATB|Nicholas Wright
 I'll Be A Famous Lady Of The Stage|SSAA|Marie Johnson
 I'll Be A Song And Dance Man Again|TTBB|Val Hicks
@@ -8379,6 +9980,8 @@ I'll Be Home For Christmas|SSAA|Jay Giallombardo
 I'll Be Home For Christmas|SSAA|Kay Bromert
 I'll Be Home For Christmas|SSAA|Larry Wright
 I'll Be Home For Christmas|SSAA|Nancy Bergman
+I'll Be Home For Christmas|SSAA|Renee Craig
+I'll Be Home For Christmas|SSAA|Sylvia Alsbury
 I'll Be Home For Christmas|SSAA|Tedda Lippincott
 I'll Be Home For Christmas|SSAA|Tom Gentry
 I'll Be Home For Christmas|TTBB|Aaron Dale
@@ -8396,6 +9999,7 @@ I'll Be Home For Christmas|TTBB|Nancy Bergman
 I'll Be Home For Christmas|TTBB|Steve Jamison
 I'll Be Home For Christmas|TTBB|Theodore Hicks
 I'll Be Home For Christmas|TTBB|Tom Gentry
+I'Ll Be Home For Christmas|SSAA|Renee Craig Judy Vidal
 I'll Be Home for Christmas/Have Yourself a Merry Little Christmas|SSAA|Jay Giallombardo
 I'll Be Satisfied|TTBB|Brian Mastrull
 I'll Be Seeing You|SATB|Joe Mannherz
@@ -8404,11 +10008,16 @@ I'll Be Seeing You|SATB|Rob Hopkins
 I'll Be Seeing You|SSAA|Andrew Carolan
 I'll Be Seeing You|SSAA|Cheryl Suhr
 I'll Be Seeing You|SSAA|Deke Sharon
+I'll Be Seeing You|SSAA|Renee Craig
 I'll Be Seeing You|SSAA|Rob Hopkins
 I'll Be Seeing You|SSAA|Sylvia Alsbury
 I'll Be Seeing You|SSAA|Tedda Lippincott
 I'll Be Seeing You|TTBB|Al Baker
+I'll Be Seeing You|TTBB|Chris Slacke
+I'll Be Seeing You|TTBB|Chuck Brooks
 I'll Be Seeing You|TTBB|Dick Rode
+I'll Be Seeing You|TTBB|Don Gray
+I'll Be Seeing You|TTBB|Jim Clancy
 I'll Be Seeing You|TTBB|Jim Shubert
 I'll Be Seeing You|TTBB|Joe Mannherz
 I'll Be Seeing You|TTBB|Patrick Bauer
@@ -8424,6 +10033,7 @@ I'll Be The Words and You'll Be The Music|TTBB|Jim Shubert
 I'll Be There|SATB|Deke Sharon
 I'll Be There|SSAA|Deke Sharon
 I'll Be There|SSAA|Larry Wright
+I'll Be There (SATB)|SATB|Dave King
 I'll Be There For You|SSAA|Jon Nicholas
 I'll Be There For You|TTBB|Jon Nicholas
 I'll Be There For You|TTBB|Matt Astle
@@ -8454,23 +10064,31 @@ I'll Dream of You Again/And So To Sleep Again Medley|SSAA|Kevin Keller
 I'll Dream of You Again/And So To Sleep Again Medley|TTBB|Kevin Keller
 I’ll Drown In My Own Tears|TTBB|Mark Hale
 I'll Fight|SSAA|Carole Prietto
+I'll Fly Away|SSAA|Burt Szabo
+I'll Fly Away|SSAA|Don Gray
 I'll Fly Away|TTBB|Burt Szabo
 I'll Fly Away|TTBB|Dennis Driscoll
 I'll Fly Away|TTBB|Don Gray
+I'll Fly Away (Keepsake Version)|TTBB|Don Gray
+I'll Fly Away (Society Stock Version)|TTBB|Don Gray
 I'll Follow The Sun|TTBB|Jay Giallombardo
+I'll Forget You|SSAA|Jay Giallombardo
 I'll Forget You|SSAA|Linda Edmondson
 I'll Forget You|TTBB|Burt Szabo
 I'll Forget You|TTBB|Jack Baird
 I'll Forget You|TTBB|Jay Giallombardo
+I'll Forget You|TTBB|Lou Perry
 I'll Forget You|TTBB|Louis Perry
 I'll Get By|SSAA|Nancy Bergman
 I'll Get By|TTBB|Joe Mannherz
+I'll Get By|TTBB|Steven Armstrong
 I'll Get By (As Long As I Have You)|SSAA|Tedda Lippincott
 I'll Get By (As Long As I Have You)|TTBB|Steven Armstrong
 I'll Have To Say I Love You In A Song|SATB|Mark Stevens
 I'll Have To Say I Love You In A Song|TTBB|Mark Stevens
 I'll Have Vanilla|TTBB|Kirk Roose
 I'll hear your voice|SATB|Joe Mannherz
+I'll Know|SATB|Steven Armstrong
 I'll Make A Man Out Of You|SATB|Deke Sharon
 I'll Make A Man Out Of You|TTBB|Adam Scott
 I'll Make A Ring Around Rosie|TTBB|Al Baker
@@ -8486,16 +10104,20 @@ I'll Never Let You Cry|TTBB|Louis Perry
 I'll Never Look Up To You|SSAA|Cris Conerty
 I'll Never Love Again|SATB|Cay Outerbridge
 I'll Never Miss Another Girl As I Miss You|TTBB|Tom Campbell
+I'll Never Say 'Never Again' Again|TTBB|Tom Gentry
+I'll Never Say Never Again|SSAA|Tom Gentry
 I'll Never Say Never Again Again|SSAA|Tom Gentry
 I'll Never Say Never Again Again|TTBB|Tom Gentry
 I'll Never Smile Again|SSAA|Nancy Bergman
 I'll Never Smile Again|TTBB|Jim Shubert
+I'll Never Smile Again|TTBB|Roy Keys
 I'll Never Smile Again|TTBB|Walter Latzko
 I'll Never Smile Again|TTBB|Wayne Grimmer
 I'll Never Stop Loving You|SSAA|Adam Reimnitz
 I'll Never Stop Loving You|SSAA|Glenda Lloyd
 I'll Never Stop Loving You|TTBB|Brent Graham
 I'll Never Write A Love Song Any More|TTBB|Joe Liles
+I'll Never Write A Love Song Anymore|SSAA|Joe Liles
 I'll Say She Does!|TTBB|Dennis Driscoll
 I'll See You In My Dreams|SSAA|Jo Lund
 I'll See You In My Dreams|TTBB|Brent Graham
@@ -8510,8 +10132,10 @@ I'll Take Care Of Your Cares|TTBB|Louis Perry
 I'll Take Care Of Your Cares|TTBB|Munson Hinman
 I'll Take Her Back|TTBB|Val Hicks
 I'll Take Romance|SSAA|Marshall Webb
+I'll Take Romance|TTBB|Marshall Webb
 I'll Take You Dreaming|TTBB|Clay Hine
 I'll Take You Dreaming|TTBB|Larry Triplett
+I'll Take You Home Again Kathleen|TTBB|Peter Nugent
 I'll Take You Home Again, Kathleen|TTBB|Barbershop Harmony Society
 I'll Take You Home Again, Kathleen|TTBB|Jay Giallombardo
 I'll Take You Home Again, Kathleen|TTBB|Jim Shubert
@@ -8519,11 +10143,14 @@ I'll Take You Home Again, Kathleen|TTBB|SPEBSQSA
 I'll Tell My Ma When I Go Home|SSAA|Joey Minshall
 I'll Walk Alone|SSAA|David Briner
 I'll Walk With God|TTBB|Bob Weiss
+I'll Walk With God|TTBB|Burt Szabo, Hank Vomacka
 I'll Walk With God|TTBB|Hank Vomacka
 I'll Walk With God|TTBB|Jeremey Johnson
+I'll Walk With God|TTBB|Pete Rupay
 I'm A Believer|SATB|Jan-Ake Westin
 I'm A Believer|SATB|Kevin Keller
 I'm A Believer|SSAA|David Wallace
+I'm A Believer|TTBB|Greg Volk
 I'm A Believer|TTBB|Jon Nicholas
 I'm A Believer|TTBB|Kevin Keller
 I'm A Believer|TTBB|Nicholas Wright
@@ -8537,6 +10164,7 @@ I'm A Fool To Want You|SSAA|Larry Triplett
 I'm A Fool To Want You|SSAA|Walter Latzko
 I'm A Fool To Want You|TTBB|Larry Triplett
 I'm A Fool To Want You|TTBB|Walter Latzko
+I'm A Great Big Baby|SSAA|Lynnell Diamond
 I'm A Lonely Little Petunia|TTBB|Ray Buntaine
 I'm A Lonesome Melody|SSAA|Carolyn Johnson
 I'm A Man of Constant Sorrow|TTBB|Aaron Dale
@@ -8549,8 +10177,10 @@ I'm A Train|SATB|Peter Knight
 I'm A Train|TTBB|Peter Knight
 I'm A Wild And Wooly Son Of The West|TTBB|Burt Szabo
 I'm A Wild And Wooly Son Of The West|TTBB|Warren 'Buzz' Haeger
+I'm a Woman|SSAA|Lorraine Rochefort
 I'm A Woman|SSAA|Nancy Bergman
 I'm Afraid Of The Beautiful Girls|TTBB|Don Gray
+I'm Afraid the Masquerade is Over|SSAA|Renee Craig
 I'm Afraid This Must Be Love|SSAA|Joe Mannherz
 I'm Afraid To Love You|TTBB|Mo Rector
 I'm Alive|SSAA|Melody Hine
@@ -8561,19 +10191,26 @@ I'm All Alone|TTBB|David Wallace
 I'm All Alone|TTBB|Louis Perry
 I'm All Prayed Up|TTBB|Jim West
 I'm All That's Left Of That Old Quartet|TTBB|Kirk Roose
+I'm Alone Because I Love You|SSAA|Brian Beck
 I'm Alone Because I Love You|SSAA|Jo Lund
 I'm Alone Because I Love You|SSAA|Marie Johnson
+I'm Alone Because I Love You|SSAA|Mary Coffman
 I'm Alone Because I Love You|SSAA|Mary K. Coffman Music Fund
+I'm Alone Because I Love You|TTBB|Brian Beck
 I'm Alone Because I Love You|TTBB|Lou Perry and Ed Waesche
+I'm Alone Because I Love You|TTBB|Lou Perry, Ed Waesche
 I'm Alone Because I Love You|TTBB|Louis Perry
 I'm Alone Because I Love You|TTBB|Rob Hopkins
 I'm Alone Because I Love You|TTBB|Tom Gentil
+I'm Alone Because I Love You|TTBB|Unspecified
 I'm Already There|TTBB|Adam Scott
 I'm Alright|SATB|Joe Mannherz
 I'm Alright|TTBB|Aaron Dale
+I'm Alright Now|TTBB|Theo Hicks
 I'm Always Chasing Rainbows|SSAA|Anna Maria Parker
 I'm Always Chasing Rainbows|SSAA|Jo Lund
 I'm Always Chasing Rainbows|SSAA|Nancy Bergman
+I'm Always Chasing Rainbows|SSAA|Ruby Rhea
 I'm Always Chasing Rainbows|SSAA|Walter Latzko
 I'm Always Chasing Rainbows|TTBB|Earl Moon
 I'm Always Chasing Rainbows|TTBB|Ed Waesche
@@ -8583,19 +10220,28 @@ I'm Always Chasing Rainbows|TTBB|Tom Gentry
 I'm Always Chasing Rainbows|TTBB|Walter Latzko
 I'm An Old Cowhand|TTBB|Don Gray
 I'm An Old Cowhand|TTBB|Rob Campbell
+I'm Back In Love/I'm In Love Again|SSAA|Betty Oliver/Marie Johnson
 I'm Back In Love/I'm In Love Again Medley|SSAA|Betty Oliver
 I'm Beginning To Like It|SSAA|Tom Gentry
 I'm Beginning To Like It|TTBB|Tom Gentry
+I'm Beginning to See the Light|SSAA|June Dale
+I'm Beginning to See the Light|SSAA|Linda Masterson
+I'm Beginning to See the Light|SSAA|Tedda Lippincott
+I'm Beginning to See the Light|TTBB|Marshall Webb
 I'm Beginning To See The Light|SSAA|Jan Meyer
 I'm Beginning To See The Light|SSAA|Kay Bromert
 I'm Beginning To See The Light|SSAA|Nancy Bergman
+I'm Beginning To See The Light|SSAA|Rob Hopkins
 I'm Beginning To See The Light|SSAA|Steve Tramack
 I'm Beginning To See The Light|SSAA|Walter Latzko
 I'm Beginning To See The Light|TTBB|Joe Mannherz
 I'm Beginning To See The Light|TTBB|John Bober
 I'm Beginning To See The Light|TTBB|John Hohl
+I'm Beginning To See The Light|TTBB|Rob Hopkins
 I'm Beginning To See The Light|TTBB|Walter Latzko
 I'm Confessin|SSAA|Ann Minihane
+I'm Confessin'|SSAA|Don Gray
+I'm Confessin'|TTBB|Don Gray
 I'm Confessin' That I Love You|SSAA|Jo Lund
 I'm Confessin' That I Love You|SSAA|Tedda Lippincott
 I'm Dancing This Dance in the Wrong Romance|SSAA|Frank Marzocco
@@ -8605,9 +10251,11 @@ I'm Drifting Back To Dreamland|TTBB|J. I. Ruehle
 I'm Drifting Tonight Through Old Memory Lane|SSAA|Jo Lund
 I'm Feelin' Fine|SATB|Joe Liles
 I'm Feelin' Fine|SSAA|Joe Liles
+I'm Feelin' Fine|TTBB|Darin Drown
 I'm Feelin' Fine|TTBB|Joe Liles
 I'm Feeling Fine|SATB|Joe Liles
 I'm Feeling Fine|SSAA|Joe Liles
+I'm Feeling Fine|SSAA|Tedda Lippincott
 I'm Feeling Fine|TTBB|Joe Liles
 I'm Flyin High Medley|SSAA|Carolyn Schmidt
 I'm Flying|SSAA|Larry Wright
@@ -8635,31 +10283,43 @@ I'm Going Over The Hills To Virginia|TTBB|Jack Baird
 I'm Gonna Buy A One-Way Ticket To A Little One-Horse Town|TTBB|Paul Engel
 I'm Gonna Eat at the Welcome Table|SATB|Jim Shubert
 I'm Gonna Follow The Boys Over There|SSAA|Nancy Bergman
+I'm Gonna Live 'Til I Die|SSAA|Unspecified
+I'm Gonna Live 'Til I Die|TTBB|Greg Volk
+I'm Gonna Live 'Til I Die|TTBB|Robert Rund
 I'm Gonna Live Till I Die|SSAA|Aaron Dale
 I'm Gonna Live Till I Die|SSAA|Jeannie Vercillo
 I'm Gonna Live Till I Die|TTBB|Greg Volk
+I'm Gonna Live Till I Die|TTBB|Greg Volk, Keepsake
 I'm Gonna Live Till I Die|TTBB|Robert Rund
+I'm Gonna Live TillI Die|SSAA|Greg Volk
 I'm Gonna Lock My Heart|SSAA|Jean Shook
 I'm Gonna Lock My Heart|SSAA|Marsha Zwicker
 I'm Gonna Lock My Heart|TTBB|Ed Waesche
+I'm Gonna Love That Guy|SSAA|Norma Andersen
 I'm Gonna Make Hay While the Sun Shines in Virginia|SSAA|Jay Giallombardo
 I'm Gonna Make Hay While the Sun Shines in Virginia|TTBB|Jay Giallombardo
+I'm Gonna Make It, Joe|TTBB|Phil Ordaz
 I'm Gonna Marry Harry|SSAA|Carolyn Johnson
 I'm Gonna Meet My Sweetie Now|TTBB|Burt Szabo
 I'm Gonna Miss Her|TTBB|Brent Graham
 I'm Gonna Miss Her|TTBB|Rob Hopkins
 I'm Gonna Rise (When The Son Comes Down)|SSAA|Adam Scott
 I'm Gonna Rise (When The Son Comes Down)|TTBB|Adam Scott
+I'm Gonna Sing|TTBB|Gloria Gaither
 I'm Gonna Sing 'Til The Spirit Moves My Heart|TTBB|Darin Drown
+I'm Gonna Sing Til The Spirit Moves In My Heart(Darin D|TTBB|Darin Drown
 I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Bev Sellers
 I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tedda Lippincott
 I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tom Gentry
 I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Jimbob Kahlke
+I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Mo Rector (w/slight changes)
 I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Tom Gentry
+I'm Gonna Sit Right Down And Write Myself A Letter(Jim Ka|TTBB|Jim Kahlke
 I'm Gonna Steal Somebody Else's Baby|SSAA|Avis Fellows
 I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ken Potter
 I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ruby Rhea
 I'm Gonna' Be A Star|TTBB|Jim West
+I'm Happy|TTBB|Alan Siegal
 I'm Havin' A Ball (from Dirty Grandpa)|TTBB|Cay Outerbridge
 I'm Having A Ball|SSAA|Larry Wright
 I'm Having A Ball|TTBB|Kevin Koehl
@@ -8668,20 +10328,26 @@ I'm Headin' South (North)|TTBB|Jay Giallombardo
 I'm Henry VIII I Am|TTBB|Jim Shubert
 I'm Henry VIII I Am|TTBB|Tom Gentry
 I'm In A Hurry (And Don't Know Why)|TTBB|Mark Stevens
+I'm In Love With A Big Blue Frog|SSAA|Carolyn Healey
 I'm In Love With A Brand New Baby|SSAA|June Berg
+I'm In Love With the Mother of My Best Girl|TTBB|Dave Briner and Lloyd Steinkamp
 I'm In Love With The Mother Of My Best Girl|SSAA|Jay Giallombardo
 I'm In Love With The Mother Of My Best Girl|TTBB|Dave Briner
 I'm In Love With The Mother Of My Best Girl|TTBB|David Briner
 I'm In Love With The Sound Effects Man|SSAA|Marie Johnson
+I'm In the Mood For Love|TTBB|Webb Comfort
 I'm In The Mood For Love|SSAA|David Harrington
 I'm In The Mood For Love|SSAA|David Wright
 I'm In The Mood For Love|SSAA|Diane Clark
 I'm In The Mood For Love|SSAA|Linda Samuelsson
 I'm In The Mood For Love|TTBB|David Harrington
+I'm Into Something Good|SSAA|John Fortino (Intro by Norbert Hammes)
+I'm Into Something Good|TTBB|Christopher Peterson
 I'm Into Something Good|TTBB|Dan Wessler
 I'm Into Something Good|TTBB|Deke Sharon
 I'm Into Something Good|TTBB|John Fortino
 I'm Into Something Good|TTBB|Liz Garnett
+I'm Into Something Good / Happy Together Medley|SSAA|Aaron Dale
 I'm Into Something Good/Happy Together|SSAA|Aaron Dale
 I'm Into Something Good/Happy Together Medley|SSAA|Aaron Dale
 I'm Just A Bill|TTBB|Lance Fisher
@@ -8710,17 +10376,21 @@ I'm Left On The Corner Alone|TTBB|Einar Pedersen
 I'm Lonesome For You Dear Old Pal|TTBB|Bill Pellant
 I'm Lonesome For You Dear Old Pal|TTBB|Burt Szabo
 I'm Lonesome For You Dear Old Pal|TTBB|Louis Perry
+I'm Lonesome For You, Dear Old Pal|TTBB|Lou Perry
 I'm Lonesome For You, Dear Old Pal|TTBB|Unknown
 I'm Looking at the World Through Rose Colored Glasses / When You Wore a Tulip|SSAA|Jim Arns
 I'm Looking For A Girl Named Mary|TTBB|Ed Waesche
+I'm Looking Over a 4-Leaf Clover Medley|SSAA|Jim Arns
 I'm Looking Over A Four Leaf Clover|SSAA|Bev Sellers
 I'm Looking Over A Four Leaf Clover|SSAA|Ed Waesche
 I'm Looking Over A Four Leaf Clover|SSAA|Larry Wright
+I'm Looking Over A Four Leaf Clover|SSAA|Lorraine Rochefort
 I'm Looking Over A Four Leaf Clover|TTBB|Barbershop Harmony Society
 I'm Looking Over A Four Leaf Clover|TTBB|Ed Waesche
 I'm Looking Over A Four Leaf Clover|TTBB|Larry Wright
 I'm Making A Study Of Beautiful Girls|TTBB|Burt Szabo
 I'm Making A Study Of Beautiful Girls (And I'm Still In My Abc's)|TTBB|Dennis Driscoll
+I'M Making Believe I Don'T Care|SSAA|Joni Bescos
 I'm Making Believe That I Don't Care|SSAA|Avis Fellows
 I'm Making Believe That I Don't Care|TTBB|Carl Surfler
 I'm Making Believe That I Don't Care|TTBB|Hal Snyder
@@ -8746,13 +10416,18 @@ I'm Off To See My Sweetness|TTBB|Dan Wilson
 I'm Off To See My Sweetness|TTBB|Patrick McAlexander
 I'm Old Fashioned|SSAA|Diane Clark
 I'm Old Fashioned|SSAA|Jo Lund
+I'm Old Fashioned|SSAA|Renee Craig
 I'm Old Fashioned|TTBB|Brent Graham
+I'm Old Fashioned|TTBB|Roy Dawson
 I'm Old Fashioned|TTBB|Walter Latzko
+I'm Old-Fashioned|SSAA|Diane Clark
+I'm Old-Fashioned|SSAA|Jo Lund
 I'm On Fire|TTBB|Mark Stevens
 I'm On My Way|TTBB|Jon Nicholas
 I'm Outta Love|SSAA|Staffan Paulson
 I'm Pretty Good At Drinkin' Beer|TTBB|Jim West
 I'm Proud To Be An American|TTBB|Jim West
+I'M Proud To Be An American|SSAA|Brian Beck
 I'm Putting All My Eggs In One Basket|TTBB|Aaron Dale
 I'm Putting All My Eggs In One Basket|TTBB|Jim Shubert
 I'm Putting All My Eggs In One Basket|TTBB|Patrick McAlexander
@@ -8768,13 +10443,19 @@ I'm Shooting High|TTBB|Walter Latzko
 I'm Singing Your Love Song To Somebody Else|TTBB|John Hohl
 I'm Singing Your Love Song To Somebody Else|TTBB|Renee Craig
 I'm Singing Your Love Song To Somebody Else|TTBB|Rob Hopkins
+I'm Singing Your Love Songs to Somebody Else|SSAA|Renee Craig
+I'm Sittin' On Top of the World|TTBB|Bonston Consort and Rob Hopkins
+I'm Sittin' On Top Of The World|TTBB|Boston Consort
 I'm Sittin' Pretty In A Pretty Little City|TTBB|Don Hewey
+I'm Sitting on Top of the World|SSAA|John Hohl/Dave Stevens
 I'm Sitting On Top of the World|SATB|The Boston Consort
+I'm Sitting On Top of the World|SSAA|Lorraine Rochefort
 I'm Sitting On Top of the World|SSAA|The Boston Consort
 I'm Sitting On Top of the World|TTBB|John Hohl & Dave Stevens
 I'm Sitting On Top Of The World|SSAA|Nancy Bergman
 I'm Sitting On Top Of The World|SSAA|Renee Craig
 I'm Sitting On Top Of The World|SSAA|Walter Latzko
+I'm Sitting On Top Of The World|TTBB|Boston Consort
 I'm Sitting On Top Of The World|TTBB|Jay Giallombardo
 I'm Sitting On Top Of The World|TTBB|John Hohl
 I'm Sitting On Top Of The World|TTBB|Rob Hopkins
@@ -8786,6 +10467,7 @@ I'm So Excited|SSAA|Liz Garnett
 I'm So Glad We Had This Time Together|SSAA|Brent Graham
 I'm So Glad We Had This Time Together|SSAA|Nancy Bergman
 I'm So Glad We Had This Time Together|TTBB|Jim Franklin
+I'm So Glad We Had This Time Together|TTBB|Roger Olsen
 I'm So Glad You Chose Me|TTBB|Todd Troutman
 I'm Somebody Else's Now/Who's Sorry Now Medley|TTBB|Jay Giallombardo
 I'm Sorry|TTBB|Deke Sharon
@@ -8824,6 +10506,7 @@ I'm The Good Man That Was So Hard To Find|TTBB|Burt Szabo
 I'm the Last One Left On the Corner|SSAA|Jo Lund
 I'm The Last One Left On The Corner Of That Old Gang Of Mine|TTBB|Ed Waesche
 I'm The Music Man|TTBB|David Wright
+I'm the One You're Looking For|SSAA|Marie Johnson
 I'm The One Your're Looking For|SSAA|Marie Johnson
 I'm Thru with Love|SATB|Kevin Keller
 I'm Thru with Love|SSAA|Anna Maria Parker
@@ -8847,10 +10530,12 @@ I'm Yours|SSAA|Carole Prietto
 I'm Yours|SSAA|David Wallace
 I'm Yours|SSAA|Glenda Lloyd
 I'm Yours|SSAA|Kirby Shaw
+I'm Yours|SSAA|Rice/Florence
 I'm Yours|TTBB|Kirby Shaw
 I'm Yours|TTBB|Steve Tramack
 I've Been Everywhere|TTBB|Earl Moon
 I've Been Floating Down The Old Green River|TTBB|Munson Hinman
+I've Been Waiting For Your Phone Call|SSAA|Nancy Bergman
 I've Been Waiting For Your Phone Call for 18 Years|SSAA|Nancy Bergman
 I've Been Workin' on My Golf Game|TTBB|Tom Gentry
 I've Been Workin' On The Railroad|SATB|Roger Payne
@@ -8869,6 +10554,7 @@ I've Found A New Baby (I Found A New Baby)|TTBB|Walter Latzko
 I've Found My Sweetheart Sally|TTBB|Ed Waesche
 I've Got a Cross-Eyed Papa But He Looks Straight to Me|SSAA|Jay Giallombardo
 I've Got a Cross-Eyed Papa But He Looks Straight to Me|TTBB|Jay Giallombardo
+I've Got a Crush on You|SSAA|Joe Liles
 I've Got A Crush On You|SSAA|Jo Lund
 I've Got A Crush On You|SSAA|Joe Mannherz
 I've Got A Crush On You|SSAA|Kevin Keller
@@ -8877,8 +10563,10 @@ I've Got A Crush On You|TTBB|Jim Shubert
 I've Got A Crush On You|TTBB|Joe Mannherz
 I've Got A Crush On You|TTBB|Kevin Keller
 I've Got A Crush On You|TTBB|Walter Latzko
+I've Got A Crush/As Time Boes By|SSAA|Tedda Lippincott
 I've Got A Dream|TTBB|Soren Detlefsen
 I’ve Got A Dream|TTBB|Darin Drown
+I've Got A Feeling I'm Fallin'|SSAA|Nancy Bergman
 I've Got A Feeling I'm Falling|SSAA|David Wright
 I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
 I've Got A Feeling I'm Falling|TTBB|David Wright
@@ -8910,9 +10598,14 @@ I've Got No Strings|TTBB|Jackson Pinder
 I've Got No Strings|TTBB|Jeremey Johnson
 I've Got Rings On My Fingers|TTBB|Walter Latzko
 I've Got The Blues For Tennessee|SSAA|Marie Johnson
+I've Got the Music In Me|SSAA|Mary Ann Wydra
 I've Got The Music In Me|SATB|Deke Sharon
 I've Got The Music In Me|SSAA|Dede Nibler
+I've Got the Time|SSAA|Joe Liles
+I've Got The Time - I've Got The Place|TTBB|Joe Liles
 I've Got The Time, I've Got The Place|TTBB|Joe Liles
+I've Got the World on a String|SSAA|Mac Huff
+I've Got the World on a String|TTBB|Unspecified
 I've Got The World On A String|SATB|Joe Mannherz
 I've Got The World On A String|SSAA|Dede Nibler
 I've Got The World On A String|SSAA|Joe Mannherz
@@ -8922,9 +10615,11 @@ I've Got The World On A String|TTBB|Adam Reimnitz
 I've Got The World On A String|TTBB|Dom Finetti
 I've Got The World On A String|TTBB|Kohl Kitzmiller
 I've Got The World On A String|TTBB|Larry Wright
+I've Got The World On A String|TTBB|Rob Hopkins
 I've Got The World On A String|TTBB|Todd Troutman
 I've Got The World On A String|TTBB|Tom Gentry
 I've Got The World On A String|TTBB|Walter Latzko
+I've Got You Under My Skin|SSAA|Brian Beck
 I've Got You Under My Skin|TTBB|Walter Latzko
 I've Got You Under My Skin|TTBB|Wayne Grimmer
 I've Gotta Be Me|SSAA|Larry Wright
@@ -8947,12 +10642,14 @@ I've Lost All My Love For You|TTBB|Fred King
 I've Lost All My Love For You|TTBB|Randy Conner
 I've Lost You So Why Should I Care|TTBB|Jack Baird
 I've Never Been In Love Before|SATB|David Wright
+I've Never Been In Love Before|SATB|Don Gray
 I've Never Been In Love Before|TTBB|Theodore Hicks
 I've Seen All Good People|SATB|Joe Mannherz
 I've Seen It|SATB|Mark Stevens
 I've Seen My Baby (And It Won't Be Long Now)|TTBB|Dennis Driscoll
 I've Told Ev'ry Little Star|SSAA|Takako Fuke
 Icarus|SATB|Nicholas Wright
+Icarus|TTBB|Ralph Towner and Gary Rosen
 Ice Cream|TTBB|Walter Kaestner
 Ice Cream/Sincere/It'S You Medley|TTBB|Walter Latzko
 Ich will keine Schokolade|SSAA|Kevin Koehl
@@ -8984,10 +10681,14 @@ If All My Dreams Were Made Of Gold|TTBB|Aaron Dale
 If All My Dreams Were Made Of Gold|TTBB|Ed Hinkley
 If All My Dreams Were Made Of Gold|TTBB|Louis Perry
 If All My Dreams Were Made of Gold, I'd Buy the World for You|TTBB|Louis Perry
+If All My Dreams Were Made Of Gold, I'd Buy The World For You|TTBB|Lou Perry
 If Anything Happened to You|TTBB|Tom Gentry
 If Ever I Would Leave You|SSAA|Brent Graham
+If Ever I Would Leave You|SSAA|Clay Hine
 If Ever I Would Leave You|TTBB|Brent Graham
 If Ever I Would Leave You|TTBB|Clay Hine
+If Ever I Would Leave You|TTBB|Kris Olson
+If He Can Fight Like He Can Love|SSAA|Russ Foris
 If He Can Fight Like He Can Love, Good Night Germany|SSAA|Marie Johnson
 If He Can Fight Like He Can Love, Good Night Germany|SSAA|Russ Foris
 If He Can Fight Like He Can Love, Good Night Germany|TTBB|C. J. Sams Jr.
@@ -9038,8 +10739,11 @@ If I Ever Say I'm Over You|TTBB|Brent Graham
 If I Ever Say I'm Over You (from It's Only Life)|TTBB|Brent Graham
 If I Fell|SSAA|Brian Harding
 If I Fell|SSAA|Carolyn Schmidt
+If I Fell|TTBB|Brian A. Harding
 If I Fell|TTBB|Brian Harding
+If I Fell In Love With You|SSAA|Nova Evans
 If I Find Another Boy Like You|TTBB|Tom Gentry
+If I Give My Heart to You|SSAA|Jim Clancy
 If I Give My Heart To You|TTBB|Jay Giallombardo
 If I Give My Heart To You|TTBB|Jim Clancy
 If I Give My Heart To You|TTBB|Marilyn Penketh
@@ -9050,7 +10754,9 @@ If I Had A Girl Like You|TTBB|Warren 'Buzz' Haeger
 If I Had a Hammer|SSAA|Tom Gentry
 If I Had a Hammer|TTBB|Tom Gentry
 If I Had A Million Dollars|TTBB|Dan Naumann
+If I Had A Voice|SSAA|Dede Nibler
 If I Had My Druthers|TTBB|Mark Goodney
+If I Had My Life to Live Over|SSAA|Joni Bescos
 If I Had My Life To Live Over|SSAA|June Berg
 If I Had My Life To Live Over|SSAA|Mary K. Coffman Music Fund
 If I Had My Life To Live Over|SSAA|Nancy Bergman
@@ -9062,10 +10768,13 @@ If I Had My Life To Live Over|TTBB|Ted Cobb
 If I Had My Life To Live Over|TTBB|Tom Gentry
 If I Had My Way|SATB|Marshall Webb
 If I Had My Way|SSAA|Adam Scott
+If I Had My Way|SSAA|Clay Hine
 If I Had My Way|SSAA|David Harrington
 If I Had My Way|SSAA|Floyd Connett
 If I Had My Way|SSAA|Jan Meyer
 If I Had My Way|SSAA|Jo Lund
+If I Had My Way|SSAA|Joni Bescos
+If I Had My Way|SSAA|Lorraine Rochefort
 If I Had My Way|SSAA|Mark Rusch
 If I Had My Way|SSAA|Nancy Bergman
 If I Had My Way|TTBB|David Harrington
@@ -9073,6 +10782,7 @@ If I Had My Way|TTBB|Earl Moon
 If I Had My Way|TTBB|Jack Baird
 If I Had My Way|TTBB|Mark Rusch
 If I Had My Way|TTBB|Tom Gentry
+If I Had My Way Parody|TTBB|Adam Reimnitz
 If I Had Rhythm In My Nursery Rhymes|SSAA|Larry Wright
 If I Had Rhythm In My Nursery Rhymes|TTBB|Steve Hardy
 If I Had Someone To Love|TTBB|Jerry Bockus
@@ -9081,16 +10791,19 @@ If I Had The Last Dream Left In The World|SSAA|Carolyn Schmidt
 If I Had The Last Dream Left In The World|SSAA|Joe Liles
 If I Had The Last Dream Left In The World|TTBB|Joe Liles
 If I Had The Last Dream Left In The World|TTBB|Steve Jamison
+If I Had You|SSAA|Nancy Bergman
 If I Had You|TTBB|Dan Wessler
 If I Had You|TTBB|Dennis Driscoll
 If I Had You|TTBB|Ed Waesche
 If I Had You|TTBB|Frank Marzocco
 If I Had You|TTBB|Jim Shubert
+If I Had You|TTBB|Joe Johnson
 If I Had You|TTBB|Mike Menefee
 If I Had You|TTBB|Robert Martin
 If I Had You|TTBB|Walter Latzko
 If I Had You/Cuddle Up a Little Closer Medley|SSAA|Jo Lund
 If I Have To Go To War|TTBB|Kim Brittain
+If I Hear Another Song About Christmas|SSAA|Lynnell Diamond
 If I Knew|TTBB|Jackson Pinder
 If I Lose Myself|SSAA|Nicholas Wright
 If I Lose Myself|TTBB|Nicholas Wright
@@ -9107,15 +10820,19 @@ If I Loved You|SATB|Deke Sharon
 If I Loved You|SSAA|Jay Giallombardo
 If I Loved You|SSAA|Kohl Kitzmiller
 If I Loved You|SSAA|Larry Wright
+If I Loved You|SSAA|Renee Craig
 If I Loved You|SSAA|Tom Gentry
 If I Loved You|SSAA|Walter Latzko
 If I Loved You|TTBB|Deke Sharon
 If I Loved You|TTBB|Don Gray
+If I Loved You|TTBB|Jay Giallombardo
 If I Loved You|TTBB|Jon Nicholas
 If I Loved You|TTBB|Mike Sobeleski
 If I Loved You|TTBB|Robert Rund
+If I Loved You|TTBB|Steve Tramack
 If I Loved You|TTBB|Tom Gentry
 If I Loved You|TTBB|Walter Latzko
+If I Loved You ('Carousel')|SSAA|Renee Craig
 If I Loved You (from Carousel)|TTBB|Jay Giallombardo
 If I Loved You (from Carousel)|TTBB|Rasmus Krigström
 If I Loved You More|SSAA|Avis Fellows
@@ -9125,6 +10842,8 @@ If I Never Knew You|SATB|Theodore Hicks
 If I Never Knew You|SSAA|Theodore Hicks
 If I Never Knew You|TTBB|Theodore Hicks
 If I Never See You Again|TTBB|Walter Latzko
+If I Only Had a Brain|SSAA|Nancy Bergman
+If I Only Had a Brain|SSAA|Paula Mauritzen
 If I Only Had A Brain|SATB|Kyle Snook
 If I Only Had A Brain|SSAA|Clay Hine
 If I Only Had A Brain|SSAA|Jo Lund
@@ -9132,9 +10851,13 @@ If I Only Had A Brain|TTBB|Clay Hine
 If I Only Had A Brain / Heart Medley|TTBB|Lloyd Steinkamp
 If I Only Had A Heart (Brain)|SATB|Deke Sharon
 If I Only Knew Where She's Gone|TTBB|Robert Rund
+If I Ruled the World|SSAA|Renee Craig
+If I Ruled The World|SSAA|Don Gray
 If I Ruled The World|SSAA|Ed Waesche
 If I Ruled The World|SSAA|Jay Giallombardo
+If I Ruled The World|SSAA|June Dale
 If I Ruled The World|SSAA|Nancy Bergman
+If I Ruled The World|SSAA|Renee Craig/Nancy Bergman
 If I Ruled The World|SSAA|Robert Rund
 If I Ruled The World|TTBB|Don Gray
 If I Ruled The World|TTBB|Ed Waesche
@@ -9144,6 +10867,7 @@ If I Ruled The World|TTBB|Jim Clancy
 If I Ruled The World|TTBB|Joe Mannherz
 If I Ruled The World|TTBB|Todd Troutman
 If I Stay Away Too Long from Carolina|TTBB|Tom Gentry
+If I Were A Bell|SATB|Don Gray, Steven Armstrong
 If I Were A Bell|SSAA|Adam Reimnitz
 If I Were A Bell|SSAA|Joey Minshall
 If I Were A Bell|SSAA|Tony Nasto
@@ -9154,6 +10878,7 @@ If I Were a Boy/Girls Medley|SSAA|Liz Garnett
 If I Were A Fish|SATB|Melody Hine
 If I Were A Rich Man|TTBB|Walter Latzko
 If I Were King Of The Forest|TTBB|Lloyd Steinkamp
+If I Were the Only Girl|SSAA|Renee Craig
 If I Were The Only Girl In The World|SSAA|Nancy Bergman
 If I Were You|SSAA|LaVeda Redfield
 If I Were You I'd Fall In Love With Me|SSAA|Larry Wright
@@ -9163,6 +10888,7 @@ If It Doesn't Snow On Christmas|TTBB|Jay Giallombardo
 If Love Is Good To Me|TTBB|Walter Latzko
 If Moon Was Cookie|TTBB|Cay Outerbridge
 If My Friends Could See Me Now|SSAA|Joy McGregor
+If My Friends Could See Me Now|SSAA|Renee Craig
 If My Friends Could See Me Now|TTBB|Mark Goodney
 If My Friends Could See Me Now|TTBB|Mel Knight
 If My Friends Could See Me Now|TTBB|Ray Danley
@@ -9170,6 +10896,7 @@ If My Friends Could See Me Now|TTBB|Renee Craig
 If My Friends Could See Me Now|TTBB|Rob Hopkins
 If My Friends Could See Me Now|TTBB|Walter Latzko
 If My Friends Could See Me Now Medley|TTBB|Patrick McAlexander
+If My Nose Was Running Money|SSAA|Sharon Holmes
 If My Nose Was Running Money|TTBB|David Lorenz
 If My Nose Was Running Money|TTBB|Steven Sturgis
 If My Nose Was Running Money (I'd Blow It All On You)|TTBB|Steve Delehanty
@@ -9183,21 +10910,31 @@ If The Lord Be Willin'|TTBB|Don Gray
 If The Lord Be Willin'|TTBB|Jay Giallombardo
 If The Lord Be Willin'|TTBB|Mark Smith
 If The Lord Be Willin'|TTBB|SPEBSQSA
+If The Lord Be Willin' (And The Creek Don't Rise)|TTBB|Barbershop Harmony Society
+If the Lord Be Willing|TTBB|Dave Briner
 If The Rest Of The World Don't Want You|TTBB|Louis Perry
+If The Rest Of The Worlds Don't Want You|TTBB|Lou Perry
 If The World Was Ending|TTBB|Greg Mallett
+If There Never Was An Ireland|SSAA|Nancy Bergman
 If There'd Never Been An Ireland|SSAA|Jay Giallombardo
 If There'd Never Been An Ireland|TTBB|Jay Giallombardo
 If There'd Never Been An Ireland|TTBB|Louis Perry
+If There's Anybody Here|SATB|Dave Briner
 If There's Anybody Here|SATB|David Briner
 If There's Anybody Here|SSAA|David Briner
 If There's Anybody Here|TTBB|Ardeth Fullmer
 If There's Anybody Here (From Out Of Town)|TTBB|Ardeth Fullmer
 If There's Anybody Here From My Home Town|TTBB|Dennis Driscoll
+If There's Anybody Here From My Hometown|SATB|Dave Briner
+If There's Anybody Here From Out Of Town|SATB|Dave Briner
+If There's Anybody Here From Out Of Town (8-Part Mixed)|SATB|Dave Briner
 If They String Me Up, I'll Never Live It Down|SSAA|Jay Giallombardo
 If They String Me Up, I'll Never Live It Down|TTBB|Jay Giallombardo
 If This Isn't Love|TTBB|Mark Goodney
 If War Is What Sherman Said It Was|TTBB|Paul Engel
 If We All Said A Prayer|SSAA|Renee Craig
+If We Can't Be the Same Old Sweethearts|TTBB|Carl Dahlke
+If We Can't Be The Same Old Sweethearts|SSAA|Jay Giallombardo
 If We Can't Be The Same Old Sweethearts|SSAA|Tedda Lippincott
 If We Can't Be The Same Old Sweethearts|TTBB|Burt Szabo
 If We Can't Be The Same Old Sweethearts|TTBB|Jay Giallombardo
@@ -9205,6 +10942,7 @@ If We Can't Be The Same Old Sweethearts|TTBB|Tom Pearson
 If We Can't Be The Same Old Sweethearts, We'll Just Be The Same Old Friends|TTBB|Burt Szabo
 If We Ever Needed the Lord Before|SSAA|Tom Gentry
 If We Ever Needed the Lord Before|TTBB|Tom Gentry
+If We Hold On Together|SSAA|Greg Volk
 If We Hold On Together|TTBB|Darwin Scheel
 If You Ain't Lovin'|TTBB|Jon Nicholas
 If You Are But A Dream|SSAA|Nancy Bergman
@@ -9229,6 +10967,7 @@ If You Go Away|SSAA|Kevin Keller
 If You Go Away|TTBB|David Wright
 If You Go Away|TTBB|Kevin Keller
 If You Go Away (Ne Me Quitte Pas)|TTBB|David Wright
+If You Had All the World and It's Gold|SSAA|Joni Bescos
 If You Had All The World And It's Gold|TTBB|Unknown
 If You Had All The World And Its Gold|SSAA|Jay Giallombardo
 If You Had All The World And Its Gold|TTBB|Barbershop Harmony Society
@@ -9244,8 +10983,12 @@ If You Leave Me Now|SATB|Deke Sharon
 If You Leave Me Now|SSAA|David Wright
 If You Leave Me Now|TTBB|Anders Lindqvist
 If You Leave Me, I'll Never Cry|TTBB|Dennis Burnett
+If You Love Me|SSAA|Nancy Bergman
+If You Love Me (Really Love Me)|TTBB|Renee Craig
+If You Love Me Really Love Me|SSAA|Nancy Bergman
 If You Love Me, Really Love Me|SSAA|David Wright
 If You Love Me, Really Love Me|SSAA|Nancy Bergman
+If You Love Me, Really Love Me|SSAA|Renee Craig
 If You Love Me, Really Love Me|TTBB|David Wright
 If You Love Me, Really Love Me|TTBB|Nancy Bergman
 If You Love Somebody Set Them Free|SATB|Deke Sharon
@@ -9257,6 +11000,7 @@ If You Want The Rainbow|SSAA|Asuka Ichikawa
 If You Want the Rainbow/April Showers|SSAA|Jay Giallombardo
 If You Want the Rainbow/April Showers|TTBB|Jay Giallombardo
 If You Were Gay|TTBB|Thomas Degan
+If You Were Only Mine|TTBB|Tony Nasto
 If You Were The Only Girl In The World|SSAA|Ed Waesche
 If You Were The Only Girl In The World|SSAA|Walter Latzko
 If You Were The Only Girl In The World|TTBB|Douglas Smith
@@ -9272,22 +11016,30 @@ If You're Out There|SATB|Deke Sharon
 If You've Got The Money|TTBB|Aaron Dale
 If You've Only Got A Moustache|TTBB|Tom Gentry
 Imagination|SSAA|Jay Giallombardo
+Imagination|TTBB|Herman Zimmerman
 Imagination|TTBB|Jay Giallombardo
+Imagination|TTBB|Lou Perry
 Imagine|SATB|Deke Sharon
 Imagine|SSAA|Chris Arnold
 Imagine|SSAA|Deke Sharon
 Imagine|SSAA|Joey Minshall
 Imagine|SSAA|Larry Wright
+Imagine|SSAA|Lynnell Diamond
 Imagine|SSAA|Marge Bailey
 Imagine|TTBB|Chris Arnold
+Imagine|TTBB|Steve Delehanty
 Imagine|TTBB|Wendy Hofmann
+Imagine (YWIH)|SSAA|Marge Bailey
 Imagine That|SATB|Mark Stevens
 Imagine That|TTBB|Mike Tipton
 Immanuel|TTBB|Kevin Keller
 Immortals|SATB|Deke Sharon
 Impossible|TTBB|Liz Garnett
+Impossible Dream|SSAA|Jay Giallombardo
+Impossible Medley|TTBB|Rob Hopkins, Steven Armstrong
 Impossible Year|SATB|Nicholas Wright
 Impossible Year|TTBB|Simon Arnott
+In A Boat For Two|TTBB|Paul Santino
 In a Box on a Shelf|SSAA|Kay Bromert
 In A Little Red Barn|TTBB|Jerry Tracey
 In A Little Red Barn|TTBB|John Mulkin
@@ -9306,9 +11058,11 @@ In A Shanty In Old Shanty Town|TTBB|Walter Latzko
 In a Very Unusual Way|TTBB|Adam Scott
 In A World Like This|TTBB|Simon Arnott
 In An Old Barbershop Chair|TTBB|Joe Liles
+In Apple Blossom Time|TTBB|Dick Johnson
 In Between Ox & Donkey Gray|SSAA|Diane Clark
 In Flander's Fields|TTBB|Adam Scott
 In Flander's Fields|TTBB|Douglas Smith
+In Heaven's Eyes|SSAA|Carolyn Schmidt
 In Heavens Eyes|SSAA|Carolyn Schmidt
 In His Eyes|SSAA|Adam Bock
 In His Eyes|SSAA|Michael Gellert
@@ -9319,10 +11073,12 @@ In My Album of Memories|SSAA|Tom Gentry
 In My Album of Memories|TTBB|Tom Gentry
 In My Daughter's Eyes|SSAA|Carole Prietto
 In My Daughter's Eyes|SSAA|Dan Naumann
+In My Daughter's Eyes|SSAA|Lynnell Diamond
 In My Daughter's Eyes|SSAA|Melody Hine
 In My Daughter's Eyes|SSAA|Tedda Lippincott
 In My Daughter's Eyes|TTBB|Clay Hine
 In My Daughter's Eyes|TTBB|Eric Ruthenberg
+In My Daughter'S Eyes (W Solo)|SSAA|Lynnell Diamond
 In My Dreams|SATB|Don Staffin
 In My Dreams|TTBB|Don Staffin
 In My Harem|TTBB|Dennis Driscoll
@@ -9333,7 +11089,10 @@ In My Life|SSAA|Melody Hine
 In My Life|SSAA|Tom Gentry
 In My Life|TTBB|Steven Armstrong
 In My Life|TTBB|Tom Gentry
+In My Life (YWIH)|SSAA|Carolyn Schmidt
+In My Merry Oldsmobile|SSAA|Unspecified
 In My Merry Oldsmobile|TTBB|Burt Szabo
+In My Room|SSAA|Jonathan Wikeley
 In My Room|SSAA|Karen McCarville
 In My Room|SSAA|Tom Gentry
 In My Room|TTBB|Aaron Dale
@@ -9349,6 +11108,8 @@ In The Air Tonight|TTBB|Mark Stevens
 In The Arms Of Love|SSAA|Jay Giallombardo
 In The Arms Of Love|TTBB|Earl Moon
 In The Arms Of Love|TTBB|Walter Latzko
+In The Bleak Mid-Winter|TTBB|Joseph Jennings
+In the Bleak Midwinter|SSAA|Joe Liles
 In The Bleak Midwinter|SATB|Simon Lubkowski
 In The Bleak Midwinter|SSAA|Carolyn Johnson
 In The Bleak Midwinter|SSAA|June Berg
@@ -9360,25 +11121,33 @@ In The Blood|TTBB|David Wright
 In The Blood|TTBB|Gary Thiel
 In The Chapel In the Moonlight|SSAA|Tedda Lippincott
 In The City Of God Knows Where|TTBB|Burt Szabo
+In the City of God-Knows-Where|SSAA|Burt Szabo
 In The City Where Nobody Cares|TTBB|Burt Szabo
 In The Cool Cool Cool Of The Evening|SSAA|Susan Kegley
 In The Cool Cool Cool Of The Evening|TTBB|Jack Schievelbein
 In The Cool Cool Cool Of The Evening|TTBB|Jim Dodge
 In The Cool Cool Cool Of The Evening|TTBB|Jim Shubert
 In The Cool Cool Cool Of The Evening|TTBB|Kohl Kitzmiller
+In the Cool, Cool, Cool of the Evening|TTBB|Jim Dodge
+In The Cool, Cool, Cool Of The Evening|TTBB|Don Gray
 In The Evening By The Moonlight|TTBB|Jim West
 In The Evening By The Moonlight|TTBB|Tom Gentry
 In the First Light|SSAA|Sheryl Neal
+In the First Light|TTBB|Bob Kauflin
 In the First Light|TTBB|Sheryl Neal
+In the Garden|TTBB|Joe Johnson
 In The Garden|SSAA|Diane Clark
 In The Garden|SSAA|Jo Lund
 In The Garden|SSAA|Joe Liles
 In The Garden|SSAA|Tedda Lippincott
 In The Garden|SSAA|Vicki Uhr
+In The Garden|TTBB|Jason Graham
 In The Garden|TTBB|Joe Liles
 In The Garden|TTBB|Roy Keys
 In The Ghetto|SATB|Deke Sharon
+In the Good Old Summer Time|TTBB|Barbershop Harmony Society
 In the Good Old Summer Time|TTBB|SPEBSQSA
+In the Good Old Summertime|SSAA|Joe Liles
 In The Good Old Summertime|SSAA|Jan-Ake Westin
 In The Good Old Summertime|SSAA|Jay Giallombardo
 In The Good Old Summertime|SSAA|Nancy Bergman
@@ -9401,12 +11170,16 @@ In The Land Where The Shamrock Grows|TTBB|Louis Perry
 In The Light|TTBB|Deke Sharon
 In The Light Of Tomorrow|SATB|Richard Curtis
 In The Little Red School House|TTBB|Burt Szabo
+In the Little Red Schoolhouse|SSAA|Fred King/Ronaleen Gapetz
 In The Little Red Schoolhouse|SSAA|Ronaleen Gapetz
 In The Little Red Schoolhouse|TTBB|Burt Szabo
 In The Little Red Schoolhouse|TTBB|Ed Waesche
 In The Market For A Miracle|TTBB|Greg Mallett
+In the Mood|SSAA|Steve Jamison
 In The Mood|SATB|Alexander Ronneburg
 In The Mood|SSAA|Melody Hine
+In The Mood|SSAA|Renee Craig
+In The Mood|TTBB|Dallas Town North
 In The Mood|TTBB|Mark Goodney
 In The Mood|TTBB|Walter Latzko
 In The Name of Love|SATB|Nicholas Wright
@@ -9421,18 +11194,27 @@ In The Still Of The Night|SSAA|Larry Wright
 In The Still Of The Night|SSAA|Tom Gentry
 In The Still Of The Night|TTBB|Larry Wright
 In The Still Of The Night|TTBB|Tom Gentry
+In The Still Of The Night|TTBB|Unspecified
 In the Still of the Nite|SATB|Tom Gentry
 In the Still of the Nite|SSAA|Tom Gentry
 In the Still of the Nite|TTBB|Tom Gentry
 In The Sweet Long Ago|SSAA|Walter Latzko
+In The Wee Small Hours / Always|TTBB|Walter Latzko
+In the Wee Small Hours of the Morning|SSAA|Clay Hine
+In the Wee Small Hours of the Morning|SSAA|Tedda Lippincott
+In the Wee Small Hours of the Morning|TTBB|Adam Reimnitz
+In the Wee Small Hours of the Morning|TTBB|Walter Latzko, Frank Salter, Paul Davies, Bob Walker, John Grant
 In The Wee Small Hours Of The Morning|SSAA|Jim Arns
 In The Wee Small Hours Of The Morning|TTBB|Adam Scott
 In The Wee Small Hours Of The Morning|TTBB|Jimbob Kahlke
 In The Wee Small Hours Of The Morning|TTBB|Kevin Keller
+In The Wee Small Hours Of The Morning|TTBB|Walter Latzko
 In This Heart|SSAA|Kevin Keller
+In This Life|SSAA|Dave Briner
 In This Life|TTBB|Mark Stevens
 In This Life|TTBB|Matt Astle
 In This Very Room|SSAA|Kay Bromert
+In This Very Room|TTBB|Greg Volk
 In Your Eyes|SATB|Deke Sharon
 In Your Eyes|SATB|Nicholas Wright
 In Your Eyes|SSAA|Larry Wright
@@ -9444,13 +11226,16 @@ Incomplete|TTBB|Deke Sharon
 Incredibles 2 Theme Songs Medley|TTBB|Deke Sharon
 Indian Love Call|TTBB|Archie Steen
 Indian Love Call|TTBB|Manoj Padki
+Indiana|SSAA|Dot Calvin
 Indiana|TTBB|Don Gray
 Indiana|TTBB|Ed Waesche
 Indiana|TTBB|Jack Baird
 Indiana|TTBB|Jon Nicholas
 Indiana|TTBB|Sherry Brown
 Indiana (Back Home Again In Indiana)|TTBB|Sherry Brown
+Indiana [Back Home Again]|TTBB|Sherry Brown
 Indiana / Banks Of The Wabash Medley|TTBB|Scott Kitzmiller
+Indiana Christmas|SSAA|Joyce Stanbery
 Indiana Medley|SSAA|Jim Arns
 Infant Holy, Infant Lowly|TTBB|Burt Szabo
 Infant Joy|SATB|David Avshalomov
@@ -9462,6 +11247,7 @@ Insomnia|SSAA|Carolyn Johnson
 Instrument of Peace|SSAA|Tom Gentry
 Instrument of Peace|TTBB|Tom Gentry
 Intermission|SSAA|Avis Fellows
+International Medley|TTBB|Roger Payne
 Into My Arms|SSAA|Hannah Braham
 Into My Arms|TTBB|Luke Stevenson
 Into The Fire|TTBB|Aaron Dale
@@ -9480,7 +11266,9 @@ Into the Unknown|TTBB|Deke Sharon & David Wright
 Into the Unknown|TTBB|Nicholas Wright
 Into the Unknown|TTBB|Simon Arnott
 Invocation|TTBB|Brent Graham
+Invocation|TTBB|Claudia Bigler
 Iowa|TTBB|Don Fraser
+Iowa|TTBB|Unspecified
 Iowa Stubborn|TTBB|Walter Latzko
 Ireland Must Be Heaven|SSAA|Larry Wright
 Ireland Must Be Heaven|TTBB|Dennis Driscoll
@@ -9495,9 +11283,11 @@ Irgendwo Auf Der Welt|TTBB|Kohl Kitzmiller
 Iridescent|TTBB|Deke Sharon
 Irish Blessing|SATB|Don Gray
 Irish Blessing|SSAA|Don Gray
+Irish Blessing|SSAA|Greg Backwell
 Irish Blessing|SSAA|Jay Giallombardo
 Irish Blessing|SSAA|Jean McFadyen
 Irish Blessing|SSAA|Paul Grimm
+Irish Blessing|SSAA|Sylvia Alsbury
 Irish Blessing|TTBB|Dennis Driscoll
 Irish Blessing|TTBB|Don Gray
 Irish Blessing|TTBB|Mel Knight
@@ -9505,19 +11295,25 @@ Irish Farewell|SSAA|Norma Holzmeier
 Irish Lullabye|SSAA|Nancy Bergman
 Irish Medley|SSAA|Jay Giallombardo
 Irish Medley|SSAA|Larry Wright
+Irish Medley|SSAA|Nancy Bergman
 Irish Medley|TTBB|Jay Giallombardo
 Irish Medley|TTBB|Larry Wright
 Irish Medley (Harrigan / Toora Loora Loora)|SSAA|Nancy Bergman
 Irish Montage|SSAA|Jay Giallombardo
 Irish Montage|TTBB|Jay Giallombardo
 Irish Songs Give Me A Pain (Parody)|SSAA|Marie Johnson
+Is It Nothing To You?|TTBB|James Koerts
+Is It True What They Say About Dixie?|SSAA|Nancy Bergman
 Is She Really Going Out With Him|SATB|Nicholas Wright
+Is Somebody Singing|TTBB|Chris Arnold
 Is This Just Another Song|SSAA|Robert Disney
 Is This Just Another Song|TTBB|Robert Disney
 Is This Just Another Song?|TTBB|Bob Disney
 Is You Is Or Is You Ain't (Ma Baby)|SSAA|Jean McFadyen
 Is You Is Or Is You Ain't (Ma Baby)|TTBB|Ian Crane
 Is You Is Or Is You Ain't (Ma Baby)?|TTBB|Greg Volk
+Is You Is Or Is You Ain't My Baby|SSAA|Clay Hine
+Is You Is Or Is You Ain't My Baby|TTBB|Louis Jordan
 Island Life|SATB|Joe Mannherz
 Island of Dreams|SATB|Tom Gentry
 Island of Dreams|SSAA|Tom Gentry
@@ -9530,6 +11326,7 @@ Isn't It Romantic|SATB|Sam Hubbard
 Isn't It Romantic|SSAA|Joan D 'Agostino
 Isn't It Romantic|TTBB|Walter Latzko
 Isn't She Lovely|SATB|Adam Scott
+Isn't She Lovely|TTBB|John Brockman
 Isn't She Lovely|TTBB|Mike Menefee
 Isn't That Just Like Love?|SATB|Dan Wessler
 Isn't This A Lovely Day|SSAA|Nancy Bergman
@@ -9557,30 +11354,41 @@ It Came Upon A Midnight Clear|TTBB|Jay Giallombardo
 It Came Upon A Midnight Clear|TTBB|Jim Clancy
 It Came Upon A Midnight Clear / O Come All Ye Faithful Medley|SSAA|Carolyn Johnson
 It Came Upon A Midnight Clear / Silent Night Medley|TTBB|Earl Moon
+It Came Upon A Midnight Clear/Silent Night Medley(Jim Cl|TTBB|Jim Clancy
 It Can't Be Wrong|SSAA|Sonny Steffan
 It Could Happen To You|SATB|Gene Cokeroft
 It Could Happen To You|SSAA|Dede Nibler
 It Could Happen To You|SSAA|Gene Cokeroft
 It Could Happen To You|TTBB|Dennis Driscoll
 It Could Happen To You|TTBB|Gene Cokeroft
+It Could Happen To You|TTBB|Joe Johnson
 It Could Happen To You|TTBB|Scott Kitzmiller
 It Could Happen To You|TTBB|Steven Armstrong
 It Could Happen To You|TTBB|Walter Latzko
 It Doesn't Matter Anymore|TTBB|Hilary Allen
 It Don't Have to Change|SATB|Nicholas Wright
+It Don't Mean a Thing|SSAA|Bev Sellers
 It Don't Mean A Thing|SATB|Deke Sharon
+It Don't Mean A Thing|SSAA|Lorraine Rochefort
 It Don't Mean A Thing|SSAA|Steve Tramack
 It Don't Mean A Thing|TTBB|Deke Sharon
 It Don't Mean A Thing|TTBB|Mark Goodney
+It Don't Mean A Thing|TTBB|Steve Delehanty
 It Don't Mean A Thing (If It Ain't Got That Swing)|TTBB|Dan Mulligan
+It Don't Mean A Thing / Sing, Sing, Sing|TTBB|Walter Latzko
 It Don't Mean A Thing/Classical Music Parody|TTBB|Jay Giallombardo
+It Don't Mean A Thing/Sing Sing Sing|SSAA|Bev Sellers
 It Feels Good When You Sing a Song|TTBB|Jackson Pinder
 It Feels Like Christmas|SSAA|Debbie Keretz
 It Feels Like Christmas|TTBB|Matt Astle
 It Feels Like Home|SSAA|Mark Burnip
+It Feels Like Home|SSAA|Nancy Shumard
 It Feels Like Home|TTBB|Mark Burnip
 It Gets You Right Here|SSAA|Nancy Bergman
 It Gets You Right Here|TTBB|Nancy Bergman
+It Gets You Right Here!|SSAA|Nancy Bergman
+It Had to Be You|SSAA|Nancy Bergman
+It Had to Be You|TTBB|Steve Armstrong
 It Had To Be You|SATB|Barbershop Harmony Society
 It Had To Be You|SSAA|Barbershop Harmony Society
 It Had To Be You|SSAA|Carolyn Schmidt
@@ -9588,23 +11396,31 @@ It Had To Be You|SSAA|Connie Kash
 It Had To Be You|SSAA|Debbie Keretz
 It Had To Be You|SSAA|Dennis Malone
 It Had To Be You|SSAA|Eugene Lefkowitz
+It Had To Be You|SSAA|Fred King
 It Had To Be You|SSAA|Jo Lund
+It Had To Be You|SSAA|Joni Bescos
 It Had To Be You|SSAA|Kevin Keller
 It Had To Be You|SSAA|Suzy Lobaugh
+It Had To Be You|SSAA|Suzy Lobaugh, Greg Williams
 It Had To Be You|SSAA|Tedda Lippincott
 It Had To Be You|TTBB|Barbershop Harmony Society
 It Had To Be You|TTBB|Bruce Evans
 It Had To Be You|TTBB|Dennis Driscoll
 It Had To Be You|TTBB|Don Gray
+It Had To Be You|TTBB|Earl Moon
+It Had To Be You|TTBB|Earl Moon / Ed Waesche
 It Had To Be You|TTBB|Ed Hinkley
 It Had To Be You|TTBB|Ed Waesche
+It Had To Be You|TTBB|Greg Volk
 It Had To Be You|TTBB|Harry Swenson
 It Had To Be You|TTBB|Joe Mannherz
 It Had To Be You|TTBB|Kevin Keller
 It Had To Be You|TTBB|Steve Jamison
 It Had To Be You|TTBB|Steven Armstrong
 It Had To Be You|TTBB|Walter Latzko
+It Had to Be You/Nevertheless|SSAA|Nancy Bergman
 It Happened In Monterey|TTBB|John Brockman
+It Happened In Monterrey|TTBB|John Brockman
 It Hurt So Bad|TTBB|Kyle Snook
 It Is No Secret|TTBB|R. Ellwanger
 It Is No Secret|TTBB|R. J. Margison
@@ -9615,7 +11431,9 @@ It Is Well With My Soul|SSAA|Joe Liles
 It Is Well With My Soul|SSAA|Larry Wright
 It Is Well With My Soul|SSAA|Takako Fuke
 It Is Well With My Soul|TTBB|Adam Scott
+It Is Well With My Soul|TTBB|Bradford Taylor
 It Is Well With My Soul|TTBB|Burt Szabo
+It Is Well With My Soul|TTBB|Dan Tice
 It Is Well With My Soul|TTBB|David Harrington
 It Is Well With My Soul|TTBB|David Zimmerman
 It Is Well With My Soul|TTBB|Derric Johnson
@@ -9623,6 +11441,7 @@ It Is Well With My Soul|TTBB|Jim Clancy
 It Is Well With My Soul|TTBB|Joe Liles
 It Is Well With My Soul|TTBB|Larry Wright
 It Is Well With My Soul|TTBB|Paul Jorg
+It Is Well With My Soul|TTBB|R. Vaughan
 It Is Well With My Soul|TTBB|Tom Gentry
 It Looks Like Rain In Cherry Blossom Lane|SSAA|Jean Kane
 It Looks Like Rain In Cherry Blossom Lane|TTBB|Sherry Brown
@@ -9663,11 +11482,13 @@ It Was Almost Like A Song|TTBB|Brent Graham
 It Was Almost Like A Song|TTBB|Dan Naumann
 It Was Almost Like A Song|TTBB|Tom Gentry
 It Was Always You|TTBB|Nicholas Wright
+It Was Just One of Those Things|TTBB|Joni Bescos
 It Was Love At First Sight|SSAA|Jon Nicholas
 It Was Love At First Sight|TTBB|Jon Nicholas
 It Was Magic|TTBB|Jon Nicholas
 It Was Only A Fool's Paradise|TTBB|Burt Szabo
 It Will Have To Do Until The Real Thing Comes Along|SSAA|Lyndal Thorburn
+It'll Be Lonely This Christmas|SSAA|Zac Booles
 It's A Beautiful Day|SSAA|Jen Squires
 It's A Beautiful Day|TTBB|Aaron Dale
 It's A Beautiful Day|TTBB|Dan Wessler
@@ -9682,6 +11503,8 @@ It's A Beautiful Day For A Ball Game|TTBB|Jay Giallombardo
 It's A Beautiful Morning|TTBB|Deke Sharon
 It's A Blue World|SSAA|Jean McFadyen
 It's A Blue World|TTBB|Jim West
+It's a Brand New Day|TTBB|Bob Disney
+It's A Brand New Day|SSAA|Bob Disney
 It's A Brand New Day|SSAA|Joe Liles
 It's A Brand New Day|SSAA|Robert Disney
 It's A Brand New Day|TTBB|Jim West
@@ -9703,8 +11526,11 @@ It's A Good Day|TTBB|Lloyd Steinkamp
 It's A Good Day|TTBB|Richard Curtis
 It's A Good Day|TTBB|Val Hicks
 It's a Grand Night for Singing|TTBB|Pete Rupay
+It's A Grand Night for Singing|SSAA|Joni Bescos
 It's A Grand Night For Singing|SSAA|Molly Clark
 It's A Grand Night For Singing|TTBB|Jay Giallombardo
+It's A Grand Night For Singing|TTBB|Rob Hopkins
+It's A Grand Night For Singing|TTBB|Steve Delehanty
 It's A Grand Night For Singing|TTBB|Walter Latzko
 It's A Great Day For The Irish|SSAA|Larry Wright
 It's A Great Day For The Irish|SSAA|Nancy Bergman
@@ -9713,6 +11539,7 @@ It's A Great Day For The Irish|TTBB|Jack Baird
 It's A Great Day For The Irish|TTBB|Larry Wright
 It's A Great Day For The Irish|TTBB|Paul Bowman
 It's A Great Day For The Irish / MacNamara's Band|SSAA|Nancy Bergman
+It's a Great Day for the Irish/MacNamara's Band|SSAA|Nancy Bergman
 It's A Hanukkah Song|TTBB|Deke Sharon
 It's a Hanukkah Song (In a Major Key)|TTBB|Larry Triplett
 It's A Jungle Out There|SATB|Kevin Keller
@@ -9723,6 +11550,7 @@ It's A Long Way To Tipperary|TTBB|Jack Baird
 It's A Long Way To Tipperary|TTBB|Joe Samuel
 It's A Lovely Day Today|SSAA|Larry Wright
 It's A Lovely Day Today|TTBB|Jim Shubert
+It's A Lovely Day Today|TTBB|Joe Johnson
 It's A Lovely Day Today|TTBB|Kohl Kitzmiller
 It's A Lovely Day Today (from Call Me Madam)|TTBB|Kohl Kitzmiller
 It's A Lovely Day Today/I Love To Singa Medley|SSAA|Larry Wright
@@ -9735,11 +11563,13 @@ It's A Million To One You're In Love|SSAA|Marie Johnson
 It's A Most Unusual Day|SATB|Joe Mannherz
 It's A Most Unusual Day|SATB|Kohl Kitzmiller
 It's A Most Unusual Day|SSAA|Kohl Kitzmiller
+It's A Most Unusual Day|TTBB|Adam Reimnitz
 It's A Most Unusual Day|TTBB|David Wright
 It's A Most Unusual Day|TTBB|Dick Stuart
 It's A Most Unusual Day|TTBB|Joel Guyer
 It's A Most Unusual Day|TTBB|Tom Ball
 It's A Most Unusual Day|TTBB|Walter Latzko
+It's a Pity to Say Goodnight|SSAA|Nancy Bergman
 It's A Pity To Say Goodnight|SATB|Kohl Kitzmiller
 It's A Pity To Say Goodnight|SSAA|Avis Fellows
 It's A Pity To Say Goodnight|SSAA|Jan Meyer
@@ -9751,17 +11581,21 @@ It's A Pity To Say Goodnight|TTBB|Rasmus Krigstrom
 It's A Pity To Say Goodnight|TTBB|Rasmus Krigström
 It's A Pity To Say Goodnight|TTBB|Walter Latzko
 It's A Sign Of Spring|TTBB|Walter Latzko
+It's a Sin to Tell a Lie|SATB|Dave Briner
+It's A Sin to Tell A Lie|SSAA|Lorraine Rochefort
 It's A Sin To Tell A Lie|SATB|David Briner
 It's A Sin To Tell A Lie|SSAA|David Wright
 It's A Sin To Tell A Lie|SSAA|Walter Latzko
 It's A Sin To Tell A Lie|TTBB|David Wright
 It's A Sin To Tell A Lie|TTBB|Dennis Driscoll
+It's A Sin To Tell A Lie|TTBB|Don Bazely
 It's A Sin To Tell A Lie|TTBB|Don Gray
 It's A Sin To Tell A Lie|TTBB|John Spence
 It's A Sin To Tell A Lie|TTBB|Kohl Kitzmiller
 It's A Sin To Tell A Lie|TTBB|Walter Latzko
 It's A Sin To Tell A Lie/Lies Medley|TTBB|David Briner
 It's A Small World|SATB|Deke Sharon
+It's A Small World|SSAA|Mary Coffman
 It's A Small World|SSAA|Mary K. Coffman Music Fund
 It's A Wonderful Life|TTBB|Walter Latzko
 It's A Wonderful World|TTBB|Joel Guyer
@@ -9780,6 +11614,7 @@ It's All Right With Me|TTBB|Aaron Dale
 It's Almost Tomorrow|SSAA|Walter Latzko
 It's Almost Tomorrow|TTBB|Walter Latzko
 It's Alright|SATB|Deke Sharon
+It's Alright|TTBB|Adam Scott
 It's Always You|TTBB|Kyle Snook
 It's Been A Long, Long Time|SATB|Rob Hopkins
 It's Been A Long, Long Time|SSAA|Joy McGregor
@@ -9796,14 +11631,19 @@ It's Been A Long, Long Time|TTBB|Theodore Hicks
 It's beginning to look a lot like christmas|SSAA|Nancy Bergman
 It's beginning to look a lot like christmas|TTBB|Joe Mannherz
 It's beginning to look a lot like christmas|TTBB|Walter Latzko
+It's Beginning to Look a Lot Like Christmas|SSAA|Louise Hamilton
 It's Beginning To Look A Lot Like Christmas|SSAA|Jeanne Elmuccio
 It's Beginning To Look A Lot Like Christmas|SSAA|Joan Smith
 It's Beginning To Look A Lot Like Christmas|SSAA|Willis Diekema
 It's Beginning To Look A Lot Like Christmas|TTBB|Willis Diekema
+It'S Beginning To Look A Lot Like Christmas|SSAA|Unspecified
 It's Beginning To Look A Lot Like Christmas / Silver Bells|TTBB|Nancy Bergman
+It's Beginning to Look a Lot Like Xmas/Pine Cones|SSAA|Jean Flinn
+It's Beginning to Look a Lot Like Xmas/Pine Cones|SSAA|Joni Bescos
 It's Beginning to Look Like Christmas|TTBB|Willis Diekema
 It's Beginning To Look Like Christmas|SSAA|Willis Diekema
 It's Beginning to Look Like Christmas/Pine Cones and Holly Berries|TTBB|Jay Giallombardo
+It's Beginning to Look/I'll Be Home For Christmas|SSAA|Kay Bromert
 It's Christmas|SSAA|Brian Beck
 It's Christmas|TTBB|Brian Beck
 It's Christmas 1973!|TTBB|Liz Garnett
@@ -9820,17 +11660,20 @@ It's Getting Better|SSAA|Tedda Lippincott
 It's Goin' To Be A Cold, Cold Winter|TTBB|Dennis Driscoll
 It's Goin' To Be A Cold, Cold Winter|TTBB|Toban Dvoretsky
 It's Gonna Rain|TTBB|Todd Troutman
+It's Good To Know I'm Welcome|TTBB|1967 HEP
 It's Good To Know I'm Welcome (In My Old Hometown)|TTBB|the 1967 H.E.P. Advanced Arrangers Class
 It's Hairspray|TTBB|Rasmus Krigström
 It's Hard To Be Humble (Oh, Lord)|SSAA|Mary K. Coffman Music Fund
 It's Hard To Be Humble (Oh, Lord)|TTBB|Jim West
 It's Impossible|SSAA|Rob Hopkins
+It's Impossible|TTBB|Ed Waesche
 It's Impossible|TTBB|Rob Hopkins
 It's Impossible (Somos Novios)|TTBB|Rob Hopkins
 It's Just A Matter Of Time|TTBB|Mark Stevens
 It's Late|TTBB|Tom Gentry
 It's Madness Medley|SSAA|Mark Burnip
 It's Madness Medley|TTBB|Mark Burnip
+It's Magic|SSAA|Michael Gellert
 It's Magic|SSAA|Tom Gentry
 It's Magic|TTBB|Ken Tillmanns
 It's Magic|TTBB|Tom Gentry
@@ -9840,9 +11683,13 @@ It's My Life|TTBB|Anders Lindqvist
 It's My Life|TTBB|Joey Minshall
 It's My Party|SSAA|Carolyn Schmidt
 It's My Party|SSAA|Deke Sharon
+It's My Party|SSAA|Marsha Zwicker
 It's My Song|SSAA|Jim Arns
+It's Never Too Late|SSAA|Lorraine Rochefort
+It's Never Too Late to Fall in Love|SSAA|Lorraine Rochefort
 It's No Secret Any More|TTBB|Adam Scott
 It's No Secret Anymore|TTBB|Adam Scott
+It's Not Easy|TTBB|Johan Wikstrom
 It's Not For Me To Say|TTBB|Brian Mastrull
 It's Not For Me To Say|TTBB|Jeremey Johnson
 It's Not For Me To Say|TTBB|Mark Goodney
@@ -9850,6 +11697,7 @@ It's Not Unusual|SATB|Kohl Kitzmiller
 It's Not Unusual|SSAA|Kohl Kitzmiller
 It's Not Unusual|TTBB|Dan Mulligan
 It's Not Unusual|TTBB|Kohl Kitzmiller
+It's Not Unusual|TTBB|Shaun Agnew
 It's Not Where You Start (It's Where You Finish)|TTBB|Theo Hicks
 It's Not Where You Start It's Where You Finish|SSAA|Doris Twardosky
 It's Not Where You Start It's Where You Finish|SSAA|Jim Arns
@@ -9860,11 +11708,15 @@ It's Not Where You Start It's Where You Finish|TTBB|Larry Wright
 It's Not Where You Start It's Where You Finish|TTBB|Theodore Hicks
 It's Now Or Never|TTBB|Kohl Kitzmiller
 It's Now Or Never|TTBB|Wayne Grimmer
+It's Only A Paper Moon|SSAA|Clay Hine
+It's Only A Paper Moon|SSAA|Tedda Lippincott
 It's Only A Paper Moon|TTBB|Clay Hine
 It's Only A Paper Moon|TTBB|Joe Mannherz
+It's Only A Paper Moon|TTBB|Steve Jamison
 It's Only A Paper Moon|TTBB|Walter Latzko
 It's Only a Wee-Wee|TTBB|Tom Gentry
 It's Only Love|TTBB|Steve Jamison
+It's Only the End of a Romance to You|SSAA|Burt Szabo
 It's Only The End Of A Romance To You|TTBB|Burt Szabo
 It's Over|SSAA|Jo Lund
 It's Over Isn't It|SSAA|Steve Tramack
@@ -9872,14 +11724,18 @@ It's Over Isn't It|SSAA|Theodore Hicks
 It's Over Isn't It|TTBB|Theodore Hicks
 It’s Party Time|TTBB|Jackson Pinder
 It's Ragtime (That I Love)|TTBB|Jay Giallombardo
+It's Rainin' Men|SSAA|Ase Hagerman
+It's Rainin' Men|SSAA|Brian Beck
 It's Raining|SATB|Melody Hine
 It's Raining|TTBB|Burt Szabo
+It's Raining Men|SSAA|Ase Hagerman
 It's Raining on Prom Night|SSAA|Jo Lund
 It's Ray-Ray- Raining|TTBB|Nick Papageorge
 It's Sand, Man|SATB|Joe Mannherz
 It's Sand, Man|SSAA|Joe Mannherz
 It's Sand, Man|SSAA|Larry Wright
 It's Sand, Man|TTBB|Larry Wright
+It's So Hard To Say Goodbye (To Yesterday)|SATB|Henrik Rosenberg
 It's So Hard To Say Goodbye To Yesterday|SATB|Deke Sharon
 It's So Hard To Say Goodbye To Yesterday|SATB|Tom Gentry
 It's So Hard To Say Goodbye To Yesterday|TTBB|Larry Wright
@@ -9895,16 +11751,20 @@ It's The Girl|TTBB|Larry Triplett
 It's The Girl|TTBB|Tom Gentry
 It's The Hard-Knock Life|SSAA|Michael Gellert
 It's The Hard-Knock Life|TTBB|Walter Latzko
+It's The Most Wonderful Time of the Year|SSAA|Gwen Schweitzer
+It's The Most Wonderful Time of the Year|SSAA|Nancy Bergman
 It's The Most Wonderful Time Of The Year|SATB|Kay Bromert
 It's The Most Wonderful Time Of The Year|SATB|Mike Menefee
 It's The Most Wonderful Time Of The Year|SSAA|Adam Scott
 It's The Most Wonderful Time Of The Year|SSAA|Larry Wright
+It's The Most Wonderful Time Of The Year|SSAA|Matt Swann
 It's The Most Wonderful Time Of The Year|TTBB|Adam Scott
 It's The Most Wonderful Time Of The Year|TTBB|Brian Hogan
 It's The Most Wonderful Time Of The Year|TTBB|Clay Hine
 It's The Most Wonderful Time Of The Year|TTBB|Derric Johnson
 It's The Most Wonderful Time Of The Year|TTBB|Jay Giallombardo
 It's The Most Wonderful Time Of The Year|TTBB|Larry Wright
+It's The Most Wonderful Time Of The Year|TTBB|Matt Swann
 It's The Most Wonderful Time Of The Year|TTBB|Nancy Bergman
 It's The Most Wonderful Time Of The Year|TTBB|Rob Hopkins
 It's The Most Wonderful Time Of The Year|TTBB|Simon Lubkowski
@@ -9916,6 +11776,7 @@ It's The Same Old Dream|SSAA|Joan D 'Agostino
 It's The Same Old Dream|SSAA|Joe Mannherz
 It's The Same Old Dream|TTBB|Joe Mannherz
 It's The Same Old Shillelagh|SSAA|Jay Giallombardo
+It's The Same Old Shillelagh|TTBB|Barbershop Harmony Society
 It's The Same Old Shillelagh|TTBB|Jay Giallombardo
 It's The Same Old Shillelagh|TTBB|Rollie Ransom
 It's The Same Old Shillelagh|TTBB|SPEBSQSA
@@ -9923,6 +11784,7 @@ It's The Same Old Song|TTBB|Steve Tramack
 It's The Talk Of The Town|SSAA|Dede Nibler
 It's Time|SATB|Deke Sharon
 It's Time|SSAA|David Briner
+It's Time|SSAA|Kelly Brennan
 It's Time For Christmas|TTBB|Matt Astle
 It's Time For You|TTBB|Walter Latzko
 It's Time To Fall In Love|SSAA|Marie Johnson
@@ -9937,7 +11799,9 @@ It's Today|TTBB|Tom Gentry
 It's Today (from Mame)|TTBB|Bryan Ziegler
 It's You|SSAA|Cris Conerty
 It's You|SSAA|Robert Rund
+It's You|TTBB|Bob Rund
 It's You|TTBB|Larry Wright
+It's You|TTBB|Meredith Willson
 It's You|TTBB|Phil Embury
 It's You|TTBB|Robert Rund
 It's You (from "The Music Man")|SSAA|Robert Rund
@@ -9954,11 +11818,15 @@ It's You, All Over Me|TTBB|Norma Andersen
 It's Your Song|SSAA|Brent Graham
 It's Your Song|SSAA|Carolyn Schmidt
 It's Your Song|SSAA|Jim Arns
+It's Your Song|SSAA|Joe Liles
 It's Your Song|SSAA|Joey Minshall
 It's Your Song|SSAA|Kim Andrews
 It's Your Song|TTBB|Brent Graham
+Its A Lovely Day Today|SSAA|Unspecified
+Its A Sin To Tell A Lie|SSAA|Unspecified
 Itsy Bitsy Spider|TTBB|Joe Grimme
 Ivory Palaces|TTBB|Derric Johnson
+Ja Da|SSAA|Marie Johnson
 Ja-Da|SSAA|Marie Johnson
 Ja-Da|SSAA|Marsha Zwicker
 Ja-Da|SSAA|Mary K. Coffman Music Fund
@@ -9968,6 +11836,8 @@ Ja-Da|TTBB|David Briner
 Ja-Da|TTBB|Jim Shubert
 Ja-Da|TTBB|Tom Gentry
 Ja-Da / Everybody's Doing It|SSAA|Nancy Bergman
+Ja-Da/Everybody's Doin It|SSAA|Nancy Bergman
+Jabberwocky|SATB|Sam Pottle
 Jack's Lament|TTBB|Theodore Hicks
 Jackson|SATB|Gary Thiel
 Jackson|TTBB|Melody Hine
@@ -9976,7 +11846,10 @@ Jackson 5 Medley|TTBB|Aaron Dale
 Jackson 5 Medley|TTBB|Deke Sharon
 Jailhouse Rock|SSAA|Larry Wright
 Jailhouse Rock|TTBB|Larry Wright
+Jalousie|SSAA|Nancy Bergman
 Jamaica Farewell|SSAA|Takako Fuke
+Jamaica Farewell|TTBB|John Hohl
+Jamaica Farewell|TTBB|John Hohl, Fred Catto
 Jamaican Noel|SSAA|Tom Gentry
 Jamaican Noel|TTBB|Tom Gentry
 Jambalaya|SSAA|Bev Sellers
@@ -9988,23 +11861,32 @@ Jane|TTBB|Burt Szabo
 Jar Of Hearts|SSAA|Kevin Koehl
 Jason's Song (Gave It Away)|SSAA|Simon Arnott
 Java Jive|SATB|Bluegrass Student Union
+Java Jive|SSAA|Ann Minihane
 Java Jive|SSAA|Bluegrass Student Union
+Java Jive|SSAA|Carolyn E. Johnson
 Java Jive|SSAA|Carolyn Johnson
 Java Jive|SSAA|Carolyn Schmidt
+Java Jive|SSAA|Don Gray
+Java Jive|SSAA|Joe Liles
 Java Jive|SSAA|Joe Mannherz
 Java Jive|SSAA|Jon Nicholas
 Java Jive|SSAA|June Dale
 Java Jive|SSAA|Larry Wright
 Java Jive|TTBB|Bluegrass Student Union
 Java Jive|TTBB|Ed Waesche
+Java Jive|TTBB|Ed Waesche, Tim Hauser
 Java Jive|TTBB|Joe Mannherz
 Java Jive|TTBB|Larry Wright
+Java Jive|TTBB|Steve Jamison
 Java Jive (SSAA) (arr. Bluegrass Student Union) (Australia & New Zealand)|SSAA|Bluegrass Student Union
 Java Jive (TTBB) (arr. Bluegrass Student Union) (Australia & New Zealand)|TTBB|Bluegrass Student Union
+Java Jive (YWIH)|SSAA|June Dale
 Jazz Baby|SSAA|Jay Giallombardo
 Jazz Baby|TTBB|David Briner
 Jazz Baby|TTBB|Jay Giallombardo
 Jazz Band|SATB|Joey Minshall
+Jazz Came Up the River|SSAA|David Wright
+Jazz Came Up the River|SSAA|Nancy Bergman
 Jazz Came Up The River From New Orleans|SSAA|Jack Baird
 Jazz Came Up The River From New Orleans|SSAA|Nancy Bergman
 Jazz Came Up The River From New Orleans|TTBB|David Wright
@@ -10012,10 +11894,13 @@ Jazz Came Up The River From New Orleans|TTBB|Jack Baird
 Jazz Came Up The River From New Orleans|TTBB|SPEBSQSA
 Jazz Ladies Ride|SSAA|David Wright
 Jazz Me Blues|SSAA|Ann Minihane
+Jazz Me Blues|SSAA|Joe Johnson
 Jazz Me Blues|TTBB|Carolyn Schmidt
+Jazz Me Blues|TTBB|Joe Johnson
 Jazz Me Blues|TTBB|L. M. Coyle
 Jazz Me Blues|TTBB|Walter Latzko
 Jazz Me Blues/Jazzin' in New Orleans Medley|SSAA|Jo Lund
+Jazz Medley|SSAA|Ann Minihane
 Jazz Medley|SSAA|Joe Mannherz
 Jazz Medley|TTBB|Joe Mannherz
 Jazzin In New Orleans|SSAA|Jo Lund
@@ -10034,18 +11919,22 @@ Jeanie With The Light Brown Hair|TTBB|Burt Szabo
 Jeanie With The Light Brown Hair|TTBB|Ed Waesche
 Jeanie With The Light Brown Hair|TTBB|Jon Nicholas
 Jeanie With The Light Brown Hair|TTBB|Nancy Bergman
+Jeannie With The Light Brown Hair|TTBB|Ed Waesche
 Jeannine I Dream Of Lilac Time|TTBB|Alden Parker
 Jeannine I Dream Of Lilac Time|TTBB|Earl Moon
 Jeannine I Dream Of Lilac Time|TTBB|Munson Hinman
 Jeepers Creepers|SSAA|Carolyn Johnson
 Jeepers Creepers|SSAA|Fred King
+Jeepers Creepers|SSAA|Greg Volk
 Jeepers Creepers|SSAA|Jay Giallombardo
 Jeepers Creepers|SSAA|Joni Bescos
 Jeepers Creepers|SSAA|Marsha Zwicker
+Jeepers Creepers|SSAA|Sylvia Alsbury
 Jeepers Creepers|TTBB|C. J. Spatafora
 Jeepers Creepers|TTBB|Fred King
 Jeepers Creepers|TTBB|Jay Giallombardo
 Jeepers Creepers/I'm In Love Again|TTBB|Erik Eliason
+Jeepers Creepers/Them There Eyes Medley|TTBB|David Harrington
 Jenny Rebecca|SSAA|Tom Gentry
 Jenny Rebecca|TTBB|Tom Gentry
 Jeopardy Theme|SSAA|Jim Arns
@@ -10058,6 +11947,7 @@ Jersey Boys Medley|TTBB|Stephen Delehanty
 Jersey Boys Medley|TTBB|Steve Delehanty
 Jerusalem|SSAA|Fran Carter
 Jerusalem, Jerusalem|SSAA|Sonny Steffan
+Jesis Jesus Rest Your Head|SSAA|Judy Vidal
 Jesse|SSAA|Sheryl Neal
 Jessie's Girl|SSAA|Deke Sharon
 Jessie's Girl|TTBB|Deke Sharon
@@ -10069,6 +11959,8 @@ Jesus Loves Me|TTBB|Todd Troutman
 Jesus Loves Me|TTBB|Tom Gentry
 Jesus Take The Wheel|SSAA|Larry Wright
 Jesus Walks|SATB|Deke Sharon
+Jesus, Hold My Hand|TTBB|David Briner
+Jesus, Jesus Rest Your Head|TTBB|Greg Lyne
 Jesus, Jesus, Rest Your Head|SATB|Gregory Lyne
 Jesus, Jesus, Rest Your Head|SSAA|Barbara McNeill
 Jesus, Jesus, Rest Your Head|SSAA|Diane Clark
@@ -10078,13 +11970,19 @@ Jesus, Lover Of My Soul|TTBB|Derric Johnson
 Jesus, What a Wonderful Child!|TTBB|Aaron Dale
 Jet Airliner|TTBB|Deke Sharon
 Jezebel|TTBB|Milton Teitel
+Jezebel|TTBB|Walter Latzko
 Jillian|TTBB|Walter Latzko
 Jilted|SSAA|Deke Sharon
 Jimmy Durante Medley|TTBB|Renee Craig
 Jimmy Valentine|TTBB|Kirk Roose
+Jimmy Webb Medley|SSAA|Jim Clancy
 Jing-a-ling, Jing-a-ling|SSAA|Emily Moriarty
 Jing-a-ling, Jing-a-ling|TTBB|Adam Bock
+Jingle All The Way|SSAA|Unspecified
 Jingle Bell Jazz|SSAA|June Berg
+Jingle Bell Jazz|SSAA|June Berg/Ed Wells
+Jingle Bell Rock|SSAA|Pat LeVezu
+Jingle Bell Rock|SSAA|Renee Craig
 Jingle Bells|SATB|David Harrington
 Jingle Bells|SATB|Deke Sharon
 Jingle Bells|SATB|Derric Johnson
@@ -10102,19 +12000,29 @@ Jingle Bells|TTBB|Gabriel Lawson
 Jingle Bells|TTBB|Joe Liles
 Jingle Bells|TTBB|Jon Nicholas
 Jingle Bells|TTBB|SPEBSQSA
+Jingle Bells|TTBB|Traditional
 Jingle Bells|TTBB|Walter Latzko
 Jingle Bells / Sleigh Ride Medley|TTBB|Mark Smith
 Jingle Bells Parody|TTBB|Jon Nicholas
+Jingle Bells/Sleigh Ride|TTBB|Pete Rupay
 Jingle Jangle Jingle|TTBB|Burt Szabo
 Jingle Jangle Jingle|TTBB|Larry Wright
+Jingle Jangle Jingle|TTBB|Unspecified
 Jingle Jangle Jingle (I Got Spurs) -|TTBB|Burt Szabo
 Jingle Jingle Jingle|TTBB|Kevin Keller
+Jingle the Bells|SSAA|Bea Howell
 Jingle-Bell Rock|SATB|Burt Szabo
 Jingle-Bell Rock|SATB|Joe Mannherz
 Jingle-Bell Rock|SSAA|Burt Szabo
 Jingle-Bell Rock|TTBB|Burt Szabo
 Joanna|TTBB|Adam Scott
 Joe Howard Medley|TTBB|Unknown
+John Denver Medley|TTBB|Steve Jamison
+Johnny Angel|SSAA|Anita Barzilla
+Johnny Angel|SSAA|Debbie Porter
+Johnny Angel|SSAA|Harmony Inc., Music Judges
+Johnny Angel|SSAA|Ken Hatton
+Johnny Angel|SSAA|Lorraine Rochefort
 Johnny Angel|TTBB|Tom Colville
 Johnny Appleseed District Theme Song|TTBB|Tom Gentry
 Johnny Doughboy Found A Rose In Ireland|SSAA|Russ Foris
@@ -10122,13 +12030,17 @@ Johnny Doughboy Found A Rose In Ireland|TTBB|Ed Williamson
 Johnny Fedora and Alice Blue Bonnet|SSAA|Joe Mannherz
 Johnny Fedora and Alice Blue Bonnet|SSAA|Zona Snyder
 Johnny Fedora and Alice Blue Bonnet|TTBB|Joe Mannherz
+Johnny Medley|SSAA|Betty Oliver
 Johnny Medley|SSAA|Carolyn Johnson
 Johnny Medley|SSAA|Nancy Bergman
+Johnny One Note|TTBB|Adam Reimnitz
 Johnny One Note|TTBB|Dan Wessler
 Johnny One Note|TTBB|Walter Latzko
 Johnny Rae Medley|TTBB|Todd Troutman
+Johnny Schmoker|TTBB|James Rodde
 Johnny's In Town|SSAA|Carolyn Johnson
 Johnny's In Town|TTBB|Dennis Driscoll
+Johnny's Off To War Medley|TTBB|Rob Hopkins
 Join Me In A Dream|TTBB|Andrew Wittenberg
 Join The Circus|TTBB|Dan Wilson
 Joint Is Jumpin'/Truckin'|SSAA|Tom Gentry
@@ -10163,11 +12075,14 @@ Journey To The Past|TTBB|Adam Bock
 Joy|SSAA|Kohl Kitzmiller
 Joy|TTBB|Kevin Keller
 Joy Medley|SSAA|Carolyn Johnson
+Joy to the World|SSAA|David Harrington
 Joy To The World|SATB|David Harrington
 Joy To The World|SATB|Deke Sharon
 Joy To The World|SATB|Derric Johnson
 Joy To The World|SATB|Joe Liles
+Joy To The World|SATB|John Rutter
 Joy To The World|SATB|Mel Knight
+Joy To The World|SSAA|Brian Beck
 Joy To The World|SSAA|Carole Prietto
 Joy To The World|SSAA|Carolyn Johnson
 Joy To The World|SSAA|Cris Conerty
@@ -10175,21 +12090,29 @@ Joy To The World|SSAA|Glenda Lloyd
 Joy To The World|SSAA|Jay Giallombardo
 Joy To The World|SSAA|Jeremey Johnson
 Joy To The World|SSAA|Joe Liles
+Joy To The World|TTBB|Brian Beck
 Joy To The World|TTBB|David Harrington
 Joy To The World|TTBB|David Wright
 Joy To The World|TTBB|Deke Sharon
 Joy To The World|TTBB|Jay Giallombardo
 Joy To The World|TTBB|Jeremey Johnson
+Joy To The World|TTBB|Joe Johnson
 Joy To The World|TTBB|Joe Liles
 Joy To The World|TTBB|Jon Nicholas
 Joy To The World|TTBB|Nick Bryant
+Joy To The World - Deck The Halls Medley|TTBB|Adam Scott
+Joy to the World (Jeremiah was a Bullfrog)|SSAA|Deke Sharon
+Joy To the World/Adeste Fidelis|TTBB|Greg Lyne
 Joy To The World/Deck The Halls (Medley)|TTBB|Adam Scott
 Joy to the World/O Come All Ye Faithful|TTBB|Jay Giallombardo
+Joy to the World/O Come All Ye Faithful Medley|SSAA|Jay Giallombardo
 Joyful, Joyful, We Adore Thee|TTBB|Derric Johnson
 Juke Box Saturday Night|SSAA|Joni Bescos
 Jukebox Baby|TTBB|John Hohl
 Jukebox In My Mind|TTBB|Richard Carr
 Jukebox Saturday Night Medley|SSAA|Jo Lund
+Jukebox Saturday Night Medley|TTBB|Walter Latzko
+Jump in the Line|SSAA|Sylvia Alsbury
 Jump Jive And Then You Wail|TTBB|Aaron Dale
 Jump Medley|SSAA|Aaron Dale
 Jump Right In|SATB|Nicholas Wright
@@ -10197,13 +12120,18 @@ Jump Shout Boogie|SSAA|Jay Giallombardo
 Jump Shout Boogie|SSAA|Larry Wright
 Jump Shout Boogie|TTBB|Larry Wright
 Jump Shout Boogie|TTBB|Roger Payne
+Jump, Jive & Wail|SSAA|Lynnell Diamond
+Jump, Jive and Wail|SSAA|Lynnell Diamond
 Jumpin' East Of Java|SSAA|Kohl Kitzmiller
 June In January|SSAA|Greta Somers
 June Is Bustin' Out All Over|TTBB|Jay Giallombardo
 June Medley|TTBB|Dennis Driscoll
 June Night|TTBB|Walter Latzko
 Jungle Book Medley|TTBB|Deke Sharon
+Jungle Rhythm|SSAA|Alex Kaiserman
+Junglingswonne|TTBB|Franz Schubert
 Jus' Maybe|SATB|Wayne Grimmer
+Just a Baby's Prayer at Twilight|SSAA|Tom Gentry
 Just A Baby's Prayer At Twilight|SSAA|Carolyn Johnson
 Just A Baby's Prayer At Twilight|SSAA|Russ Foris
 Just A Baby's Prayer At Twilight|TTBB|Burt Szabo
@@ -10216,17 +12144,22 @@ Just A Closer Walk With Thee|SSAA|Jim West
 Just A Closer Walk With Thee|SSAA|Nancy Bergman
 Just A Closer Walk With Thee|SSAA|Tedda Lippincott
 Just A Closer Walk With Thee|TTBB|Barney Johnson
+Just A Closer Walk With Thee|TTBB|Clay Hine
 Just A Closer Walk With Thee|TTBB|Paul Jorg
 Just A Closer Walk With Thee / When The Saints Go Marching In Medley|TTBB|Jack Baird
 Just A Closer Walk With Thee / When The Saints Go Marching In Medley|TTBB|Lloyd Steinkamp
+Just A Closer Walk With Thee/When The Saints (Medley)|TTBB|Jack Baird
 Just A Cottage Small|SSAA|Tom Gentil
 Just A Cottage Small|TTBB|Al Rehkop
+Just A Cottage Small|TTBB|Al Rekhop
 Just A Cottage Small|TTBB|Ed Waesche
 Just A Cottage Small|TTBB|Tom Gentil
 Just A Cottage Small (By A Waterfall)|TTBB|Al Rehkop
+Just A Cottage Small (By A Waterfall)|TTBB|Chris Arnold
 Just A Dream Of You Dear|TTBB|Dennis Driscoll
 Just A Dream Of You Dear|TTBB|R. J. Margison
 Just A Dream Of You Dear|TTBB|Walter Latzko
+Just a Gigolo|TTBB|Will Hamblet
 Just A Gigolo / I Ain't Got Nobody|TTBB|Deke Sharon
 Just A Gigolo / I Ain't Got Nobody|TTBB|Roger Payne
 Just A Girl That Men Forget|TTBB|George Hulst
@@ -10251,6 +12184,7 @@ Just A Little Talk With Jesus|TTBB|Dan Wessler
 Just A Little Talk With Jesus|TTBB|David Harrington
 Just A Ride|SATB|Deke Sharon
 Just a Smile Just a Kiss from You|TTBB|Warren 'Buzz' Haeger
+Just a Wearyin' for You|TTBB|Phil Embury
 Just A-Sittin' and A-Rockin'|TTBB|Robert Rund
 Just A-Sittin' and A-Rockin'|TTBB|Tom Gentry
 Just An Ivy Covered Shack|TTBB|Steve Hardy
@@ -10265,7 +12199,10 @@ Just As I Am|TTBB|Dan Wessler
 Just As I Am|TTBB|Derric Johnson
 Just Because|TTBB|Jim West
 Just Because / How Could You Believe Me (parody) Medley|TTBB|Larry Jackson
+Just Because / Shine|TTBB|Earl Moon
 Just Because / Shine Medley|TTBB|Earl Moon
+Just Because/Shine (Medley)|TTBB|Earl Moon
+Just Between Old Friends|TTBB|Joe Johnson
 Just Bring Tulips Along|TTBB|Brent Graham
 Just For A Girl|TTBB|Toban Dvoretsky
 Just For Remembrance|TTBB|Fred King
@@ -10278,6 +12215,7 @@ Just In Case You Change Your Mind|TTBB|Jon Nicholas
 Just In Time|SATB|Kevin Keller
 Just In Time|SSAA|David Briner
 Just In Time|SSAA|Stephanie G. Gentry
+Just In Time|TTBB|Dave Briner
 Just In Time|TTBB|David Briner
 Just In Time (from "Bells Are Ringing")|TTBB|Dave Briner
 Just Keep Singin' Your Song!|SSAA|Cris Conerty
@@ -10292,6 +12230,7 @@ Just One More Chance|TTBB|Jerry Bockus
 Just One Of Those Things|SSAA|Joni Bescos
 Just One Of Those Things|TTBB|Aaron Dale
 Just One Of Those Things|TTBB|Ed Hinkley
+Just One Of Those Things|TTBB|Joni Bescos
 Just One Person|TTBB|Todd Troutman
 Just Sing|SATB|Dan Wessler
 Just Sing|SSAA|Dan Wessler
@@ -10313,12 +12252,16 @@ Just The Way You Are|TTBB|Nicholas Wright
 Just The Way You Are|TTBB|Simon Arnott
 Just The Way You Are|TTBB|Steve Hardy
 Just the Way You Are / Just A Dream (Mashup)|SSAA|Deke Sharon
+Just the Way You Are/Just a Dream|SSAA|Deke Sharon
 Just Walking In The Rain|SSAA|Walter Latzko
+Just Want To Dance The Night Away|TTBB|Liz Garnett
 Just When The Lights Are Low|TTBB|Dennis Driscoll
 Just When The Lights Are Low|TTBB|Donn Updegrove
 Just When The Lights Are Low|TTBB|Jay Giallombardo
 Justin Timberlake Medley|SATB|Kevin Keller
 K-K-K-Katie|SSAA|Nancy Bergman
+K.P.|TTBB|Jim Henry
+Kalamazoo|TTBB|Greg Volk
 Kalamazoo (I've Got A Gal In)|TTBB|Walter Latzko
 Kansas City|SSAA|Jay Giallombardo
 Kansas City|SSAA|Jo Kraut
@@ -10328,6 +12271,7 @@ Kansas City Here I Come|TTBB|Jay Giallombardo
 Kansas City Star|SSAA|Jay Giallombardo
 Kansas City Star|TTBB|Jack Baird
 Kansas City Star|TTBB|Jay Giallombardo
+Kansas City, Here I Come|TTBB|Jay Giallombardo
 Karmastition|SATB|Deke Sharon
 Karmastition|TTBB|Deke Sharon
 Katrina|TTBB|Jon Nicholas
@@ -10344,37 +12288,53 @@ Keep In The Middle Of The Road|SSAA|June Berg
 Keep Marching|SSAA|Cay Outerbridge
 Keep Me Warm|SATB|Don Staffin
 Keep On Movin'|SATB|Jack Bridges
+Keep On The Firing Line|TTBB|John Peterson
+Keep On The Sunny Side|SSAA|Sharon Holmes
 Keep On The Sunny Side|TTBB|Ed Waesche
 Keep The Customer Satisfied|SSAA|Sam Hubbard
 Keep The Customer Satisfied|TTBB|Cay Outerbridge
 Keep The Customer Satisfied|TTBB|Sam Hubbard
 Keep The Home Fires Burning|SSAA|Joey Minshall
 Keep The Home Fires Burning|TTBB|Marie Johnson
+Keep the Music Ringing|SSAA|Lynnell Diamond
 Keep The Whole World Singing|SATB|Barbershop Harmony Society
 Keep The Whole World Singing|SSAA|Barbershop Harmony Society
 Keep The Whole World Singing|TTBB|Barbershop Harmony Society
 Keep The Whole World Singing|TTBB|Joe Liles
+Keep The Whole World Singing|TTBB|Willis Diekema
 Keep Young and Beautiful|TTBB|Walter Latzko
 Keep Your Eye On The Girlie You Love|TTBB|Barbershop Harmony Society
 Keep Your Eye On The Girlie You Love|TTBB|Jack Baird
 Keep Your Eye On The Girlie You Love|TTBB|Steve Delehanty
+Keep Your Eye On The Girlie You Love / Somebody Stole My Gal|TTBB|Jack Baird, Dick Johnson
 Keep Your Eyes On The Hands|TTBB|David Briner
 Keep Your Head Up|TTBB|Nicholas Wright
+Keep Your Sunny Side Up|SSAA|Nancy Bergman
+Keep Your Sunnyside Up|SSAA|Nancy Bergman
 Keep Yourself Alive|TTBB|Jay Giallombardo
+Keeper Of the Stars|SSAA|Tedda Lippincott
+Keepin' Out of Mischief|SSAA|June Berg
 Keepin' Out Of Mischief Now|SATB|Joe Mannherz
 Keepin' Out Of Mischief Now|SSAA|David Wright
 Keepin' Out Of Mischief Now|SSAA|June Berg
+Keeping Out of Mischief|SSAA|David Wright
 Keeping The Dream Alive|SSAA|Sam Hubbard
 Keeping The Dream Alive|TTBB|Sam Hubbard
 Kehna Hi Kya|TTBB|Nicholas Wright
+Kentucky Babe|SSAA|Anna Maria Parker
+Kentucky Babe|SSAA|Kirk Roose
 Kentucky Babe|TTBB|Derric Johnson
+Kentucky Babe|TTBB|Kirk Roose
+Kerry Dance|SSAA|Renee Craig
 Key to Success with the Beautiful Girls|TTBB|John Hohl
 Keystone Cops|TTBB|Jay Giallombardo
 Kickin' 'n' Screamin'|TTBB|Jim Shubert
+Kickin' It Up a Notch|SSAA|Nancy Faddegon
 Kid Days|TTBB|Jim West
 Kid's Song/Coney Island Washboard|SSAA|Larry Wright
 Kid's Song/Coney Island Washboard|TTBB|Larry Wright
 Kids In America|SATB|Deke Sharon
+Kids/Coney Island Washboard|TTBB|139th Street Quartet
 Killer Queen|SSAA|Adam Bock
 Killer Queen|TTBB|Adam Bock
 Killer Queen|TTBB|Adam Scott
@@ -10394,6 +12354,7 @@ King Hymn Medley|TTBB|Jim Clancy
 King of Anything|SSAA|Deke Sharon
 King Of My Heart|SATB|Nicholas Wright
 King Of New York (from Newsies)|TTBB|Josh Ehrlich/Larry Bomback
+King Of Spain|TTBB|Moxy Fruvous
 King Of The Road|SATB|Anders Lindqvist
 King Of The Road|SATB|Joe Mannherz
 King Of The Road|SATB|Kevin Keller
@@ -10415,23 +12376,29 @@ Kingston Town|SSAA|Mark Burnip
 Kingston Town|TTBB|Mark Burnip
 Kiss|TTBB|Kevin Koehl
 Kiss|TTBB|Tony Nasto
+Kiss|TTBB|Unspecified
 Kiss From A Rose|SATB|Deke Sharon
 Kiss From A Rose|TTBB|Anders Lindqvist
 Kiss From A Rose|TTBB|Deke Sharon
 Kiss From A Rose|TTBB|Liz Garnett
 Kiss From A Rose|TTBB|Nicholas Wright
+Kiss Him Goodbye|TTBB|Don Gillespie
 Kiss It (And Make It Well)|TTBB|Norma Andersen
 Kiss Me|SATB|Kevin Koehl
 Kiss Me|SSAA|Deke Sharon
 Kiss Me|TTBB|Mark Stevens
+Kiss Me Goodnight|SSAA|Brent Graham
 Kiss Me Goodnight!|SSAA|Brent Graham
 Kiss Me Goodnight!|TTBB|Brent Graham
+Kiss Me One More Time|SSAA|Norma Andersen
+Kiss Me One More Time|SSAA|Unspecified
 Kiss Me One More Time|TTBB|Norma Andersen
 Kiss On My List|TTBB|Joe Grimme
 Kiss On My List|TTBB|Melody Hine
 Kiss That Made Me Cry|TTBB|Gary Eliason
 Kiss the Boys Goodbye|SSAA|Joe Mannherz
 Kiss The Girl|SATB|Deke Sharon
+Kiss The Girl|TTBB|Kirby Shaw
 Kiss The Girl|TTBB|Larry Wright
 Kiss The Girl|TTBB|Theodore Hicks
 Kiss To Build A Dream On|SSAA|Chris Arnold
@@ -10441,10 +12408,13 @@ Kiss To Build A Dream On/Dreams Medley|SSAA|Anthony Sparks
 Kiss, Kiss, Kissin' In The Corn|SSAA|Walter Latzko
 Kisses Sweeter Than Wine|TTBB|David Briner
 Kisses Sweeter Than Wine|TTBB|Walter Latzko
+Kissing A Fool|TTBB|Chris Arnold
 Kissing A Fool|TTBB|Jay Giallombardo
 Kissing A Fool|TTBB|Kyle Kitzmiller
 Kitten On The Keys|TTBB|Walter Latzko
 Knee Deep|TTBB|Kevin Keller
+Knight Quest Medley|TTBB|Tom Gentry
+Knight Rhythm Medley|TTBB|Tom Gentry
 Knight School Medley|TTBB|Tom Gentry
 Knighthood Medley|TTBB|Roger Payne/Steve Tramack
 Knighthood Quest Medley|TTBB|Tom Gentry
@@ -10452,17 +12422,28 @@ Knighthood Rhythm Medley|TTBB|Tom Gentry
 Knights Of The Round Table|TTBB|Theodore Hicks
 Knock Knock Song|SSAA|Tom Gentry
 Knock Knock Song|TTBB|Tom Gentry
+Knock On My Door|SSAA|Donya Metzger
 Knockin' On Heaven's Door|SATB|Deke Sharon
 Knocks Me Off My Feet|SSAA|Sam Hubbard
+Knowing Me, Knowing You|SSAA|Chris MacMartin
+Ko-Ko-Mo|TTBB|Don Reckenbeil
 Kodachrome|SSAA|Don Staffin
+Kodachrome|TTBB|David Gillingham
 Kodachrome|TTBB|Don Staffin
+Kokomo|SSAA|B. Sellars/C. Schmidt (YWIH)
 Kokomo|SSAA|Bev Sellers
+Kokomo|SSAA|Bev Sellers/Carolyn Schmidt
 Kokomo|SSAA|Carolyn Schmidt
 Kokomo|SSAA|Jo Lund
+Kokomo|SSAA|Lorraine Rochefort
 Kokomo|TTBB|Brian Mastrull
 Kokomo|TTBB|Don Reckenbeil
+Kokomo (YWIH)|SSAA|Bev Sellers
 Komm Trink Aus, Jack|TTBB|Tom Gentry
 Kriminal Tango|TTBB|Tom Gentry
+Kuimba|TTBB|Victor Johnson
+Kwmbayah|TTBB|K.J. Dinham
+Kyrie|TTBB|Mark Stevens, Will Makra
 L-O-V-E|SATB|Larry Triplett
 L-O-V-E|SSAA|Anastasio Rossi
 L-O-V-E|SSAA|Larry Triplett
@@ -10474,6 +12455,8 @@ L-O-V-E|TTBB|Dan Mulligan
 L-O-V-E|TTBB|Ed Waesche
 L-O-V-E|TTBB|Larry Triplett
 L-O-V-E|TTBB|Mark Goodney
+L-O-V-E and Marriage Medley|TTBB|Matt Gallagher
+L.O.V.E.|SSAA|Larry Triplett
 L.O.V.E. Medley|SSAA|Joe Mannherz
 L.O.V.E. Medley|TTBB|Joe Mannherz
 La Bamba|SATB|Deke Sharon
@@ -10495,6 +12478,7 @@ Lady Madonna|TTBB|Jay Giallombardo
 Lady Madonna|TTBB|Mark Burnip
 Lady Marmalade|SSAA|Staffan Paulson
 Lady Of Spain|TTBB|Jay Giallombardo
+Lady Takes the Cowboy Every Time|SSAA|Nancy Bergman
 Lagrimas Negras|TTBB|Jay Dougherty
 Land Of A Thousand Dances|SATB|Deke Sharon
 Land Of Hope And Glory|TTBB|Paul Engel
@@ -10506,7 +12490,9 @@ Landslide|SSAA|Steve Tramack
 Landslide|TTBB|Deke Sharon
 Landslide|TTBB|Melody Hine
 Landslide|TTBB|Robert Rund
+Langtan Till Landet|TTBB|Traditional
 Larger Than Life|TTBB|Deke Sharon
+Last Christmas|SATB|Henrik Rosenberg
 Last Name|SATB|Deke Sharon
 Last night|SATB|Joe Mannherz
 Last Night On The Back Porch|SSAA|Nancy Bergman
@@ -10516,6 +12502,7 @@ Last Night On The Back Porch|TTBB|Dick Belote
 Last Night On The Back Porch|TTBB|Gay Notes
 Last Night On The Back Porch|TTBB|The Gaynotes
 Last Night On The Back Porch|TTBB|Tom Gentry
+Last Night Was the End of the World|SSAA|Jim Clancy
 Last Night Was The End Of The World|SATB|Barbershop Harmony Society
 Last Night Was The End Of The World|SSAA|Barbershop Harmony Society
 Last Night Was The End Of The World|SSAA|Inc. SPEBSQSA
@@ -10524,6 +12511,7 @@ Last Night Was The End Of The World|SSAA|SPEBSQSA
 Last Night Was The End Of The World|SSAA|Tedda Lippincott
 Last Night Was The End Of The World|TTBB|Barbershop Harmony Society
 Last Night Was The End Of The World|TTBB|Brent Graham
+Last Night Was The End Of The World|TTBB|Buzz Haeger
 Last Night Was The End Of The World|TTBB|David Wright
 Last Night Was The End Of The World|TTBB|Dick Stern
 Last Night Was The End Of The World|TTBB|Inc. SPEBSQSA
@@ -10542,10 +12530,13 @@ Lately|TTBB|Matt Gallagher
 Lately|TTBB|Matthew Gallagher
 Lately|TTBB|Sam Hubbard
 Latika's Theme|SATB|Nicholas Wright
+Laugh Clown Laugh|SSAA|Lyle Pilcher
 Laugh Clown Laugh|TTBB|Curt Kimball
 Laugh Clown Laugh|TTBB|Lyle Pilcher
 Laugh Clown Laugh|TTBB|Warren 'Buzz' Haeger
+Laughing On the Outside|SSAA|Nancy Bergman
 Laughing On The Outside|SSAA|Jo Lund
+Laughing On The Outside (Crying On The Inside)|SSAA|Nancy Bergman
 Laughing Song|SATB|David Avshalomov
 Laughter In The Rain|SSAA|Sam Hubbard
 Laughter In The Rain|SSAA|Staffan Paulson
@@ -10557,10 +12548,13 @@ Laundry|SSAA|Mike Menefee
 Laura|SATB|Scott Kitzmiller
 Laura|TTBB|Robert Rund
 Laura|TTBB|Steve Jamison
+Laura|TTBB|Webb Comfort
 Laura Bell Lee|TTBB|Jim West
 Lava|SATB|Kohl Kitzmiller
 Lavender and Lace|TTBB|Norma Andersen
 Lavender Blue|TTBB|Brent Graham
+LaWanda Darlene the Rodeo Queen|SSAA|Marcia Hill/Nancy Bergman
+Lawanda Darlene, Rodeo Queen|SSAA|Hill Nancy Bergman
 LaWanda Darlene, The Rodeo Queen|SSAA|Nancy Bergman
 LaWanda Darlene, The Rodeo Queen|TTBB|Nancy Bergman
 Lawdy Miss Clawdy|TTBB|Deke Sharon
@@ -10569,6 +12563,7 @@ Lay Me Down|SATB|Nicholas Wright
 Lay Me Down|TTBB|Nicholas Wright
 Lazy|TTBB|Alan Siegal
 Lazy Afternoon|SATB|Joe Mannherz
+Lazy Bones|TTBB|Webb Comfort
 Lazy Day|SATB|David Wright
 Lazy Day|SSAA|David Wright
 Lazy Day|SSAA|Patsee Parker
@@ -10578,14 +12573,17 @@ Lazy River|SSAA|Jim Massey
 Lazy River|SSAA|Mary K. Coffman Music Fund
 Lazy River|SSAA|Tom Gentry
 Lazy River|TTBB|Clay Hine
+Lazy River|TTBB|Ed Waesche
 Lazy River|TTBB|Jon Nicholas
 Lazy River|TTBB|Kohl Kitzmiller
 Lazy River|TTBB|Steve Delehanty
 Lazy River|TTBB|Thomas Gentry
 Lazy River|TTBB|Tom Gentry
 Lazybones|TTBB|David Wright
+Le Canon|SSAA|Dianne Harding
 Le Canon|SSAA|Joey Minshall
 Le Canon|TTBB|Joey Minshall
+Le Jazz Hot!|SSAA|Ann Minihane
 Le Jazz Hot!|SSAA|Joe Mannherz
 Le Jazz Hot!|TTBB|Joe Mannherz
 Le Jazz Hot!|TTBB|Patrick McAlexander
@@ -10603,14 +12601,18 @@ Lean On Me|SATB|Tom Gentry
 Lean On Me|SSAA|Gayle Haley
 Lean On Me|SSAA|Jan-Ake Westin
 Lean On Me|SSAA|Joey Minshall
+Lean On Me|SSAA|Joey Minshall YWIH
 Lean On Me|SSAA|Nancy Shumard
 Lean On Me|SSAA|Tedda Lippincott
+Lean On Me|TTBB|Adam Anders and Tim Davis
 Lean On Me|TTBB|Alex Kaiserman
+Lean On Me|TTBB|Craig Gibbins
 Lean On Me|TTBB|Deke Sharon
 Lean On Me|TTBB|Joey Minshall
 Lean On Me|TTBB|Michael Gellert
 Lean On Me|TTBB|Tom Gentry
 Lean On Me|TTBB|Wayne Grimmer
+Lean On Me (YWIH)|SSAA|Joey Minshall
 Leaning On A Lamppost|SSAA|Larry Wright
 Leaning On A Lamppost|TTBB|Larry Wright
 Leaning On The Everlasting Arms|TTBB|Derric Johnson
@@ -10631,11 +12633,17 @@ Let A Smile Be Your Umbrella|TTBB|Bob Benson
 Let A Smile Be Your Umbrella|TTBB|Jay Giallombardo
 Let A Smile Be Your Umbrella|TTBB|Mo Rector
 Let A Smile Be Your Umbrella / Powder Your Face With Sunshine / When You're Smiling Medley|TTBB|Ed Waesche
+Let A Smile Be Your Umbrella / Rain|TTBB|Ed Waesche
 Let A Smile Be Your Umbrella / When You're Smiling|TTBB|Douglas Beck
+Let a Songbird Fly|TTBB|Paul Davies - Used for National Learn to Sing Day
+Let A Songbird Fly|TTBB|Paul Davies
+Let All Mortal Flesh Keep Silence|TTBB|J Taylor
 Let All Mortal Flesh Keep Silence|TTBB|Jeff Taylor
 Let Freedom Ring|SSAA|Larry Wright
 Let Freedom Ring|TTBB|Larry Wright
 Let Freedom Ring|TTBB|Paul Jorg
+Let Freedom Ring (8-Part Arrangement)|TTBB|Mel Knight
+Let Freedon Ring|SSAA|Larry Wright
 Let Him Go, Let Him Tarry|SSAA|Joey Minshall
 Let It Be|SATB|Deke Sharon
 Let It Be|SATB|Jay Dougherty
@@ -10657,15 +12665,22 @@ Let It Go|SATB|Deke Sharon
 Let It Go|SSAA|Carole Prietto
 Let It Go|SSAA|Glenda Lloyd
 Let It Go|SSAA|Larry Wright
+Let It Go|SSAA|Lorraine Rochefort
 Let It Go|TTBB|Deke Sharon
 Let It Go|TTBB|Gabriel Lawson
 Let It Go|TTBB|Nicholas Wright
 Let It Go (from Frozen) (Parody)|TTBB|Mac Huff
+Let It Go/Let Her Go Mashup|SSAA|Brittany E. Griffith
 Let It Rain|SSAA|Dawn Haggerty
 Let It Rain Let It Pour|TTBB|Burt Szabo
 Let It Rain Let It Pour|TTBB|Jay Giallombardo
 Let It Rain Let It Pour|TTBB|Tom Gentry
 Let It Shine|SSAA|Mary K. Coffman Music Fund
+Let It Snow|SSAA|Ann Minihane
+Let It Snow|SSAA|Becky Wilkins
+Let It Snow|TTBB|Joe Liles
+Let It Snow|TTBB|Mando Fonseca
+Let It Snow|TTBB|Unspecified
 Let It Snow Let It Snow Let It Show|TTBB|Steve Jamison
 Let It Snow Let It Snow Let It Snow|SATB|Lauren Kahn
 Let It Snow Let It Snow Let It Snow|SSAA|Jay Giallombardo
@@ -10673,12 +12688,17 @@ Let It Snow Let It Snow Let It Snow|SSAA|Kay Bromert
 Let It Snow Let It Snow Let It Snow|TTBB|Derric Johnson
 Let It Snow Let It Snow Let It Snow|TTBB|Jay Giallombardo
 Let It Snow Let It Snow Let It Snow|TTBB|Jon Nicholas
+Let It Snow! Let It Snow! Let It Snow!|SSAA|Ann Minihane
+Let It Snow! Let It Snow! Let It Snow!|TTBB|Joe Liles
 Let It Whip|TTBB|Deke Sharon
+Let Me Be There|SSAA|Carolyn Healey
+Let Me Be There|SSAA|LABBS Polecat
 Let Me Be There|SSAA|Liz Garnett
 Let Me Be There|TTBB|Dennis Driscoll
 Let Me Be Your Star|SSAA|Joe Mannherz
 Let Me Be Your Star|SSAA|Michael Gellert
 Let Me Be Your Star|TTBB|Greg Mallett
+Let Me Be Your Teddy Bear|SSAA|Jon Nicholas
 Let Me Be Your Wings|TTBB|Tom Gentry
 Let Me Call You Sweetheart|SSAA|Carolyn Johnson
 Let Me Call You Sweetheart|SSAA|Jan Meyer
@@ -10686,9 +12706,13 @@ Let Me Call You Sweetheart|SSAA|Jean Shook
 Let Me Call You Sweetheart|SSAA|Jim Arns
 Let Me Call You Sweetheart|SSAA|Jo Lund
 Let Me Call You Sweetheart|SSAA|June Berg
+Let Me Call You Sweetheart|SSAA|Sylvia Alsbury
 Let Me Call You Sweetheart|SSAA|Unknown
+Let Me Call You Sweetheart|SSAA|Unspecified
 Let Me Call You Sweetheart|SSAA|Walter Latzko
 Let Me Call You Sweetheart|TTBB|Barbershop Harmony Society
+Let Me Call You Sweetheart|TTBB|Beth Slater Whitson and Leo Friedman
+Let Me Call You Sweetheart|TTBB|Greg Lyne
 Let Me Call You Sweetheart|TTBB|Gregory Lyne
 Let Me Call You Sweetheart|TTBB|Rob Hopkins
 Let Me Call You Sweetheart|TTBB|SPEBSQSA
@@ -10699,6 +12723,8 @@ Let Me Entertain You|SSAA|Jo Lund
 Let Me Entertain You|TTBB|Alex Morris
 Let Me Entertain You|TTBB|Hal Snyder
 Let Me Go, Lover|SSAA|Walter Latzko
+Let Me Sing and I'm Happy|TTBB|Ed Waesche
+Let Me Sing and I'm Happy|TTBB|Katie Farrell
 Let Me Sing And I'm Happy|SSAA|Brent Graham
 Let Me Sing And I'm Happy|SSAA|Renee Craig
 Let Me Sing And I'm Happy|TTBB|Kevin Keller
@@ -10735,11 +12761,13 @@ Let There Be Music Let There Be Love|TTBB|Joe Liles
 Let There Be Peace On Earth|SATB|David Harrington
 Let There Be Peace On Earth|SATB|Nancy Bergman
 Let There Be Peace On Earth|SATB|Tom Gentry
+Let There Be Peace On Earth|SSAA|Alsbury
 Let There Be Peace On Earth|SSAA|Anna Maria Parker
 Let There Be Peace On Earth|SSAA|Carolyn Schmidt
 Let There Be Peace On Earth|SSAA|Donna Shorkey
 Let There Be Peace On Earth|SSAA|Jo Lund
 Let There Be Peace On Earth|SSAA|Marie Johnson
+Let There Be Peace On Earth|SSAA|S Alsbury
 Let There Be Peace On Earth|SSAA|Sylvia Alsbury
 Let There Be Peace On Earth|SSAA|Tom Gentry
 Let There Be Peace On Earth|TTBB|Dennis Driscoll
@@ -10752,12 +12780,16 @@ Let There Be Peace On Earth|TTBB|Kohl Kitzmiller
 Let There Be Peace On Earth|TTBB|M. Gill
 Let There Be Peace On Earth|TTBB|Mel Knight
 Let There Be Peace On Earth|TTBB|Paul C. Olguin
+Let There Be Peace On Earth|TTBB|Ralph Aldridge
 Let There Be Peace On Earth|TTBB|Roger Blackburn
 Let There Be Peace On Earth|TTBB|Thomas Gentry
 Let There Be Peace On Earth|TTBB|Tom Gentry
 Let There Be Peace On Earth|TTBB|Wilburn Elrod
 Let There Be Peace On Earth|TTBB|William Behrendt
+Let There Be Peace On Earth (8-Part Mixed)|SATB|David Harrington
+Let There Be Peace On Earth (SATB)|SATB|Tom Gentry
 Let Tonight Be The Night|SSAA|Dot Calvin
+Let Us Break Bread Together|TTBB|Lloyd Erickson
 Let Us Entertain You / It's A Good Day Medley|TTBB|Sonny Steffon
 Let Us Sing (A Show Opener)|SSAA|Peg Millard
 Let You Break My Heart Again|SATB|Andrew Wittenberg
@@ -10771,7 +12803,9 @@ Let Yourself Go|SSAA|Kyle Snook
 Let Yourself Go|SSAA|Larry Wright
 Let Yourself Go|TTBB|David Wright
 Let Yourself Go|TTBB|Larry Wright
+Let Yourself Go / Crazy Rhythm Medley|TTBB|Dave Ebersole
 Let Yourself Go/Crazy Rhythm Medley|TTBB|David Ebersole
+Let Yourself Go/Doin' the New Low Down|SSAA|Dave Briner
 Let Yourself Go/Stepping Out With My Baby|SSAA|Larry Wright
 Let Yourself Go/Stepping Out With My Baby|TTBB|Larry Wright
 Let's All Go Down to the Old Barber Shop|TTBB|Tom Gentry
@@ -10779,10 +12813,13 @@ Let's All Sing Like The Birdies Sing|SSAA|Zona Snyder
 Let's Be Bad|SATB|Melody Hine
 Let's Be Buddies|SSAA|David Briner
 Let's Be Buddies|TTBB|David Briner
+Let's Burn Up the Town|SSAA|Anthony Nasto
 Let's Burn Up The Town|TTBB|Adam Reimnitz
+Let's Burn Up The Town|TTBB|Tony Nasto
 Let's Call The Whole Thing Off|SATB|Gene Cokeroft
 Let's Call The Whole Thing Off|SSAA|Carolyn Schmidt
 Let's Call The Whole Thing Off|SSAA|Joe Mannherz
+Let's Call The Whole Thing Off|TTBB|Hal Maples
 Let's Call The Whole Thing Off|TTBB|Joe Mannherz
 Let's Call The Whole Thing Off|TTBB|Steve Jamison
 Let's Call The Whole Thing Off|TTBB|Walter Latzko
@@ -10794,6 +12831,9 @@ Let's Do It (Let's Fall In Love)|TTBB|David Briner
 Let's Do It (Let's Fall In Love)|TTBB|John Brockman
 Let's Do It (Let's Fall In Love) / Let's Misbehave Medley|TTBB|Matthew Gallagher
 Let's Do It Again|TTBB|Tom Gentry
+Let's Do It, Let's Fall in Love|SSAA|Lynnell Diamond
+Let's Do It, Let's Fall In Love|SSAA|John Brockman
+Let's Do It/Let's Misbehave (Medley)|TTBB|Matt Gallagher
 Let's Elope|SSAA|Carolyn Schmidt
 Let's Face The Music And Dance|SSAA|David Wright
 Let's Face The Music And Dance|SSAA|Liz Garnett
@@ -10801,6 +12841,7 @@ Let's Face The Music And Dance|TTBB|Kohl Kitzmiller
 Let's Face The Music And Dance|TTBB|Liz Garnett
 Let's Face The Music And Dance|TTBB|Walter Latzko
 Let's Face The Music And Dance (from Follow The Fleet)|TTBB|Wayne Grimmer
+Let's Face The Music And Dance-Cheek To Cheek Medley(Andrew Ho|TTBB|Andrew Howson
 Let's Fall In Love|TTBB|Kevin Keller
 Let's Gather Round The Parlor Piano|SSAA|Michael Hengelsberg
 Let's Get Away From It All|SATB|Joe Mannherz
@@ -10814,8 +12855,11 @@ Let's Get Away From It All|TTBB|Kevin Keller
 Let's Get Away From It All|TTBB|Larry Wright
 Let's Get Away From It All|TTBB|Mark Goodney
 Let's Get Away From It All|TTBB|Rob Hopkins
+Let's Get Away From It All (Canadian)|TTBB|Rob Hopkins
 Let's Get It On|TTBB|Deke Sharon
 Let's Get Lost|TTBB|Andrew Carolan
+Let's Get Together Again / Keep the Whole World Singing|SSAA|Unspecified
+Let's Get Together Again/Keep The Whole World Singing|TTBB|Joseph Stern/Bill Diekema/SPEBSQSA
 Let's Go Fly a Kite|SSAA|Nick Bryant
 Let's Go Fly a Kite|TTBB|Liz Garnett
 Let's Go Fly a Kite|TTBB|Nick Bryant
@@ -10853,9 +12897,11 @@ Let's Misbehave|TTBB|Adam Scott
 Let's Misbehave|TTBB|Harry Swenson
 Let's Misbehave|TTBB|Walter Latzko
 Let's Sing Again|SSAA|David Wright
+Let's Sing Again|TTBB|David Wright
 Let's Sing Again Medley|SSAA|Tom Gentry
 Let's Sing An Old Time Song|SSAA|Renee Craig
 Let's Start the New Year Right|SSAA|Larry Wright
+Let's Start The New Year Right/Auld Lang Syne (Medley)|TTBB|Bryan Ziegler
 Let's Start Tomorrow Tonight|SATB|Kevin Keller
 Let's Start Tomorrow Tonight|SSAA|Joe Mannherz
 Let's Start Tomorrow Tonight|SSAA|Kevin Keller
@@ -10865,23 +12911,33 @@ Let's Start Tomorrow Tonight|TTBB|Theo Hicks
 Let's Start Tomorrow Tonight|TTBB|Theodore Hicks
 Let's Stay Together|TTBB|Adam Bock
 Let's Take A Walk|TTBB|Michael Webber
+Let's Talk About My Sweetie|SSAA|Nancy Bergman
 Let's Talk About My Sweetie|TTBB|Barbershop Harmony Society
 Let's Talk About My Sweetie|TTBB|John Piercy
 Let's Talk About My Sweetie|TTBB|SPEBSQSA
 Let's Talk About My Sweetie|TTBB|Unknown
 Let's Talk About My Sweetie / Ain't She Sweet Medley|TTBB|John Hohl
 Let's Talk About MY Sweetie / Yessir That's My Baby|SSAA|Nancy Bergman
+Let's Talk About My Sweetie/Yes Sir That's My Sweetie|SSAA|Nancy Bergman
 Let's Twist Again|SSAA|Carole Prietto
 Let's Twist Again|SSAA|Takako Fuke
 Let's Twist Again|TTBB|Carole Prietto
 Let's Twist Again|TTBB|Kevin Koehl
+Lets Burn Up the Town|SSAA|Tony Nasto
 Levitating|SATB|Nicholas Wright
 Li'l Red Riding Hood|SATB|Deke Sharon
 Liability|SATB|Nicholas Wright
+Liar Medley|SATB|Nancy Bergman
+Liar Medley|SSAA|Renee Craig
 Liar Medley|TTBB|Renee Craig
+Liar Medley|TTBB|Unspecified
+Liar Medley Parody|TTBB|Unspecified
 Liar With An Achin' Breakin' Heart Medley|TTBB|David Wright
+Liar/Angry Medley|SSAA|Marge Bailey/Bea Howley
 Lida Rose|TTBB|Floyd Connett
 Lida Rose|TTBB|Larry Wright
+Lida Rose|TTBB|Meredith Willson
+Lida Rose|TTBB|Nancy Bergman
 Lida Rose|TTBB|SPEBSQSA
 Lida Rose|TTBB|Walter Latzko
 Lida Rose (from "The Music Man")|TTBB|Floyd Connett
@@ -10892,9 +12948,12 @@ Lida Rose / Will I Ever Tell You|SSAA|Nancy Bergman
 Lida Rose / Will I Ever Tell You|TTBB|Floyd Connett
 Lida Rose / Will I Ever Tell You|TTBB|Nancy Bergman
 Lida Rose Opener|TTBB|Kirk Roose
+Lida Rose Will I Ever Tell You?|SATB|Meredith Willson
 Lida Rose/Dream Of Now|SATB|Larry Wright
 Lida Rose/Dream Of Now|SSAA|Larry Wright
 Lida Rose/Dream Of Now|TTBB|Larry Wright
+Lida Rose/Will I Ever Tell You|TTBB|Meredith Willson
+Lida Rose/Will I Never Tell You|SATB|Nancy Bergman
 Life In A Northern Town|TTBB|Mark Stevens
 Life In Technicolor II|TTBB|Jon Nicholas
 Life In Technicolor II|TTBB|Nicholas Wright
@@ -10909,6 +12968,7 @@ Life Upon The Wicked Stage-Ain't Nothing For A Girl|SSAA|Walter Latzko
 Life's A Happy Song|TTBB|Aaron Dale
 Life's Railway To Heaven|TTBB|Jim West
 Lift Every Voice And Sing|SATB|Jon Nicholas
+Lift Every Voice And Sing|TTBB|Dan Tice
 Light My Fire|TTBB|David Wright
 Light Of A Clear Blue Morning|SSAA|Cay Outerbridge
 Light Of A Clear Blue Morning|SSAA|Kohl Kitzmiller
@@ -10916,6 +12976,7 @@ Light One Candle|SSAA|Carole Prietto
 Light One Candle|SSAA|Carolyn Schmidt
 Light One Candle|SSAA|Jay Giallombardo
 Light One Candle|SSAA|Muriel Berg
+Light One Candle|TTBB|Carole Prietto
 Light One Candle|TTBB|Jay Giallombardo
 Light The Candles|SSAA|Tedda Lippincott
 Light The Legend|SSAA|Jay Giallombardo
@@ -10930,6 +12991,7 @@ Like A Prayer|SSAA|Carole Prietto
 Like A Prayer|SSAA|Dawn Haggerty
 Like A Prayer|TTBB|Melody Hine
 Like A Sad Song|TTBB|Ken Potter
+Like An Eagle|SSAA|Jim Arns
 Like I Can|SATB|Nicholas Wright
 Like I Can|SSAA|Nicholas Wright
 Like I'm Gonna Lose You|SATB|Anders Lindqvist
@@ -10939,12 +13001,14 @@ Like It's Christmas|SATB|Joe Mannherz
 Like It's Christmas|SSAA|Joe Mannherz
 Like It's Christmas|TTBB|Joe Grimme
 Like It's Christmas|TTBB|Joe Mannherz
+Like Someone In Love|TTBB|Adam Reimnitz
 Like The Rain|TTBB|Jeremey Johnson
 Lil Darlin'|TTBB|Jim Shubert
 Lil Darlin'|TTBB|Wayne Grimmer
 Lil From Daffodil Hill|TTBB|Louis Perry
 Lili Marlene|SSAA|Nancy Bergman
 Lili Marlene|TTBB|Brent Graham
+Lili Marlene|TTBB|Knights of Harmony
 Lili Marlene|TTBB|Tom Gentry
 Lily's Eyes|TTBB|Wayne Grimmer
 Lime Jello Marshmallow Cottage Cheese Surprise|SSAA|Marie Johnson
@@ -10962,22 +13026,28 @@ Lion Sleeps Tonight|SATB|Deke Sharon
 Lion Sleeps Tonight|SATB|Scott Turnbull
 Lion Sleeps Tonight|SSAA|Charlene Yazurlo
 Lion Sleeps Tonight|SSAA|Joey Minshall
+Lion Sleeps Tonight|SSAA|Lorraine Rochefort
 Lion Sleeps Tonight|SSAA|Molly Clark
 Lion Sleeps Tonight|SSAA|Scott Turnbull
 Lion Sleeps Tonight|SSAA|Tedda Lippincott
 Lion Sleeps Tonight|TTBB|Scott Turnbull
 Lion Sleeps Tonight|TTBB|Thomas Degan
+Lion Sleeps Tonight (The) SATB|SATB|Anne Raugh and Seke Sharon
+Lion Sleeps Tonight, The (Wimoweh)|TTBB|Ron Smail
 Listen|SSAA|Liz Garnett
 Listen|TTBB|Theodore Hicks
 Listen (from Dreamgirls)|TTBB|Theo Hicks
 Listen To My Heart|SSAA|Larry Wright
 Listen To My Heart|SSAA|Michael Gellert
+Listen To That Dixie Band|SSAA|Greg Volk
 Listen To That Dixie Band|SSAA|Melvin Knight
 Listen To That Dixie Band|TTBB|Mel Knight
 Listen To That Dixie Band|TTBB|Melvin Knight
 Listen to the Dawn|SATB|Joe Mannherz
+Listen to the Music|SSAA|Sharon Holmes
 Listen To The Music|SSAA|Liz Garnett
 Listen To The Music|TTBB|Aaron Dale
+Listen To The Music (Doobie Brothers)|SSAA|Liz Garnett
 Listen to your Heart|SSAA|Deke Sharon
 Listening|TTBB|Dennis Driscoll
 Little Arrows|SSAA|Kathy Barnett
@@ -10993,6 +13063,7 @@ Little Bit Of Heaven|TTBB|Keith Hamilton
 Little Bit Of Heaven|TTBB|Steve Jamison
 Little bitty pretty one|SATB|Joe Mannherz
 Little Black Dress|SATB|Hannah Braham
+Little Black Me (Lead Melody Tag)|TTBB|Tom Gentry
 Little Blue|SSAA|Sheryl Neal
 Little Boy|SSAA|Michael Gellert
 Little Boy Blue|SSAA|Marie Johnson
@@ -11007,9 +13078,11 @@ Little Brown Church in the Vale|TTBB|Willis Diekema
 Little Bunch Of Shamrocks|TTBB|Toban Dvoretsky
 Little Curly Hair In A High Chair|TTBB|Steve Hardy
 Little Darlin'|SATB|Joe Mannherz
+Little Darlin'|TTBB|J. McCready
 Little Darlin'|TTBB|Tom Gentry
 Little Devil|TTBB|Jeremey Johnson
 Little Drummer Boy|SSAA|Joey Minshall
+Little Drummer Boy|SSAA|Tedda Lippincott
 Little Drummer Boy|TTBB|Adam Scott
 Little Drummer Boy|TTBB|Bruce Early
 Little Drummer Boy|TTBB|David Wright
@@ -11019,15 +13092,20 @@ Little Drummer Boy|TTBB|Jon Nicholas
 Little Drummer Boy|TTBB|M. Gill
 Little Drummer Boy|TTBB|Todd Troutman
 Little Drummer Boy|TTBB|Tracy Shirk
+Little Drummer Boy / Peace On Earth|TTBB|Jay Giallombardo
+Little Drummer Boy & Silent Night Medley|SSAA|Rosey Frerking
+Little Drummer Boy/Peace on Earth|SSAA|Joey Minshall
 Little Girl|SSAA|David Wallace
 Little Girl|SSAA|Mac Huff
 Little Girl|SSAA|Tom Gentry
+Little Girl|TTBB|Lou Perry
 Little Girl|TTBB|Mac Huff
 Little Girl|TTBB|Todd Troutman
 Little Girl|TTBB|Tom Gentry
 Little Girl From Little Rock|SSAA|Walter Latzko
 Little Girl Lost|SATB|David Avshalomov
 Little Gomez|SSAA|Lyndal Thorburn
+Little Gray Donkey|SSAA|Avis Fellows
 Little Green Apples|SSAA|Larry Wright
 Little Green Apples|TTBB|Gerald Hooper
 Little Green Apples|TTBB|Larry Wright
@@ -11084,12 +13162,14 @@ Little Patch Of Heaven|SSAA|Michael Gellert
 Little Patch Of Heaven|TTBB|Aaron Dale
 Little Patch Of Heaven|TTBB|Dennis Driscoll
 Little Patch Of Heaven|TTBB|Mark Goodney
+Little Rascals Medley|TTBB|Greg Volk
 Little Red Riding Hood|TTBB|Adam Scott
 Little Red Riding Hood|TTBB|Steve Jamison
 Little Red Riding Hood|TTBB|Tom Gentry
 Little Red School|TTBB|Todd Troutman
 Little Saint Nick|SATB|Deke Sharon
 Little Saint Nick|SATB|Kevin Keller
+Little Saint Nick|SSAA|Ann Minihane
 Little Saint Nick|SSAA|Barbara McNeill
 Little Saint Nick|SSAA|Dianne Goldrick
 Little Saint Nick|SSAA|Jon Nicholas
@@ -11104,6 +13184,8 @@ Little Saint Nick|TTBB|Steve Jamison
 Little Secrets|SATB|Deke Sharon
 Little Shop Of Horrors|SSAA|Ken Potter
 Little Skipper|TTBB|Robert Strand
+Little Snow Girl|TTBB|Jim Clancy
+Little St Nick|TTBB|Steve Jamison
 Little Street Where Old Friends Meet|TTBB|Burt Szabo
 Little Street Where Old Friends Meet|TTBB|Jay Giallombardo
 Little Street Where Old Friends Meet|TTBB|Sam Breedon
@@ -11111,6 +13193,7 @@ Little Things Mean A Lot|SSAA|June Dale
 Little Things Mean A Lot|TTBB|Bob Biallas
 Little Things Mean A Lot|TTBB|Dennis Driscoll
 Little Things Mean A Lot|TTBB|Michael Webber
+Little Tin Box|TTBB|Gene Cokeroft
 Little Tin Box|TTBB|Walter Latzko
 Little Town In Ould County Down|TTBB|Larry Newth
 Little Town In Ould County Down|TTBB|Louis Perry
@@ -11121,6 +13204,7 @@ Little White Lies|TTBB|Bill Pellant
 Little White Lies|TTBB|Walter Latzko
 Live and Let Die|TTBB|Deke Sharon
 Live and Let Die|TTBB|Liz Garnett
+Live And Let Die|TTBB|Stefan Pugliese
 Live Like an Angel|TTBB|Tom Gentry
 Live Like We're Dying|SATB|Deke Sharon
 Live Like You Were Dying|TTBB|Gary Thiel
@@ -11138,16 +13222,25 @@ Lo How a Rose Ere Blooming|SSAA|Diane Clark
 Lo How a Rose Ere Blooming|SSAA|Glenda Lloyd
 Lo How a Rose Ere Blooming|TTBB|Gabriel Lawson
 Lo How a Rose Ere Blooming|TTBB|Walter Latzko
+Lo, How a Rose E'er Blooming|TTBB|Alice Parker and Robert Shaw
+Lo, How a Rose E'er Blooming|TTBB|Barbershop Harmony Society
 Lo! How A Rose|SSAA|Carolyn Johnson
 Lo! How A Rose|SSAA|Jay Giallombardo
 Lo! How A Rose|TTBB|Jay Giallombardo
 Lo! How A Rose|TTBB|Jeremey Johnson
 Loading Up The Mandy Lee|TTBB|Dennis Driscoll
 Loading Up The Mandy Lee|TTBB|Don Gray
+Loch Lomond|SATB|Jonathan Quick
 Loch Lomond|SSAA|Steve Tramack
+Loch Lomond|TTBB|David Overton
+Loch Lomond|TTBB|Jonathan Quick
+Loch Lomond|TTBB|Peter Bryant
+Loch Lomond|TTBB|Ralph Vaughan Williams
 Loch Lomond|TTBB|Steve Tramack
+Loch Lomond|TTBB|Unspecified
 Lock My Heart / Goody Goody Medley|SSAA|Jo Lund
 Locked Out Of Heaven|SATB|Deke Sharon
+Locked Out Of Heaven|SATB|Henrik Rosenberg
 Locked Out Of Heaven|SATB|Nicholas Wright
 Lois|TTBB|Jim Shubert
 Lollipop|SSAA|Anna Maria Parker
@@ -11167,10 +13260,12 @@ Lonely Nights Medley|TTBB|David Wright
 Lonely No More|TTBB|Deke Sharon
 Lonely People Do Foolish Things|SSAA|Sylvia Alsbury
 Lonely Road With Jelly Roll|SATB|Mark Stevens
+Lonely Town|TTBB|Jay Giallombardo
 Lonesome|SSAA|Jo Lund
 Lonesome - That's All|TTBB|Norm Duggan
 Lonesome - That's All|TTBB|Wes Farmer
 Lonesome Looser|SATB|Joe Mannherz
+Lonesome Road|TTBB|Mike Menefee
 Lonesome Suzie|TTBB|Joe Mannherz
 Lonesomest Girl In Town|SSAA|Jay Giallombardo
 Lonesomest Girl In Town|SSAA|Joni Bescos
@@ -11180,6 +13275,8 @@ Lonesomest Girl In Town|TTBB|David Harrington
 Lonesomest Girl In Town|TTBB|Jack Clark
 Lonesomest Girl In Town|TTBB|SPEBSQSA
 Lonesomest Girl In Town|TTBB|Steve Jamison
+Lonesomest Girl in Town (You're the)|SSAA|Clay Hine
+Lonesomest Girl in Town (You're the)|SSAA|Joni Bescos
 Long Ago (And Far Away)|SSAA|Cheryl Suhr
 Long Ago (And Far Away)|SSAA|Dede Nibler
 Long Ago (And Far Away)|SSAA|Diane Clark
@@ -11193,6 +13290,7 @@ Longer|SSAA|Betty Oliver
 Longer|SSAA|Diane Buschel
 Longer|SSAA|Linda Edmondson
 Longer|TTBB|III Eddie Holmes
+Longest Time (The)|SATB|Tom Gentry
 Look At That Face|SSAA|Tedda Lippincott
 Look At Us|SSAA|Tedda Lippincott
 Look For Me At Jesus Feet|SSAA|Janice Wheeler
@@ -11211,6 +13309,7 @@ Look For The Silver Lining|TTBB|Dan Jimenez
 Look For The Silver Lining|TTBB|Hal Snyder
 Look For The Silver Lining|TTBB|Howard Dale
 Look For The Silver Lining|TTBB|Walter Latzko
+Look Me Up When You're In Dixie|TTBB|Renee Craig
 Look Out World|TTBB|Melvin Knight
 Look Out World / Powder Your Face With Sunshine Medley|TTBB|Mel Knight
 Look Out, World!|TTBB|Mel Knight
@@ -11218,6 +13317,9 @@ Look To The Rainbow|TTBB|Clay Hine
 Look To The Rainbow|TTBB|Mark Goodney
 Look What The Dog Drug In|TTBB|Michael Webber
 Look Who's Laughing Now|TTBB|Anders Lindqvist
+Lookin At the World Thru Rose Colored Glasses|SSAA|Renee Craig
+Lookin' At The World Through Rose Colored Glasses(Greg|TTBB|Greg Lyne
+Lookin' At The World Thru Rose Colored Glasses|TTBB|David Wright
 Looking At The Rain And Missing You|SSAA|Marie Johnson
 Looking At The World Through Rose Colored Glasses|SSAA|David Wright
 Looking At The World Through Rose Colored Glasses|TTBB|Chuck Williams
@@ -11230,9 +13332,13 @@ Looking At The World Through Rose Colored Glasses|TTBB|Johann Stoessel
 Looking At The World Through Rose Colored Glasses|TTBB|Mark Freedkin
 Looking At The World Through Rose Colored Glasses|TTBB|Sherry Brown
 Looking At The World Through Rose Colored Glasses|TTBB|Ted Cobb
+Looking At The World Through Rose Colored Glasses(David Wr|TTBB|David Wright
+Looking at the World through Rose Coloured Glasses|TTBB|Ed Waesche
+Looking at the World thru Rose Colored Glasses|TTBB|Ed Waesche
 Looking at You/I Love You Medley|TTBB|Brent Graham
 Looking For A Boy|SSAA|David Harrington
 Looking For A City|TTBB|Mason Eubank
+Looking Through the Eyes of Love|SATB|John Hohl
 Looking Through The Eyes Of Love|SSAA|June Berg
 Looking Through The Eyes Of Love|TTBB|Ed Hinkley
 Looking Through The Eyes Of Love|TTBB|John Hohl
@@ -11240,6 +13346,7 @@ Lookout, Here Comes My Cookie|TTBB|Larry Hull
 Looks Like You Started Something|SSAA|Adam Scott
 Looks Like You've Started Something|SSAA|Adam Scott
 Looks Like You've Started Something|TTBB|Adam Scott
+Lora-Belle Lee|TTBB|Dave Briner
 Lora-Belle Lee|TTBB|David Briner
 Lora-Belle Lee (aka "Lorabelle Lee")|TTBB|Dave Briner
 Lorabelle Lee|TTBB|Dave Calland
@@ -11269,17 +13376,20 @@ Losing My Mind|TTBB|Simon Arnott
 Losing My Mind|TTBB|Theodore Hicks
 Losing My Mind (from Follies)|TTBB|Theo Hicks
 Losing You|TTBB|Mark Burnip
+Lost|TTBB|Soren Wohlers
 Lost (A Wonderful Girl)|TTBB|Robert Rund
 Lost Boy|SATB|Nicholas Wright
 Lost Boy|TTBB|Nicholas Wright
 Lost In Loveliness|TTBB|Walter Latzko
 Lost In My Dreams|SSAA|Linda Edmondson
+Lost In the Fifties Tonight|SSAA|Joe Liles
 Lost In The Fifties Tonight (In The Still Of The Nite)|SSAA|Joe Liles
 Lost In The Heart Of My Own Home Town|TTBB|James Moore
 Lost In The Heart Of My Own Home Town|TTBB|Renee Craig
 Lost In The Music|SSAA|Paul Jorg
 Lost In The Music|TTBB|Paul Jorg
 Lost In The Stars|SATB|Tom Gentry
+Lost In The Stars|TTBB|Buzz Haeger
 Lost In The Stars|TTBB|Dennis Driscoll
 Lost In The Stars|TTBB|Jim West
 Lost In The Stars|TTBB|Tom Gentry
@@ -11301,6 +13411,7 @@ Lounging At The Waldorf|SSAA|David Wright
 Love|TTBB|Kohl Kitzmiller
 Love (Jesu, Joy Of Man's Desiring)|TTBB|Derric Johnson
 Love Again|SSAA|Larry Wright
+Love and Marriage|SSAA|June Dale
 Love and Marriage|SSAA|Marsha Zwicker
 Love and Marriage|TTBB|Jim Shubert
 Love At Home|TTBB|Brent Graham
@@ -11312,13 +13423,20 @@ Love Can Turn The World|SSAA|Steve Tramack
 Love Changes Everything|SSAA|Tom Gentry
 Love Changes Everything|TTBB|Tom Gentry
 Love Don't Need A Reason|SSAA|Carole Prietto
+Love Eyes Medley|SSAA|David Wright
+Love Eyes Medley|SSAA|Unspecified
+Love In A Home|SSAA|Jay Giallombardo
 Love in a Home (You Can Tell When There's)|SSAA|Becky Cartine
 Love in a Home (You Can Tell When There's)|SSAA|Jay Giallombardo
 Love in a Home (You Can Tell When There's)|TTBB|Jay Giallombardo
 Love In Any Language|SSAA|Avis Fellows
+Love In Any Language|SSAA|Dave Briner
+Love In Any Language|SSAA|Dave Briner Tom Gentry
 Love In Any Language|SSAA|David Briner
 Love In Any Language|TTBB|Derric Johnson
+Love in Any Language (solo and chorus)|SSAA|Dave Briner
 Love In Bloom|TTBB|Walter Latzko
+Love is a Many Splendored Thing|SSAA|Dave Briner
 Love Is A Many Splendored Thing|SSAA|Brent Graham
 Love Is A Many Splendored Thing|SSAA|David Briner
 Love Is A Many Splendored Thing|SSAA|Jay Giallombardo
@@ -11337,6 +13455,7 @@ Love Is Friendship Set To Music|SSAA|Marie Johnson
 Love Is Here To Stay|SSAA|David Wright
 Love Is Here To Stay|SSAA|Dianne Goldrick
 Love Is Here To Stay|TTBB|Dennis Malone
+Love Is Here To Stay|TTBB|Ed Waesche
 Love Is Here To Stay|TTBB|Rob Hopkins
 Love Is Here To Stay|TTBB|Steve Jamison
 Love Is Here To Stay|TTBB|Walter Latzko
@@ -11356,6 +13475,7 @@ Love Led Us Here|TTBB|Jack Bridges
 Love Letters|SSAA|Carolyn Healey
 Love Letters|SSAA|Debbie Keretz
 Love Letters|SSAA|Fred King
+Love Letters|SSAA|Jim Arns
 Love Letters|SSAA|June Berg
 Love Letters|TTBB|Jim Shubert
 Love Letters|TTBB|John Piercy
@@ -11363,8 +13483,10 @@ Love Letters|TTBB|Stephen Delehanty
 Love Letters|TTBB|Steve Delehanty
 Love Letters In The Sand|TTBB|Dennis Driscoll
 Love Letters In The Sand|TTBB|Joe Mannherz
+Love Letters Straight From Your Heart|SSAA|Jim Arns
 Love Letters Straight From Your Heart|SSAA|Joe Mannherz
 Love Letters Straight From Your Heart|TTBB|Joe Mannherz
+Love Letters Straight From Your Heart|TTBB|Steve Delehanty
 Love Lifted Me|SSAA|Marie Johnson
 Love looks so well on you|TTBB|Joe Mannherz
 Love Me|SSAA|Aaron Dale
@@ -11382,6 +13504,7 @@ Love Me And The World Is Mine|TTBB|Jay Giallombardo
 Love Me And The World Is Mine|TTBB|Roger Payne
 Love Me And The World Is Mine|TTBB|SPEBSQSA
 Love Me And The World Is Mine|TTBB|the Barbershop Harmony Society
+Love Me as Though There Were No Tomorrow|SSAA|Lorraine Rochefort
 Love Me in December/September Song Medley|SSAA|Jay Giallombardo
 Love Me in December/September Song Medley|TTBB|Jay Giallombardo
 Love Me Like A Rock|TTBB|Deke Sharon
@@ -11389,9 +13512,11 @@ Love Me Like You Do|SATB|Nicholas Wright
 Love Me Like You Do|SSAA|Nicholas Wright
 Love Me or Leave Me|SATB|Joe Mannherz
 Love Me or Leave Me|TTBB|Patrick McAlexander
+Love Me Or Leave Me|TTBB|Janne Olsson
 Love Me or Leave Me (from "Whoopee!")|TTBB|Patrick McAlexander
 Love Me Tender|SSAA|Bev Sellers
 Love Me Tender|SSAA|David Wright
+Love Me Tender|SSAA|Lorraine Rochefort
 Love Me Tender|SSAA|Norma Andersen
 Love Me Tender|SSAA|Tom Gentry
 Love Me Tender|TTBB|David Wright
@@ -11402,9 +13527,12 @@ Love Me With All Your Heart|SSAA|Carolyn Schmidt
 Love Me With All Your Heart|SSAA|LaVeda Redfield
 Love Me With All Your Heart|SSAA|Mary Lou Gomez-Leon
 Love Me With All Your Heart|SSAA|Nancy Bergman
+Love Me, And The World Is Mine|SSAA|David Wright
+Love Medley|SSAA|Marsha Zwicker
 Love Medley|TTBB|Robert Rund
 Love Medley (I Have A Love/One Hand, One Heart)|TTBB|Kirk Young
 Love Never Fails|TTBB|Deke Sharon
+Love of My Life|TTBB|Dale Kynaston
 Love Of My Life|SATB|Anders Lindqvist
 Love Of My Life|SSAA|Alex Kaiserman
 Love Of My Life|SSAA|Anders Lindqvist
@@ -11412,6 +13540,8 @@ Love Of My Life|SSAA|David Wright
 Love Of My Life|TTBB|Anders Lindqvist
 Love Of My Life|TTBB|Jay Giallombardo
 Love Of My Life|TTBB|Luke Stevenson
+Love Of My Life (Queen)|SSAA|Unspecified
+Love of My Live|SSAA|David Wright
 Love On The Rocks|SATB|Grant Goulding
 Love On Top|SATB|Aaron Dale
 Love On Top|SATB|Deke Sharon
@@ -11419,6 +13549,7 @@ Love On Top|SSAA|Aaron Dale
 Love On Top|SSAA|Deke Sharon
 Love On Top|SSAA|Melody Hine
 Love On Top|TTBB|Nicholas Wright
+Love Potion #9|SSAA|June Dale
 Love Potion No. 9|SSAA|Carolyn Johnson
 Love Potion No. 9|SSAA|Connie Nickel
 Love Potion No. 9|SSAA|Joey Minshall
@@ -11435,23 +13566,29 @@ Love Story|TTBB|Simon Arnott
 Love Story|TTBB|Theo Hicks
 Love Story|TTBB|Theodore Hicks
 Love Story (Where Do I Begin)|TTBB|Dennis Driscoll
+Love That Ragtime|TTBB|Jay Giallombardo
 Love The One You're With|SSAA|Deke Sharon
 Love The One You're With|SSAA|Joe Liles
 Love The One You're With|TTBB|Adam Bock
 Love The Way You Lie, Pt. 2|SSAA|Nicholas Wright
+Love the World Away|SSAA|Avis Fellows
 Love The World Away|SSAA|Kay Bromert
 Love Today|SSAA|Deke Sharon
 Love Walked In|SSAA|Anastasio Rossi
 Love Walked In|SSAA|David Wright
 Love Walked In|SSAA|Joe Mannherz
+Love Walked In|SSAA|Nancy Bergman
 Love Walked In|TTBB|Anastasio Rossi
 Love Walked In|TTBB|David Wright
 Love Walked In|TTBB|Jim Shubert
 Love Walked In|TTBB|Joe Mannherz
+Love Walked In|TTBB|Stash Rossi
 Love Was Waiting Here|SATB|Richard Curtis
+Love Will Be Our Home|SSAA|Bob Rund
 Love Will Be Our Home|SSAA|Kim Andrews
 Love Will Be Our Home|SSAA|Robert Rund
 Love Will Come To You|TTBB|Deke Sharon
+Love Will Keep Us Together|SSAA|Renee Craig
 Love Without End, Amen|TTBB|Darwin Scheel
 Love Won't Let You Get Away|TTBB|Mark Goodney
 Love You Anymore|TTBB|Liz Garnett
@@ -11465,10 +13602,12 @@ Love's Been Good To Me|TTBB|Douglas Smith
 Love's In Need Of Love Today|SATB|Anders Lindqvist
 Love's Old Sweet Song|SATB|Derric Johnson
 Love's Old Sweet Song|SSAA|Anna Maria Parker
+Love's Old Sweet Song|SSAA|Clay Hine
 Love's Old Sweet Song|SSAA|Emily Moriarty
 Love's Old Sweet Song|SSAA|Floyd Connett
 Love's Old Sweet Song|SSAA|Joe Liles
 Love's Old Sweet Song|SSAA|Val Hicks
+Love's Old Sweet Song|TTBB|Clay Hine
 Love's Old Sweet Song|TTBB|Ed Waesche
 Love's Old Sweet Song|TTBB|George Booth
 Love's Old Sweet Song|TTBB|Tom Gentry
@@ -11487,6 +13626,8 @@ Lovely Way To Spend An Evening|SSAA|Larry Wright
 Lovely Way To Spend An Evening|TTBB|Joe Mannherz
 Lovely Way To Spend An Evening|TTBB|Larry Wright
 Lover|TTBB|Ed Waesche
+Lover Come Back|SSAA|Ed Waesche
+Lover Come Back|TTBB|Ed Waesche
 Lover Come Back To Me|SSAA|Ed Waesche
 Lover Come Back To Me|SSAA|Jay Giallombardo
 Lover Come Back To Me|SSAA|Nancy Bergman
@@ -11494,6 +13635,8 @@ Lover Come Back To Me|SSAA|Rebecca J. Wood
 Lover Come Back To Me|TTBB|Ed Waesche
 Lover Come Back To Me|TTBB|Frank De Wolfe
 Lover Come Back To Me|TTBB|Jay Giallombardo
+Lover, Come Back to Me|SSAA|Ed Waesche
+Lover, Come Back To Me|TTBB|Ed Waesche
 Lover's Lane Is Crowded Again|SSAA|Larry Wright
 Lover's Lane Is Crowded Again|TTBB|Larry Wright
 Lovers In A Dangers Time|TTBB|Mark Stevens
@@ -11505,13 +13648,17 @@ Lovesick Blues|TTBB|Tom Gentry
 Lovesick Blues|TTBB|Walter Latzko
 Lovin' Life|TTBB|Adam Bock
 Lovin', Touchin', Squeezin'|TTBB|Dan Wessler
+Loving You|SSAA|Lorraine Rochefort
 Loving You|TTBB|Ralph Urquhart
 Lovingless Day|TTBB|Walter Latzko
 Low Down Rhythm|SSAA|Barbara McNeill
+Low Gravy|SSAA|Walter Latzko
 Lower Case Love|SSAA|Joe Mannherz
 Lower Case Love|TTBB|Joe Mannherz
+Lu Lu's Back In Town|TTBB|Ed Waesche
 Lucille|SSAA|Dan Wessler
 Lucille|TTBB|Eric Ruthenberg
+Luck Be a Lady|TTBB|Walter Latzko ed. Mark Hale
 Luck Be A Lady|SSAA|Avis Fellows
 Luck Be A Lady|SSAA|Carolyn Schmidt
 Luck Be A Lady|SSAA|Dan Naumann
@@ -11534,23 +13681,32 @@ Lucky Day|TTBB|Jon Nicholas
 Lucky Day|TTBB|Lloyd Steinkamp
 Lucky Day|TTBB|Roy Keys
 Lucky Day|TTBB|Russ Foris
+Lucky Day (This is Some)|TTBB|Greg Volk
 Lucky Day (TTBB) (arr. BHS) - US Only|TTBB|TTBB Harmony Society
 Lucky Day / Lucky In Love Medley|TTBB|Ed Waesche
 Lucky Day/Innocent When You Dream|TTBB|Jordan Johnson
+Lucky Day/Sitting On Top of the World|SSAA|Nancy Bergman
+Lucky Old Sun|TTBB|David Wright
 Lucy In The Sky with Diamonds|SATB|Manoj Padki
 Luke's Desk|TTBB|Michael Webber
 Lulajze Jezuniu|TTBB|Jim West
+Lullaby|SSAA|Kirk Young
 Lullaby|TTBB|Jim West
 Lullaby|TTBB|Justin Miller
 Lullaby|TTBB|Todd Troutman
+Lullaby (Goodnight, My Angel)|TTBB|Kirk Young
 Lullaby for Baby Jesus|SSAA|Kevin Keller
 Lullaby for Baby Jesus|TTBB|Kevin Keller
 Lullaby For Christmas Eve|TTBB|Mark Goodney
 Lullaby In Ragtime|SSAA|Joe Mannherz
+Lullaby In Ragtime|SSAA|Nancy Bergman
 Lullaby In Ragtime|SSAA|Tom Gentry
+Lullaby In Ragtime|SSAA|Unspecified
+Lullaby In Ragtime|TTBB|Bill Mitchell
 Lullaby In Ragtime|TTBB|Dale Hanson
 Lullaby In Ragtime|TTBB|Joe Mannherz
 Lullaby In Ragtime|TTBB|Tom Gentry
+Lullaby In Ragtime|TTBB|Tom Gentry, Bill Mitchell
 Lullaby In Ragtime|TTBB|William Mitchell
 Lullaby League And Lollypop Guild|SATB|Kevin Keller
 Lullaby Medley|TTBB|J Rae Jamieson
@@ -11570,13 +13726,20 @@ Lullabye|SATB|Joe Mannherz
 Lullabye|SATB|Kirk Young
 Lullabye|SSAA|Cheryl Suhr
 Lullabye|SSAA|Deke Sharon
+Lullabye|SSAA|Kirby Shaw
 Lullabye|SSAA|Kirk Young
 Lullabye|SSAA|Susan Kegley
 Lullabye|TTBB|Kirk Young
+Lullabye (Goodnight My Angel) (Lower Lead Voicing Version)|SSAA|Kirk Young
 Lullabye (Goodnight, My Angel)|SATB|Kirk Young
+Lullabye (Goodnight, My Angel)|SSAA|Cheryl Suhr
 Lullabye (Goodnight, My Angel)|SSAA|Kirk Young
 Lullabye (Goodnight, My Angel)|TTBB|Kirk Young
+Lullabye in Ragtime|TTBB|Unspecified
+Lullabye Of Birdland|TTBB|Mark Hale
 Lullay My Liking|SATB|Joe Mannherz
+Lulu's Back in Town|SSAA|Nancy Bergman
+Lulu's Back In Town|SSAA|Bergman/Nightingale
 Lulu's Back In Town|SSAA|Jim Arns
 Lulu's Back In Town|SSAA|Judy Vidal
 Lulu's Back In Town|TTBB|Bob Jones
@@ -11586,8 +13749,11 @@ Lulu's Back In Town|TTBB|Ed Waesche
 Lulu's Back In Town|TTBB|Edward Boehm
 Lulu's Back In Town|TTBB|Kim Brittain
 Lulu's Back In Town|TTBB|Mike Bell
+Lux Aurumque|SATB|Eric Whitacre
+Lux Aurumque|TTBB|Eric Whitacre
 Lydia (The Tattooed Lady)|TTBB|Duane Enders
 Lydia (The Tattooed Lady)|TTBB|Lloyd Steinkamp
+Lydia the Tattooed Lady|TTBB|Lloyd Steinkamp
 Lyin' Eyes|SATB|Tom Gentry
 Lyin' Eyes|TTBB|Thomas Degan
 M-O-T-H-E-R|SSAA|Lauree Cogley
@@ -11598,6 +13764,9 @@ M-O-T-H-E-R|TTBB|Lloyd Steinkamp
 M-O-T-H-E-R|TTBB|Patrick McAlexander
 Ma Belle Evangeline|TTBB|Gabriel Lawson
 Ma Belle Evangeline|TTBB|Matt Astle
+Ma, She's Makin' Eyes At Me|TTBB|David Wallace
+Ma, She's Making Eyes At Me|TTBB|Chuck Morris
+Ma, They're Makin' Eyes At Me|TTBB|David Wallace
 Ma!|TTBB|Jeff Taylor
 Ma! (He's Making Eyes At Me)|SSAA|Anastasio Rossi
 Ma! (He's Making Eyes At Me)|SSAA|Dave Stevens
@@ -11609,7 +13778,9 @@ Ma! (She's Makin' Eyes At Me)|TTBB|Harry Swenson
 Ma! (She's Makin' Eyes At Me)|TTBB|Jeff Taylor
 Ma! (She's Makin' Eyes At Me)|TTBB|Mo Rector
 Ma! (She's Making Eyes at Me)|TTBB|Mo Rector
+Ma! She's Makin' Eyes At Me|TTBB|Mo Rector
 Macavity: the Mystery Cat|SSAA|Joey Minshall
+Mack the Knife|SSAA|Jim Arns
 Mack The Knife|SATB|Jay Dougherty
 Mack The Knife|SATB|Joe Mannherz
 Mack The Knife|SSAA|Jay Dougherty
@@ -11623,6 +13794,7 @@ MacNamara's Band|SSAA|Nancy Bergman
 MacNamara's Band|SSAA|Paul Grimm
 MacNamara's Band|TTBB|Barbershop Harmony Society
 MacNamara's Band|TTBB|SPEBSQSA
+MacNamara's Band/Great Day For The Irish Medley|SSAA|Nancy Bergman
 Mad Dogs and Englishmen|TTBB|Jay Giallombardo
 Mad Scientist Idol|TTBB|Steve Armstrong
 made You Look|SSAA|Tom Gentry
@@ -11649,6 +13821,7 @@ Mah-na Mah-na|TTBB|Mark Goodney
 Maharajah Of Magador|TTBB|Dennis Driscoll
 Mairzy Doats|SSAA|Tedda Lippincott
 Mairzy Doats|TTBB|Mark Goodney
+Majsang|TTBB|Traditional
 Make 'Em Laugh|SSAA|Brent Graham
 Make 'Em Laugh|SSAA|Clay Hine
 Make 'Em Laugh|SSAA|Debbie Keretz
@@ -11667,11 +13840,13 @@ Make Believe|TTBB|Walter Latzko
 Make Love To Me|SSAA|Barbara McNeill
 Make Love To Me|SSAA|Jean McFadyen
 Make Mine Barbershop|SSAA|Kay Bromert
+Make Our Garden Grow|TTBB|Jay Giallombardo
 Make Someone Happy|SSAA|Joey Minshall
 Make Someone Happy|TTBB|Ed Waesche
 Make Someone Happy|TTBB|John Brockman
 Make Them Hear You|TTBB|Dan Wessler
 Make Them Hear You|TTBB|Kevin Keller
+Make Them Hear You|TTBB|Kevin Keller, Steven Armstrong
 Make Them Hear You|TTBB|Matt Parks
 Make Them Hear You (from Ragtime)|TTBB|Theo Hicks
 Make You Feel My Love|SATB|Gary Thiel
@@ -11680,10 +13855,12 @@ Make You Feel My Love|SSAA|Jack Bridges
 Make You Feel My Love|TTBB|Aaron Dale
 Make You Feel My Love|TTBB|Alex Kaiserman
 Make You Feel My Love|TTBB|Clay Hine
+Make You Feel My Love|TTBB|Dale Kynaston
 Make You Feel My Love|TTBB|Eric Ruthenberg
 Make You Feel My Love|TTBB|Hilary Allen
 Make You Feel My Love|TTBB|Luke Stevenson
 Make You Feel My Love|TTBB|Mark Burnip
+Make You Feel My Love (SATB)|SATB|Dale Kynaston
 Make You Feel My Love/Chasing Cars|TTBB|Tom Gentry
 Make Your Own Kind of Music|SSAA|Lauren Kahn
 Make Your Own Kind of Music|SSAA|Michael Gellert
@@ -11696,6 +13873,7 @@ Makin' Whoopee|TTBB|Craig Gibbins
 Makin' Whoopee|TTBB|Todd Troutman
 Makin' Whoopee|TTBB|Tom Gentry
 Makin' Whoopee|TTBB|Walter Latzko
+Makin' Whoopie|TTBB|Unspecified
 Making Memories|TTBB|Todd Troutman
 Making Our Dreams Come True|SATB|Cay Outerbridge
 Making Our Dreams Come True|SSAA|Cay Outerbridge
@@ -11705,25 +13883,31 @@ Mam'selle|TTBB|Adam Reimnitz
 Mam'selle|TTBB|Joe Mannherz
 Mam'selle|TTBB|Tom Sando
 Mama Don't Low|SSAA|Mary K. Coffman Music Fund
+Mama Goes Where Papa Goes|SSAA|Nancy Bergman
 Mama Says|TTBB|Bryan Ziegler
 Mama Who Bore Me|SSAA|Simon Arnott
 Mama Yo Quiero|SSAA|Jim Campbell
+Mama, I Wanna Make Rhythm|SSAA|Walter Latzko
 Mama, I'm a Big Girl now|SSAA|Deke Sharon
 Mama, I'm a Big Girl now|TTBB|Deke Sharon
 Mama, I'm Coming Home|SATB|Lauren Kahn
 Mama's Broken Heart|SSAA|Melody Hine
 Mama's Shoes|SSAA|Liz Garnett
+Mamas and Papas Medley|SSAA|Sharon Holmes
 Mambo Italiano|SSAA|Dan Naumann
 Mambo Italiano|SSAA|Jean McFadyen
 Mambo Italiano|SSAA|Melody Hine
 Mambo Italiano|TTBB|Dan Naumann
 Mame|SSAA|Nancy Bergman
+Mame|TTBB|Renee Craig
 Mamma Goes Where Papa Goes|SSAA|Nancy Bergman
 Mamma Mia|SATB|Soren Detlefsen
 Mamma Mia|SSAA|Elaine Gain
 Mamma Mia|SSAA|Liz Garnett
 Mamma's Gone/I Used to Love You Medley|SSAA|Jo Lund
+Mammas & Papas Medley|TTBB|Peter Mumford
 Mammas, Don't Let Your Babies Grow Up to Be Cowboys|TTBB|Tom Gentry
+Mammy O' Mine|TTBB|Tom Gentry
 Man I Love|SSAA|David Briner
 Man I Love|SSAA|David Wright
 Man I Love|SSAA|Dorothy Herivel
@@ -11736,16 +13920,19 @@ Man In The Mirror|SSAA|Carole Prietto
 Man In The Mirror|SSAA|Deke Sharon
 Man In The Mirror|TTBB|Aaron Dale
 Man In The Mirror|TTBB|Deke Sharon
+Man In The Mirror|TTBB|Kirby Shaw
 Man of Constant Sorrow|SATB|Deke Sharon
 Man of Constant Sorrow|TTBB|Deke Sharon
 Man of La Mancha|SSAA|David Wright
 Man of La Mancha|TTBB|David Wright
+Man Of La Mancha|TTBB|Roger Payne
 Man On The Flying Trapeze|SSAA|Jean Shook
 Man On The Flying Trapeze|TTBB|Dennis Driscoll
 Man On The Flying Trapeze|TTBB|Ed Waesche
 Man On The Flying Trapeze|TTBB|Jack Baird
 Man On The Flying Trapeze|TTBB|Richard Floersheimer
 Man On The Flying Trapeze|TTBB|Tom Gentry
+Man With the Bag|SSAA|Lorraine Rochefort
 Man With The Bag|SATB|Joe Mannherz
 Man With The Bag|SATB|Tom Gentry
 Man With The Bag|SSAA|Deke Sharon
@@ -11765,6 +13952,7 @@ Man With The Bag|TTBB|Tom Gentry
 Man With The Ladder And The Hose|TTBB|Warren 'Buzz' Haeger
 Man! I Feel Like A Woman|SSAA|Becky Wilkins
 Man! I Feel Like A Woman|SSAA|Jay Dougherty
+Man! I Feel Like A Woman|SSAA|Lorraine Rochefort
 Man! I Feel Like A Woman|SSAA|Melody Hine
 Man! I Feel Like A Woman|TTBB|Steven Armstrong
 Manager Medley: There's A Song In The Air / Away In A Manger|SSAA|Carolyn Johnson
@@ -11786,11 +13974,13 @@ Mango Tree|SATB|Kohl Kitzmiller
 Mango Tree|TTBB|Adam Bock
 Mango Tree|TTBB|Dom Finetti
 Mango Tree|TTBB|Eric Ruthenberg
+Manhattan|SSAA|Liz Garnet
 Manhattan|SSAA|Liz Garnett
 Manhattan|SSAA|Nicholas Wright
 Manhattan|TTBB|Adam Bock
 Manhattan|TTBB|John Hohl
 Manhattan|TTBB|Wayne Grimmer
+Manhattan Transfer|SSAA|Renee Craig
 Manilow Magic|SSAA|Mark Burnip
 Manilow Magic|TTBB|Mark Burnip
 Manilow Medley|SSAA|Jay Giallombardo
@@ -11809,26 +13999,35 @@ March of the Wooden Soldiers|TTBB|Jay Giallombardo
 Marching Along Together|TTBB|Don Gray
 Marching Along Together|TTBB|Robert Meyer
 Marching Along With Time|TTBB|David Wright
+Marching Along/Stout Hearted Men Medley|TTBB|Unspecified
 Mardi Gras March|SATB|Aaron Dale
 Mardi Gras March|SSAA|Aaron Dale
 Mardi Gras March|SSAA|David Briner
+Mardi Gras March|SSAA|Nancy Bergman
+Mardi Gras March|SSAA|Renee Craig
 Mardi Gras March|TTBB|Aaron Dale
 Mardi Gras March|TTBB|David Briner
 Mardi Gras March|TTBB|Howard Mesecher
 Mardi Gras March|TTBB|Russ Foris
 Mardi Gras March / South Rampart Street Parade Medley|TTBB|David Wright
+Margaritaville|SSAA|Lorraine Rochefort
 Margaritaville|TTBB|Thomas Degan
 Margate|TTBB|Matthew Spinner
 Margie|TTBB|Burt Szabo
 Margie|TTBB|Clay Hine
 Margie|TTBB|David Harrington
 Margie|TTBB|Jim Shubert
+Margie|TTBB|Renee Craig
 Margie|TTBB|Tom Gentry
 Margie|TTBB|Walter Latzko
+Maria|TTBB|Jay Giallombardo
 Maria|TTBB|Mark Burnip
 Maria Elena|TTBB|Jim West
+Maria-Somewhere Medley|TTBB|Jay Giallombardo
 Marian|TTBB|Walter Latzko
+Marian The Librarian|TTBB|Walter Latzko
 Marion's Girls|SSAA|Jo Lund
+Maritime Medley (Haul on the Bowline, The Squid Jiggin' Ground, Farewell to Nova Scotia)|TTBB|Bob Pyper
 Marks Medley|TTBB|Tom Gentry
 Married / Shuffle off to Buffalo Medley|SSAA|Carolyn Schmidt
 Married Medley|SSAA|Avis Fellows
@@ -11837,6 +14036,7 @@ Marry Me|TTBB|Nicholas Wright
 Marry You|TTBB|Alex Kaiserman
 Marry You|TTBB|Deke Sharon
 Marry You|TTBB|Michael Webber
+Marshmallow World|SSAA|Joni Bescos
 Martha, My Dear|TTBB|Todd Troutman
 Marvelous Toy|SSAA|Doris Twardosky
 Marvelous Toy|TTBB|Jay Giallombardo
@@ -11850,6 +14050,8 @@ Mary Did You Know|SSAA|Joe Liles
 Mary Did You Know|SSAA|Jon Nicholas
 Mary Did You Know|SSAA|Julie Starr
 Mary Did You Know|SSAA|June Berg
+Mary Did You Know|SSAA|Mac Huff
+Mary Did You Know|SSAA|Tedda Lippincott
 Mary Did You Know|SSAA|Theodore Hicks
 Mary Did You Know|SSAA|Tom Gentry
 Mary Did You Know|TTBB|Bryan W. Pulver
@@ -11859,6 +14061,10 @@ Mary Did You Know|TTBB|Joe Liles
 Mary Did You Know|TTBB|Jon Nicholas
 Mary Did You Know|TTBB|Theodore Hicks
 Mary Did You Know|TTBB|Walter Latzko
+Mary Did You Know?|SSAA|David Wright
+Mary Did You Know?|SSAA|Jan Meyer
+Mary Did You Know?|TTBB|Joe Liles
+Mary Did You Know?|TTBB|Tom Gentry
 Mary Had A Baby|SSAA|David Wright
 Mary Had A Baby|TTBB|David Wright
 Mary In The Morning|TTBB|Tom Gentry
@@ -11873,20 +14079,30 @@ Mary You're A Little Bit Old Fashioned|SSAA|Mike Senter Music
 Mary You're A Little Bit Old Fashioned|TTBB|Louis Perry
 Mary You're A Little Bit Old Fashioned|TTBB|Russ Foris
 Mary You're A Little Bit Old Fashioned|TTBB|Tom Gentry
+Mary, Did You Know?|TTBB|Jon Nicholas
+Mary, Mary|SSAA|Charlene Yazurlo
 Mary, Mary Aka Mary Rock|SSAA|Charlene Yazurlo
 Mary, You're A Little Bit Old|TTBB|Russ Foris
+Mary, You're A Little Bit Old Fashiond|SSAA|Mike Senter
 Mary's A Grand Old Name|SSAA|Carolyn Johnson
 Mary's A Grand Old Name|TTBB|Burt Szabo
 Mary's Boy Child|SSAA|Glenda Lloyd
+Mary's Boy Child|SSAA|Jean Flemming
 Mary's Boy Child|SSAA|Kay Bromert
 Mary's Boy Child|TTBB|Derric Johnson
+Mary's Boy Child|TTBB|Larry Triplett
+Mary's Little Boy Child|SSAA|Joey Minshall
 Mary's Little Boy Child|SSAA|Larry Triplett
 Mary's Little Boy Child|SSAA|Larry Wright
+Mary's Little Boy Child|SSAA|Marie Johnson
+Mary's Little Boy Child|SSAA|Tedda Lippincott
 Mary's Little Boy Child|TTBB|Don Reckenbeil
 Mary's Little Boy Child|TTBB|Larry Triplett
 Mary's Little Boy Child|TTBB|Larry Wright
+Mary'S Little Boy Chile|SSAA|Jarmela Speta
 Mas Que Nada|SATB|Joe Mannherz
 Masochism Tango|TTBB|Marie Johnson
+Master Of The House|TTBB|Joe Pickin
 Masters In This Hall|TTBB|Aaron Dale
 Masters In This Hall|TTBB|Walter Latzko
 Material Girl|SSAA|Jon Nicholas
@@ -11901,6 +14117,7 @@ May Each Day|TTBB|Walter Latzko
 May Each Day/Goody Goodbye|SSAA|Larry Wright
 May Each Day/Goody Goodbye|TTBB|Larry Wright
 May I Never Love Again|SSAA|Charlotte Pernert
+May I Never Love Again|SSAA|Jean Sutton
 May I Never Love Again|SSAA|Renee Craig
 May I Never Love Again|TTBB|Renee Craig
 May I?|TTBB|Jim West
@@ -11909,6 +14126,7 @@ May The Good Lord Bless And Keep You|SSAA|Joey Minshall
 May The Good Lord Bless And Keep You|TTBB|Dennis Driscoll
 May The Good Lord Bless And Keep You|TTBB|Jon Nicholas
 May The Lord|TTBB|Jim West
+May the Peace of God Be Within You|TTBB|Russell Wilson
 May The Road Rise Up To Meet You|SATB|Derric Johnson
 May You Always|SSAA|Ann Minihane
 May You Always|SSAA|Joey Minshall
@@ -11918,6 +14136,7 @@ May You Always|SSAA|Tom Gentry
 May You Always|SSAA|Walter Latzko
 May You Always|TTBB|Al Baker
 May You Always|TTBB|Dennis Driscoll
+May You Always|TTBB|Greg Lyne
 May You Always|TTBB|Gregory Lyne
 May You Always|TTBB|Tom Gentry
 May You Always|TTBB|Walter Latzko
@@ -11925,11 +14144,13 @@ May you always walk in Sunshine|TTBB|Joe Mannherz
 May You Never Know Sadness|TTBB|Jeremey Johnson
 Maybe|SATB|Deke Sharon
 Maybe|SATB|Sam Hubbard
+Maybe|SSAA|Lorraine Rochefort
 Maybe|SSAA|Michael Gellert
 Maybe|SSAA|Sam Hubbard
 Maybe|TTBB|Dennis Driscoll
 Maybe|TTBB|Sam Hubbard
 Maybe|TTBB|Todd Troutman
+Maybe|TTBB|Walter Latzko
 Maybe I'm Amazed|SSAA|Robert Rund
 Maybe I'm Amazed|TTBB|Dan Wessler
 Maybe I'm Amazed|TTBB|Robert Rund
@@ -11952,7 +14173,9 @@ Maybe This Time|TTBB|Steve Tramack
 Maybe You'll Be There|TTBB|Norm Benson
 Maybe You'll Be There|TTBB|Walter Latzko
 Mayberry|SATB|Deke Sharon
+McGuire Sisters Medley|SSAA|Jean Shook
 Me And Bobby Mcgee|SATB|Deke Sharon
+Me And Julio Down By The Schoolyard|TTBB|Anthony Nasto
 Me And Julio Down By The Schoolyard|TTBB|Tony Nasto
 Me And Marie|TTBB|Burt Szabo
 Me And Mrs. Jones|SATB|Deke Sharon
@@ -11971,6 +14194,7 @@ Meadowlark|TTBB|Greg Mallett
 Mean|SSAA|Glenda Lloyd
 Mean Ol' Moon|SSAA|Carole Prietto
 Mean Ol' Moon|TTBB|Kevin Koehl
+Mean To Me|SSAA|David Wright
 Mean To Me|SSAA|Jo Lund
 Mean To Me|SSAA|Kevin Keller
 Mean To Me|SSAA|Sylvia Alsbury
@@ -11981,6 +14205,8 @@ Mean To Me|TTBB|Walter Latzko
 Mean to You|SSAA|Jo Lund
 Mean, Mean Mama|SSAA|Jay Giallombardo
 Mean, Mean Mama|TTBB|Jay Giallombardo
+Meatballs|TTBB|Clay Hine
+Medley from Mary Poppins|SSAA|Lorretta Martin
 Medley In The Rain|TTBB|Bob Graham
 Medley Of George M. Cohan Songs|TTBB|Unknown
 Medley: 1999, Purple Rain, Let's Go Crazy|TTBB|Steven Armstrong
@@ -12138,9 +14364,12 @@ Meet Me At Twilight|TTBB|Wes Farmer
 Meet Me In Dreamland|SSAA|Walter Latzko
 Meet Me In Rosetime Rosie|TTBB|Ed Waesche
 Meet Me In Rosetime Rosie|TTBB|Greg Lyne and Ed Waesche
+Meet Me In Rosetime Rosie|TTBB|Greg Lyne, Ed Waesche
 Meet Me In St. Louis, Louis|SSAA|Joni Bescos
 Meet Me In St. Louis, Louis|TTBB|Burt Szabo
+Meet Me Tonight in Dreamland|SSAA|Nancy Bergman
 Meet Me Tonight In Dreamland|SSAA|Carolyn Johnson
+Meet Me Tonight In Dreamland|TTBB|Barbershop Harmony Society
 Meet Me Tonight In Dreamland|TTBB|Bill Diekema
 Meet Me Tonight In Dreamland|TTBB|Jack Baird
 Meet Me Tonight In Dreamland|TTBB|Louis Perry
@@ -12149,17 +14378,20 @@ Meet Me Tonight In Dreamland|TTBB|SPEBSQSA
 Meet Me Tonight In Dreamland|TTBB|Tom Gentry
 Meet Me Under the Mistletoe|TTBB|Scott Anderson
 Meet Me Where They Play The Blues|SSAA|Gene Cokeroft
+Meet the Flintsones|TTBB|Drew Tepe
 Meet You at the Moon|SSAA|Liz Garnett
 Meetin' Here Tonight/Old Time Religion Medley|SSAA|Jay Giallombardo
 Meetin' Here Tonight/Old Time Religion Medley|TTBB|Jay Giallombardo
 Megan's Fair Daughter|SSAA|Hilary Allen
 Meglio Stasera|SATB|Kohl Kitzmiller
+Melancholy Baby|SSAA|Brian Beck
 Melancholy Blues|TTBB|Aaron Dale
 Mele Kalikimaka|SATB|Joe Mannherz
 Mele Kalikimaka|SSAA|Anastasio Rossi
 Mele Kalikimaka|SSAA|Hannah Briggs
 Mele Kalikimaka|SSAA|Joe Mannherz
 Mele Kalikimaka|SSAA|Jon Nicholas
+Mele Kalikimaka|TTBB|Dave Briner
 Mele Kalikimaka|TTBB|Deke Sharon
 Mele Kalikimaka|TTBB|Jim Shubert
 Mele Kalikimaka|TTBB|Joe Mannherz
@@ -12197,6 +14429,7 @@ Memory Medley|TTBB|Barbershop Harmony Society
 Memory Medley|TTBB|SPEBSQSA
 Memory Medley|TTBB|Todd Troutman
 Memory Medley|TTBB|Unknown
+Memphis Blues|SSAA|Dave Briner
 Memphis Blues|TTBB|Dave Briner
 Memphis Blues|TTBB|David Briner
 Memphis In June|TTBB|Dennis Driscoll
@@ -12204,6 +14437,8 @@ Men|SATB|Deke Sharon
 Men|TTBB|Derek Hatley
 Men In Black|SSAA|Joey Minshall
 Men In Tights|TTBB|Melody Hine
+Men Of God, Behold He Calls Us|TTBB|Joe Johnson
+Mention My Name in Sheboygan|TTBB|Lou Perry
 Mercy|SATB|Deke Sharon
 Mercy|SATB|Nicholas Wright
 Mercy|SSAA|Deke Sharon
@@ -12223,6 +14458,7 @@ Merry Christmas Darling|SSAA|Joan D 'Agostino
 Merry Christmas Darling|SSAA|June Berg
 Merry Christmas Darling|SSAA|Susan Kegley
 Merry Christmas Darling|SSAA|Tom Gentry
+Merry Christmas Darling|TTBB|Brian Beck
 Merry Christmas Darling|TTBB|Gabriel Lawson
 Merry Christmas Darling|TTBB|Greg Mallett
 Merry Christmas Darling|TTBB|Tom Gentry
@@ -12244,7 +14480,9 @@ Metro Rhythm Opener|SSAA|Jo Lund
 Mexicali Rose|TTBB|Tom Gentry
 Mexican National Anthem|TTBB|Tom Gentry
 Mexican Wine|TTBB|Deke Sharon
+Michael Jackson Medley|SSAA|Rasmus Krigstrom
 Michael Jackson Medley|TTBB|Todd Troutman
+Michelle|TTBB|Don Gray
 Michelle|TTBB|Stephen Delehanty
 Michelle|TTBB|Steve Delehanty
 Michigan Morn|TTBB|Jay Giallombardo
@@ -12255,7 +14493,9 @@ Mickey|TTBB|Russ Foris
 Mickey Mouse Club March|SATB|Deke Sharon
 Mickey Pretty Mickey|TTBB|Dennis Driscoll
 Mid The Green Fields Of Virginia|TTBB|Jack Baird
+Midnight Choo Choo|SSAA|Jay Giallombardo
 Midnight Cry|TTBB|Derric Johnson
+Midnight Rose|SSAA|Nancy Bergman
 Midnight Rose|TTBB|Ed Waesche
 Midnight Rose|TTBB|Tom Gentry
 Midnight Rose (TTBB) (arr. Waesche) - Australia/Canada Orders only|TTBB|Ed Waesche
@@ -12273,6 +14513,7 @@ Mighty Mouse|SSAA|Melody Hine
 Mighty Spirit|TTBB|Derric Johnson
 Mii Channel Theme|TTBB|Michael Webber
 Mika Medley|SSAA|Deke Sharon
+Miles And Miles Of Texas|TTBB|Joe Johnson
 Military Medley|TTBB|Tom Gentry
 Milk and Bread!|TTBB|Jon Nicholas
 Millionaire's Hoedown|SSAA|Larry Wright
@@ -12283,13 +14524,17 @@ Mine|SSAA|Nicholas Wright
 Minneapolis/St. Paul Theme|SSAA|Avis Fellows
 Minnie The Mermaid|SSAA|Carolyn Schmidt
 Minnie The Mermaid|TTBB|Dennis Driscoll
+Minnie the Mermaid Medley|SSAA|Carolyn Schmidt
 Minnie The Moocher|SATB|Deke Sharon
 Minnie The Moocher|SSAA|Walter Latzko
 Minnie The Moocher|TTBB|Walter Latzko
 Minstrel Medley|TTBB|Dave Stevens
+Minstrel Montage|TTBB|Barbershop Harmony Society
 Minstrel Montage|TTBB|BHS
+Minstrel Montage|TTBB|Unspecified
 Minute Waltz|SSAA|David Wright
 Miracle|SSAA|Adam Bock
+Miracle|TTBB|Kevin Keller
 Mirrors|SATB|Kevin Keller
 Mirrors|SATB|Nicholas Wright
 Mirrors|TTBB|Nicholas Wright
@@ -12297,13 +14542,16 @@ Mischief Medley|SSAA|Tom Gentry
 Misery Business|SATB|Deke Sharon
 Miss Celie's Blues|SSAA|Jo Lund
 Miss Celie's Blues|SSAA|Joe Mannherz
+Miss Celie's Blues|SSAA|Lorraine Rochefort
 Miss Celie's Blues|SSAA|Tom Gentry
 Miss Celie's Blues|TTBB|Barbara Bianchi
 Miss Celie's Blues|TTBB|Tom Gentry
+Miss Celie's Blues (Sister)|SSAA|Lorraine Rochefort
 Miss Independent|SSAA|Nicholas Wright
 Miss Otis Regrets|SSAA|Deke Sharon
 Miss Otis Regrets|SSAA|Marge Bailey
 Miss Otis Regrets|TTBB|John Hohl
+Miss Otis Regrets (a la City Voices)|SSAA|Marge Bailey
 Miss You|SSAA|Mike Menefee
 Miss You|TTBB|Ed Waesche
 Miss You|TTBB|Mike Menefee
@@ -12311,17 +14559,23 @@ Miss You|TTBB|Walter Latzko
 Miss You Most at Christmas|SATB|Joe Mannherz
 Miss You Most at Christmas|SSAA|Joe Mannherz
 Miss You Most at Christmas|TTBB|Joe Mannherz
+Mission Impossible Theme|SSAA|Steve Tramack
+Mission Impossible Theme|TTBB|Steve Tramack
 Mission: Impossible Theme|SSAA|Glenda Lloyd
 Mission: Impossible Theme|SSAA|Steve Tramack
 Mission: Impossible Theme|TTBB|Simon Arnott
 Mission: Impossible Theme|TTBB|Steve Tramack
 MISSISSIPPI (M-I-Crooked Letter)|SSAA|Nancy Bergman
+Mississippi Medley|SSAA|Jay Giallombardo
 Mississippi Medley (Roll On, Mississippi/On the Mississippi)|SSAA|Jay Giallombardo
 Mississippi Medley (Roll On, Mississippi/On the Mississippi)|TTBB|Jay Giallombardo
 Mississippi Moon|TTBB|The Doctors of Harmony
+Mississippi Mud|SSAA|Aileen Nightingale
 Mississippi Mud|SSAA|David Wright
 Mississippi Mud|SSAA|Nancy Bergman
+Mississippi Mud|TTBB|C. Morris
 Mississippi Mud|TTBB|David Wright
+Mississippi Mud|TTBB|Ed Waesche
 Mississippi Mud|TTBB|Jim West
 Mississippi Mud|TTBB|Mo Rector
 Mississippi Squirrel Revival|SSAA|Marge Bailey
@@ -12333,12 +14587,19 @@ Mistakes|SSAA|Roy Keys
 Mistakes|TTBB|Joe Mannherz
 Mistakes|TTBB|Roy Keys
 Mistakes (Parody)|TTBB|Roy Keys
+Mistakes Parody|TTBB|Unspecified
 Mister And Mississippi|SSAA|Walter Latzko
 Mister Booze|TTBB|Michael Webber
 Mister Broadway Medley|TTBB|Ed Waesche
+Mister Cellophane|SSAA|Ed Waesche
+Mister Cellophane|TTBB|Chris Slacke
+Mister Cellophane|TTBB|Ed Waesche
 Mister Lonely|TTBB|Nancy Bergman
+Mister Mom|SSAA|Michael Gellert
+Mister Postman|TTBB|Unspecified
 Mister Sandman|SATB|Dan Wessler
 Mister Sandman|SSAA|Bertha Bradley
+Mister Sandman|SSAA|Bradley
 Mister Sandman|SSAA|Dan Wessler
 Mister Sandman|SSAA|Deke Sharon
 Mister Sandman|SSAA|Kyle Snook
@@ -12353,25 +14614,32 @@ Mister, You've Gone And Got The Blues|TTBB|Tony Nasto
 Mistletoe and Wine|SATB|Karen Penketh
 Misty|SATB|Kevin Keller
 Misty|SSAA|Lauren Kahn
+Misty|SSAA|Russ Robinson
 Misty|SSAA|Sharon Holmes
 Misty|TTBB|Jim Shubert
 Misty|TTBB|Walter Latzko
+Misty|TTBB|Webb Comfort
 Misty Mountains Cold|SSAA|Deke Sharon
+MLK|TTBB|David Wright
 Mobile|TTBB|David Wright
 Mobile|TTBB|Dennis Driscoll
 Mobile|TTBB|Jon Nicholas
 Mobile with Down Mobile|TTBB|David Wright
+Mobile/Down Mobile Medley|TTBB|David Wright
 Mockin' Bird Hill|SSAA|Sheryl Neal
 Mockin' Bird Hill|TTBB|Todd Troutman
 Mockingbird|SSAA|Deke Sharon
 Modersmalets Sang|TTBB|Mike Menefee
+Molly Malone|SSAA|Paul Davies
 Molly Malone|TTBB|Donn Updegrove
 Molly Malone|TTBB|Jim Shubert
+Molly Malone|TTBB|Paul Davies
 Molly Malone|TTBB|Robert Pyper
 Mom|SSAA|Larry Wright
 Mom|SSAA|Melody Hine
 Mom|TTBB|Jon Nicholas
 Moment By Moment|TTBB|Derric Johnson
+Moment I Saw Your Eyes The|TTBB|Joe Liles
 Moment of Silence|TTBB|Robert Rund
 Moments Like This|TTBB|Walter Latzko
 Moments To Remember|SSAA|Dorothy Short
@@ -12389,11 +14657,13 @@ Monday, Monday|SSAA|Jay Giallombardo
 Monday, Monday|SSAA|Tedda Lippincott
 Monday, Monday|TTBB|Jay Giallombardo
 Monday, Monday|TTBB|Mark Stevens
+Monday, Monday Medley|SSAA|Sharon Holmes
 Money Burns A Hole In My Pocket`|TTBB|Walter Latzko
 Money, Money|SSAA|Charlene Yazurlo
 Money, Money|SSAA|Sonny Steffan
 Money, Money|SSAA|Sylvia Alsbury
 Money, Money|TTBB|Dick Rode
+Money, Money, Money|SSAA|Connie Nickel
 Money, Money, Money|SSAA|Mike Menefee
 Money, Money, Money|SSAA|Rowena Harper
 Monkees Medley|TTBB|Todd Troutman
@@ -12414,13 +14684,21 @@ Monsters|TTBB|Kohl Kitzmiller
 Monsters|TTBB|Liz Garnett
 Monsters Inc.|TTBB|Michael Webber
 Monsters Medley|SATB|Joe Mannherz
+Montana Melody|TTBB|Jack Payne and Randy Rogers
+Monty Pythin Medley|TTBB|Mikael Erlandsson
 Mood Indigo|SATB|Richard Curtis
+Mood Indigo|SSAA|Bev Sellers
+Mood Indigo|SSAA|Charlene Yazurlo
 Mood Indigo|SSAA|Debbie Keretz
+Mood Indigo|SSAA|Joe Liles
 Mood Indigo|SSAA|Joe Mannherz
+Mood Indigo|SSAA|Joni Bescos
 Mood Indigo|SSAA|Michael Hengelsberg
 Mood Indigo|SSAA|Tom Gentry
 Mood Indigo|SSAA|Walter Latzko
 Mood Indigo|TTBB|Alexander Ronneburg
+Mood Indigo|TTBB|Frank Thorne
+Mood Indigo|TTBB|J. Rae Jamieson
 Mood Indigo|TTBB|Joe Mannherz
 Mood Indigo|TTBB|Steve Jamison
 Mood Indigo|TTBB|Tom Gentry
@@ -12432,25 +14710,34 @@ Moon Love|SSAA|Emily Moriarty
 Moon Love|TTBB|Ellsworth Morey
 Moon Medley|TTBB|C. J. Sams Jr.
 Moon Medley|TTBB|Jack Baird
+Moon Medley|TTBB|Steve Delehanty
 Moon Medley|TTBB|Tom Gentry
 Moon Over Bourbon Street|SATB|Anders Lindqvist
 Moon Over Bourbon Street|TTBB|Anders Lindqvist
+Moon Over Miami|SSAA|Dot Short
 Moon River|SATB|Jack Bridges
 Moon River|SATB|Kohl Kitzmiller
 Moon River|SSAA|Brent Graham
+Moon River|SSAA|Debi Cox
 Moon River|SSAA|Dianne Goldrick
 Moon River|SSAA|Doris Twardosky
 Moon River|SSAA|Kohl Kitzmiller
 Moon River|SSAA|Mike Taylor
+Moon River|SSAA|Nigel Williams
+Moon River|SSAA|Renee Craig
 Moon River|TTBB|Brent Graham
 Moon River|TTBB|Kohl Kitzmiller
 Moon River|TTBB|Walter Latzko
 Moondance|SATB|Deke Sharon
+Moondance|SSAA|Greg Volk
 Moondance|SSAA|Liz Garnett
+Moondance|SSAA|Marshall Webb
+Moondance|TTBB|Marshall Webb
 Moondance|TTBB|Walter Latzko
 Moondance/Fever Medley|TTBB|Joe Mannherz
 Moonglow|SATB|Joe Mannherz
 Moonglow|SSAA|Debbie Keretz
+Moonglow|SSAA|Joanne Dockrell
 Moonglow|SSAA|Scott Kitzmiller
 Moonglow|SSAA|Walter Latzko
 Moonglow|TTBB|Jim Shubert
@@ -12459,6 +14746,7 @@ Moonglow|TTBB|Patrick Bauer
 Moonglow|TTBB|Scott Kitzmiller
 Moonglow|TTBB|Walter Latzko
 Moonlight|SSAA|Joan D 'Agostino
+Moonlight and Roses|SSAA|Walter Latzko
 Moonlight And Roses|SSAA|Tom Gentry
 Moonlight And Roses|TTBB|Tom Gentry
 Moonlight Bay|TTBB|Barbershop Harmony Society
@@ -12475,6 +14763,9 @@ Moonlight Brings Memories / Moonlight and Roses|SSAA|Tom Gentry
 Moonlight Brings Memories / Moonlight and Roses|TTBB|Tom Gentry
 Moonlight Cocktail|TTBB|Brent Graham
 Moonlight in Vermont|SSAA|Joan D 'Agostino
+Moonlight in Vermont|TTBB|Stephen Griffith
+Moonlight In Vermont|SSAA|Tedda Lippincott
+Moonlight In Vermont|TTBB|Webb Comfort
 Moonlight Medley|TTBB|Kim Brittain
 Moonlight On The Ganges|SSAA|Walter Latzko
 Moonlight On The Ganges|TTBB|Steve Hardy
@@ -12482,12 +14773,16 @@ Moonlight Savings Time|SSAA|Glenda Lloyd
 Moonlight Savings Time|TTBB|Mark Jennings
 Moonlight Serenade|SSAA|Carolyn Healey
 Moonlight Serenade|SSAA|David Wright
+Moonlight Serenade|SSAA|Frank Marzocco
+Moonlight Serenade|SSAA|Sheila Cope
 Moonlight Serenade|TTBB|David Wright
 Moonlight Serenade|TTBB|Derek Hatley
 Moonlight Serenade|TTBB|Lee Sutter
+Moonlight Sonata|TTBB|David Wright/Steve Wolf
 Moonshine Lullaby|SSAA|Tom Gentry
 Moonshine Lullaby|SSAA|Tony Nasto
 Moonshine Lullaby|TTBB|Tom Gentry
+Moonshine Lullabye|TTBB|Phil Ordaz
 More|SSAA|David Wright
 More|SSAA|Liz Garnett
 More|TTBB|Adam Scott
@@ -12498,7 +14793,9 @@ More|TTBB|Tom Gentry
 More I Cannot Wish You|SATB|Kevin Keller
 More I Cannot Wish You|SSAA|Kevin Keller
 More I Cannot Wish You|TTBB|Kevin Keller
+More I Cannot Wish You|TTBB|Mark Hale
 More I Cannot Wish You|TTBB|Rob Campbell
+More I Cannot Wish You|TTBB|Steven Armstrong
 More I Cannot Wish You|TTBB|Walter Latzko
 More I See You/Never Be Another You|TTBB|Brent Graham
 More Music|SATB|Larry Triplett
@@ -12527,6 +14824,8 @@ Morning Side Of The Mountain|SSAA|Kevin Keller
 Morning Side Of The Mountain|TTBB|Kevin Keller
 Morning Town Ride|SSAA|Valerie Hoy
 Moscow Nights|SSAA|Marge Bailey
+Moscow Nights|TTBB|Chris Arnold
+Mosquitoes|SSAA|Unspecified
 Most Wonderful Time Of The Year|SATB|Deke Sharon
 Most Wonderful Time Of The Year|SATB|Joe Mannherz
 Most Wonderful Time Of The Year|SSAA|Debbie Keretz
@@ -12537,6 +14836,7 @@ Most Wonderful Time Of The Year|TTBB|Kevin Keller
 Most Wonderful Time Of The Year|TTBB|Larry Wright
 Most Wonderful Time Of The Year|TTBB|Richard Floersheimer
 Most Wonderful Time Of The Year|TTBB|Rosalind Johnson
+Most Wonderful Time/We Need A Little Christmas (Medley)|TTBB|Don Gray
 Mother|SATB|Kevin Koehl
 Mother|TTBB|Lloyd Steinkamp
 Mother Goose Suite|SSAA|Joan D 'Agostino
@@ -12563,14 +14863,25 @@ Mountain Greenery|TTBB|Walter Latzko
 Mountain Music|TTBB|Jon Nicholas
 Move Like That|SATB|Erica Kelch-Slesnick
 Moves Like Jagger|SSAA|Joey Minshall
+Movie Medley|TTBB|Steve Delehanty
 Movin' Out (Anthony's Song)|TTBB|Thomas Degan
 Movin' Right Along|SSAA|Cay Outerbridge
 Movin' Right Along|TTBB|Dan Wessler
 Moving Picture Hero Of My Heart|SSAA|Tom Gentry
+Moving Right Along/Ease on Down the Road|TTBB|Ben Brown
 Moving Too Fast|TTBB|Adam Scott
 Moving Too Fast|TTBB|Greg Mallett
 Moving Too Fast|TTBB|Simon Arnott
 Moving Up To Gloryland|SSAA|Tedda Lippincott
+Mr Bassman/Mahnah Mahnah Medley|SSAA|Liz Garnett
+Mr Blue Sky|TTBB|Liz Garnett
+Mr Morton|TTBB|Lynn Ahrens
+Mr Piano Man/I Love A Piano Medley|SSAA|Brian Beck
+Mr Sandman|SATB|George Hulst
+Mr Sandman|TTBB|George Hulst
+Mr Sandman / Dream Medley|SSAA|Unspecified
+Mr Success|TTBB|Clay Hine
+Mr Touchdown USA|SSAA|Nancy Bergman
 Mr. Blue|TTBB|Gary Thiel
 Mr. Blue Sky|SATB|Deke Sharon
 Mr. Blue Sky|SATB|Kohl Kitzmiller
@@ -12597,23 +14908,36 @@ Mr. Rogers Medley|TTBB|Jeremey Johnson
 Mr. Rogers Medley|TTBB|Matt Parks
 Mr. Success|TTBB|John Brockman
 Mr. Tanner|TTBB|Kevin Keller
+Mr. Touchdown USA|TTBB|Unspecified
 Mr. Wonderful|SSAA|Kay Bromert
 Mr. Wonderful|SSAA|Walter Latzko
 Mrs. Santa Claus|SSAA|Kay Bromert
 Much To My Surprise|TTBB|Jon Nicholas
+Mummy Parody|TTBB|Steven Armstrong
 Munchkinland|SSAA|Kevin Keller
 Munchkinland|TTBB|Kevin Keller
+Muppet Show|SSAA|Kirk Young
+Muppet Show|TTBB|Kirk Young
 Murder, He Says|SSAA|Carolyn Schmidt
 Music|SSAA|Marie Johnson
+Music & The Mirror ('A Chorus Line')|SSAA|Mary Ann Wydra
+Music And The Mirror|SSAA|Maryanne Wydra
 Music For A Sushi Restaurant|SATB|Deke Sharon
 Music For A Sushi Restaurant|TTBB|Nicholas Wright
 Music In My Mothers House|SSAA|Nancy Bergman
 Music Maestro Please|SSAA|Larry Wright
 Music Maestro Please|TTBB|Larry Wright
 Music Man Ballad Medley|TTBB|Tom Gentry
+Music Man II|TTBB|Steve Delehanty
+Music Man Medley|SSAA|Joni Bescos
 Music Man Medley|TTBB|Ed Waesche
 Music Man Medley|TTBB|Kevin Keller
+Music Man Medley|TTBB|Rob Hopkins
+Music Man Medley #1|TTBB|Ed Waesche
+Music Man Medley #2|TTBB|Ed Waesche
 Music Man Medley 1|TTBB|Ed Waesche
+Music Man Medley I|TTBB|Steve Delehanty
+Music Man Mini-Show|TTBB|Jay Giallombardo
 Music Moves Me|SSAA|Kay Bromert
 Music Moves Me|SSAA|Tedda Lippincott
 Music Music Music|TTBB|Mo Rector
@@ -12621,26 +14945,35 @@ Music Music Music|TTBB|Tom Gentry
 Music Of My Heart|SSAA|Aaron Dale
 Music Of My Heart|SSAA|Carole Prietto
 Music Of My Heart|TTBB|Kevin Keller
+Music of the Night|SSAA|Lorraine Rochefort
 Music Of The Night|SSAA|David Wright
 Music Of The Night|SSAA|Tedda Lippincott
 Music Of The Night|TTBB|David Wright
+Music Of The Night|TTBB|Gordon Haines
 Music Of The Night|TTBB|Jay Giallombardo
 Music, Magic and Harmony|SSAA|Tom Gentry
 Music, Magic and Harmony|TTBB|Tom Gentry
+Music, Music, Music|TTBB|Mo Rector
+Music! Music! Music!|SSAA|Jarmela Speta
+Music! Music! Music!|SSAA|Nancy Bergman
 Musical Moon|SATB|Burt Szabo
 Muskrat Ramble|SATB|Joe Mannherz
 Muskrat Ramble|SSAA|Dorothy Short
+Muskrat Ramble|SSAA|Dot Short
 Muskrat Ramble|SSAA|Joe Mannherz
 Muskrat Ramble|TTBB|David Wright
 Muskrat Ramble|TTBB|Jim West
 Muskrat Ramble|TTBB|Joe Mannherz
 Muskrat Ramble|TTBB|Rex Reeve
+Muskrat Ramble|TTBB|Rex Reeve, Bob Wachter
 Muskrat Ramble|TTBB|Robert Wachter
 Muskrat Ramble|TTBB|Todd Troutman
 Muskrat Ramble|TTBB|Tom Gentry
 Must Be Santa|TTBB|Jon Nicholas
+My 'Wild' Irish Rose|TTBB|Burt Szabo
 My Alabama|SSAA|Larry Wright
 My Alabama|TTBB|Larry Wright
+My Baby Just Cares for Me|SSAA|Anna Maria Parker
 My Baby Just Cares For Me|SSAA|David Wright
 My Baby Just Cares For Me|SSAA|Elaine Gain
 My Baby Just Cares For Me|SSAA|Jo Lund
@@ -12652,6 +14985,7 @@ My Barney Lies Over The Ocean|TTBB|Chuck Eaker
 My Barney Lies Over The Ocean|TTBB|Toban Dvoretsky
 My Best Friend's Girl|TTBB|Deke Sharon
 My Best Girl|TTBB|Burt Szabo
+My Best Girl|TTBB|Theo Hicks
 My Best Girl|TTBB|Theodore Hicks
 My Best To You|SSAA|Sonny Steffan
 My Best To You|TTBB|Don Gray
@@ -12690,8 +15024,11 @@ My Christmas Song For You|TTBB|Mark Goodney
 My Christmas Wish For You|SSAA|Val Hicks
 My Coloring Book|SSAA|Tom Gentry
 My Coloring Book|TTBB|Tom Gentry
+My Colouring Book|TTBB|Jay Wright
+My Country|SSAA|Dot Short
 My Country 'Tis Of Thee (The Penny)|TTBB|Derric Johnson
 My Country 'Tis Of Thee (The Penny)|TTBB|Jim Clancy
+My Cup Runneth Over|SSAA|Jean Crockett Kane
 My Cup Runneth Over|TTBB|Ardeth Fullmer
 My Cup Runneth Over With Love|TTBB|Ardeth Fullmer
 My Cup Runneth Over With Love|TTBB|Jim West
@@ -12717,9 +15054,13 @@ My Dreams Are Getting Better All The Time|TTBB|Dennis Driscoll
 My Dreams Are Getting Better All The Time|TTBB|Don Fraser
 My Eyes Adored You|SSAA|Jeremey Johnson
 My Eyes Adored You|TTBB|Jeremey Johnson
+My Fair Lady Medley|SSAA|Renee Craig Anne Minihane
 My Fair Lady Medley|SSAA|Tom Gentry
+My Fair Lady Medley|TTBB|Renee Craig
 My Fair Lady Medley|TTBB|Tom Gentry
 My Faith Looks Up To Thee|TTBB|Jon Nicholas
+My Faithful Heart|TTBB|Walter Latzko
+My Father, My Friend, My Dad|TTBB|Bill Rashleigh
 My Father, My Friend, My Dad|TTBB|Brent Graham
 My Father, My Friend, My Dad|TTBB|Earl Moon
 My Favorite Things|SSAA|Dave Briner
@@ -12733,32 +15074,40 @@ My Favorite Things|TTBB|David Briner
 My Favorite Things|TTBB|Dianne Goldrick
 My Favorite Things|TTBB|Jon Nicholas
 My Favorite Things Parody|SSAA|Tom Gentry
+My Favorite Things Parody|TTBB|Dave Briner
 My Favorite Things Parody|TTBB|Tom Gentry
 My Foolish Heart|SATB|Deke Sharon
 My Foolish Heart|SATB|Joe Mannherz
 My Foolish Heart|SSAA|Brent Graham
 My Foolish Heart|SSAA|Jean Kane
+My Foolish Heart|SSAA|Joni Bescos
 My Foolish Heart|SSAA|Mark Burnip
 My Foolish Heart|SSAA|Michael Gellert
 My Foolish Heart|SSAA|Tom Gentry
 My Foolish Heart|TTBB|Brent Graham
+My Foolish Heart|TTBB|Brian Beck
+My Foolish Heart|TTBB|Dick Floersheimer
 My Foolish Heart|TTBB|Jay Giallombardo
 My Foolish Heart|TTBB|Mark Burnip
 My Foolish Heart|TTBB|Rob Hopkins
 My Foolish Heart|TTBB|Tom Gentry
+My Foolish Heart - Reprise|TTBB|Brian Beck, Jay Giallombardo
 My Foolish Heart/I Fall In Love Too Easily|TTBB|Adam Reimnitz
 My Fraternity Pin|TTBB|Thomas Gentry
 My Fraternity Pin|TTBB|Tom Gentry
 My Friend|TTBB|Fred King
 My Funny Valentine|SATB|Joe Mannherz
 My Funny Valentine|SSAA|Joe Mannherz
+My Funny Valentine|SSAA|Renee Craig
 My Funny Valentine|TTBB|Adam Scott
+My Funny Valentine|TTBB|Jim Clancy
 My Funny Valentine|TTBB|Joe Mannherz
 My Funny Valentine|TTBB|Mark Goodney
 My Funny Valentine|TTBB|Scott Kitzmiller
 My Funny Valentine|TTBB|Steve Jamison
 My Future|SSAA|Lauren Kahn
 My Future|TTBB|Robert Rund
+My Gal Sal|TTBB|Clay Hine
 My Gal Sal|TTBB|Dennis Driscoll
 My Gal Sal|TTBB|Ed Waesche
 My Girl|SATB|Deke Sharon
@@ -12769,15 +15118,18 @@ My Girl|TTBB|Joe Mannherz
 My Girl|TTBB|John Palmer
 My Girl|TTBB|Jon Nicholas
 My Girl|TTBB|Rob Campbell
+My Girl|TTBB|Steve Wolf
 My Girl (Gone, Gone, Gone)|TTBB|Mark Stevens
 My God and I|SSAA|Kay Bromert
 My Golden Baby|SSAA|Tom Gentry
 My Golden Baby|TTBB|Tom Gentry
 My Grandfather's Clock|TTBB|Jim West
+My Grown Up Christmas List|SSAA|June Berg
 My Guy|SATB|Tom Gentry
 My Guy|SSAA|Jo Lund
 My Guy|SSAA|Larry Wright
 My Guy|SSAA|Tedda Lippincott
+My Guy (YWIH)|SSAA|Tedda Lippincott
 My Guy/I Will Follow Him|SSAA|Larry Wright
 My Happy Ending|SATB|Deke Sharon
 My Heart Has Learned To Love You|TTBB|Jack Baird
@@ -12793,6 +15145,7 @@ My Heart Stood Still|TTBB|Warren 'Buzz' Haeger
 My Heart Will Go On|SSAA|Chris Arnold
 My Heart Will Go On|SSAA|Jean McFadyen
 My Heart Will Go On|SSAA|Tedda Lippincott
+My Heart Will Go On (From Titanic) (SSAA)|SSAA|Kirby Shaw
 My Heroes Have Always Been Cowboys|TTBB|Tom Gentry
 My Home|SATB|Deke Sharon
 My Hometown Is A One Horse Town|TTBB|Floyd Connett
@@ -12804,17 +15157,22 @@ My Honey's Lovin' Arms|TTBB|David Harrington
 My Honey's Lovin' Arms|TTBB|David Wright
 My Honey's Lovin' Arms|TTBB|Dennis Driscoll
 My Honey's Lovin' Arms|TTBB|Don Gray
+My Honey's Lovin' Arms|TTBB|Joseph Meyer, Don Gray, Scott Kitzmiller, Mark Betczynski
 My Honey's Lovin' Arms|TTBB|Walter Latzko
 My House|TTBB|Greg Mallett
 My Ideal|TTBB|Jim West
+My Ideal|TTBB|Leo Robin
 My Ideal|TTBB|Mark Hale
 My Immortal|TTBB|Nicholas Wright
 My Jesus, I Love Thee|TTBB|Derric Johnson
 My Kind Of Girl|TTBB|Brian Mastrull
+My Kind of Town|TTBB|Dan Wessler
 My Kind Of Town (Chicago Is)|TTBB|Dan Wessler
 My Kind Of Town (Chicago Is)|TTBB|Deke Sharon
+My Kind of Town Chicago Is|SSAA|Nancy Bergman
 My Lady Loves To Dance|TTBB|Bob Dowma
 My Life|TTBB|Liz Garnett
+My Life Flows On|SSAA|Tom Gentry
 My Life Flows On (How Can I Keep from Singing)|SSAA|Tom Gentry
 My Life Flows On (How Can I Keep from Singing)|TTBB|Tom Gentry
 My Life for a Song|SSAA|Kevin Keller
@@ -12831,6 +15189,7 @@ My Little Buttercup|TTBB|Michael Webber
 My Little Diamonds|SSAA|Carolyn Johnson
 My Little Dog Left Me Last Night|TTBB|Walter Latzko
 My Little Girl|TTBB|Dick Ellenberger
+My Little Girl|TTBB|Todd Troutman
 My Little Girl|TTBB|Tom Gentry
 My Little Girlie Medley|TTBB|Toban Dvoretsky
 My Little Grass Shack In Kealakekua, Hawaii|SSAA|Anastasio Rossi
@@ -12856,13 +15215,16 @@ My Melancholy Baby|SSAA|Charlotte Pernert
 My Melancholy Baby|SSAA|Dot Calvin
 My Melancholy Baby|SSAA|Jay Giallombardo
 My Melancholy Baby|SSAA|Jo Lund
+My Melancholy Baby|SSAA|Joni Bescos
 My Melancholy Baby|SSAA|Lyndal Thorburn
 My Melancholy Baby|SSAA|Marie Johnson
 My Melancholy Baby|SSAA|Walter Latzko
 My Melancholy Baby|TTBB|Ed Waesche
 My Melancholy Baby|TTBB|Jay Giallombardo
 My Melancholy Baby|TTBB|Kirk Roose
+My Melancholy Baby|TTBB|Lou Perry
 My Melancholy Baby|TTBB|Louis Perry
+My Melancholy Baby|TTBB|Mark Hale
 My Melancholy Blues|TTBB|Aaron Dale
 My Melancholy Blues|TTBB|Kirk Young
 My Melancholy Blues|TTBB|Luke Stevenson
@@ -12871,41 +15233,56 @@ My Melody Of Love|TTBB|Jim West
 My Mom|SSAA|Nancy Bergman
 My Mom|TTBB|Jeremey Johnson
 My Mommy's Still Singing Her Song|SSAA|Joe Liles
+My Most Beautiful Rose|TTBB|Henrik Rosenberg
 My Mother Was A Lady|TTBB|Jack Baird
+My Mother's Eyes|SSAA|Dave Briner
+My Mother's Eyes|SSAA|Nancy Bergman
 My Mother's Eyes|SSAA|Renee Craig
 My Mother's Eyes|TTBB|Bill Borah
 My Mother's Eyes|TTBB|Ed Waesche
 My Mother's Eyes|TTBB|Patrick McAlexander
 My Mother's Eyes|TTBB|Renee Craig
+My Mother's Eyes|TTBB|Unspecified
+My Mother's Pearls|TTBB|Burt Szabo
 My Mother's Rosary|TTBB|Dennis Driscoll
 My Mother's Rosary|TTBB|Unknown
 My Name Is America|TTBB|John Hohl
 My Name Is America|TTBB|Larry Wright
+My Name Is America!|TTBB|John Hohl
 My Neighbor Totoro|SSAA|Sam Hubbard
 My Neighbor Totoro|TTBB|Sam Hubbard
 My New Philosophy|TTBB|Dan Wessler
 My New Sweetie Is Plenty Sweet|TTBB|Burt Szabo
 My Old Blue Jeans|TTBB|Jim West
+My Old Dutch|TTBB|Tony Searle
 My Old Flame|SSAA|Bev Sellers
 My Old Friend(s) (My Old Man)|TTBB|Larry Wright
 My Old Kentucky Home|SATB|Barbershop Harmony Society
 My Old Kentucky Home|SSAA|Barbershop Harmony Society
+My Old Kentucky Home|SSAA|June Dale
 My Old Kentucky Home|TTBB|Barbershop Harmony Society
+My Old Kentucky Home|TTBB|David Harrington
 My Old Kentucky Home|TTBB|Jay Giallombardo
 My Old Kentucky Home|TTBB|Jon Nicholas
 My Old Kentucky Home|TTBB|Walter Latzko
+My Old Kentucky Home, Goodnight|TTBB|Aaron Dale
 My Old Kentucky Home/Jeanie|TTBB|Jay Giallombardo
 My Old Man|TTBB|Eric Ruthenberg
+My Old Man|TTBB|Jim Henry
 My Old Man|TTBB|Larry Wright
 My Old Man's A Sailor|TTBB|James Henry
+My Old Man's A Sailor|TTBB|Jim Henry
 My Old Montana Home|TTBB|Kevin Keller
+My Old Pal|SSAA|Jay Giallombardo
 My Once Upon A Time|SSAA|Tony Nasto
 My One And Only Love|TTBB|Clay Hine
 My One And Only Love|TTBB|Mark Jennings
 My One And Only Love|TTBB|Melody Hine
+My One And Only Love|TTBB|Rob Hopkins
 My One And Only Love|TTBB|Simon Arnott
 My Prayer|SSAA|Tedda Lippincott
 My Prayer|TTBB|Tom Gentry
+My Pretty Little Jesus|TTBB|Burt Szabo
 My Pretty Rose Tree|SATB|David Avshalomov
 My Romance|SATB|Joe Mannherz
 My Romance|SSAA|Burt Szabo
@@ -12913,7 +15290,9 @@ My Romance|SSAA|Donna Stewart
 My Romance|SSAA|Joe Mannherz
 My Romance|SSAA|Joey Minshall
 My Romance|SSAA|Larry Wright
+My Romance|SSAA|Renee Craig
 My Romance|SSAA|Tom Gentry
+My Romance|TTBB|Adam Reimnitz
 My Romance|TTBB|Adam Scott
 My Romance|TTBB|Burt Szabo
 My Romance|TTBB|David Wright
@@ -12921,10 +15300,12 @@ My Romance|TTBB|David Zimmerman
 My Romance|TTBB|Jay Giallombardo
 My Romance|TTBB|Joe Mannherz
 My Romance|TTBB|Larry Wright
+My Romance|TTBB|Renee Craig, adapted by Rich Hasty
 My Romance|TTBB|Rich Hasty
 My Romance|TTBB|Richard Hasty
 My Romance|TTBB|Rob Campbell
 My Romance|TTBB|Tom Gentry
+My Romance|TTBB|Walter Latzko
 My Sally|TTBB|Tom Gentry
 My Sally, Just The Same|TTBB|Barbershop Harmony Society
 My Sally, Just The Same|TTBB|Harold Ulring
@@ -12959,15 +15340,19 @@ My Way|SSAA|Joey Minshall
 My Way|SSAA|Mark Burnip
 My Way|SSAA|Takako Fuke
 My Way|TTBB|Clay Hine
+My Way|TTBB|Dave Briner
 My Way|TTBB|Eric Ruthenberg
 My Way|TTBB|Jay Giallombardo
+My Way|TTBB|John Hohl
 My Way|TTBB|Kevin Koehl
 My Way|TTBB|Mark Burnip
 My Way|TTBB|Simon Arnott
 My Way|TTBB|Theodore Hicks
+My Way|TTBB|Webb Comfort
 My Wife Is On A Diet|TTBB|Jim West
 My Wife Is On A Diet|TTBB|Thomas Gentry
 My Wife Is On A Diet|TTBB|Tom Gentry
+My Wife The Dancer|TTBB|Buzz Haeger
 My Wife The Dancer|TTBB|Warren 'Buzz' Haeger
 My Wild Irish Chrysanthemum|TTBB|Jim Emery
 My Wild Irish Rose|SSAA|Carolyn Johnson
@@ -12976,6 +15361,7 @@ My Wild Irish Rose|SSAA|Joni Bescos
 My Wild Irish Rose|TTBB|Barbershop Harmony Society
 My Wild Irish Rose|TTBB|BHS
 My Wild Irish Rose|TTBB|Don Gray
+My Wild Irish Rose|TTBB|Floyd Connett
 My Wild Irish Rose|TTBB|Jack Baird
 My Wild Irish Rose|TTBB|Jay Giallombardo
 My Wild Irish Rose|TTBB|Tom Gentry
@@ -12984,6 +15370,7 @@ My Wish|TTBB|Mark Stevens
 My Wish For You|SSAA|Kay Bromert
 My Wonderful One|SSAA|Bob Long
 My Wonderful One|SSAA|Walter Latzko
+My World is Beginning Today|SSAA|Kirk Young
 My Yiddishe Momma|TTBB|Dennis Driscoll
 Mysterious Ways|TTBB|Deke Sharon
 Na Na Hey Hey Kiss Him Goodbye|SATB|Deke Sharon
@@ -13011,6 +15398,9 @@ Nature Boy|TTBB|Joe Mannherz
 Naughty|SSAA|Melody Hine
 Naughty|TTBB|Aaron Dale
 Naughty Angeline|TTBB|Clay Hine
+Naughty Angeline|TTBB|Mark Hale
+Naughty Baby|SSAA|Marge Bailey
+Naughty Lady of Shady Lane|SSAA|Tedda Lippincott
 Naughty Lady Of Shady Lane|TTBB|Adam Scott
 Naughty Lady Of Shady Lane|TTBB|Dennis Driscoll
 Naughty Lady Of Shady Lane|TTBB|Tom Gentry
@@ -13020,10 +15410,13 @@ Near the Ivy Grown Cottage of Brown|TTBB|Adam Bock
 Near To The Heart Of God|TTBB|Rudy Hart
 Near You|SSAA|Mark Jennings
 Near You|TTBB|Todd Troutman
+Nearer My God Medley|TTBB|Joe Johnson
+Nearer My God To Thee|TTBB|James Stevens
 Nearer, My God, To Thee|SSAA|Leola Wright
 Nearer, My God, To Thee|SSAA|Nancy Bergman
 Nearer, My God, To Thee|SSAA|Walter Latzko
 Nearer, My God, To Thee|TTBB|David Harrington
+Nearer, My God, To Thee|TTBB|Joe Johnson
 Nearer, My God, To Thee|TTBB|Rudy Hart
 Nearer, My God, To Thee|TTBB|Walter Latzko
 Nearer, Still Nearer|TTBB|Rebecca J. Wood
@@ -13031,6 +15424,7 @@ Nebulous Nineties Medley|TTBB|Barbershop Harmony Society
 Nebulous Nineties Medley|TTBB|BHS
 Necessity|TTBB|Mark Goodney
 Need You Now|SATB|Nicholas Wright
+Neil Sedaka Medley (Next Door to an Angel, Happy Birthday Sweet Sixteen, Oh Carol, Breaking Up is Hard to Do, Calendar Girl)|TTBB|Jan-Ake Westin
 Nellie Introduction|TTBB|Jim West
 Nellie Kelly, I Love You|TTBB|Joe Mannherz
 Nellie Kelly, I Love You|TTBB|Sheldon Nelson
@@ -13063,12 +15457,18 @@ Never Let No Man Worry Your Mind|SSAA|David Wright
 Never Let The Same Bee|SSAA|Marie Johnson
 Never My Love|SSAA|Jon Nicholas
 Never My Love|TTBB|Jon Nicholas
+Never Never Land|TTBB|Jay Giallombardo
 Never Never Land (from Peter Pan)|TTBB|Jay Giallombardo
 Never Never Land (from Peter Pan)|TTBB|Steve Tramack
 Never Neverland|SATB|David Wright
 Never Neverland|SSAA|Joe Mannherz
+Never Neverland|TTBB|Bill Mitchell
 Never Neverland|TTBB|Joe Mannherz
+Never Pass This Way Again|TTBB|Clay Hine
+Never Say 'Never Again' Again|SSAA|Tom Gentry
 Never Say Never|TTBB|Dan Wessler
+Never Say Never / Taking a Chance on Love|TTBB|Tony Searle
+Never Throw A Lighted Lamp At Mother|TTBB|David Wright
 Never Too Late|TTBB|Manoj Padki
 Never Too Late|TTBB|Theodore Hicks
 Never Too Old For Christmas|TTBB|John Hohl
@@ -13079,6 +15479,7 @@ Never-Never Land|TTBB|Brent Graham
 Never-Never Land|TTBB|Jay Giallombardo
 Never-Never Land|TTBB|Larry Wright
 Neverland|TTBB|Jon Nicholas
+Nevertheless|SSAA|Joe Liles
 Nevertheless|SSAA|Nancy Bergman
 Nevertheless|SSAA|Tom Campbell
 Nevertheless|TTBB|Brent Graham
@@ -13087,6 +15488,7 @@ Nevertheless|TTBB|Mark Goodney
 Nevertheless|TTBB|Tom Campbell
 Nevertheless (I'm In Love With You)|SSAA|Tom Campbell
 Nevertheless (I'm In Love With You)|TTBB|Tom Campbell
+Nevertheless (I'm In Love With You)|TTBB|Webb Comfort
 New|SSAA|Emily Moriarty
 New Ashmolean Band|SSAA|David Briner
 New Ashmolean Band|SSAA|Peter Briant
@@ -13095,16 +15497,22 @@ New Ashmolean Band|TTBB|David Wright
 New Ashmolean Band|TTBB|Don Gray
 New Ashmolean Band|TTBB|Jerry Roland
 New Ashmolean Band|TTBB|Steve Delehanty
+New Ashmolean Marching Society and Student's Conservatory Band(Dave Br|TTBB|Dave Briner
+New Ashmolean, Marching Society|TTBB|Dave Briner
 New Ashmolian Marching Society And Students Conservatory Band|SSAA|Nancy Bergman
 New Attitude|SSAA|Larry Wright
+New Gospel Medley|SSAA|Ed Waesche
 New Orleans Funeral Medley|TTBB|Don Gray
 New Orleans Medley|TTBB|Einar Pedersen
 New Orleans Medley|TTBB|Joe Mannherz
+New Orleans Post Parade|SSAA|Ardeth Fullmer
 New Orleans Post Parade|TTBB|Bob Jones
+New Orleans/Sweet Georgia Brown|SSAA|Kay Bromert
 New Romantics|SSAA|Lauren Kahn
 New Way to Walk|SSAA|Carolyn Johnson
 New Words|SSAA|Michael Gellert
 New Words|TTBB|Craig Minor
+New World Symphony - 2nd Movement|TTBB|Jonathan Rathbone
 New Year Medley|SATB|Bryan Ziegler
 New Year Medley|SSAA|Bryan Ziegler
 New Year Medley|TTBB|Bryan Ziegler
@@ -13119,6 +15527,7 @@ New York Medley|TTBB|Jay Giallombardo
 New York Medley|TTBB|Lynn Haldeman
 New York Medley|TTBB|Robert Rund
 New York Medley In 3-Quarter|TTBB|Burt Szabo
+New York New York|SSAA|Renee Craig
 New York State of Mind|SATB|Kohl Kitzmiller
 New York State of Mind|SSAA|Jo Lund
 New York State of Mind|SSAA|Kohl Kitzmiller
@@ -13132,10 +15541,14 @@ New York, New York|SSAA|Jo Lund
 New York, New York|SSAA|Larry Wright
 New York, New York|SSAA|Patrick McAlexander
 New York, New York|SSAA|Steve Jamison
+New York, New York|TTBB|Alan Hale
 New York, New York|TTBB|Blaine Mack
 New York, New York|TTBB|Craig Ewing
 New York, New York|TTBB|Dan Wessler
+New York, New York|TTBB|David Wright
 New York, New York|TTBB|Dennis Morrissey
+New York, New York|TTBB|Don Gray
+New York, New York|TTBB|Don Gray, Ed Waesche
 New York, New York|TTBB|Ed Waesche
 New York, New York|TTBB|Jay Giallombardo
 New York, New York|TTBB|Jim West
@@ -13145,6 +15558,10 @@ New York, New York|TTBB|Marty Israel
 New York, New York|TTBB|Patrick McAlexander
 New York, New York|TTBB|Renee Craig
 New York, New York|TTBB|Steve Jamison
+New York, New York Opener|TTBB|Roger Payne
+New York, NY|TTBB|Jay Giallombardo
+New York(A Hell Of A Town) On Broadway Medley|SSAA|Judy Vidal
+New Zealand Song|SSAA|June Berg
 Newborn Friend|SATB|Vince Peterson
 Next Door Angel Medley|SSAA|Jan-Ake Westin
 Next Door To An Angel|TTBB|Brian Mastrull
@@ -13153,6 +15570,7 @@ Next Time I Love|TTBB|Larry Wright
 Next To Lovin (I Like Fightin Best)|SSAA|Marge Bailey
 Nice 'n Easy|SSAA|Doris Twardosky
 Nice 'n Easy|TTBB|Ig Jakovac
+Nice N' Easy|TTBB|Ig Jakovac
 Nice People|TTBB|Jay Giallombardo
 Nice Work If You Can Get It|SATB|Joe Mannherz
 Nice Work If You Can Get It|SSAA|Carolyn Schmidt
@@ -13179,6 +15597,7 @@ Nina|TTBB|Walter Latzko
 Nine Million Bicycles|TTBB|Hilary Allen
 Nine People's Favorite Thing|TTBB|Kohl Kitzmiller
 Nine People's Favorite Thing (Parody)|TTBB|Kohl Kitzmiller
+Nine to Five|SSAA|Ann Minihane
 Nine To Five|SATB|Kohl Kitzmiller
 Nine To Five|SATB|Matthew Spinner
 Nine To Five|SSAA|Jo Lund
@@ -13192,6 +15611,7 @@ Nine To Five|TTBB|Sam Hubbard
 Nine To Five|TTBB|Steve Jamison
 Nineteen Twenty Seven|SSAA|Larry Wright
 Nineteen Twenty Seven|TTBB|Larry Wright
+Ning Wendete|TTBB|Steven Armstrong
 Nitey Nite|SSAA|Joe Mannherz
 No Fancy Shoes|SSAA|Carolyn Johnson
 No Gold Can Buy The Silver In Your Hair|TTBB|Burt Szabo
@@ -13200,23 +15620,30 @@ No Hopers, Jokers & Rogues|SSAA|Don Staffin
 No Hopers, Jokers & Rogues|TTBB|Don Staffin
 No Love Song|SSAA|Joe Liles
 No Man Left For Me|SSAA|Aaron Dale
+No Matter What|SSAA|Nova Evans
 No Matter What|SSAA|Valerie Hoy
 No Matter What Happens|SSAA|Soren Detlefsen
 No Moon At All|TTBB|Jason Dyer
 No More (My Baby Don't Love Me)|SSAA|Charlene Yazurlo
 No More (My Baby Don't Love Me)|SSAA|Marsha Zwicker
 No More Nights|TTBB|Aaron Dale
+No More Sorrow|TTBB|Shelton Kilby
 No More Sorrow|TTBB|Shelton Kilby III
+No More Sorrow|TTBB|Unspecified
 No More Tears (Enough Is Enough)|SSAA|Sam Hubbard
 No No Never|SSAA|Tom Gentry
 No No Never|TTBB|Tom Gentry
+No No Nora|TTBB|Clay Hine
+No No Norman|SSAA|Clay Hine
 No One|TTBB|Matt Astle
 No One Else|TTBB|Dan Wessler
 No One Else Is Singing My Song|TTBB|Cay Outerbridge
 No One Is Alone|SSAA|Jo Lund
 No One Is Alone|TTBB|Liz Garnett
 No One Knows|TTBB|Arranging 3 Class, Harmony Univ. 2016
+No One Knows|TTBB|Brad Coon
 No One Knows Who I Am|SSAA|Kyle Kitzmiller
+No One Loves You Any Better Than Your M-A Double M-Y|TTBB|Tom Gentry
 No One's Fool|SSAA|Avis Fellows
 No Other Love|TTBB|David Wright
 No Rain|TTBB|Deke Sharon
@@ -13243,6 +15670,7 @@ Nobody But Me|TTBB|Adam Bock
 Nobody Cares Like Me|TTBB|Michael Webber
 Nobody Does It Better|SATB|Deke Sharon
 Nobody Does It Better|SSAA|Carolyn Schmidt
+Nobody Does It Better|TTBB|Josh Ehrlich
 Nobody Does It Like Me!|SSAA|Jo Lund
 Nobody Does It Like Me!|SSAA|Suzy Lobaugh
 Nobody Does It Like Me!|TTBB|Kyle Snook
@@ -13251,35 +15679,49 @@ Nobody Else But You|TTBB|Soren Detlefsen
 Nobody Know How I Miss You, Dear Old Pals|TTBB|Carole Prietto
 Nobody Knows De Trouble I've Seen|TTBB|Jim West
 Nobody Knows The Trouble I've Seen|SSAA|Nancy Bergman
+Nobody Knows What A Red-Head Mama Can Do|SSAA|Dennis Driscoll
+Nobody Knows What A Red-Head Mama Can Do|TTBB|Dennis Driscoll
 Nobody Knows What A Red-Head Mamma Can Do|SSAA|Dennis Driscoll
 Nobody Knows What A Red-Head Mamma Can Do|TTBB|Dennis Driscoll
 Nobody Knows What A Red-Headed Mama Can Do|TTBB|Dennis Driscoll
+Nobody Knows You|TTBB|Dennis Driscoll
 Nobody Knows You When You're Down And Out|SATB|Deke Sharon
 Nobody Knows You When You're Down And Out|SATB|Vince Peterson
 Nobody Knows You When You're Down And Out|TTBB|Dennis Driscoll
 Nobody Knows You When You're Down And Out|TTBB|Paul Grimm
 Nobody Knows You When You're Down And Out|TTBB|Steven Armstrong
+Nobody Knows You When You're Down And Out/That's Life (Medley)|SSAA|Joe Liles
+Nobody Knows You/That's Life Medley|SSAA|Joe Liles
 Nobody Knows, Nobody Cares|TTBB|Burt Szabo
 Nobody Like U|SATB|Deke Sharon
 Nobody Like U|SSAA|Deke Sharon
 Nobody Love|SATB|Nicholas Wright
 Nobody Love|SSAA|Nicholas Wright
+Nobody Loves Me Like You Do|SSAA|Mary Ann Wydra
 Nobody's Fool|TTBB|Joe Grimme
 Nobody's Gal|TTBB|Burt Szabo
 Nobody's Lonesome But Me|SSAA|Avis Fellows
 Nobody's Rose|SSAA|Nancy Bergman
 Nobody's Rose|TTBB|Burt Szabo
 Nobody's Singing At The Old Barbershop|TTBB|Mac Huff
+Nobody's Sweatheart Medley|SSAA|Renee Craig
 Nobody's Sweetheart|SSAA|Al Baker
 Nobody's Sweetheart|SSAA|Bev Sellers
+Nobody's Sweetheart|SSAA|Gene Cokeroft
 Nobody's Sweetheart|TTBB|David Wright
 Nobody's Sweetheart|TTBB|Ed Waesche
 Nobody's Sweetheart|TTBB|Ken Wimbish
+Nobody's Sweetheart|TTBB|Scott Kitzmiller
 Nobody's Sweetheart|TTBB|Tom Gentry
 Nobody's Sweetheart / I Used To Love You Medley|TTBB|Renee Craig
 Nobody's Sweetheart / I'm Nobody's Baby Medley|SSAA|Larry Wright
+Nobody's Sweetheart Now|SSAA|Bev Sellers
+Nobody's Sweetheart Now/Nobody's Baby Medley|SSAA|Larry Wright
+Noel Canon|TTBB|Steven Sametz
 Nonsense Medley|SSAA|Jo Lund
+Noone in the World|SSAA|David Sangster
 North To Alaska|TTBB|John Hohl
+Northwoods Woman|SSAA|Joe Liles
 Norwegian Wood|TTBB|Jay Giallombardo
 Nostalgia Medley|SSAA|Nancy Bergman
 Nostalgia Medley|TTBB|Nancy Bergman
@@ -13288,11 +15730,13 @@ Not A Day Goes By|TTBB|Adam Scott
 Not For The Life Of Me|SSAA|Soren Detlefsen
 Not Gonna Worry|TTBB|Kevin Keller
 Not My Father's Son|TTBB|Greg Mallett
+Not While I'm Around|SSAA|Jeremiah Pope
 Not While I'm Around|SSAA|Joe Mannherz
 Not While I'm Around|TTBB|Jeremiah Pope
 Not While I'm Around|TTBB|Joe Mannherz
 Not While I'm Around (from Sweeney Todd)|TTBB|Steve Tramack
 Not While I'm Around (from Sweeney Todd)|TTBB|Theo Hicks
+Nothin' Rhymes|SSAA|Sharon Holmes
 Nothing But The Best|TTBB|Andrew Carolan
 Nothing But The Best|TTBB|Dom Finetti
 Nothing But The Best|TTBB|Kevin Koehl
@@ -13309,6 +15753,7 @@ Nothing Like a Dame/Honey Bun Medley|TTBB|Jay Giallombardo
 Nothing Seems The Same Anymore|SSAA|Donna Shorkey
 Nothing Seems The Same Anymore|TTBB|Dennis Driscoll
 Nothing's Gonna Stop Us|SSAA|Carole Prietto
+Nothing's Gonna Stop Us Now|SSAA|Carole Prietto
 Notre Dame Victory March|SSAA|Kevin Keller
 Notre Dame Victory March|TTBB|Kevin Keller
 Now and Forever|SATB|Deke Sharon
@@ -13332,6 +15777,7 @@ Now The Day is Over|TTBB|Frank Thorne
 Now The Day is Over|TTBB|Walter Latzko
 Now We Sing|SATB|Wayne Grimmer
 Nowadays|SSAA|Carolyn Johnson
+Nowadays/Razzle Dazzle|SSAA|Jean McFadyen
 Nowhere Man|SATB|Manoj Padki
 Nowhere Man|TTBB|Steve Tramack
 Nowhere to Go but Up|SATB|Dan Wessler
@@ -13340,21 +15786,30 @@ Nowhere to Go but Up|SSAA|Tom Gentry
 Nowhere to Go but Up|TTBB|Dan Wessler
 Nowhere to Go but Up|TTBB|Nick Bryant
 Nowhere to Go but Up|TTBB|Tom Gentry
+Nox Aurumque|SATB|Eric Whitacre
 Nur Getraeumt|TTBB|Tom Gentry
 Nurse's Song|SATB|David Avshalomov
+Nutcracker Jingles|SSAA|Joan D'Agostino
 Nuttin' For Christmas|SSAA|Jan Meyer
+Nuttin' For Christmas|SSAA|Meyer
+Nuttin' For Christmas|SSAA|Sheila Cope
+Nuttin' For Christmas|TTBB|Burt Szabo
 Nuttin' For Christmas|TTBB|Jon Nicholas
 O|SATB|Jon Nicholas
 O|SATB|Nicholas Wright
 O Breath Of Early Spring (Pourquoi Me Reveiller)|TTBB|Jay Giallombardo
+O Canada|SSAA|Joe Liles
 O Canada!|SATB|Deke Sharon
 O Canada!|SATB|Joe Liles
 O Canada!|SSAA|Deke Sharon
 O Canada!|SSAA|Joe Liles
 O Canada!|SSAA|Joey Minshall
 O Canada!|SSAA|Norma Andersen
+O Canada!|TTBB|Barbershop Harmony Society
+O Canada!|TTBB|Chris Arnold
 O Canada!|TTBB|Jay Giallombardo
 O Canada!|TTBB|Joe Liles
+O Canada! (Bilingual)|TTBB|Chris Arnold
 O Chanukah, O Chanukah|SSAA|Carolyn Johnson
 O Christmas Tree|SATB|Deke Sharon
 O Christmas Tree|SATB|Joe Mannherz
@@ -13364,6 +15819,11 @@ O Christmas Tree|SSAA|Kay Bromert
 O Christmas Tree|TTBB|Douglas Smith
 O Christmas Tree|TTBB|Jay Giallombardo
 O Christmas Tree|TTBB|Joe Liles
+O Come All Ye Faithful|SSAA|Dan Deisroth
+O Come All Ye Faithful|SSAA|Joni Bescos
+O Come All Ye Faithful|TTBB|Unspecified
+O Come All Ye Faithful / Joy To The World Medley|TTBB|Earl Moon
+O Come Emanuel|TTBB|Kevin Keller
 O Come O Come Emmanuel|SATB|Simon Lubkowski
 O Come O Come Emmanuel|SSAA|Kevin Keller
 O Come O Come Emmanuel|SSAA|Mark Rusch
@@ -13374,6 +15834,8 @@ O Come O Come Emmanuel|TTBB|Jon Nicholas
 O Come O Come Emmanuel|TTBB|Kevin Keller
 O Come O Come Emmanuel|TTBB|Mark Rusch
 O Come O Come Emmanuel|TTBB|Nicholas Wright
+O Come O Come Emmanuel (Veni, Veni)|SSAA|Kevin Keller
+O Come O Come Emmanuel (Veni, Veni)|TTBB|Kevin Keller
 O Come, All Ye Faithful|SATB|Derric Johnson
 O Come, All Ye Faithful|SSAA|Dianne Goldrick
 O Come, All Ye Faithful|SSAA|Joni Bescos
@@ -13382,6 +15844,8 @@ O Come, All Ye Faithful|TTBB|Burt Szabo
 O Come, All Ye Faithful|TTBB|Dianne Goldrick
 O Come, All Ye Faithful|TTBB|Jim Clancy
 O Come, All Ye Faithful|TTBB|Mark Rusch
+O Come, O Come Emmanuel|SSAA|Kevin Keller
+O Come, O Come Emmanuel|TTBB|Kevin Keller
 O Euchari Columba|TTBB|David Avshalomov
 O God, Our Help In Ages Past|TTBB|Jon Nicholas
 O Happy Day|TTBB|Derric Johnson
@@ -13393,14 +15857,18 @@ O Holy Night|SATB|Mel Knight
 O Holy Night|SSAA|Adam Bock
 O Holy Night|SSAA|Avis Fellows
 O Holy Night|SSAA|Carole Prietto
+O Holy Night|SSAA|Greg Volk
 O Holy Night|SSAA|Jay Dougherty
 O Holy Night|SSAA|Jay Giallombardo
 O Holy Night|SSAA|Joni Bescos
 O Holy Night|SSAA|Mark Rusch
 O Holy Night|SSAA|Rebecca J. Wood
 O Holy Night|SSAA|Suzy Buerer
+O Holy Night|TTBB|Barbershop Harmony Society
+O Holy Night|TTBB|Chris Arnold
 O Holy Night|TTBB|David Wright
 O Holy Night|TTBB|Derric Johnson
+O Holy Night|TTBB|Ed Lojeski
 O Holy Night|TTBB|Jay Giallombardo
 O Holy Night|TTBB|Jim Clancy
 O Holy Night|TTBB|Joe Mannherz
@@ -13411,6 +15879,7 @@ O Holy Night|TTBB|Soren Detlefsen
 O Holy Night|TTBB|Walter Latzko
 O How He Loves You and Me|TTBB|Derric Johnson
 O Joe|TTBB|Frank Thorne
+O Little Town of Bethlehem|TTBB|Kris Olson
 O Little Town Of Bethlehem|SATB|David Harrington
 O Little Town Of Bethlehem|SSAA|Carolyn Johnson
 O Little Town Of Bethlehem|SSAA|Dianne Goldrick
@@ -13423,25 +15892,33 @@ O Little Town Of Bethlehem|TTBB|Dianne Goldrick
 O Little Town Of Bethlehem|TTBB|Kevin Keller
 O Little Town Of Bethlehem|TTBB|Paul Jorg
 O Little Town Of Bethlehem|TTBB|Walter Latzko
+O Love That Will Not Let Me Go|TTBB|David Phelps
 O Love That Wilt Not Let Me Go|TTBB|Derric Johnson
 O Master Let Me Walk With Thee|TTBB|Walter Latzko
 O Pato (The Duck)|TTBB|Melody Hine
 O Perfect Love|TTBB|Derric Johnson
 O Tannenbaum|TTBB|Derric Johnson
 O The Deep, Deep Love Of Jesus|TTBB|Derric Johnson
+O Thou That Tellest Good Tidings To Zion|SATB|Handel's Messiah
 O Waly Waly|SSAA|Liz Garnett
 O Worship The King|TTBB|Derric Johnson
 O, America|SSAA|Tom Gentry
 O, America|TTBB|Tom Gentry
+O, Canada|SSAA|Norma Andersen
+O, Holy Night|TTBB|Jon Nicholas
 O'Brien Is Tryin' To Learn To Talk Hawaiian|TTBB|Burt Szabo
 O'Brien To Ryan To Goldberg|TTBB|J Rae Jamieson
 O'Brien To Ryan To Goldberg|TTBB|Steve Tramack
+Ob La Di, Ob La Da|TTBB|Mark Hale
+Ob La Di, Ob La Da, Life Goes On|TTBB|Mark Hale
+Ob-La-Di|SSAA|Mark Hale
 Ob-La-Di, Ob-La-Da|SSAA|Carolyn Schmidt
 Ob-La-Di, Ob-La-Da|SSAA|Karen McCarville
 Ob-La-Di, Ob-La-Da|TTBB|Jim Shubert
 Ob-La-Di, Ob-La-Da|TTBB|Mark Hale
 Occapella|SSAA|Marie Hampton
 Ocean Eyes|SATB|Nicholas Wright
+Octopus' Garden|SSAA|Carolyn Schmidt
 Octopus's Garden|SATB|Manoj Padki
 Octopus's Garden|SSAA|Carolyn Schmidt
 Octopus's Garden|SSAA|Larry Wright
@@ -13452,46 +15929,70 @@ Ode To Joy (Joyful, Joyful)|SSAA|Barbara McNeill
 Ode To Joy (Joyful, Joyful)|SSAA|Carolyn Johnson
 Ode To Joy (Joyful, Joyful)|SSAA|Larry Wright
 Ode To Joy (Joyful, Joyful)|TTBB|Larry Wright
+Ode to Joy Medley|TTBB|Jay Giallombardo
 Ode To My Answering Machine|SSAA|Marie Johnson
 Ode To New Orleans|SSAA|David Wright
 Ode To New Orleans|TTBB|David Wright
 Of Thee I Sing, America!|TTBB|Jay Giallombardo
 Oh Atlanta|TTBB|Deke Sharon
 Oh Baby Mine|SSAA|Walter Latzko
+Oh Bury Me Out on the Lone Prairie|TTBB|The Thoroughbreds Chorus
 Oh By Jingo!|SSAA|Nancy Bergman
 Oh By Jingo!|TTBB|Bud Arberg
+Oh Come All Ye Faithful|TTBB|Barbershop Harmony Society
+Oh Daddy Blues|SSAA|Mark Jennings
 Oh Daddy Blues (You Won't Have No Mama At All)|SSAA|Mark Jennings
+Oh Darling|SSAA|David Harrington
 Oh Happy Day|SATB|Deke Sharon
 Oh Happy Day|SSAA|David Wright
 Oh Happy Day|SSAA|Larry Wright
 Oh Happy Day|TTBB|Don Thomson
 Oh Happy Day|TTBB|Larry Wright
 Oh Helen!|TTBB|Toban Dvoretsky
+Oh Holy Night|SSAA|Joni Bescos
+Oh Holy Night|TTBB|Barbershop Harmony Society
+Oh How I Miss You Tonight|SSAA|Renee Craig
+Oh How I Miss You Tonight/When I Lost You Medley|TTBB|Jay Giallombardo
 Oh How We Roared In The Twenties|TTBB|Toban Dvoretsky
+Oh How We Roared In The Twenties|TTBB|Toban Dvoretzky
 Oh Johnny|SSAA|Jay Giallombardo
 Oh Johnny, Oh Johnny, Oh!|SSAA|Carolyn Johnson
+Oh Little Town Of Bethlehem|SSAA|Nancy Bergman
+Oh Look at Me Now|TTBB|Aaron Dale
+Oh Look At Me Now|SSAA|Aaron Dale
 Oh Mabel|TTBB|Steve Hardy
 Oh My Father|TTBB|Aaron Dale
 Oh My God|TTBB|Nicholas Wright
 Oh Sherrie!|TTBB|Will Makra
+Oh Susanna (YWIH)|SSAA|Carolyn Schmidt
+Oh Susanna, Dust Off That Old Pianna|SSAA|David Wright
+Oh Susanna, Dust Off That Old Pianna|SSAA|David Wright/Carolyn Schmidt
+Oh Susannah|TTBB|Aaron Dale
+Oh Susannah, Dust Off That Old Pianna|SSAA|Avis Fellows and Randine Hartlestad
 Oh Suzanna, Dust Off That Old Pianna|TTBB|Brian Mastrull
+Oh What a Beautiful Morning|SSAA|Anna Maria Parker
 Oh What A Beautiful Morning!|SATB|Deke Sharon
 Oh What A Beautiful Morning!|SSAA|Nancy Bergman
 Oh What A Beautiful Morning!|TTBB|Nancy Bergman
 Oh Yes! I'd Climb (The Highest Mountain Just for You)|TTBB|Sam Dabrusin
+Oh You Beautiful Doll|SSAA|Jay Giallombardo
 Oh You Crazy Moon|TTBB|Walter Latzko
 Oh, Come All Ye Faithful / Joy To The World Medley|SSAA|Jay Giallombardo
 Oh, Come All Ye Faithful / Joy To The World Medley|TTBB|Earl Moon
 Oh, Come All Ye Faithful / Joy To The World Medley|TTBB|Jay Giallombardo
 Oh, How I Hate To Get Up In The Morning|SSAA|Nancy Bergman
+Oh, How I Hate To Get Up In The Morning|TTBB|Hal Maples
 Oh, How I Hate To Get Up In The Morning|TTBB|Jay Krumbholz
 Oh, How I Hate To Get Up In The Morning|TTBB|Nancy Bergman
+Oh, How I Miss You Tonight|SSAA|Craig, Wyatt, Briner
 Oh, How I Miss You Tonight|SSAA|Jim Arns
 Oh, How I Miss You Tonight|SSAA|Larry Wright
+Oh, How I Miss You Tonight|SSAA|Renee Craig/Steve Jamison
 Oh, How I Miss You Tonight|TTBB|Joe Mannherz
 Oh, How I Miss You Tonight|TTBB|Larry Wright
 Oh, How I Miss You Tonight/When I Lost Medley|SSAA|Jay Giallombardo
 Oh, How I Miss You Tonight/When I Lost Medley|TTBB|Jay Giallombardo
+Oh, How I Miss You Tonight/When I Lost You|SSAA|Jay Giallombardo
 Oh, It's A Lovely War! Medley|TTBB|Greg Mallett
 Oh, Lonesome Me|SSAA|David Wright
 Oh, Lonesome Me|TTBB|David Wright
@@ -13507,6 +16008,7 @@ Oh, Susanna Dust Off That Old Pianna|TTBB|G. W. Pellant
 Oh, Susanna Dust Off That Old Pianna|TTBB|Tom Campbell
 Oh, What A Beautiful Mornin'|SSAA|Anna Maria Parker
 Oh, What A Beautiful Mornin'|TTBB|Walter Latzko
+Oh, What A Beautiful Morning|SSAA|Nancy Bergman
 Oh, What A Merry Christmas Day|SSAA|Connie Nickel
 Oh, What A Pal Was Whoozis|TTBB|Steve Jamison
 Oh, You Beautiful Doll|SSAA|Jay Giallombardo
@@ -13525,6 +16027,7 @@ Oh! Darling|SATB|Manoj Padki
 Oh! Darling|SSAA|David Harrington
 Oh! Darling|TTBB|David Harrington
 Oh! Honey (Frenchy)|SSAA|Carolyn Johnson
+Oh! How I Hate to Get Up in the Morning|SSAA|Nancy Bergman
 Oh! How I Laugh When I Think How I Cried About You|SSAA|Marie Johnson
 Oh! Look At Me Now|SSAA|Aaron Dale
 Oh! Look At Me Now|TTBB|Aaron Dale
@@ -13540,19 +16043,25 @@ Oh! What A Pal Was Mary|TTBB|Jack Baird
 Oh! What A Pal Was Mary|TTBB|Tom Gentry
 Oh! What It Seemed To Be|TTBB|Jim Shubert
 Oh! What It Seemed To Be|TTBB|Mark Goodney
+Oh! You Beautiful Doll|TTBB|Kirk Roose
+Oh! You Beautiful Doll|TTBB|Rob Campbell
 Ohio State University Alma Mater|TTBB|Tom Gentry
 OK, It's Alright With Me|TTBB|Deke Sharon
 Oklahoma|SSAA|Mark Burnip
 Oklahoma|TTBB|Jay Giallombardo
 Oklahoma|TTBB|John Coffin
 Oklahoma|TTBB|Mark Burnip
+Oklahoma|TTBB|Mo Rector
 Oklahoma Medley|TTBB|Dennis Driscoll
 Oklahoma Medley|TTBB|Jay Giallombardo
 Ol' 55|TTBB|Craig Minor
 Ol' MacDonald|TTBB|Robert Rund
 Ol' Man River|TTBB|Steve Hardy
+Ol' Saint Nicholas|SSAA|Tedda Lippincott
 Old Bazar in Cairo|SSAA|Mark Burnip
 Old Bazar in Cairo|TTBB|Mark Burnip
+Old Black Joe|TTBB|Tom Gentry
+Old Black Magic|SSAA|Jim Massey
 Old Boffo Medley|TTBB|Barbershop Harmony Society
 Old Boffo Medley|TTBB|SPEBSQSA
 Old Boffo Medley|TTBB|Unknown
@@ -13562,13 +16071,17 @@ Old Bones|TTBB|Earl Moon
 Old Bones|TTBB|Ig Jakovac
 Old Bones|TTBB|Larry Triplett
 Old Cape Cod|SSAA|Larry Wright
+Old Cape Cod|SSAA|Marge Bailey
 Old Cape Cod|SSAA|Tom Gentry
+Old Cape Cod|TTBB|Bradford Taylor
 Old Cape Cod|TTBB|Larry Wright
 Old Cape Cod|TTBB|Phil Ordaz
 Old Cape Cod|TTBB|Russ Foris
 Old Cape Cod|TTBB|Tom Gentry
+Old Cape Cod|TTBB|Unspecified
 Old Cape Cod|TTBB|William Behrendt
 Old Devil Moon|TTBB|Aaron Dale
+Old Devil Moon|TTBB|Adam Reimnitz
 Old Devil Moon|TTBB|Justin Miller
 Old Devil Moon|TTBB|Mark Goodney
 Old Devil Moon (from Finian's Rainbow)|TTBB|Aaron Dale
@@ -13579,6 +16092,7 @@ Old Fashioned Girl|TTBB|Larry Wright
 Old Fashioned Girl|TTBB|SPEBSQSA
 Old Fashioned Girl|TTBB|Unknown
 Old Fashioned Girl/Sweet And Lovely Medley|TTBB|Richard Hasty
+Old Fashioned Girl/Sweet And Lovely Medley(Rich H|TTBB|Rich Hasty
 Old Fashioned Lady|SSAA|Barbara Bianchi
 Old Fashioned Locket And A Curl|TTBB|Dennis Driscoll
 Old Fashioned Locket And A Curl|TTBB|Warren 'Buzz' Haeger
@@ -13592,19 +16106,29 @@ Old Folks|TTBB|Jim West
 Old Folks|TTBB|Robert Rund
 Old Folks|TTBB|Tom Gentry
 Old Folks|TTBB|Warren 'Buzz' Haeger
+Old Folks At Home|TTBB|Clay Hine
 Old Folks At Home|TTBB|David Wright
 Old Folks Boogie|TTBB|Deke Sharon
 Old Friends|SSAA|Lauren Kahn
+Old Friends|TTBB|Kirk Young
 Old Friends Medley|SSAA|Tom Gentry
 Old Friends Medley|TTBB|Tom Gentry
 Old Glory|SATB|Joe Mannherz
 Old Grey Bonnet Medley|TTBB|Merrill Miller
+Old Hymns Medley|TTBB|David Wright
 Old Irish Blessing|SSAA|Larry Wright
 Old Is In|SSAA|Walter Latzko
+Old Kentucky Home Medley|TTBB|Jay Giallombardo
 Old Landmark|SATB|Deke Sharon
 Old Love Letters|TTBB|Burt Szabo
 Old Macdonald Had A Farm|SATB|Derric Johnson
 Old Macdonald Had A Farm|SSAA|Asuka Ichikawa
+Old Man River|TTBB|Bryan Ziegler
+Old Man River|TTBB|Ed Boehm
+Old Man River|TTBB|Fred King
+Old Man River|TTBB|Melvin Knight
+Old Man River|TTBB|Ty Gwyn
+Old Man Time|TTBB|Dennis Malone, John Hohl
 Old Man Time|TTBB|John Hohl
 Old Me Better|TTBB|Clay Hine
 Old Mother Hubbard|TTBB|Dan Wessler
@@ -13621,16 +16145,23 @@ Old Rugged Cross|TTBB|Dennis Morrissey
 Old Rugged Cross|TTBB|Joe Liles
 Old Rugged Cross|TTBB|Roy Keys
 Old Rugged Cross|TTBB|Walter Latzko
+Old Saint Louis|TTBB|David Wright
 Old Shep|TTBB|Tom Gentry
 Old Songs / Roll Dem Bones Medley|TTBB|G. W. Pellant
+Old Songs are Just Like Old Friends|SSAA|Lou Perry
 Old Songs Are Just Like Old Friends|SSAA|Einar Pedersen
 Old Songs Are Just Like Old Friends|SSAA|Louis Perry
 Old Songs Are Just Like Old Friends|TTBB|Einar Pedersen
 Old Songs Are Just Like Old Friends|TTBB|Louis Perry
+Old Songs Medley|TTBB|Ed Waesche
 Old Songs Medley|TTBB|Jack Ware
+Old Songs, Old Friends|SSAA|Vicki Uhr
+Old Songs, Old Friends|TTBB|Vicki Uhr
 Old St. Louie|SSAA|David Wright
 Old St. Louie|TTBB|David Wright
 Old St. Louie|TTBB|Jim West
+Old St. Louis|SSAA|David Wright
+Old Teddy Bear|SSAA|Lynnell Diamond
 Old Time Hymn Medley|SSAA|Kay Bromert
 Old Time Love Songs|TTBB|Mac Huff
 Old Time Medley|TTBB|Barbershop Harmony Society
@@ -13640,12 +16171,14 @@ Old Time Religion|TTBB|Archie Steen
 Old Time Religion|TTBB|Jay Giallombardo
 Old Time Religion Medley|SSAA|Betty Oliver
 Old Time Religion Medley|SSAA|Karen McCarville
+Old Time Religion Medley|TTBB|Steven Armstrong
 Old Toy Trains|SSAA|Gail Docktor
 Old Toy Trains|TTBB|Shelagh Radcliffe
 Old Toy Trains|TTBB|Will Makra
 Old Upright Piano|TTBB|Ken McPhaden
 Old Upright Piano|TTBB|Mark Stevens
 Old Virginia Moon|TTBB|Edwin Smith
+Old World Christmas Medley|TTBB|Larry Triplett
 Old World Christmas Melody|SATB|Larry Triplett
 Old World Christmas Melody|SSAA|Larry Triplett
 Old World Christmas Melody|TTBB|Larry Triplett
@@ -13658,13 +16191,18 @@ Oliver Medley|SSAA|Kevin Keller
 Oliver Medley|SSAA|Liz Garnett
 Oliver Medley|SSAA|Tom Gentry
 Oliver Medley|TTBB|Jay Giallombardo
+Oliver Medley|TTBB|Kevin Keller
+Oliver Medley|TTBB|Pete Rupay
 Oliver Medley|TTBB|Tom Gentry
 Olivia|TTBB|Greg Mallett
 Omar Sharif|TTBB|Greg Mallett
 Omen|TTBB|Nicholas Wright
+On A Bicycle Built for Two|SSAA|Marie Johnson
 On A Bicycle Built For Two (Daisy Bell)|SSAA|Marie Johnson
 On A Chinese Honeymoon|SSAA|Walter Latzko
+On a Clear Day|TTBB|Adam Reimnitz
 On A Clear Day|SATB|Kevin Keller
+On A Clear Day|SSAA|Sylvia Alsbury
 On A Cruise|SSAA|Nancy Bergman
 On A Mission|SSAA|Jen Squires
 On A Rainy Day Medley|TTBB|Dan Wilson
@@ -13684,15 +16222,20 @@ On A Slow Boat To China/Shanghai Medley|SSAA|Jay Giallombardo
 On A Slow Boat To China/Shanghai Medley|TTBB|Jay Giallombardo
 On A Sunday Afternoon|TTBB|Val Hicks
 On A Sunday By The Sea|SSAA|Walter Latzko
+On A Wonderful Day Like Today|SSAA|George Avener
 On A Wonderful Day Like Today|SSAA|Joey Minshall
 On A Wonderful Day Like Today|SSAA|Tedda Lippincott
 On A Wonderful Day Like Today|TTBB|Aaron Dale
+On A Wonderful Day Like Today|TTBB|Mo Rector
 On An Island Surrounded By Girls|TTBB|Burt Szabo
 On and On|TTBB|Craig Minor
+On and On|TTBB|Marshall Webb
+On Angel's Wings|SSAA|Michael Gellert
 On Another's Sorrow|SATB|David Avshalomov
 On Bended Knee|TTBB|Adam Scott
 On Broadway|SATB|Brian Doepke
 On Broadway|SSAA|Nancy Bergman
+On Eagle's Wings|SSAA|Nancy Bergman
 On eagles wings|SSAA|Joe Mannherz
 On Green Dolphin Street|SSAA|Scott Kitzmiller
 On Green Dolphin Street|TTBB|Jim Shubert
@@ -13703,12 +16246,15 @@ On Moonlight Bay|TTBB|David Wright
 On Moonlight Bay|TTBB|Douglas Miller
 On Moonlight Bay|TTBB|Jim West
 On My Mind|SATB|Nicholas Wright
+On My Own|SSAA|Barabara McNeill
 On My Own|SSAA|Barbara McNeill
 On My Own|SSAA|Jo Lund
+On My Own|SSAA|Jo Lund/Lorraine Rochefort
 On My Own|SSAA|Joey Minshall
 On My Own|SSAA|June Dale
 On My Own|SSAA|Sylvia Alsbury
 On My Own|TTBB|Kevin Keller
+On My Own|TTBB|Kevin Keller, Steven Armstrong, Chris Arnold
 On My Own|TTBB|Steve Jamison
 On My Way|SATB|Cay Outerbridge
 On My Way|SSAA|Simon Arnott
@@ -13724,6 +16270,7 @@ On The Atchison, Topeka And The Santa Fe|SSAA|Walter Latzko
 On The Atchison, Topeka And The Santa Fe|TTBB|Dick Rode
 On The Atchison, Topeka And The Santa Fe|TTBB|Jay Giallombardo
 On The Atchison, Topeka And The Santa Fe|TTBB|Walter Latzko
+On The Atchison, Topeka, And The Santa Fe|TTBB|Dick Rode
 On The Banks Of The Brandywine|TTBB|Steve Jamison
 On The Banks Of The Wabash|SSAA|Suzy Buerer
 On The Banks Of The Wabash|TTBB|David Wright
@@ -13736,6 +16283,7 @@ On The Beaches Of Normandy|TTBB|Douglas Smith
 On The Bright Side of Life|TTBB|Will Hamblet
 On The Farm In Old Missouri|TTBB|Gregory Lyne
 On The Farm In Old Missouri|TTBB|Unknown
+On the Mississippi|SSAA|Bev Sellers
 On The Mississippi|TTBB|Burt Szabo
 On The Mississippi Queen|TTBB|Dennis Driscoll
 On The Old Dominion Line|TTBB|Burt Szabo
@@ -13743,16 +16291,19 @@ On The Old Front Porch|TTBB|Burt Szabo
 On The Other End Of A Kiss|TTBB|Steve Hardy
 On The Road Again|SATB|Kyle Snook
 On The Road Again|SSAA|Carolyn Schmidt
+On The Road Again|SSAA|Dot Calvin
 On The Road Again|SSAA|June Berg
 On The Road Again|TTBB|Aaron Dale
 On The Road Again|TTBB|Jon Nicholas
 On The South Side Of Chicago|SSAA|Larry Wright
+On the Street Where You Live|SSAA|June Berg
 On The Street Where You Live|SSAA|Brent Graham
 On The Street Where You Live|SSAA|Jay Giallombardo
 On The Street Where You Live|SSAA|Liz Garnett
 On The Street Where You Live|SSAA|Steve Tramack
 On The Street Where You Live|TTBB|David Wright
 On The Street Where You Live|TTBB|Jay Giallombardo
+On The Street Where You Live|TTBB|Ron Middlestadt
 On The Street Where You Live|TTBB|Ron Middlestaedt
 On The Street Where You Live|TTBB|Steve Tramack
 On The Street Where You Live|TTBB|Walter Latzko
@@ -13771,12 +16322,16 @@ On The Way to Cape May|SSAA|Carolyn Schmidt
 On The Way to Cape May|SSAA|Larry Triplett
 On The Way to Cape May|TTBB|Larry Triplett
 On The Way To Home Sweet Home|TTBB|Joe Liles
+On Top of Old Smokey|TTBB|Unspecified
 On Wisconsin|SATB|Kevin Keller
 On Wisconsin|SSAA|Kevin Keller
 On Wisconsin|TTBB|Kevin Keller
 On With The Show|TTBB|Dennis Morrissey
+On! On! U Of K|TTBB|Jon Nicholas
 Once In A Lifetime|SATB|Joe Mannherz
+Once In A Lifetime|SSAA|Mark Hale
 Once In A Lifetime|SSAA|Sonny Steffan
+Once in a Lifetime-I'll be Seeing You|SSAA|Rob Hopkins
 Once In A While|SATB|Scott Kitzmiller
 Once In A While|SSAA|Jo Lund
 Once In A While|TTBB|Ed Waesche
@@ -13786,11 +16341,15 @@ Once In A While|TTBB|John Hohl
 Once In A While|TTBB|Mel Knight
 Once In A While|TTBB|Todd Troutman
 Once In Love With Amy|TTBB|Jim Shubert
+Once In Love With Amy|TTBB|Lou Perry
 Once In Love With Amy|TTBB|Rob Hopkins
 Once In Love With Amy|TTBB|Walter Latzko
+Once In My Life|TTBB|Joni Bescos
 Once in Royal David's City|SSAA|Glenda Lloyd
+Once In Royal David's City|TTBB|Paul Selby
 Once More I Can See|TTBB|Dan Wessler
 Once More I Can See|TTBB|Theodore Hicks
+Once Upon a December|SSAA|Judy Hendrickson
 Once Upon A December|SATB|Joe Mannherz
 Once Upon A December|SSAA|Chris Arnold
 Once Upon A December|TTBB|Chris Arnold
@@ -13802,6 +16361,7 @@ Once Upon A Dream|TTBB|Steve Tramack
 Once Upon A Summertime|TTBB|Walter Latzko
 Once Upon A Time|SSAA|Frank Marzocco
 Once Upon A Time|SSAA|Jo Lund
+Once Upon A Time|SSAA|June Dale
 Once Upon A Time|SSAA|Larry Wright
 Once Upon A Time|SSAA|Rob Campbell
 Once Upon A Time|SSAA|Stephanie G. Gentry
@@ -13813,8 +16373,13 @@ Once Upon A Time (from All American)|TTBB|Rob Campbell
 Once You Lose Your Heart|SSAA|Gayle Haley
 Once You Lose Your Heart|SSAA|Jan-Ake Westin
 One|SSAA|Liz Garnett
+One|SSAA|Renee Craig
 One|TTBB|David Briner
+One|TTBB|Dot Calvin
 One|TTBB|Val Hicks
+One (12 parts)|SSAA|Renee Craig
+One (Chorus Line)|SSAA|Dot Calvin
+One & Only Genuine Original Family Band|SSAA|Cheryl Suhr
 One Alone|SSAA|David Wright
 One Alone|TTBB|David Wright
 One Alone|TTBB|Don Gray
@@ -13831,16 +16396,20 @@ One Day|TTBB|Nicholas Wright
 One Day I'll Fly Away|SSAA|Joey Minshall
 One Day Like This|SSAA|Liz Garnett
 One Day Like This|TTBB|Liz Garnett
+One Day More|TTBB|Brian Beck
 One Fine Day|SSAA|Carole Prietto
 One Fine Day|SSAA|David Wright
 One Fine Day|SSAA|Dawn Haggerty
 One Fine Day|SSAA|Deke Sharon
+One Fine Day|SSAA|M. Zwicker (YWIH)
 One Fine Day|SSAA|Marsha Zwicker
 One Fine Day|SSAA|Tedda Lippincott
 One Fine Day|TTBB|Chris Arnold
 One Fine Day|TTBB|Dale Hanson
 One Fine Day|TTBB|Jeremey Johnson
 One Fine Day|TTBB|Joe Mannherz
+One For My Baby|TTBB|Nathan Peplinski
+One For My Baby|TTBB|Roger Payne
 One For My Baby (And One More For The Road)|SSAA|Larry Wright
 One For My Baby (And One More For The Road)|TTBB|Larry Wright
 One For My Baby (And One More For The Road)|TTBB|Mark Goodney
@@ -13850,8 +16419,10 @@ One God|SSAA|Anita Barzilla
 One God|SSAA|Anna Maria Parker
 One God|TTBB|John Hohl
 One Hand, One Heart|TTBB|Mark Burnip
+One Hand, One Heart/Tonight Medley|SSAA|Sylvia Alsbury
 One Heart|SATB|Anders Lindqvist
 One Heart|TTBB|Anders Lindqvist
+One Heart, One Voice|SSAA|Joe Liles
 One Heart, One Voice|TTBB|Joe Liles
 One Heartbeat|SATB|Melody Hine
 One In A Million Like Mary|TTBB|Louis Perry
@@ -13872,6 +16443,8 @@ One Moment in Time|SSAA|David Wright
 One Moment in Time|TTBB|Brent Graham
 One Moment in Time|TTBB|David Wright
 One Moment in Time|TTBB|Derric Johnson
+One Moment In Time|SSAA|Bev Sellers
+One Moment In Time|TTBB|Greg Volk
 One More Last Chance|SSAA|Aaron Dale
 One More Last Chance|TTBB|Aaron Dale
 One More Minute|SATB|Deke Sharon
@@ -13880,17 +16453,21 @@ One More Minute|TTBB|Grant Goulding
 One More Payment|TTBB|Joe Grimme
 One More Sleep 'til Christmas|TTBB|Ken Potter
 One More Song|SSAA|Jim West
+One More Song|SSAA|Joe Liles
 One More Song|SSAA|Nancy Bergman
 One More Time|SSAA|Carolyn Schmidt
 One More Time|TTBB|Lloyd Steinkamp
 One Note Samba|SATB|Joe Mannherz
 One Note Samba|SSAA|Larry Wright
+One Note Samba|TTBB|Brian Beck
 One Note Samba|TTBB|Larry Wright
 One Of These Things Is Not Like The Others|TTBB|Wayne Grimmer
+One of Those Songs|SSAA|Dan Gray
 One Of Those Songs|SSAA|Kay Bromert
 One Of Those Songs|SSAA|Nancy Bergman
 One Of Those Songs|TTBB|R. B. Easterlin
 One Of Those Songs|TTBB|Steve Jamison
+One Of Those Songs|TTBB|Unspecified
 One Of Those Songs|TTBB|Walter Latzko
 One Pair Of Hands|TTBB|Jim West
 One Pair Of Hands|TTBB|Jon Nicholas
@@ -13914,15 +16491,23 @@ One Tin Soldier|TTBB|Tom Gentry
 One Toy Soldier|SSAA|June Dale
 One True Love|TTBB|Deke Sharon
 One Voice|SATB|Larry Triplett
+One Voice|SSAA|Ann Minihane
 One Voice|SSAA|Jay Giallombardo
+One Voice|SSAA|Jim Arns
 One Voice|SSAA|Joey Minshall
+One Voice|SSAA|Joni Bescos
+One Voice|SSAA|M. Wert
 One Voice|SSAA|Marge Bailey
 One Voice|SSAA|Susan Heimburger
+One Voice|SSAA|Tony Searle
 One Voice|TTBB|Deke Sharon
 One Voice|TTBB|Derric Johnson
+One Voice|TTBB|Jim Clancy
 One Voice|TTBB|M. Gill
+One Voice|TTBB|Michael Gill
 One Voice|TTBB|Susan Kegley
 One Voice|TTBB|Walter Latzko
+One Voice (YWIH)|SSAA|Ann Minihane
 One Voice/Peace on Earth|SSAA|Mark Burnip
 One Voice/Peace on Earth|TTBB|Mark Burnip
 One Way Ticket|SSAA|Takako Fuke
@@ -13936,6 +16521,7 @@ Only A Rose|TTBB|Walter Latzko
 Only A Voice On The Air|SSAA|Tom Gentry
 Only Hope|TTBB|Patrick McAlexander
 Only Ifs|SATB|Greg Mallett
+Only In My Dreams|SSAA|Sylvia Alsbury
 Only In New York|SSAA|Soren Detlefsen
 Only Jesus Can Satisfy Your Soul|TTBB|Derric Johnson
 Only Love|SSAA|Nick Bryant
@@ -13943,6 +16529,8 @@ Only Make Believe|TTBB|Todd Troutman
 Only Me|SSAA|Kay Bromert
 Only One|SATB|Deke Sharon
 Only One|SSAA|Jean McFadyen
+Only Remembered|TTBB|Paul Selby
+Only Time|SSAA|Brian Beck
 Only Time|SSAA|Kay Bromert
 Only Us|TTBB|David Holst
 Only Us|TTBB|Matt Astle
@@ -13950,8 +16538,10 @@ Only Wanna Be With You|TTBB|Mark Stevens
 Only You|SATB|Deke Sharon
 Only You|SSAA|Glenda Lloyd
 Only You|SSAA|Tedda Lippincott
+Only You|TTBB|David Harrington
 Only You|TTBB|Gary Thiel
 Only You|TTBB|Jack Bridges
+Only You|TTBB|Lorenz Maierhofer
 Only You|TTBB|Todd Troutman
 Only You (And You Alone)|SSAA|David Harrington
 Only You (And You Alone)|SSAA|Jim Kahlke
@@ -13961,7 +16551,10 @@ Only You (And You Alone)|SSAA|Nancy Bergman
 Only You (And You Alone)|TTBB|Chuck Clauser
 Only You (And You Alone)|TTBB|David Harrington
 Only You (And You Alone)|TTBB|Deke Sharon
+Only You (And You Alone)|TTBB|Jim Kahlke
 Only You (And You Alone)|TTBB|Jimbob Kahlke
+Only You / The Great Pretender|TTBB|Unspecified
+Only You, as sung by the Flying Pickets (SATB)|SATB|Dale Kynaston
 Onward, Christian Soldiers|TTBB|Joe Liles
 Oo-de-lally|TTBB|Gabriel Lawson
 Ooh! My Feet!|SSAA|Carolyn Johnson
@@ -13979,16 +16572,20 @@ Open Arms|SSAA|Michael Gellert
 Open Arms|TTBB|Bryan Ziegler
 Open Arms|TTBB|Mark Stevens
 Open My Eyes That I May See|TTBB|Joe Liles
+Open Your Arms, My Alabamy|TTBB|Norma Andersen
 Open Your Eyes|TTBB|Nicholas Wright
 Open Your Heart|SATB|Anders Lindqvist
+Opener Medley|TTBB|Mark Hale
 Opening Night|SSAA|Michael Gellert
 Opening Night On Broadway|SSAA|Nancy Bergman
 Opening Night On Broadway|TTBB|Nancy Bergman
 Opening Up|TTBB|Melody Hine
 Operator|SSAA|Bev Sellers
+Operator|SSAA|C. Yazurlo
 Operator|SSAA|Charlene Yazurlo
 Operator|SSAA|Tom Gentry
 Operator|SSAA|Wayne Grimmer
+Operator|TTBB|Ed Waesche
 Operator|TTBB|Tom Gentry
 Optimistic Voices|SSAA|Joey Minshall
 Optimistic Voices|TTBB|Lloyd Steinkamp
@@ -13999,28 +16596,48 @@ Opus One|SSAA|Jo Lund
 Opus One|TTBB|Jim West
 Orange Colored Sky|SATB|Deke Sharon
 Orange Colored Sky|SATB|Tom Gentry
+Orange Colored Sky|SSAA|B. McNeill
+Orange Colored Sky|SSAA|Barbara McNeill
 Orange Colored Sky|SSAA|Carolyn Schmidt
 Orange Colored Sky|SSAA|David Harrington
+Orange Colored Sky|SSAA|Diana Franceschi
 Orange Colored Sky|SSAA|Jo Lund
+Orange Colored Sky|SSAA|June Dale
 Orange Colored Sky|SSAA|Larry Wright
+Orange Colored Sky|SSAA|Nick Papageorge
 Orange Colored Sky|SSAA|Tom Gentry
 Orange Colored Sky|TTBB|David Harrington
 Orange Colored Sky|TTBB|Deke Sharon
+Orange Colored Sky|TTBB|Greg Volk
 Orange Colored Sky|TTBB|Jim Shubert
 Orange Colored Sky|TTBB|Joe Mannherz
 Orange Colored Sky|TTBB|Larry Wright
 Orange Colored Sky|TTBB|Mark Goodney
+Orange Colored Sky|TTBB|Nick Papageorge
 Orange Colored Sky|TTBB|Patrick McAlexander
 Orange Colored Sky|TTBB|Robert Rund
 Orange Colored Sky|TTBB|Tom Gentry
+Orange Colored Sky (Contest)|TTBB|Tom Gentry
+Orange Colored Sky (YWIH)|SSAA|Barbara McNeill
+Orange Coloured Sky|SSAA|Unspecified
+Orange Coloured Sky|TTBB|David Harrington
+Orange Coloured Sky|TTBB|Tom Gentry
+Orange-Colored Sky|SSAA|Diane Franchesci/Jim Arns
 Ordinary|SATB|Deke Sharon
 Ordinary Day|TTBB|Mark Stevens
 Ordinary Miracle|SSAA|Carole Prietto
 Ordinary People|SATB|Nicholas Wright
 Ordinary People|SSAA|Nicholas Wright
 Ordinary People|TTBB|Nicholas Wright
+Original Dixieland One Step|SSAA|Bev Sellers
+Original Dixieland One Step|SSAA|Unspecified
+Original Dixieland One Step|TTBB|David Wright
+Original Dixieland One Step|TTBB|Greg Volk
 Original Dixieland One Step|TTBB|Renee Craig
+Original Dixieland One Step|TTBB|Renee Craig, David Harrington
 Original Dixieland One-Step|SSAA|David Wright
+Original Dixieland One-Step|SSAA|Greg Volk
+Original Dixieland One-Step|SSAA|Renee Craig
 Original Dixieland One-Step|TTBB|David Wright
 Orinocco Flow|SSAA|Sheryl Neal
 Oseh Shalom (grant peace)|TTBB|Ken Potter
@@ -14029,6 +16646,9 @@ Our Country|TTBB|Don Staffin
 Our House|SATB|Joey Minshall
 Our Lips Are Sealed|SSAA|Deke Sharon
 Our Love Goes Deeper Than This|SSAA|Deke Sharon
+Our Love Is Here to Stay|TTBB|Ed Waesche
+Our Love Is Here to Stay|TTBB|Steve Delehanty
+Our Love Is Here To Stay|SSAA|Renee Craig
 Our Love Is Here To Stay|SSAA|Tedda Lippincott
 Our Love Is Here To Stay|TTBB|Steve Jamison
 Our Own House|SSAA|Nicholas Wright
@@ -14047,6 +16667,7 @@ Out There|TTBB|Brent Graham
 Out There|TTBB|Steve Tramack
 Out There (from The Hunchback Of Notre Dame)|TTBB|Steve Tramack
 Over The Hill|SSAA|Marge Bailey
+Over the Rainbow|SSAA|Nancy Bergman
 Over The Rainbow|SATB|Ed Waesche
 Over The Rainbow|SATB|Melody Hine
 Over The Rainbow|SSAA|Anna Maria Parker
@@ -14065,6 +16686,7 @@ Over The Rainbow|TTBB|Cliff Harris
 Over The Rainbow|TTBB|Don Reckenbeil
 Over The Rainbow|TTBB|Don Thomson
 Over The Rainbow|TTBB|Ed Waesche
+Over The Rainbow|TTBB|Ed Waesche, Lloyd Steinkamp, Joe Caulkins
 Over The Rainbow|TTBB|Gary Bertelsen
 Over The Rainbow|TTBB|Gene Cokeroft
 Over The Rainbow|TTBB|Jay Giallombardo
@@ -14077,6 +16699,12 @@ Over The Rainbow|TTBB|Rob Hopkins
 Over The Rainbow|TTBB|Sam Hubbard
 Over The Rainbow|TTBB|Steven Armstrong
 Over The Rainbow|TTBB|Tony Nasto
+Over The Rainbow|TTBB|Unspecified
+Over the Rainbow (SATB)|SATB|Dale Kynaston
+Over The Rainbow (YWIH)|SSAA|Joni Bescos
+Over The Rainbow [Interpolating 'I'm Always Chasing Rainbows'](Darin D|TTBB|Darin Drown
+Over The Rainbow 2006|TTBB|Jon Nicholas
+Over The Rainbow 2009|TTBB|Jon Nicholas
 Over The River And Through The Woods|SATB|Deke Sharon
 Over The River And Through The Woods|SSAA|Norma Holzmeier
 Over The River And Through The Woods|TTBB|Mark Goodney
@@ -14087,6 +16715,8 @@ Over There|TTBB|Marie Johnson
 Over There|TTBB|Robert Curt
 Overjoyed|TTBB|Adam Bock
 Overkill|TTBB|Matt Astle
+Overs (by Paul Simon)|SATB|Peter Eldridge (NY Voices)
+Overture (This Is It)|TTBB|Unspecified
 Overture Curtain Lights (This Is It)|SSAA|Larry Wright
 Overture Curtain Lights (This Is It)|TTBB|Larry Wright
 Oye Como Va|SATB|Deke Sharon
@@ -14094,6 +16724,7 @@ Oye Como Va|SATB|Joe Mannherz
 P.S. I Love You|SSAA|Jo Lund
 P.S. I Love You|TTBB|Adam Reimnitz
 P.S. I Love You|TTBB|Robert Rund
+P.S. I Love You|TTBB|Rod Alexander
 Pachelbel Canon|SATB|Joe Mannherz
 Pachelbel Canon|SSAA|Greg Mallett
 Pachelbel Canon|TTBB|Greg Mallett
@@ -14101,15 +16732,22 @@ Pachelbel's Noel|TTBB|Joe Grimme
 Pack Up|SSAA|Liz Garnett
 Pack Up Your Sins And Go To The Devil|TTBB|Ed Waesche
 Pack Up Your Troubles / Long Way To Tipperary Medley|TTBB|Jack Baird
+Pack Up Your Troubles in Your Old Kit Bag|TTBB|Clay Hine
+Pack Up Your Troubles/Long Way To Tipperary Medley|TTBB|Jack Baird
 Paddlin' Madelin' Home|SSAA|Nancy Bergman
 Paddlin' Madelin' Home|TTBB|Benjamin Miller
 Paddlin' Madelin' Home|TTBB|Don Gray
 Paddlin' Madelin' Home|TTBB|Joe Mannherz
+Paddlin' Madeline/Row, Row Row|SSAA|Nancy Bergman
 Paging Mr. Sousa|TTBB|Tom Gentry
 Paid In Full|TTBB|Larry Triplett
 Pain, Pain, Pain|TTBB|Jim Shubert
+Paint Your Wagon Medley|SSAA|June Dale
+Paint Your Wagon Medley|TTBB|Dick Kneeland
 Paintin' This Old Town Blue|SSAA|David Briner
+Painting This Old Town Blue|SSAA|Unspecified
 Pal Of Mine|TTBB|Dennis Driscoll
+Pal of My Cradle Days|SSAA|Joni Bescos/Brian Beck
 Pal Of My Cradle Days|SSAA|Lyle Pilcher
 Pal Of My Cradle Days|TTBB|Bob Graham
 Pal Of My Cradle Days|TTBB|Ed Waesche
@@ -14136,12 +16774,16 @@ Paper Doll|SSAA|Aaron Dale
 Paper Doll|TTBB|Aaron Dale
 Paper Doll|TTBB|David Harrington
 Paper Doll|TTBB|Jim Shubert
+Paper Doll|TTBB|Lou Perry
 Paper Doll|TTBB|Louis Perry
 Paper Doll|TTBB|Walter Latzko
+Paper Moon|SSAA|Clay Hine
+Paper Moon|TTBB|Clay Hine
 Paperback Writer|SSAA|Jay Giallombardo
 Paperback Writer|TTBB|James Henry
 Paperback Writer|TTBB|Jay Giallombardo
 Parade Medley|TTBB|Jay Giallombardo
+Parade of the Wooden Soldiers|SSAA|Teresa Reed
 Parade Of The Wooden Soldiers|SSAA|Penny Hartmann
 Parade Of The Wooden Soldiers|TTBB|Marty Israel
 Paradise|SATB|Deke Sharon
@@ -14172,10 +16814,13 @@ Pass Me By|TTBB|Walter Latzko
 Pass Me The Jazz|TTBB|Jeremey Johnson
 Pass That Peacepipe / I'm an Indian, Too|SSAA|Tom Gentry
 Pass That Peacepipe / I'm an Indian, Too|TTBB|Tom Gentry
+Pass the Apples Medley|TTBB|Jay Giallombardo
+Pass the Apples Medley|TTBB|Unspecified
 Passing The Faith Along|TTBB|Larry Wright
 Past LIfe|SSAA|Lauren Kahn
 Pastime Paradise|TTBB|Deke Sharon
 Pat Your Foot|TTBB|Toban Dvoretsky
+Pat-a-pan|TTBB|Katherine Davis
 Patapan|SATB|Deke Sharon
 Patapan|SSAA|Kevin Keller
 Patapan|TTBB|Derric Johnson
@@ -14189,13 +16834,18 @@ Payphone|SATB|Joe Mannherz
 Payphone|SATB|Nicholas Wright
 Payphone|TTBB|Nicholas Wright
 PD Medley|TTBB|Clay Hine
+Peace I Leave with You|TTBB|Chris MacMartin
 Peace I Leave With You|TTBB|Joe Liles
 Peace Like A River|TTBB|Adam Scott
+Peace on Earth/Little Drummer Boy|SSAA|Joe Liles
+Peace On Earth/Little Drummer Boy|TTBB|Gil Dubray
+Peace on Earth/Little Drummer Boy Medley|SSAA|Joe Liles
 Peace On Earth/Little Drummer Boy medley|SSAA|Jay Giallombardo
 Peace On Earth/Little Drummer Boy medley|SSAA|Lauree Cogley
 Peace On Earth/Little Drummer Boy medley|TTBB|Deke Sharon
 Peace On Earth/Little Drummer Boy medley|TTBB|Gil Dubray
 Peace On Earth/Little Drummer Boy medley|TTBB|Jay Giallombardo
+Peace on Earth/The Little Drummer Boy|SSAA|Joe Liles
 Peace Prayer Mandala|SSAA|Joey Minshall
 Peace, It Is I|TTBB|Jim West
 Peace, Love and Understanding|SATB|Deke Sharon
@@ -14206,6 +16856,7 @@ Peaches|TTBB|Dom Finetti
 Peanut Butter and Jelly|SSAA|Kathy Barnett
 Peel me a Grape|SSAA|Deke Sharon
 Peel me a Grape|SSAA|Melody Hine
+Peel Me A Grape|SSAA|Lynnell Diamond
 Peg O' My Heart|TTBB|Burt Szabo
 Peg O' My Heart|TTBB|Ed Waesche
 Peg O' My Heart|TTBB|Jim Shubert
@@ -14214,6 +16865,7 @@ Peggy O'Neil|TTBB|Ed Hubbard
 Peggy O'Neil|TTBB|Eugene McHugh
 Peggy O'Neil|TTBB|Richard Floersheimer
 Peggy O'Neil|TTBB|Val Hicks
+Peggy Sue|TTBB|Dale Hanson
 Pennies from Heaven|SSAA|David Harrington
 Pennies from Heaven|SSAA|Susan Kegley
 Pennies from Heaven|SSAA|Tom Gentry
@@ -14226,6 +16878,7 @@ Pennies from Heaven|TTBB|Ray Buntaine
 Pennies from Heaven|TTBB|Robert Martin
 Pennies from Heaven|TTBB|Tom Gentry
 Pennies from Heaven|TTBB|Vincent Zito
+Pennies From Heaven|SSAA|Steve Shannon
 Pennsylvania 6-5000|TTBB|Jon Nicholas
 Penny Lane|SATB|Anders Lindqvist
 Penny Lane|SATB|Manoj Padki
@@ -14269,11 +16922,13 @@ Perfect Story|SSAA|Tom Gentry
 Perfect Stranger|SSAA|Bram Van Leer
 Perfidia|SATB|Kevin Keller
 Perfidia|SSAA|Kevin Keller
+Perfidia|TTBB|Greg Volk
 Perfidia|TTBB|Walter Latzko
 Perhaps Love|SATB|Manoj Padki
 Perhaps Love|SSAA|Charlotte Rubio
 Perhaps Love|SSAA|Joey Minshall
 Perhaps Love|SSAA|Kay Bromert
+Perhaps Love|SSAA|Tedda Lippincott
 Perhaps Love|TTBB|Bob Landry
 Perhaps, Perhaps, Perhaps|TTBB|Liz Garnett
 Permission To Shine|SSAA|Glenda Lloyd
@@ -14281,7 +16936,10 @@ Personality|TTBB|Steve Tramack
 Personality|TTBB|Walter Latzko
 Peter Cottontail|TTBB|Michael Webber
 Peter Pan Medley|SSAA|Larry Wright
+Peter Pan Medley|TTBB|Steve Tramack
 Peter Pan Medley|TTBB|Tom Gentry
+Phantom / Music Of The Night|TTBB|Joe Spiecker
+Phantom Medley|SSAA|David Wright
 Phantom Of The Opera|SSAA|Tedda Lippincott
 Phfft! You Were Gone Parody|SSAA|Cris Conerty
 Phfft! You Were Gone Parody|SSAA|Susan Heimburger
@@ -14292,6 +16950,8 @@ Photograph|TTBB|Nicholas Wright
 Piano Man|TTBB|Gary Thiel
 Piano Man|TTBB|Patrick McAlexander
 Piano Man|TTBB|Rob Hopkins
+Pick A Little-Talk A Little/Goodnight Ladies(Walter La|SATB|Walter Latzko
+Pick A Little, Talk A Little / Good Night Ladies|TTBB|Walter Latzko
 Pick A Pocket Or Two|SSAA|June Dale
 Pick Yourself Up|SSAA|David Harrington
 Pick Yourself Up|SSAA|Sheryl Neal
@@ -14311,6 +16971,8 @@ Pine Cones And Holly Berries|TTBB|Archie Steen
 Pine Cones And Holly Berries|TTBB|Mark Goodney
 Pink|SATB|Liz Garnett
 Piping down the Valleys Wild|SATB|David Avshalomov
+Pirate Medley|TTBB|Greg Volk
+Pirate Medley|TTBB|Roger Payne
 Pirate Parody On Moonlight Bay|SSAA|Carolyn Johnson
 Pirate Seaside Medley|SSAA|Carolyn Johnson
 Pirate's Life|TTBB|Denny Stiers
@@ -14326,6 +16988,7 @@ Pitch Perfect Riff Off 'Songs About Sex'|SATB|Deke Sharon
 Pittsburgh, Pennsylvania|TTBB|Jim West
 Pittsburgh's Welcome|TTBB|Jim West
 Pity Party|SSAA|Patrick McAlexander
+Pity Party|SSAA|Sharon Holmes
 Place in the Choir|SSAA|Dianne Goldrick
 Place in the Choir|SSAA|Kay Bromert
 Place in the Choir|SSAA|Tom Gentry
@@ -14337,6 +17000,7 @@ Places We Won't Walk|TTBB|Gabriel Lawson
 Plain|TTBB|Tom Gentry
 Plain Plate of Noodles|TTBB|Cay Outerbridge
 Play|TTBB|Adam Scott
+Play A Simple Melody|SATB|Joe Liles
 Play A Simple Melody|TTBB|Joe Liles
 Play A Simple Melody|TTBB|Mark Goodney
 Play A Simple Melody|TTBB|Mark Rusch
@@ -14354,6 +17018,7 @@ Play The Game|SSAA|Liz Garnett
 Play the Game/Killer Queen Medley|SSAA|Liz Garnett
 Playground Life|TTBB|Dick Stuart
 Playing Right Field|TTBB|Tom Gentry
+Playing the Clown|SSAA|Joey Minshall
 Playing The Clown|TTBB|Einar Pedersen
 Please Come Home For Christmas|SATB|Jay Dougherty
 Please Come Home For Christmas|SATB|Kohl Kitzmiller
@@ -14377,6 +17042,9 @@ Please Don't Go|SATB|Kristina Roper
 Please Don't Make Me Love You|SSAA|Joe Mannherz
 Please Don't Make Me Love You|TTBB|Clay Hine
 Please Don't Take That Baby Grand|TTBB|Jim Shubert
+Please Don't Talk About Me|SSAA|Floyd Connett
+Please Don't Talk About Me|SSAA|Joni Bescos
+Please Don't Talk About Me|SSAA|Nancy Bergman
 Please Don't Talk About Me When I'm Gone|SATB|Jay Dougherty
 Please Don't Talk About Me When I'm Gone|SATB|Patrick McAlexander
 Please Don't Talk About Me When I'm Gone|SSAA|Becky Cartine
@@ -14388,6 +17056,7 @@ Please Don't Talk About Me When I'm Gone|TTBB|Ed Waesche
 Please Don't Talk About Me When I'm Gone|TTBB|Jay Giallombardo
 Please Don't Talk About Me When I'm Gone|TTBB|Melody Hine
 Please Don't Talk About Me When I'm Gone|TTBB|Tom Gentry
+Please Don'T Talk About Me When I'M Gone|SSAA|Nancy Bergman
 Please Mr. Columbus|TTBB|Don Gray
 Please Mr. Columbus|TTBB|Gene Cokeroft
 Please Mr. Columbus|TTBB|Mo Rector
@@ -14395,6 +17064,8 @@ Please Please Me|TTBB|Carolyn Schmidt
 Please Please Please|SSAA|Dan Wessler
 Please Please Please|SSAA|Kyle Snook
 Please Send Me Someone To Love|TTBB|Jackson Pinder
+Please, Mr. Columbus|TTBB|David Wallace
+Please, Mr. Columbus|TTBB|Don Gray, Jack Baird and Dave Wallace
 Plenty To Be Thankful For|SSAA|Adam Bock
 Poems, Prayers, and Promises|TTBB|Mark Stevens
 Poinciana (Song of the Tree)|SSAA|Anastasio Rossi
@@ -14407,13 +17078,17 @@ Poisoning Pigeons In The Park|TTBB|Jay Giallombardo
 Poisoning Pigeons In The Park|TTBB|Jordan Johnson
 Poisoning Pigeons In The Park|TTBB|Thomas Degan
 Pokare Kare Ana|TTBB|Tom Gentry
+Pokemon|TTBB|Steve Wolf
 Poker Face|SSAA|Larry Wright
 Polka Dots And Moonbeams|SSAA|Bill Biffle
+Polka Dots And Moonbeams|TTBB|John Bober
 Polka Dots And Moonbeams|TTBB|Larry Wright
 Polka Dots And Moonbeams|TTBB|Rob Campbell
 Polka Dots And Moonbeams|TTBB|Steven Armstrong
 Polka Medley|SSAA|Russ Foris
 Polka Medley|TTBB|Russ Foris
+Polkadots And Moonbeams|TTBB|Steven Armstrong
+Polkadots And Moonbeams (version 2)|TTBB|Steven Armstrong
 Pomp And Circumstances|SATB|Deke Sharon
 Pomp And Circumstances|SSAA|Debbie Porter
 Pompeii|SATB|Deke Sharon
@@ -14430,11 +17105,13 @@ Poor Little Raggedy Andy|SSAA|Marge Bailey
 Poor Little Rhode Island|TTBB|Jim Shubert
 Poor Little Rich Girl|TTBB|Rob Campbell
 Poor Monty|SSAA|Gabriel Spector
+Poor Papa|SSAA|Dot Calvin
 Poor Unfortunate Souls|SSAA|Adam Scott
 Poor Unfortunate Souls|SSAA|Doris Twardosky
 Pop Songs Medley II|TTBB|Clay Hine
 Pop Songs Medley III|TTBB|Clay Hine
 Pop, Pop, Popin, Popcorn|SSAA|Avis Fellows
+Pop, Pop, Poppin' Popcorn|SSAA|Avis Fellows
 Popeye Medley|TTBB|Tom Gentry
 Popular|SSAA|Dianne Goldrick
 Popular|SSAA|Larry Wright
@@ -14444,6 +17121,7 @@ Popular|TTBB|Dan Wessler
 Popular Song|SSAA|Larry Wright
 Por Una Cabeza|TTBB|Gabriel Lawson
 Pore Jud Is Daid|TTBB|Howard Dale
+Porgy And Bess Medley|TTBB|Walter Latzko
 Portrait Of My Love|SSAA|Larry Wright
 Portrait Of My Love|TTBB|Dennis Driscoll
 Portrait Of My Love|TTBB|Jim West
@@ -14464,14 +17142,21 @@ Powder Your Face With Sunshine|TTBB|Gene Cokeroft
 Powder Your Face With Sunshine|TTBB|Ken Bastien
 Powder Your Face With Sunshine|TTBB|Roy Keys
 Powder Your Face With Sunshine / Let A Smile Be Your Umbrella Medley|TTBB|Mike Sotiriou
+Powder Your Face With Sunshine Medley|SSAA|Nancy Bergman
+Powder Your Face With Sunshine/Smile Medley|SSAA|Nancy Bergman
 Powerful|SATB|Nicholas Wright
 Practical arrangement|TTBB|Theodore Hicks
 Praise The Lord And Pass The Ammunition|TTBB|Jim West
+Praise The Lord And Pass The Ammunition|TTBB|Merle Savage
 Praise The Lord And Pass The Ammunition / Comin' In On A Wing And A Prayer|SSAA|Tedda Lippincott
 Praise Ye The Lord, The Almighty|TTBB|Barbershop Harmony Society
 Praise Ye The Lord, The Almighty|TTBB|Jon Nicholas
 Praise Ye The Lord, The Almighty|TTBB|Unknown
 Pray For Sunshine|TTBB|Tom Gentry
+Prayer of the Children|SSAA|Joe Liles
+Prayer of the Children|TTBB|Andrea Klouse
+Prayer Of The Children|SATB|Andrea S. Klouse
+Prayer Of The Children (TTBB)|TTBB|Kurt Bestor / Andrea Klouse
 Precious Child|SSAA|Jay Giallombardo
 Precious Child|TTBB|Jay Giallombardo
 Precious Friends|SSAA|Tedda Lippincott
@@ -14481,12 +17166,19 @@ Precious Lord Take My Hand|SATB|Tom Gentry
 Precious Lord Take My Hand|SSAA|Tom Gentry
 Precious Lord Take My Hand|TTBB|Jon Nicholas
 Precious Lord Take My Hand|TTBB|Tom Gentry
+Precious Lord, Take My Hand|TTBB|Buzz Haeger
+Precious Lord, Take My Hand|TTBB|Dan Tice
+Precious Lord, Take My Hand|TTBB|Jon Nicholas
+Precious Lord, Take My Hand|TTBB|Roy Ringwald
 Prepare The Way|TTBB|Jon Nicholas
 Prepared|TTBB|Greg Mallett
+Presents|TTBB|Phil Ordaz
 Pressed Roses|SSAA|Jeanne Elmuccio
 Pretend You Dont See Her (Him)|SSAA|Sonny Steffan
 Pretty Baby|TTBB|Dennis Driscoll
+Pretty Baby|TTBB|Paul Engel, Paul Eastman
 Pretty Baby|TTBB|Tom Gentry
+Pretty Baby|TTBB|Verse Bernie Cureton, song unknown
 Pretty Girl Is Like A Melody/With A Song In My Heart|TTBB|Jay Giallombardo
 Pretty Good At Drinkin' Beer|TTBB|Kyle Snook
 Pretty Good At Drinkin' Beer|TTBB|Thomas Degan
@@ -14504,6 +17196,7 @@ Primetime|SSAA|Nicholas Wright
 Prince Ali|SATB|Deke Sharon
 Prince Ali|TTBB|Steve Tramack
 Prince Ali (from Aladdin)|TTBB|Steve Tramack
+Prism Song|TTBB|Kris Olson
 Prison Medley|TTBB|Tom Gentry
 Prisoner of Love|TTBB|Brent Graham
 Private Eyes|SATB|Nicholas Wright
@@ -14512,6 +17205,7 @@ Professional Pirate|TTBB|Tom Gentry
 Proud Mary|SATB|Deke Sharon
 Proud Mary|SSAA|David Wright
 Proud Mary|SSAA|Kohl Kitzmiller
+Proud Mary|SSAA|Tedda Lippincott
 Proud Mary|TTBB|David Wright
 Proud Mary|TTBB|Jon Nicholas
 Proud Mary|TTBB|Kohl Kitzmiller
@@ -14521,6 +17215,7 @@ Proud of Your Boy|TTBB|Kevin Keller
 Proud of Your Boy|TTBB|Simon Arnott
 Proud of Your Boy|TTBB|Steve Tramack
 Proud Of Your Boy|TTBB|Patrick McAlexander
+Psalm 23|TTBB|Paul Basler
 Public Melody Number One|SATB|Kyle Snook
 Public Melody Number One|TTBB|Dan Wessler
 Puff The Magic Dragon|SATB|Kevin Keller
@@ -14547,6 +17242,7 @@ Pure Imagination|TTBB|Aaron Dale
 Pure Imagination|TTBB|Dave Briner
 Pure Imagination|TTBB|David Briner
 Pure Imagination|TTBB|Jay Giallombardo
+Pure Imagination|TTBB|Jim Clancy
 Pure Imagination|TTBB|Joe Mannherz
 Pure Imagination|TTBB|Kevin Keller
 Pure Imagination|TTBB|Matt Gallagher
@@ -14555,14 +17251,19 @@ Pure Imagination|TTBB|Richard Curtis
 Pure Imagination|TTBB|Walter Latzko
 Purple People Eater|SSAA|Tedda Lippincott
 Pusher Love Girl|TTBB|Nicholas Wright
+Pussywillows Cattails|SSAA|June Dale
+Put 'Em In A Box|SSAA|Sharon Holmes
 Put 'em In A Box, Tie 'em With A Ribbon|SSAA|Glenda Lloyd
 Put 'em In A Box, Tie 'em With A Ribbon|SSAA|Marsha Zwicker
 Put 'em In A Box, Tie 'em With A Ribbon|TTBB|Walter Latzko
+Put 'em In A Box, Tie 'em With A Ribbon (And Throw 'em In The Deep Blue Sea)|SSAA|Marsha Zwicker
 Put A Little Holiday InYour Heart|SSAA|Jeanne Elmuccio
+Put A Little Love In Your Heart|SSAA|Lorraine Rochefort
 Put A Little Love In Your Heart|TTBB|Aaron Dale
 Put Another Chair At The Table|TTBB|Louis Perry
 Put Another Chair At The Table|TTBB|Mark Goodney
 Put Me To Sleep With An Old Fashioned Melody|TTBB|Burt Szabo
+Put Me To Sleep With An Old Fashioned Melody|TTBB|Clay Hine
 Put Me To Sleep With An Old Fashioned Melody|TTBB|Ed Waesche
 Put On A Happy Face|SATB|Deke Sharon
 Put On A Happy Face|SSAA|Tedda Lippincott
@@ -14570,6 +17271,7 @@ Put On A Happy Face|TTBB|Howard Dale
 Put On A Happy Face|TTBB|Jay Giallombardo
 Put On A Happy Face|TTBB|Kevin Keller
 Put On A Happy Face|TTBB|Walter Latzko
+Put On A Happy Face/Let A Smile Be Your Umbrella Medley(Adam Reim|TTBB|Adam Reimnitz
 Put On An Old Pair Of Shoes|SSAA|Norma Andersen
 Put On An Old Pair Of Shoes|TTBB|Inc. SPEBSQSA
 Put On An Old Pair Of Shoes|TTBB|SPEBSQSA
@@ -14578,6 +17280,7 @@ Put On Your Old Grey Bonnet|TTBB|Jack Baird
 Put On Your Old Grey Bonnet|TTBB|Jay Giallombardo
 Put On Your Old Grey Bonnet|TTBB|Rob Hopkins
 Put On Your Old Grey Bonnet|TTBB|Russ Foris
+Put On Your Sunday Clothes|TTBB|Adam Reimnitz
 Put On Your Sunday Clothes|TTBB|Ed Waesche
 Put One Foot In Front of the Other|TTBB|Steve Tramack
 Put Your Arms Around Me Honey|SSAA|Aaron Dale
@@ -14585,16 +17288,22 @@ Put Your Arms Around Me Honey|SSAA|Nancy Bergman
 Put Your Arms Around Me Honey|TTBB|Aaron Dale
 Put Your Arms Around Me Honey|TTBB|Burt Szabo
 Put Your Arms Around Me Honey|TTBB|Lloyd Steinkamp
+Put Your Arms Around Me Honey|TTBB|Rob Hopkins
+Put Your Arms Around Me, Honey|SSAA|Aaron Dale
+Put Your Arms Around Me, Honey|TTBB|Aaron Dale
 Put Your Arms Around Me, Honey|TTBB|Rob Hopkins
 Put Your Arms Around Me/Side By Side|SSAA|Nancy Bergman
 Put Your Dreams Away (For Another Day)|TTBB|Dylan Oxford
 Put Your Dreams Away (For Another Day)|TTBB|Jim Shubert
+Put Your Hands Together|SSAA|Renee Craig
 Put Your Head On My Shoulder|SSAA|Aaron Dale
 Put Your Head On My Shoulder|SSAA|Carolyn Healey
 Put Your Head On My Shoulder|TTBB|Aaron Dale
+Put Your Head On My Shoulder|TTBB|Jim Clancy
 Put Your Head On My Shoulder|TTBB|Jim Shubert
 Put Your Records On|SATB|Deke Sharon
 Put Your Records On|SSAA|Sofia De Rama
+Puttin' on the Ritz|SSAA|Bev Sellers/Kay Bromert
 Puttin' On The Ritz|SSAA|Bev Sellers
 Puttin' On The Ritz|SSAA|David Wright
 Puttin' On The Ritz|SSAA|Jo Lund
@@ -14604,7 +17313,9 @@ Puttin' On The Ritz|TTBB|David Wright
 Puttin' On The Ritz|TTBB|Larry Wright
 Putting It Together|TTBB|David Wright
 Quartet Opener|SSAA|Jo Lund
+Que Reste-t-il De Nos Amours ?|TTBB|John Hohl
 Que Sera, Sera (whatever will be, will be)|SSAA|Jay Dougherty
+Queen Medley|SSAA|Steve Wolf
 Queen Montage|TTBB|Jay Giallombardo
 Queen of Hearts|SSAA|Deke Sharon
 Queen of the Senior Prom|TTBB|Jim West
@@ -14615,6 +17326,7 @@ Quicksilver|TTBB|Jon Nicholas
 Quiet Moon|TTBB|Deke Sharon
 Quiet Nights of Quiet Stars|SATB|Joe Mannherz
 Quiet Please There's a Lady Onstage|SSAA|Joey Minshall
+R-E-S-P-E-C-T|SSAA|Anne Raugh
 Rabbit|SATB|Matthew Spinner
 Rachel Was Here|TTBB|Jay Giallombardo
 Radio|SSAA|David Briner
@@ -14624,6 +17336,7 @@ Radio Jingles|TTBB|Barbershop Harmony Society
 Radio Jingles|TTBB|Burt Szabo
 Radioactive|SATB|Nicholas Wright
 Radioactive|TTBB|Nicholas Wright
+Rag Mop|SSAA|Nancy Bergman
 Rag Mop|TTBB|Nancy Bergman
 Ragime Cowgirl Jo|SSAA|Nancy Bergman
 Ragtime Cowboy Joe|SSAA|Carolyn Johnson
@@ -14631,14 +17344,17 @@ Ragtime Cowboy Joe|TTBB|Barbershop Harmony Society
 Ragtime Cowboy Joe|TTBB|BHS
 Ragtime Cowboy Joe|TTBB|Jack Baird
 Ragtime Cowboy Joe|TTBB|Jim Shubert
+Ragtime Cowgirl Jo|SSAA|Nancy Bergman
 Ragtime Drafted Man|TTBB|Jay Giallombardo
 Railroad Man|TTBB|Jim West
 Railroad Medley|SATB|Derric Johnson
+Railroad Medley|TTBB|Walter Latzko
 Rain|SSAA|Walter Latzko
 Rain|TTBB|Bob Benson
 Rain|TTBB|Bob Peculski
 Rain|TTBB|Gregory Lyne
 Rain In Spain|SSAA|Joe Mannherz
+Rain Medley|TTBB|Ed Waesche
 Rainbow|SATB|Steve Tramack
 Rainbow|SSAA|Dan Wessler
 Rainbow|SSAA|Melody Hine
@@ -14665,10 +17381,14 @@ Raindrops Keep Falling On My Head|TTBB|Larry Wright
 Raindrops Keep Falling On My Head|TTBB|Mark Goodney
 Raindrops Keep Falling On My Head|TTBB|Tom Gentry
 Raindrops Keep Falling On My Head|TTBB|Walter Latzko
+Raining in My Heart|SSAA|Paul Davies / Bob Croft
+Raining In My Heart|TTBB|Paul Davies
+Rainsong|TTBB|Houston Bright
 Rainy Night In Rio|SATB|Kevin Keller
 Rainy Night In Rio|SSAA|Kevin Keller
 Rainy Night In Rio|TTBB|Kevin Keller
 Raise You Up|SSAA|Carole Prietto
+Raise Your Baton, Mister Leaderman|TTBB|Pete Rupay
 Raise Your Glass|SSAA|Melody Hine
 Raise Your Voice|SSAA|Larry Wright
 Ramblin' Rose|TTBB|Jim Shubert
@@ -14681,18 +17401,25 @@ Rawhide|TTBB|Alex Morris
 Rawhide|TTBB|Eric Ruthenberg
 Rawhide|TTBB|Jon Nicholas
 Ray-Ray-Raining|TTBB|Nick Papageorge
+Ray's Rockhouse|SSAA|Clay Hine
 Razzapple Medley|TTBB|Tom Gentry
 Razzle Dazzle|SSAA|Anna Maria Parker
+Razzle Dazzle|SSAA|Bev Sellers
 Razzle Dazzle|SSAA|Carolyn Johnson
+Razzle Dazzle|SSAA|Clay Hine
 Razzle Dazzle|SSAA|Jo Lund
+Razzle Dazzle|SSAA|Renee Craig
 Razzle Dazzle|SSAA|Tom Gentry
 Razzle Dazzle|TTBB|Clay Hine
 Razzle Dazzle|TTBB|Jim West
+Razzle Dazzle|TTBB|Phil Ordaz
 Razzle Dazzle|TTBB|Tom Gentry
+Razzle Dazzle|TTBB|Unspecified
 Re Your Brains|TTBB|Jay Dougherty
 Reach|SSAA|Glenda Lloyd
 Reach|SSAA|Jan Meyer
 Reach|SSAA|Joey Minshall
+Reach|SSAA|Pat LeVezu
 Reach|SSAA|Sharon Carlson
 Reach For The Light|SSAA|June Dale
 Reach Out And Touch|TTBB|Ed Waesche
@@ -14706,6 +17433,8 @@ Ready, Willing And Able (from Young At Heart)|TTBB|Aaron Dale
 Real American Folk Song, The (Is A Rag)|SSAA|Becky Cartine
 Real American Folk Song, The (Is A Rag)|TTBB|Walter Latzko
 Real Emotional Girl|TTBB|Michael Webber
+Real Emotional Girl|TTBB|Rich Hasty
+Recipe For Love|TTBB|Barbershop Harmony Society
 Recipe For Love|TTBB|Ben Ferguson
 Recipe For Love|TTBB|Dennis Driscoll
 Recipe For Love|TTBB|Dianne Goldrick
@@ -14716,10 +17445,12 @@ Red Head|SSAA|Brent Graham
 Red Head|SSAA|Larry Wright
 Red Head|TTBB|Brent Graham
 Red Head|TTBB|Larry Wright
+Red Hot|SSAA|Nancy Bergman
 Red Hot Henry Brown|SSAA|Kevin Keller
 Red Hot Henry Brown|TTBB|Kevin Keller
 Red Hot Mama Medley|SSAA|Larry Wright
 Red Hot Mama Medley|TTBB|Larry Wright
+Red Hot Mama Medley (cut)|SSAA|Greg Volk
 Red Hot Mamma|SSAA|Jo Lund
 Red Hot Mamma|TTBB|J. Rae Jamison Words and Music by: Gilbert Wells, Bud Cooper and Fred Rose
 Red Hot Mamma|TTBB|SPEBSQSA
@@ -14738,11 +17469,14 @@ Red Sails In The Sunset|TTBB|Alden Parker
 Red Sails In The Sunset|TTBB|Todd Troutman
 Red Solo Cup|TTBB|Tom Gentry
 Red Wing|TTBB|Thomas Degan
+Red, Red Robin|SSAA|Greg Volk
 Red, White and Blue|SATB|Derric Johnson
 Redemption Song|SSAA|Jay Dougherty
+Redhead|SSAA|Marge Bailey
 Redhead|TTBB|A Polaneczky
 Redhead|TTBB|Burt Szabo
 Redhead|TTBB|Ed Waesche
+Redhead|TTBB|Jim Clancy
 Redhead|TTBB|Jim Clancy/Ed Waesche
 Redhead|TTBB|Mo Rector
 Redhead|TTBB|Ozzie Westley
@@ -14787,6 +17521,7 @@ Remembering You|SSAA|Kevin Keller
 Remembering You|TTBB|Kevin Keller
 Remind Me|SATB|Jay Giallombardo
 Remind Me|SSAA|Walter Latzko
+Renaissance Woman|SSAA|Dave Briner
 Renaissance Woman|SSAA|David Briner
 Renegade|TTBB|Deke Sharon
 Rescue Me|SSAA|Glenda Lloyd
@@ -14800,10 +17535,12 @@ Return to Pooh Corner|TTBB|Manoj Padki
 Return To Sender|SSAA|Kohl Kitzmiller
 Return To Sender|TTBB|Duane Enders
 Reuben And Rachel (Parody)|TTBB|Adam Scott
+Reunion|TTBB|Todd Troutman
 Reunite Commercial|SSAA|Jo Lund
 Revolting Children|SATB|James Henry
 Rewrite The Stars|SATB|Simon Lubkowski
 Rewrite The Stars|TTBB|Nicholas Wright
+Rhapsody in Blue|SSAA|David Wright
 Rhapsody of New York|SSAA|David Wright
 Rhiannon|SSAA|Rowena Harper
 Rhode Island Is Famous For You|SSAA|Jo Lund
@@ -14811,25 +17548,41 @@ Rhode Island Is Famous For You|TTBB|Eric Ruthenberg
 Rhode Island Is Famous For You|TTBB|Kevin Keller
 Rhode Island Is Famous For You|TTBB|Larry Wright
 Rhythm And Dance Medley|TTBB|John Hohl
+Rhythm Conga|SSAA|Brian Beck
+Rhythm In My Nursery Rhymes|SSAA|Kay Griffin
 Rhythm In My Nursery Rhymes (If I Had)|SSAA|Kay Griffin
 Rhythm In My Nursery Rhymes/ABC Medley|SSAA|Larry Wright
+Rhythm Is Gonna Get You|SSAA|Brian Beck
 Rhythm Is Gonna Get You|SSAA|Jon Nicholas
 Rhythm Is Our Business|SSAA|Marsha Zwicker
 Rhythm Is Our Business|TTBB|Patrick McAlexander
 Rhythm Is Our Business (Parody)|TTBB|Patrick McAlexander
+Rhythm Medley|SSAA|Ann Minihane
 Rhythm Medley|SSAA|Larry Wright
+Rhythm Medley|TTBB|A.C Steen/Jay Dearling
 Rhythm Medley|TTBB|Aaron Dale
 Rhythm Medley|TTBB|Larry Wright
+Rhythm Medley|TTBB|Webb Comfort
 Rhythm Medley (I Got Rhythm/Fascinating Rhythm/Crazy Rhythm)|TTBB|Aaron Dale
+Rhythm Of Life|SSAA|David Wallace
+Rhythm Of Life|SSAA|Jim Massey
+Rhythm Of Life|SSAA|Jo Kraut
 Rhythm of Love|SSAA|Deke Sharon & David Wright
 Rhythm of Love|TTBB|Deke Sharon & David Wright
+Rhythm of Love|TTBB|Deke Sharon and David Wright
 Rhythm Of Love|SSAA|Brent Graham
+Rhythm Of Love|SSAA|David Wright
 Rhythm Of Love|SSAA|Deke Sharon
 Rhythm Of Love|SSAA|Jeremey Johnson
+Rhythm Of Love|TTBB|Alex Kaiserman
+Rhythm Of Love|TTBB|Brent Graham
+Rhythm Of Love|TTBB|David Wright
 Rhythm Of Love|TTBB|Deke Sharon
 Rhythm Of Love|TTBB|Jeremey Johnson
 Rhythm Of Love|TTBB|Sharon Wright
+Rhythm of the Night|SSAA|Cindy Becker
 Rhythm Of The Night|SSAA|Cynthia Becker
+Rhythm Of The Rain|SSAA|Kathy Hannesen
 Rhythm Of The Rain|SSAA|Kathy Hanneson
 Rhythm Of The Rain|TTBB|Bob Shami
 Rhythm Of The Rain|TTBB|Fred Ganter
@@ -14838,7 +17591,9 @@ Ribbons Down My Back|SSAA|Bryan Ziegler
 Richest Man In The World|TTBB|Adam Scott
 Richest Man In The World|TTBB|Earl Moon
 Ricochet Romance|SSAA|Sonny Steffan
+Ride in That Chariot|SSAA|Unspecified
 Ride Like the Wind|SATB|Joe Mannherz
+Ride Red Ride|TTBB|Emi Mills
 Ride Red Ride|TTBB|Ernie Boring
 Ride The Chariot|SATB|Barbershop Harmony Society
 Ride The Chariot|SSAA|Barbershop Harmony Society
@@ -14850,13 +17605,17 @@ Ride The Railroad|TTBB|Robert Disney
 Ride, Red Ride|TTBB|Kevin Keller
 Riders in the Sky|TTBB|Peter Rupay
 Riders In The Sky|TTBB|David Briner
+Riders In The Sky|TTBB|Don Gray
 Riders In The Sky|TTBB|Einar Pedersen
 Riders In The Sky|TTBB|Mike Menefee
+Riders In The Sky|TTBB|Pete Rupay
+Ridin' Down the Canyon|TTBB|Unspecified
 Ridin' Down The Canyon|TTBB|Don Reeves
 Riding With Private Malone|TTBB|Adam Scott
 Right As Rain|SSAA|Deke Sharon
 Right As Rain|SSAA|Lauren Kahn
 Right As The Rain|SSAA|Joan D 'Agostino
+Right From The Start|TTBB|David Wright
 Right From The Start She Had My Heart|TTBB|David Wright
 Right Here In Your Arms|TTBB|Jim Shubert
 Right Here Right Now|SATB|Liz Garnett
@@ -14864,6 +17623,8 @@ Right Here Waiting|SSAA|Kay Bromert
 Right Now|SATB|Deke Sharon
 Right Round|TTBB|Deke Sharon
 Righteous Brothers Medley|TTBB|Todd Troutman
+Ring a Ding Ding|TTBB|Anthony Bartholemew
+Ring de Christmas Bells|TTBB|Dave Briner
 Ring Of Fire|SATB|Kevin Keller
 Ring Of Fire|SATB|Sam Hubbard
 Ring Of Fire|SSAA|Kevin Keller
@@ -14887,23 +17648,31 @@ Ripped Pants|TTBB|Dan Mulligan
 Ripple|SSAA|Steve Tramack
 Rise|SSAA|Lauren Kahn
 Rise|TTBB|Nicholas Wright
+Rise Again|SSAA|Russ Foris
 Rise Like A Phoenix|SSAA|David Wright
 Rise Like A Phoenix|SSAA|Erica Kelch-Slesnick
 Rise Up|SATB|David Zimmerman
+Rise Up Shepherd|TTBB|Steve Armstrong
 Rise Up Shepherd And Follow|TTBB|Derric Johnson
 Rise Up Shepherd And Follow|TTBB|Jon Nicholas
 Rise Up Shepherd And Follow|TTBB|Walter Latzko
+Rise Up, Shepherd, and Follow|TTBB|Jon Nicholas
+Rise Up, Shepherd, And Follow|TTBB|David Maddux
+Rise, Shine, For the Light is A-Comin|SSAA|Unspecified
 Rise, Shine, For The Light Is A-Comin'|TTBB|Burt Szabo
+Riu Riu Chiu|TTBB|Michael McGlynn
 River|SATB|Nicholas Wright
 River|SSAA|Nicholas Wright
 River Deep Mountain High|SSAA|Deke Sharon
 River In Judea|SSAA|Marie Johnson
 River In Judea|SSAA|Marsha Zwicker
 River Jordan|TTBB|Ken Lang
+River of Dreams|SSAA|Becky Wilkins
 River of Song|SSAA|Tom Gentry
 River of Song|TTBB|Tom Gentry
 River Of Tears|SATB|Nicholas Wright
 River Road|TTBB|Todd Troutman
+River Stay 'Way from My Door *|TTBB|Ed Waesche
 River, Stay 'Way from My Door|SSAA|June Dale
 River, Stay 'Way from My Door|TTBB|Dennis Driscoll
 River, Stay 'Way from My Door|TTBB|Ed Waesche
@@ -14916,8 +17685,12 @@ Roam|SSAA|Emily Moriarty
 Roar|SATB|Nicholas Wright
 Roar|SSAA|Nicholas Wright
 Roar|TTBB|Deke Sharon
+Roar (Gain)|SSAA|Elaine Gain
+Roar (Katy Perry)|SATB|Jonathan Sparks
+Roar and Brave|SSAA|Whitney Fontoura
 Roaring Twenties|TTBB|Renee Craig
 Roaring Twenties|TTBB|Robert Wachter
+Robot Parody|TTBB|Steven Armstrong
 Rock 'n' Roll Song|TTBB|Greg Mallett
 Rock and Rock Medley|SSAA|Jo Lund
 Rock and Rock Medley|TTBB|Tom Gentry
@@ -14934,8 +17707,10 @@ Rock Around The Clock|SSAA|Bev Sellers
 Rock Around The Clock|SSAA|Glenda Lloyd
 Rock Around The Clock|SSAA|Jon Nicholas
 Rock Around The Clock|SSAA|Norma Andersen
+Rock Around The Clock|TTBB|James Shubert
 Rock Around The Clock|TTBB|Jon Nicholas
 Rock Around The Clock|TTBB|Tom Gentry
+Rock Around The Clock (YWIH)|SSAA|Norma Andersen
 Rock It For Me|SSAA|Aaron Dale
 Rock It For Me|TTBB|Aaron Dale
 Rock It To (For) Me|TTBB|Aaron Dale
@@ -14961,9 +17736,12 @@ Rock-a-bye Baby|TTBB|Munson Hinman
 Rock-a-bye Baby|TTBB|Tom Gentry
 Rock-A-Bye Baby Days|TTBB|Lloyd Steinkamp
 Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Don Gray
+Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Don Gray, Mel Knight
 Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Mel Knight
 Rocket Man|SATB|Deke Sharon
 Rockies Medley|TTBB|Dan Paymar
+Rockin Around the Christmas Tree|SSAA|Sandy Sharpe
+Rockin Around The Christmas Tree|TTBB|Aaron Dale
 Rockin' Around The Christmas Tree|SATB|Deke Sharon
 Rockin' Around The Christmas Tree|SSAA|Aaron Dale
 Rockin' Around The Christmas Tree|SSAA|Adam Reimnitz
@@ -14974,15 +17752,20 @@ Rockin' Around The Christmas Tree|TTBB|Aaron Dale
 Rockin' Around The Christmas Tree|TTBB|Gabriel Lawson
 Rockin' Around The Christmas Tree|TTBB|Jon Nicholas
 Rockin' Around The Christmas Tree|TTBB|Kevin Koehl
+Rockin' Around The Christmas Tree|TTBB|Ruby Rhea
 Rockin' Around The Christmas Tree|TTBB|Todd Troutman
+Rockin' Around the Christmas Tree (SATB)|SATB|Kirby Shaw and Dale Kynaston
 Rockin' Around The Pole|TTBB|Greg Mallett
 Rockin' Chair|SSAA|Nancy Bergman
 Rockin' Chair|TTBB|Aaron Dale
 Rockin' Chair|TTBB|Robert Rund
 Rockin' Chair|TTBB|Walter Latzko
+Rockin' Christmas Medley|TTBB|Adam Reimnitz
 Rockin' Robin|SSAA|Deke Sharon
 Rockin' Robin|SSAA|Tedda Lippincott
 Rockin' Robin|TTBB|Mike Menefee
+Rockin' Robin (YWIH)|SSAA|Tedda Lippincott
+Rockin' Round The Christmas Tree|TTBB|Kirby Shaw
 Rockstar|SATB|Nicholas Wright
 Rocky Mountain High|SATB|Nicholas Wright
 Rocky Mountain High|TTBB|Deke Sharon
@@ -15004,7 +17787,11 @@ Rocky Top|TTBB|Tom Gentry
 Rodgers & Hammerstein Medley|SSAA|Jo Lund
 Roger Whittaker Medley|TTBB|Todd Troutman
 Rogue River Valley|TTBB|Jud Finley
+Roll Jordan, Roll|TTBB|Jim Henry/Crossroads
 Roll On (Eighteen Wheeler)|TTBB|Mark Stevens
+Roll On Mississippi Roll On|TTBB|Aaron Dale
+Roll On Mississippi, Roll On|TTBB|Barbershop Harmony Society
+Roll On Mississippi, Roll On|TTBB|Floyd Connett
 Roll On You Riverboat, Roll On|TTBB|Dan Wilson
 Roll On, Columbia|SSAA|Marge Bailey
 Roll On, Mississippi, Roll On|SSAA|Aaron Dale
@@ -15020,12 +17807,15 @@ Roll Out the Barrel/Zip-A-Dee-Doo-Dah Medley|TTBB|Jay Giallombardo
 Roll, Michigan Roll|TTBB|Jeremey Johnson
 Rollin' Home|TTBB|G. W. Pellant
 Rolling Along on Long Island|SSAA|Jo Lund
+Rolling in the Deep|SSAA|Don Henken
 Rolling In The Deep|SATB|Alex Morris
 Rolling In The Deep|SSAA|Anthony Bartholomew
 Rolling In The Deep|SSAA|Elaine Gain
 Rolling In The Deep|SSAA|Michael Gellert
 Rolling In The Deep|TTBB|Deke Sharon
 Rolling In The Deep|TTBB|Richard Curtis
+Rolling in the Deep (Beck)|SSAA|Brian Beck
+Rolling in the Deep (Gain)|SSAA|Elaine Gain
 Romancin' The Blues|SSAA|David Briner
 Romancin' The Blues|SSAA|June Berg
 Ronstadt, Linda Medley|SSAA|Jo Lund
@@ -15035,6 +17825,7 @@ Rose (A Ring To The Name Of Rose)|SATB|Nancy Bergman
 Rose (A Ring To The Name Of Rose)|TTBB|Lloyd Steinkamp
 Rose Medley|SSAA|Tom Gentry
 Rose Medley|TTBB|Tom Gentry
+Rose Of Bethelem|SSAA|Joe Liles
 Rose Of No Man's Land|TTBB|Jack Baird
 Rose Of No Man's Land|TTBB|SPEBSQSA
 Rose Of The Rio Grande|TTBB|Walter Latzko
@@ -15062,6 +17853,7 @@ Rosie|TTBB|Carl Walters
 Rosie (from Bye, Bye, Birdie)|TTBB|Patrick McAlexander
 Rosie Medley|TTBB|Archie Steen
 Rosie Medley|TTBB|Steve Jamison
+Rosie the Riveter|SSAA|Bryan Ziegler
 Rosie The Riveter|SSAA|Larry Wright
 Rosie, You Are My Posie/You Made Me Love You|TTBB|Jay Giallombardo
 Round and Round|TTBB|Brian Mastrull
@@ -15070,6 +17862,7 @@ Route 66|SATB|Dan Wessler
 Route 66|SATB|Deke Sharon
 Route 66|SATB|Joe Mannherz
 Route 66|SSAA|Ardeth Fullmer
+Route 66|SSAA|Chris Droegmuller
 Route 66|SSAA|Dan Wessler
 Route 66|SSAA|Dorothy Herivel
 Route 66|SSAA|Jim Arns
@@ -15078,7 +17871,12 @@ Route 66|TTBB|Dan Wessler
 Route 66|TTBB|Deke Sharon
 Route 66|TTBB|Jay Giallombardo
 Route 66|TTBB|Ken Potter
+Route 66|TTBB|Mason Kaye
 Route 66|TTBB|Ruby Rhea
+Route 66 (YWIH)|SSAA|Marge Bailey
+Route Sixty-Six|SSAA|Jim Arns
+Route Sixty-Six|SSAA|Lorraine Rochefort
+Route Sixty-Six|SSAA|Marge Bailey
 Row Your Boat|SSAA|Jon Nicholas
 Row Your Boat|TTBB|Jon Nicholas
 Row Your Boat|TTBB|Melody Hine
@@ -15087,8 +17885,11 @@ Row, Row, Row|SSAA|Marsha Zwicker
 Row, Row, Row|SSAA|Mary K. Coffman Music Fund
 Row, Row, Row|TTBB|Don Gray
 Row, Row, Row|TTBB|Jon Nicholas
+Row, Row, Row|TTBB|Paul Olguin
 Row, Row, Row|TTBB|Steve Jamison
 Row, Row, Row|TTBB|Val Hicks
+Row, Row, Row|TTBB|Val Hicks, Marv Klingerman
+Row, Row, Row / Paddlin' Madeline|TTBB|Renee Craig
 Row, Row, Row/Paddlin' Madelin' Home - Medley|TTBB|Renee Craig
 Roxie|SSAA|David Wright
 Roy Rogers Medley|TTBB|Larry Wright
@@ -15100,6 +17901,7 @@ Royal Garden Blues|TTBB|Renee Craig
 Royal Garden Blues|TTBB|Tom Gentry
 Royals|SATB|Deke Sharon
 Royals|SATB|Nicholas Wright
+Royals|SSAA|Alex Kaiserman
 Royals|SSAA|Deke Sharon
 Royals|SSAA|Dianne Goldrick
 Royals|TTBB|Simon Arnott
@@ -15111,6 +17913,8 @@ Rubber Duckie|TTBB|Jim Shubert
 Rubber Duckie|TTBB|Kirk Roose
 Rubber Duckie|TTBB|Scott Kitzmiller
 Ruby Gentry|SSAA|Doris Twardosky
+Rude|SATB|Henrik Rosenberg
+Rudolf The Red-Nosed Reindeer|TTBB|The Blenders
 Rudolph Montage|SATB|Kevin Keller
 Rudolph The Red Nosed Reindeer|SATB|Deke Sharon
 Rudolph The Red Nosed Reindeer|SSAA|Brent Graham
@@ -15128,7 +17932,11 @@ Rudolph The Red Nosed Reindeer|TTBB|Ed Jarley
 Rudolph The Red Nosed Reindeer|TTBB|Jay Giallombardo
 Rudolph The Red Nosed Reindeer|TTBB|Kevin Keller
 Rudolph The Red Nosed Reindeer|TTBB|Mike Menefee
+Rudolph the Red-Nosed Reindeer|SSAA|Burt Szabo
+Rudolph the Red-Nosed Reindeer|SSAA|Nancy Bergman
+Rudolph the Red-Nosed Reindeer|TTBB|Burt Szabo
 Rule the World|SSAA|Liz Garnett
+Rule The World|SATB|Unspecified
 Rum And Coca Cola|SSAA|Walter Latzko
 Rumor Has It|SATB|Kevin Keller
 Rumor Has It|SSAA|Deke Sharon
@@ -15167,6 +17975,7 @@ Runnin' Wild|TTBB|Ed Waesche
 Runnin' Wild|TTBB|Mark Rusch
 Runnin' Wild|TTBB|Walter Latzko
 Runnin' Wild Medley|TTBB|Rob Hopkins
+Runnin' Wild!|TTBB|David Wright
 Running Bear|SSAA|Greta Somers
 Running Up That Hill|SATB|Nicholas Wright
 Rural Rhythm|TTBB|Hal Snyder
@@ -15175,9 +17984,11 @@ Russian Roulette|SSAA|Liz Garnett
 Rusty Old American Dream|TTBB|Melody Hine
 S Wonderful|SATB|Kevin Keller
 S Wonderful|SSAA|Charlotte Pernert
+S Wonderful|TTBB|Chris Arnold
 S Wonderful|TTBB|David Wright
 S Wonderful|TTBB|Kevin Keller
 S.O.S.|SSAA|Glenda Lloyd
+S.O.S.|SSAA|Lynnell Diamond
 S'vivon|TTBB|Gary A. Lewis
 S'Vivon|TTBB|Gary Lewis
 Sabbath Prayer|TTBB|Manoj Padki
@@ -15187,8 +17998,10 @@ Sadder But Wiser Girl|TTBB|Walter Latzko
 Sadie, Sadie, Married Lady|SSAA|Kay Bromert
 Safe and Sound|SSAA|Adam Bock
 Safe and Sound|SSAA|Lauren Kahn
+Sag Mir, Wo Di Blumen|SSAA|Jo Lund
 Sailin' Away On The Henry Clay|TTBB|Don Gray
 Sailin' Away On The Henry Clay|TTBB|Jack Baird
+Sailin' Away On The Henry Clay|TTBB|Rob Campbell
 Sailin' Away On The Henry Clay|TTBB|Rob Hopkins
 Sailing|TTBB|Mark Jennings
 Sailing|TTBB|Mark Stevens
@@ -15197,6 +18010,7 @@ Sailing Down The Chesapeake Bay|SSAA|Jim Arns
 Sailing Down The Chesapeake Bay|TTBB|Burt Szabo
 Sailing Down The Chesapeake Bay|TTBB|Dennis Driscoll
 Sailing Down The Chesapeake Bay|TTBB|Fred King
+Sailor Medley|TTBB|Steve Delehanty
 Sailors Medley|TTBB|Ray Buntaine
 Saints In The Street Medley|TTBB|Aaron Dale
 Sakura Sakura|SSAA|Takako Fuke
@@ -15211,7 +18025,10 @@ Salty Dog|SATB|Kevin Keller
 Salty Dog|SSAA|Kevin Keller
 Salty Dog|TTBB|Kevin Keller
 Salute to America|SSAA|Carolyn Schmidt
+Salvation Is Created (Spasineye Sodelal) (Pavel Chesn|TTBB|Pavel Chesnokov
 Sam Cooke Medley|TTBB|Rob Campbell
+Sam the Old Accordian Man|TTBB|Earl Moon
+Sam You Made the Pants Too Long|SSAA|Tedda Lippincott
 Sam, The Old Accordion Man|SSAA|Kevin Keller
 Sam, The Old Accordion Man|SSAA|Tedda Lippincott
 Sam, The Old Accordion Man|TTBB|Earl Moon
@@ -15223,14 +18040,19 @@ Sam, You Made The Pants Too Long|SSAA|Tedda Lippincott
 Sam, You Made The Pants Too Long|TTBB|Walter Latzko
 Samba Do Aviao|SATB|Joe Mannherz
 Same Boat|SATB|Melody Hine
+Same Old Saturday Night|TTBB|Jay Krumbholz
 Same Old Saturday Night|TTBB|Jim Halvorson
 Sammy Put the Paper on the Wall|SSAA|Tom Gentry
 Sammy Put the Paper on the Wall|TTBB|Tom Gentry
 Samson|SATB|Nicholas Wright
 San Antonio Rose|SSAA|Tedda Lippincott
+San Antonio Rose|TTBB|Dick Carr
+San Fernando Valley|TTBB|Phil Ordaz
 San Francisco|SSAA|Joe Samuel
 San Francisco|TTBB|Dennis Driscoll
 San Francisco Bay Blues|SSAA|Dave Stevens
+San Francisco Bay Blues|SSAA|Jean Sutton
+San Francisco Bay Blues|TTBB|C.J. Sams Jr.
 San Francisco Bay Blues|TTBB|Denis Murphy
 San Francisco Bay Blues|TTBB|Frank Sysel
 San Francisco Bay Blues|TTBB|Jon Nicholas
@@ -15241,14 +18063,21 @@ Sandbox of Dreams|SSAA|Jo Lund
 Sandcastles|SSAA|Simon Arnott
 Santa Baby|SATB|Aaron Dale
 Santa Baby|SATB|Deke Sharon
+Santa Baby|SATB|Tom Gentry
 Santa Baby|SSAA|June Berg
 Santa Baby|SSAA|Larry Wright
+Santa Baby|SSAA|Lorraine Rochefort
 Santa Baby|SSAA|Tom Gentry
+Santa Baby|TTBB|Aaron Dale
+Santa Baby|TTBB|Clay Hine
 Santa Baby|TTBB|Jon Nicholas
 Santa Baby|TTBB|Tom Gentry
 Santa Bring My Baby Back|TTBB|Jon Nicholas
+Santa Bring My Baby Back (To Me)|TTBB|Jon Nicholas
 Santa Catalina|TTBB|Todd Troutman
+Santa Claus Has Moved to Indiana|SSAA|Tedda Lippincott
 Santa Claus Is Back In Town|TTBB|Deke Sharon
+Santa Claus is Back Town|SSAA|Lynnell Diamond
 Santa Claus Is Comin' To Town|SATB|Deke Sharon
 Santa Claus Is Comin' To Town|SATB|Jack Bridges
 Santa Claus Is Comin' To Town|SSAA|Anna Maria Parker
@@ -15261,7 +18090,12 @@ Santa Claus Is Comin' To Town|TTBB|Melody Hine
 Santa Claus Is Comin' To Town|TTBB|Sam Stahl
 Santa Claus Is Comin' To Town|TTBB|Steve Snow
 Santa Claus Is Comin' To Town|TTBB|Steve Tramack
+Santa Claus is Coming to Town|SSAA|Roger Pyne and Jean Sutton
+Santa Claus Is Coming to Town|SSAA|Nancy Bergman
+Santa Claus Is Coming To Town|SSAA|LaVeda Redfield
+Santa Claus Is Coming To Town|TTBB|Hal Maples
 Santa Claus Is Coming To Town|TTBB|Joe Liles
+Santa Claus Is Coming To Town - Here Comes Santa Claus Medley|TTBB|Rick Spencer
 Santa Claus Parade|TTBB|Tom Gentry
 Santa Fe|TTBB|Gabriel Lawson
 Santa Fe|TTBB|Theodore Hicks
@@ -15269,6 +18103,7 @@ Santa Fe (from Newsies)|TTBB|Chris Lewis
 Santa is Watching|TTBB|Todd Troutman
 Santa Lost His Keys|TTBB|Jim Shubert
 Santa Lucia|SSAA|Carole Prietto
+Santa Medley|SSAA|Aaron Dale
 Santa Medley|SSAA|Carolyn Johnson
 Santa Medley|TTBB|Aaron Dale
 Santa Mouse|TTBB|Cay Outerbridge
@@ -15280,12 +18115,15 @@ Sara Lee|SSAA|Joey Minshall
 Sarah|TTBB|Greg Mallett
 Satan's Li'l Lamb|TTBB|Kevin Keller
 Satin Doll|SATB|Joe Mannherz
+Satin Doll|TTBB|Peter Beers
 Satin Doll|TTBB|Scott Kitzmiller
 Satin Doll|TTBB|Steve Jamison
 Satin Doll|TTBB|Wayne Grimmer
+Satisfied|SSAA|Mary Coffman
 Satisfied|SSAA|Mary K. Coffman Music Fund
 Saturday In The Park|SATB|Deke Sharon
 Saturday In The Park|SSAA|Jim Arns
+Saturday In The Park|TTBB|David Wise
 Saturday In The Park|TTBB|Steve Tramack
 Saturday Night|TTBB|Toban Dvoretsky
 Saturday Night in Toledo, Ohio|SSAA|Carolyn Healey
@@ -15304,6 +18142,8 @@ Save The Last Dance For Me|SSAA|Aaron Dale
 Save The Last Dance For Me|SSAA|Takako Fuke
 Save The Last Dance For Me|TTBB|Aaron Dale
 Save The Last Dance For Me|TTBB|Kohl Kitzmiller
+Save The Last Dance/Sway Medley|SSAA|Aaron Dale
+Save The Last Dance/Sway Medley|TTBB|Aaron Dale
 Save Tonight|SATB|Nicholas Wright
 Save Tonight|TTBB|Deke Sharon
 Save Your Love for Me|TTBB|Kevin Keller
@@ -15314,6 +18154,7 @@ Saved|TTBB|Tom Gentry
 Saving All My Love For You|TTBB|Matthew Gallagher
 Saving All My Love For You|TTBB|Wayne Grimmer
 Saxaphone Man|SSAA|Bev Sellers
+Saxophone Man|SSAA|Bev Sellers
 Say (All I Need)|SATB|Deke Sharon
 Say (All I Need)|SATB|Nicholas Wright
 Say Hello to Pittsburgh|TTBB|Tom Gentry
@@ -15324,6 +18165,7 @@ Say It With Music|SSAA|Flora Beth Cunningham
 Say It With Music|SSAA|Kay Bromert
 Say It With Music|SSAA|Linda Edmondson
 Say Mister / If You Knew Susie Medley|TTBB|Rob Hopkins
+Say Mister, Have You Met Rosie's Sister|TTBB|Adam Scott
 Say My Name|SSAA|Emily Moriarty
 Say My Name|TTBB|Nicholas Wright
 Say Si Si|TTBB|Kyle Snook
@@ -15336,16 +18178,22 @@ Say You Love Me|SSAA|Nicholas Wright
 Say, Has Anybody Seen My Sweet Gypsy Rose|TTBB|Mark Goodney
 Says My Heart|SSAA|Joy McGregor
 Scarborough Fair|SATB|Joe Mannherz
+Scarborough Fair|SATB|Yumiko Matsuoka
 Scarborough Fair|SSAA|Diane Clark
 Scarborough Fair|SSAA|Glenda Lloyd
 Scarborough Fair|SSAA|Hilary Allen
 Scarborough Fair|SSAA|Jo Lund
 Scarborough Fair|SSAA|Joe Mannherz
 Scarborough Fair|TTBB|Diane Clark
+Scarborough Fair|TTBB|Greg Lyne/Paul Davies
 Scarborough Fair|TTBB|Joe Mannherz
+Scarborough Fair|TTBB|Stan Engebretson
 Scarborough Fair|TTBB|Todd Troutman
+Scarlet Ribbons|SSAA|Nigel Williams
+Scarlet Ribbons|SSAA|Renee Craig
 Scarlet Ribbons (For Her Hair)|SSAA|Renee Craig
 Scarlet Ribbons (For Her Hair)|TTBB|Don Gray
+Scarlett Ribbons|TTBB|Roger Payne
 Scenes From An Italian Restaurant|TTBB|Dan Wessler
 School Days|TTBB|Burt Szabo
 School Days|TTBB|Jack Baird
@@ -15363,6 +18211,7 @@ Scotch And Soda|SSAA|Mary K. Coffman Music Fund
 Scotch And Soda|SSAA|Scott Kitzmiller
 Scotch And Soda|SSAA|Sylvia Alsbury
 Scotch And Soda|TTBB|Brent Graham
+Scotch And Soda|TTBB|Steve Iannacchione
 Scottish Tribute|SSAA|Jay Giallombardo
 Scottish Tribute|TTBB|Jay Giallombardo
 Scream|SATB|Nicholas Wright
@@ -15379,6 +18228,7 @@ Seaside Rendezvous|SATB|Dan Naumann
 Seaside Rendezvous|SSAA|Kirsten Bridges
 Seaside Rendezvous|SSAA|Melody Hine
 Seaside Rendezvous|TTBB|Ken Potter
+Seaside Rendezvous|TTBB|Paul Hart
 Seasons Greetings|SSAA|Carolyn Johnson
 Seasons of Love|SATB|Carolyn Schmidt
 Seasons of Love|SSAA|Carolyn Schmidt
@@ -15392,6 +18242,7 @@ Seasons of Love|TTBB|Deke Sharon
 Seasons of Love|TTBB|Greg Mallett
 Seasons of Love|TTBB|Robert Rund
 Seasons of Love|TTBB|Walter Latzko
+Seasons Of Love (from Rent)|SATB|Sylvia Posso
 Seattle|SSAA|Larry Wright
 Seattle|TTBB|Matt Astle
 Seattle/Blue Skies Medley|SSAA|Larry Wright
@@ -15399,9 +18250,12 @@ Second Hand Rose|SSAA|Al Baker
 Second Hand Rose|SSAA|Jo Lund
 Second Hand Rose|SSAA|Nancy Bergman
 Second Hand Rose|SSAA|Norma Andersen
+Second Hand Rose|SSAA|Unspecified
 Second Hand Rose|SSAA|Walter Latzko
 Second Hand Rose|TTBB|J Rae Jamieson
 Second Hand Rose / She Is More To Be Pitied...|SSAA|Nancy Bergman
+Second Hand Rose/More to Be Pitied|SSAA|Nancy Bergman
+Second Hand Rose/She Is More to Be Pitied|SSAA|Nancy Bergman
 Second Star to the Right|SSAA|Sam Hubbard
 Second Star to the Right|SSAA|Tom Gentry
 Second Star to the Right|TTBB|Sam Hubbard
@@ -15413,11 +18267,15 @@ Secondhand White Baby Grand|SSAA|Larry Wright
 Secondhand White Baby Grand|TTBB|Theo Hicks
 Secondhand White Baby Grand|TTBB|Theodore Hicks
 Secret For The Mad|SSAA|Lauren Kahn
+Secret Love|SATB|Jay Giallombardo
+Secret Love|SSAA|Jay Giallombardo
 Secret Love|SSAA|Tom Gentry
 Secret Love|SSAA|Walter Latzko
 Secret Love|TTBB|Jay Giallombardo
 Secret Love|TTBB|Paul Grimm
+Secret Love|TTBB|Rosling
 Secret Love|TTBB|Tom Gentry
+Secrets|SSAA|Sylvia Alsbury
 See Clearly|TTBB|Mark Stevens
 See Saw|TTBB|Tom Gentry
 See You Again|SATB|Deke Sharon
@@ -15429,13 +18287,18 @@ Seeds and Stems Again|TTBB|Tom Gentry
 Seeing For The Very First Time|TTBB|David Wright
 Seems Like Old Times|SSAA|Debbie Porter
 Seems Like Old Times|SSAA|Dorothy Short
+Seems Like Old Times|SSAA|Lou Perry
 Seems Like Old Times|TTBB|Louis Perry
 Seize The Day|SSAA|Jim Arns
+Seize The Day|SSAA|June Dale
+Seize The Day|SSAA|Kirby Shaw
 Seize The Day|TTBB|Aaron Dale
 Seize The Day|TTBB|Theodore Hicks
 Seize The Day (from Newsies)|TTBB|Theo Hicks
+Seize The Day (From Newsies)|SSAA|Carole Prietto
 Semi Charmed Life|SATB|Deke Sharon
 Semper Paratus|TTBB|Jim West
+Send In the Clowns|TTBB|Randy Rogers
 Send In The Clowns|SSAA|Joey Minshall
 Send In The Clowns|SSAA|Kay Bromert
 Send In The Clowns|SSAA|Larry Wright
@@ -15460,6 +18323,7 @@ Sentimental Gentleman From Georgia|SSAA|Ed Waesche
 Sentimental Gentleman From Georgia|TTBB|Ed Waesche
 Sentimental Gentleman From Georgia|TTBB|Roy Keys
 Sentimental Journey|SSAA|Audrey Oakley
+Sentimental Journey|SSAA|Carolyn Healey
 Sentimental Journey|SSAA|Carolyn Johnson
 Sentimental Journey|SSAA|Deke Sharon
 Sentimental Journey|SSAA|Jay Giallombardo
@@ -15472,13 +18336,17 @@ Sentimental Journey|TTBB|Bob Benson
 Sentimental Journey|TTBB|Charles Warren
 Sentimental Journey|TTBB|Fran Wilson
 Sentimental Journey|TTBB|James Bazewicz
+Sentimental Journey|TTBB|Jason Ryner
 Sentimental Journey|TTBB|Jay Giallombardo
 Sentimental Journey|TTBB|Jerry Roland
 Sentimental Journey|TTBB|Jim West
 Sentimental Journey|TTBB|John Hohl
 Sentimental Journey|TTBB|Jud Finley
 Sentimental Journey|TTBB|Larry Wright
+Sentimental Journey|TTBB|Steve Jamison
+Sentimental Journey|TTBB|Unspecified
 Sentimental Journey|TTBB|Walter Latzko
+Sentimental Journey|TTBB|Webb Comfort
 Separate Ways (Worlds Apart)|SATB|Mark Stevens
 September|SATB|Deke Sharon
 September|SATB|Lance Fisher
@@ -15492,8 +18360,11 @@ September In The Rain|SSAA|June Berg
 September In The Rain|TTBB|Jim Shubert
 September In The Rain|TTBB|Walter Latzko
 September Song|SSAA|Brent Graham
+September Song|SSAA|Ruth Emley
 September Song|TTBB|Brent Graham
+September Song|TTBB|Don Gray
 September Song|TTBB|Jon Nicholas
+September Song|TTBB|Renee Craig
 September Song|TTBB|Roy Keys
 September Song|TTBB|Todd Troutman
 September Song|TTBB|Walter Latzko
@@ -15502,6 +18373,8 @@ Serenade In Blue|SSAA|Cheryl Suhr
 Serenade In Blue|TTBB|Brent Graham
 Serenade In Blue|TTBB|Walter Latzko
 Serenade Of The Bells|TTBB|Jim West
+Service Five Medley (Armed Forces Medley)|TTBB|Fred King
+Sesame Street Medley|TTBB|Steve Tramack
 Sesame Street Songs|SSAA|Kay Bromert
 Sesame Street Theme|TTBB|Aaron Dale
 Sesame Street Theme|TTBB|Kirk Young
@@ -15518,11 +18391,18 @@ Seven Bridges Road|TTBB|Jeremey Johnson
 Seven Bridges Road|TTBB|Jon Nicholas
 Seven Bridges Road|TTBB|Sean Mootrey
 Seven Bridges Road|TTBB|Sheryl Neal
+Seven Bridges Road|TTBB|The Eagles
 Seven Nation Army|TTBB|Deke Sharon
 Seven Or Eleven|TTBB|Nancy Bergman
 Seventeen|SSAA|Mark Jennings
 Seventies Medley|SSAA|Jo Lund
 Seventy Six Percent|TTBB|Tom Gentry
+Seventy Six Trombones|SSAA|Nancy Bergman
+Seventy Six Trombones|TTBB|David Wright
+Seventy Six Trombones|TTBB|George Hulst
+Seventy Six Trombones|TTBB|John Peterson
+Seventy Six Trombones|TTBB|Kenosha
+Seventy Six Trombones|TTBB|Kevin Keller
 Seventy-Six Trombones|SATB|Kevin Keller
 Seventy-Six Trombones|SSAA|Betty Oliver
 Seventy-Six Trombones|SSAA|Jay Giallombardo
@@ -15548,18 +18428,30 @@ Sh Boom|TTBB|Dan Naumann
 Sh Boom|TTBB|Diane Butler
 Sh Boom|TTBB|John Spence
 Sh Boom|TTBB|Mark Goodney
+Sh Boom (Life Could be A Dream)|SSAA|Unspecified
+Sh-Boom|SSAA|Marsha Zwicker
+Sh-Boom|SSAA|Tedda Lippincott
+Sh-Boom|TTBB|Tedda Lippincott
 Sh-Boom (Life Could Be a Dream)|SATB|Dave Briner
 Sh-Boom (Life Could Be a Dream)|SSAA|Dave Briner
 Sh-Boom (Life Could Be A Dream)|TTBB|Dave Briner
 Sh-Boom (Life Could Be A Dream)|TTBB|Deke Sharon
+Sh-Boom (Life Could Be A Dream)|TTBB|Webb Comfort
+Sh-Boom (Life Could Be A Dream) (YWIH)|SSAA|Tedda Lippincott
+Sh-Boom/Splish Splash|SSAA|Joni Bescos
+Shackles|SSAA|Lynnell Diamond
 Shaddap You Face|SSAA|Jo Lund
 Shadrach|TTBB|Derric Johnson
 Shake It Off|SATB|Deke Sharon
 Shake It Off|SSAA|Erica Kelch-Slesnick
 Shake It Out|SATB|Nicholas Wright
+Shakin' the Blues Away|TTBB|Clay Hine
+Shakin' The Blues Away|SSAA|Renee Craig
+Shakin' The Blues Away|TTBB|Steve Delehanty
 Shakin' The Blues Away (from Easter Parade)|TTBB|Cay Outerbridge
 Shakin' The Blues Away (from Easter Parade)|TTBB|Clay Hine
 Shaking The Blues Away|SSAA|Renee Craig
+Shaking The Blues Away|SSAA|Steve Delehanty
 Shaking The Blues Away|TTBB|Cay Outerbridge
 Shaking The Blues Away|TTBB|Jay Giallombardo
 Shaking The Blues Away|TTBB|Steve Delehanty
@@ -15574,8 +18466,10 @@ Shallow|TTBB|Sam Hubbard
 Shalom Chaverim|SSAA|Carolyn Johnson
 Shalom Chaverim - Round|SSAA|Carolyn Johnson
 Sham-a-ling-dong-ding|TTBB|Greg Mallett
+Shambala|SATB|Kirby Shaw
 Shambala|SSAA|Becky Wilkins
 Shambala|SSAA|Jim Arns
+Shambala|SSAA|Kirby Shaw
 Shameless|TTBB|Thomas Degan
 Shamey Shamey Shame|SSAA|Matt Parks
 Shanghai|SSAA|Nancy Bergman
@@ -15625,6 +18519,8 @@ She'll Be Comin' Round The Mountain|SSAA|Nancy Bergman
 She's A Typical Tip from Tipperary|TTBB|Tom Parker
 She's All I Ever Had|TTBB|Steve Jamison
 She's Always A Woman|TTBB|Simon Rylander
+She's Always A Woman To Me|TTBB|Zac Booles
+She's Called Nova Scotia|TTBB|Joe Liles
 She's Funny That Way|TTBB|Walter Latzko
 She's Gonna Fly|SSAA|Michael Gellert
 She's Gonna Love That Barbershop Song|TTBB|David Longroy
@@ -15636,6 +18532,7 @@ She's Got You|SSAA|June Berg
 She's Leaving Home|SATB|Manoj Padki
 She's Leaving Home|SSAA|Liz Garnett
 She's Leaving Home|TTBB|Jay Giallombardo
+She's Like The Swallow|TTBB|Steven Armstrong
 She's Out Of My Life|SSAA|Kevin Keller
 She's Out Of My Life|TTBB|Chris Arnold
 She's Out Of My Life|TTBB|David Harrington
@@ -15651,17 +18548,38 @@ Sheik Of Araby|TTBB|Ellsworth Morey
 Shelter|SSAA|Glenda Lloyd
 Shenandoah|SATB|Burt Szabo
 Shenandoah|SATB|Derric Johnson
+Shenandoah|SATB|James Erb
 Shenandoah|SSAA|Burt Szabo
 Shenandoah|SSAA|Carolyn Johnson
+Shenandoah|SSAA|Michael Gellert
 Shenandoah|TTBB|Burt Szabo
+Shenandoah|TTBB|Don Gray
 Shenandoah|TTBB|Jay Giallombardo
+Shenandoah|TTBB|Joe DeRosa
+Shenandoah|TTBB|Mike Taylor
+Shenandoah|TTBB|Rick Spencer
+Shenendoah|SSAA|Burt Szabo
+Shenendoah|TTBB|Burt Szabo
+Shenendoah|TTBB|Jay Giallombardo
+Shenendoah|TTBB|Joe DeRosa
+Shenendoah|TTBB|Unspecified
+Shepherds Farewell|SSAA|Unspecified
+Shepherds, Come Quick|TTBB|Mark Hale
 Sherry|TTBB|Thomas Degan
+Shine|SSAA|Heather Lane
+Shine|SSAA|James Porter
 Shine|SSAA|Joey Minshall
 Shine|SSAA|June Dale
 Shine|SSAA|Liz Garnett
+Shine|SSAA|Lorraine Rochefort
 Shine|TTBB|David Wright
+Shine Medley|TTBB|David Wright
 Shine Medley|TTBB|Ed Waesche
+Shine On Harvest Moon|SSAA|Dot Short
 Shine On Me|TTBB|Brent Graham
+Shine On Me|TTBB|Floyd Connett
+Shine On Me|TTBB|Unspecified
+Shine On Your Shoes / Steppin' Out Medley|TTBB|Greg Volk
 Shine On, Harvest Moon|SSAA|Carolyn Johnson
 Shine On, Harvest Moon|SSAA|Dot Calvin
 Shine On, Harvest Moon|SSAA|Jo Lund
@@ -15669,8 +18587,11 @@ Shine On, Harvest Moon|SSAA|Walter Latzko
 Shine On, Harvest Moon|TTBB|Jack Baird
 Shine On, Harvest Moon|TTBB|John Muir
 Shine On, Harvest Moon|TTBB|Val Hicks
+Shine On, Harvest Moon|TTBB|Val Hicks and Earl Moon
+Shine On, Harvest Moon|TTBB|Val Hicks, Earl Moon
 Shine On, Harvest Moon / For Me And My Gal Medley|TTBB|Jack Baird
 Shine Silently|SATB|Liz Garnett
+Shine Your Light|SSAA|Nancy Faddegon
 Shiny|SATB|Deke Sharon
 Shiny Stockings|SSAA|Walter Latzko
 Shiny Stockings|TTBB|Walter Latzko
@@ -15683,7 +18604,9 @@ Shiver My Timbers|SSAA|Carole Prietto
 Shiver My Timbers|TTBB|Jon Nicholas
 Shoe Shine Boy|TTBB|Jeremey Johnson
 Shoo Fly Pie and Apple Pan Dowdy|TTBB|Chris Droegemueller
+Shoo-Fly Pie and Apple Pan Dowdy|SSAA|Ruby Rhea
 Shoo-shoo Baby|SSAA|Larry Wright
+Shoop Shoop Song ('It's In His Kiss')|SSAA|Lorraine Rochefort
 Shoop-Shoop Song, The (It's In His Kiss)|SSAA|Deke Sharon
 Shoop-Shoop Song, The (It's In His Kiss)|SSAA|Jo Lund
 Shoot For The Moon|SSAA|Kay Bromert
@@ -15692,9 +18615,12 @@ Shop-Vac|TTBB|Tom Gentry
 Short People|SSAA|Jay Giallombardo
 Short People|SSAA|Larry Wright
 Short People|TTBB|Jay Giallombardo
+Short People|TTBB|Jim Henry
+Short People|TTBB|King's Singers
 Short People|TTBB|Larry Wright
 Short People|TTBB|Michael Webber
 Short People|TTBB|Steve Delehanty
+Short People|TTBB|Unspecified
 Shotgun|TTBB|Jack Bridges
 Should Have Been Us|SSAA|Nicholas Wright
 Should I|SSAA|Kathy Hanneson
@@ -15705,6 +18631,7 @@ Show Biz Is|TTBB|Keith Clark
 Show Business Medley|TTBB|Jay Giallombardo
 Show Me The Way|SSAA|Cris Conerty
 Show Me The Way|TTBB|Anders Lindqvist
+Show Me Where the Good Times Are|TTBB|Dot Short and Gene Cokeroft
 Show Me Where The Good Times Are|SATB|Gene Cokeroft
 Show Me Where The Good Times Are|SSAA|Gene Cokeroft
 Show Me Where The Good Times Are|TTBB|Bob Dowma
@@ -15714,7 +18641,9 @@ Show Me Where The Good Times Are|TTBB|Don Gray
 Show Me Where The Good Times Are|TTBB|Gene Cokeroft
 Show Me Where The Good Times Are|TTBB|Gene Cokeroft/Dot Short
 Show Opener|SSAA|Jo Lund
+Showbiz Medley|TTBB|Jay Giallombardo
 Shuffle Off To Buffalo|TTBB|Al Baker
+Shure They Called It Ireland|TTBB|Unspecified
 Shut De Do|SATB|Dr. Kirby Shaw
 Shut De Do|SSAA|Dr. Kirby Shaw
 Shut De Do|TTBB|Kirby Shaw
@@ -15730,6 +18659,7 @@ Side by Side|SSAA|Carolyn Johnson
 Side by Side|SSAA|David Harrington
 Side by Side|SSAA|Jan Meyer
 Side by Side|SSAA|Kathy Hanneson
+Side by Side|SSAA|Lorraine Rochefort
 Side by Side|SSAA|Nancy Bergman
 Side by Side|SSAA|Ruth Emley Craven
 Side by Side|SSAA|Tom Gentry
@@ -15739,10 +18669,15 @@ Side by Side|TTBB|SPEBSQSA
 Side by Side|TTBB|the Barbershop Harmony Society
 Side by Side|TTBB|Thomas Gentry
 Side by Side|TTBB|Tom Gentry
+Side By Side|SSAA|Bill Stauffer
+Side By Side|SSAA|Ruth Emley
+Side By Side|TTBB|Buzz Haeger
 Side By Side / Ain't We Got Fun Medley|TTBB|Mel Knight
+Side By Side Parody|TTBB|Unspecified
 Sierra Sue|TTBB|Todd Troutman
 Sign Your Name|SATB|Deke Sharon
 Signed, Sealed, Delivered|SATB|Deke Sharon
+Signed, Sealed, Delivered|SATB|Henrik Rosenberg
 Signed, Sealed, Delivered|SSAA|Staffan Paulson
 Signed, Sealed, Delivered|TTBB|Deke Sharon
 Signed, Sealed, Delivered|TTBB|Staffan Paulson
@@ -15752,6 +18687,7 @@ Silent E|TTBB|Chuck Eaker
 Silent Night|SATB|David Harrington
 Silent Night|SATB|Joe Mannherz
 Silent Night|SATB|Nancy Bergman
+Silent Night|SATB|Steve Plumb
 Silent Night|SSAA|Avis Fellows
 Silent Night|SSAA|Cris Conerty
 Silent Night|SSAA|David Wallace
@@ -15760,7 +18696,9 @@ Silent Night|SSAA|Eugene McHugh
 Silent Night|SSAA|Floyd Connett
 Silent Night|SSAA|Jay Giallombardo
 Silent Night|SSAA|Jeremey Johnson
+Silent Night|SSAA|Renee Craig
 Silent Night|TTBB|Aaron Dale
+Silent Night|TTBB|Barbershop Harmony Society
 Silent Night|TTBB|David Harrington
 Silent Night|TTBB|Deke Sharon
 Silent Night|TTBB|Derric Johnson
@@ -15779,8 +18717,13 @@ Silent Night|TTBB|Manoj Padki
 Silent Night|TTBB|Nick Bryant
 Silent Night|TTBB|Rick Spencer
 Silent Night|TTBB|SPEBSQSA
+Silent Night|TTBB|Steven Armstrong
+Silent Night|TTBB|Unspecified
 Silent Night|TTBB|Walter Latzko
 Silent Night (Not The Traditional Hymn)|SSAA|June Berg
+Silent Night, Holy Night|TTBB|Jon Nicholas
+Silent Night/It Came Upon a Midnight Clear|TTBB|Jim Clancy
+Silent Night/Night of Silence|SSAA|Brian Beck
 Silhouettes|SATB|Deke Sharon
 Silhouettes|SATB|Tom Gentry
 Silhouettes|SSAA|Marge Bailey
@@ -15789,6 +18732,7 @@ Silhouettes|TTBB|Thomas Gentry
 Silhouettes|TTBB|Tom Gentry
 Silver And Gold|TTBB|Andrew Wittenberg
 Silver And Gold|TTBB|Kevin Keller
+Silver Bells|SATB|Barbershop Harmony Society
 Silver Bells|SATB|Joe Mannherz
 Silver Bells|SSAA|Brent Graham
 Silver Bells|SSAA|Carole Townsend
@@ -15802,24 +18746,31 @@ Silver Bells|SSAA|Jay Giallombardo
 Silver Bells|SSAA|Katie Taylor
 Silver Bells|SSAA|Kay Bromert
 Silver Bells|SSAA|Linda Edmondson
+Silver Bells|SSAA|Louise Hamilton
 Silver Bells|SSAA|Nancy Bergman
 Silver Bells|TTBB|Barbershop Harmony Society
 Silver Bells|TTBB|Brent Graham
 Silver Bells|TTBB|Derric Johnson
+Silver Bells|TTBB|Greg Lyne
 Silver Bells|TTBB|Harry Buerer
 Silver Bells|TTBB|Jay Giallombardo
 Silver Bells|TTBB|Jon Nicholas
 Silver Bells|TTBB|Todd Troutman
 Silver Bells|TTBB|TTBB Harmony Society
+Silver Bells|TTBB|Unspecified
 Silver Medals And Sweet Memories|SSAA|Marie Johnson
 Silver Sorority Song|SSAA|Jo Lund
 Silver Threads Among The Gold|TTBB|Dennis Driscoll
+Silver Threads Among The Gold|TTBB|Joe Liles
 Silver Threads Among The Gold|TTBB|Phil Embury
 Silver Threads Among The Gold|TTBB|Tom Gentry
+Silvia|TTBB|David Zimmerman
+Simon & Garfunkel Montage|TTBB|Greg Volk
 Simple Gifts|SATB|Derric Johnson
 Simple Gifts|SSAA|Dianne Goldrick
 Simple Gifts|TTBB|Deke Sharon
 Simple Gifts / Shenandoah|TTBB|David Zimmerman
+Sinatra Medley|TTBB|Ed Waesche
 Sinatra Medley|TTBB|Tom Gentry
 Since I Don't Have You|TTBB|Aaron Dale
 Since I Fell For You|TTBB|Robert Rund
@@ -15829,13 +18780,17 @@ Since U Been Gone|SSAA|Deke Sharon
 Since U Been Gone|TTBB|Deke Sharon
 Since You've Been Gone|SSAA|Alex Kaiserman
 Since You've Been Gone|SSAA|Jen Lee
+Since You've Been Gone|SSAA|Jen Miller Lee
 Since You've Been Gone|SSAA|Joey Minshall
 Sincere|TTBB|Jay Giallombardo
 Sincere|TTBB|Larry Wright
+Sincere|TTBB|Meredith Willson
 Sincere|TTBB|Phil Embury
 Sincere|TTBB|Walter Latzko
 Sincere (from "The Music Man")|TTBB|Phil Embury
 Sincere (from the musical "The Music Man") -|TTBB|Dave Mohr
+Sincere (The Music Man)|TTBB|Meredith Willson
+Sincere-It's You|TTBB|Walter Latzko
 Sincerely|TTBB|Walter Latzko
 Sing|SATB|Cay Outerbridge
 Sing|SATB|Melody Hine
@@ -15850,6 +18805,8 @@ Sing|TTBB|Jay Giallombardo
 Sing|TTBB|Marilyn Penketh
 Sing|TTBB|Mason Eubank
 Sing|TTBB|Wayne Grimmer
+Sing & Celebrate|SSAA|Sylvia Alsbury and Bev Sellers
+Sing A Christmas Carol|TTBB|Charlie Kinnison
 Sing A Little Doo Wop|TTBB|Steve Delehanty
 Sing A Rainbow|SSAA|Carole Prietto
 Sing A Song|SATB|Joe Mannherz
@@ -15873,33 +18830,44 @@ Sing It A Cappella|TTBB|Tom Gentry
 Sing Lullaby|SATB|Tom Gentry
 Sing Lullaby|SSAA|Tom Gentry
 Sing Lullaby|TTBB|Tom Gentry
+Sing Me A Baby Song|TTBB|Renee Craig
 Sing Me A Baby Song|TTBB|Steve Jamison
+Sing Me A Song About Ireland|SSAA|Joni Bescos
 Sing Me That Song Again|SSAA|Ed Waesche
 Sing Me That Song Again|SSAA|Larry Wright
 Sing Me That Song Again|TTBB|Ed Waesche
 Sing Me That Song Again|TTBB|Frank Smith
 Sing Me That Song Again|TTBB|Larry Wright
+Sing Me To Heaven|SATB|Daniel Gawthrop
 Sing Off Halloween Medley|SATB|Deke Sharon
 Sing Out A Song|TTBB|Joe Liles
 Sing Out, Sing Out|TTBB|Joe Liles
 Sing Sing|SSAA|Joey Minshall
 Sing Sing Sing|SATB|Deke Sharon
 Sing Sing Sing|SSAA|Larry Wright
+Sing Sing Sing/It Don't Mean a Thing|TTBB|Tony Nasto
 Sing The Lovers|SSAA|Joe Liles
+Sing We Noel|SSAA|Brian Beck
+Sing We Noel|SSAA|Judy Vidal
+Sing We Noel|TTBB|Judy Vidal
 Sing We Now of Christmas|SATB|Joe Liles
 Sing We Now of Christmas|SSAA|Joe Liles
 Sing We Now of Christmas|TTBB|Derric Johnson
 Sing We Now of Christmas|TTBB|Gabriel Lawson
 Sing We Now of Christmas|TTBB|Joe Liles
+Sing You Sinners|SSAA|Sharon Holmes
+Sing Your Way Home|SSAA|Joseph M. Martin
 Sing, Sing, Sing|TTBB|David Wright
 Sing! (Sing A Song!)|SSAA|Brent Graham
 Sing! (Sing A Song!)|TTBB|Brent Graham
 Singa Tagga Daya Fraternity Song|TTBB|Joe Liles
 Singin' About Love|TTBB|Derric Johnson
 Singin' About Singing|TTBB|Derric Johnson
+Singin' in the Bathtub|SSAA|Roger Payne
 Singin' In The Bathtub|SSAA|Scott Colman
 Singin' In The Bathtub|TTBB|John Muir
 Singin' In The Bathtub|TTBB|Roger Payne
+Singin' In the Rain|SSAA|Marie Johnson
 Singin' In The Rain|SSAA|David Wright
 Singin' In The Rain|SSAA|Dianne Goldrick
 Singin' In The Rain|SSAA|Jay Giallombardo
@@ -15915,20 +18883,27 @@ Singin' In The Rain|TTBB|Jim Shubert
 Singin' In The Rain|TTBB|Marie Johnson
 Singin' In The Rain|TTBB|Mark Burnip
 Singin' In The Rain Medley|TTBB|Mark Hale
+Singin' In The Rain Medley Overture|TTBB|Mark Hale
+Singin's Great In The Sunshine State|TTBB|Burt Szabo
 Singing For You In That Barbershop Style|TTBB|Jon Nicholas
 Singing Here With Dad|TTBB|Val Hicks
 Singing In A Great Quartet|SSAA|Marie Johnson
+Singing In The Bathtub|TTBB|Rog
 Singing My Troubles Away|TTBB|Jon Nicholas
 Singing The Blues|TTBB|Dennis Malone
+SINGING VALENTINE Package|TTBB|Barbershop Harmony Society
+Single Ladies (Beyonce)|SSAA|H Zimmerman
 Sioux City Sue|TTBB|Bob Graham
 Sioux City Sue|TTBB|Jim Hickman
 Sir Duke|SATB|Dan Wessler
 Sir Duke|SATB|Deke Sharon
 Sir Duke|SSAA|Aaron Dale
+Sir Duke|SSAA|Karen Proctor
 Sir Duke|SSAA|Walter Latzko
 Sir Duke|TTBB|Aaron Dale
 Sir Duke|TTBB|Dan Wessler
 Sir Duke|TTBB|Deke Sharon
+Sir Duke|TTBB|Rob Hopkins
 Sister Act|SSAA|Katie Taylor
 Sister Act|SSAA|Larry Wright
 Sister Act|SSAA|Sam Hubbard
@@ -15941,21 +18916,30 @@ Sister Susie's Sewing Shirts For Soldiers|TTBB|Walter Latzko
 Sisters|SSAA|Tedda Lippincott
 Sisters Are Doin' It for Themselves|SSAA|Patrick McAlexander
 Sisters Are Doing It For Themselves|SSAA|Ã…se Hagerman
+Sisters Are Doing It For Themselves|SSAA|Ase Hagerman
 Sisters Are Doing It For Themselves|SSAA|Patrick McAlexander
 Sisters In Song|TTBB|Jim West
+Sisters/Together Wherever We Go|SSAA|Dede Nibler
 Sit Down You're Rockin' The Boat|SSAA|Bev Sellers
 Sit Down You're Rockin' The Boat|SSAA|David Wright
 Sit Down You're Rockin' The Boat|SSAA|Kevin Keller
 Sit Down You're Rockin' The Boat|SSAA|Liz Garnett
 Sit Down You're Rockin' The Boat|TTBB|David Wright
+Sit Down You're Rockin' The Boat|TTBB|David Wright, Steven Armstrong
 Sit Down You're Rockin' The Boat|TTBB|Kevin Keller
 Sit Down You're Rockin' The Boat|TTBB|Richard Floersheimer
 Sit Down You're Rockin' The Boat|TTBB|Steve Jamison
 Sit Down You're Rockin' The Boat|TTBB|Walter Latzko
+Sit Down You're Rocking The Boat|SSAA|Bev Sellers
 Sit Still, Look Pretty|SSAA|Deke Sharon
+Sittin' On Top Of The World|TTBB|Roger Payne
 Sitting on The Dock of the Bay/Under the Boardwalk|TTBB|Deke Sharon
 Six Feet|TTBB|Adam Scott
+Sixteen Tons|SSAA|Tedda Lippincott
 Sixteen Tons|TTBB|David Wright
+Sixteen Tons|TTBB|Don Fraser
+Sixteen Tons|TTBB|Jim Clancy
+Sixteen Tons|TTBB|John Hohl
 Sixty Minute Man|SATB|Deke Sharon
 Sixty Minute Man|TTBB|Deke Sharon
 Sixty Seconds Got Together|TTBB|Theodore Hicks
@@ -15970,9 +18954,12 @@ Skyfall|SSAA|Diane Butler
 Skyfall|SSAA|Kay Bromert
 Skyfall|SSAA|Larry Wright
 Skyfall|SSAA|Nicholas Wright
+Skyfall|SSAA|Nick Wright
 Skyfall|TTBB|Dan Wessler
 Skyfall|TTBB|Larry Wright
 Skyfall|TTBB|Theodore Hicks
+Skyfall (Adele)|SSAA|Jonathan Sparks
+Skyfall 4-part|SSAA|Nick Wright
 Skylark|SATB|Scott Kitzmiller
 Skylark|SSAA|Glenda Lloyd
 Skylark|SSAA|Jean McFadyen
@@ -15982,6 +18969,7 @@ Skylark|SSAA|Walter Latzko
 Skylark|TTBB|Jon Nicholas
 Skylark|TTBB|Tom Gentry
 Skylark|TTBB|Walter Latzko
+Skylark|TTBB|Webb Comfort
 Slap That Bass|SATB|Rob Campbell
 Slap That Bass|SSAA|Kevin Keller
 Slap That Bass|SSAA|Walter Latzko
@@ -15993,12 +18981,15 @@ Sleep Little Tiny King|SSAA|Tedda Lippincott
 Sleep Soldier (Sailor) Boy|TTBB|Douglas Smith
 Sleep Warm|TTBB|Chuck Pettis
 Sleep Well Little Children|SATB|Ken Potter
+Sleeps Judea Fair|SSAA|Diane Clark
 Sleepy Time Gal|SSAA|Sylvia Alsbury
 Sleepy Time Gal|TTBB|Dennis Driscoll
 Sleepy Time Gal|TTBB|Earl Moon
+Sleepy Time Gal|TTBB|Walter Latzko
 Sleepyhead|TTBB|George Hulst
 Sleigh Ride|SATB|Deke Sharon
 Sleigh Ride|SSAA|Jay Giallombardo
+Sleigh Ride|SSAA|Joni Bescos
 Sleigh Ride|SSAA|Norma Andersen
 Sleigh Ride|SSAA|Tom Gentry
 Sleigh Ride|TTBB|Clay Hine
@@ -16007,11 +18998,15 @@ Sleigh Ride|TTBB|Dennis Driscoll
 Sleigh Ride|TTBB|Jay Giallombardo
 Sleigh Ride|TTBB|Joe Mannherz
 Sleigh Ride|TTBB|Tom Gentry
+Sleigh Ride|TTBB|Walter Latzko
 Slide, Bill, Slide|TTBB|Toban Dvoretsky
 Slippery Sal and Dirty Dan|TTBB|Bob Jones
 Slipping Through My Fingers|SSAA|Carolyn Schmidt
 Slipping Through My Fingers|SSAA|Jay Dougherty
 Sloop John B|TTBB|Aaron Dale
+Sloop John B|TTBB|Alan T Rowe
+Slow Boat to China|SSAA|Greg Backwell
+Slow Boat to China|SSAA|Sue Kegley
 Slow Down|TTBB|Nicholas Wright
 Slow Hands|TTBB|Thomas Degan
 Slow Poke|TTBB|Lyle Pettigrew
@@ -16026,11 +19021,13 @@ Smile|SSAA|Carolyn Schmidt
 Smile|SSAA|Dot Calvin
 Smile|SSAA|Kevin Keller
 Smile|SSAA|Steve Tramack
+Smile|SSAA|Tom Gentry
 Smile|TTBB|Clay Hine
 Smile|TTBB|Kevin Keller
 Smile|TTBB|Steve Tramack
 Smile|TTBB|Tom Gentry
 Smile Away Each Rainy Day|TTBB|Mark Goodney
+Smile Medley|SSAA|Clay Hine
 Smile Medley|SSAA|Jay Giallombardo
 Smile Medley|SSAA|Jim Arns
 Smile Medley|TTBB|Clay Hine
@@ -16038,7 +19035,13 @@ Smile Medley|TTBB|Ed Waesche
 Smile Medley|TTBB|Jay Giallombardo
 Smile Medley|TTBB|Ron Black
 Smile Medley|TTBB|Steve Delehanty
+Smile Medley|TTBB|Steve Delehanty, Ed Waesche
+Smile Medley|TTBB|Unspecified
+Smile Medley|TTBB|Vic Brimmacombe
+Smile Medley (A Smile will go a Long Long Way, Smile Darn ya Smile)|TTBB|Ed Waesche
+Smile Medley (Let A Smile/Smile, Darn Ya)|SSAA|Nancy Bergman
 Smile Medley (Pack Up Your Troubles / Smile, Darn Ya, Smile / Let A Smile Be Your Umbrella)|SSAA|Nancy Bergman
+Smile Medley (Powder Your Face/Smile Darn Ya)|SSAA|Clay Hine
 Smile Medley II|TTBB|David Wright
 Smile Will Go A Long Long Way|TTBB|Dennis Driscoll
 Smile Will Go A Long Long Way|TTBB|Vern Knapp
@@ -16052,15 +19055,22 @@ Smiles|TTBB|Kirk Roose
 Smiles|TTBB|Todd Troutman
 Smiles / Blues Medley|TTBB|Ed Waesche
 Smiles Medley|TTBB|Vic Brimacombe
+Smilin' Medley|TTBB|Will Hamblet
 Smilin' Through|SSAA|Ed Waesche
 Smilin' Through|SSAA|Greg Blackwell
 Smilin' Through|TTBB|David Wright
 Smilin' Through|TTBB|Ed Waesche
 Smilin' Through|TTBB|Howard Dale
 Smilin' Through|TTBB|Larry Triplett
+Smilin' Through|TTBB|Lou Perry
 Smilin' Through|TTBB|Lou Perry/Ed Waesche
 Smilin' Through|TTBB|Louis Perry
+Smoke Gets in Your Eyes|SATB|Brian Beck
+Smoke Gets in Your Eyes|TTBB|David Gillingham
+Smoke Gets in Your Eyes|TTBB|Rob Hopkins
 Smoke Gets In Your Eyes|SSAA|Bev Sellers
+Smoke Gets In Your Eyes|TTBB|Brian Beck
+Smoke Gets In Your Eyes|TTBB|Joel T. Rutherford
 Smoke Gets In Your Eyes|TTBB|Patrick McAlexander
 Smoke Gets In Your Eyes|TTBB|Todd Troutman
 Smoke Gets In Your Eyes|TTBB|Walter Latzko
@@ -16080,9 +19090,11 @@ Snow|SSAA|Tedda Lippincott
 Snow|TTBB|Adam Bock
 Snow|TTBB|Jay Giallombardo
 Snow|TTBB|Mark Goodney
+Snow Miser/Heat Miser|TTBB|Mark Jennings
 Snowbird|SATB|Jon Nicholas
 Snowbird|SSAA|Carole Prietto
 Snowbird|TTBB|Jon Nicholas
+Snowfall|TTBB|Jason Smith
 Snowman|SSAA|Rowena Harper
 Snowmiser/Heatmiser|SSAA|Melody Hine
 So Big/So Small|TTBB|Theodore Hicks
@@ -16092,13 +19104,18 @@ So Far|SSAA|Joey Minshall
 So Far Away|SATB|Deke Sharon
 So Far Away|SSAA|Glenda Lloyd
 So Far Away|SSAA|Jan Meyer
+So High, So Low|TTBB|Walter Latzko
 So High, So Low, So Wide|TTBB|Walter Latzko
 So In Love|TTBB|David Wright
 So In Love|TTBB|Frank Oglesby
 So In Love|TTBB|Harry Swenson
+So Long Dearie|SSAA|Nancy Bergman
+So Long Dearie|SSAA|Renee Craig
+So Long Mother, Kiss Your Boy Goodbye|SSAA|Senter/Kraut
 So Long Song|TTBB|Joe Liles
 So Long, Dearie|SSAA|Nancy Bergman
 So Long, Dearie|SSAA|Sharon Holmes
+So Long, Dearie|TTBB|Barbershop Harmony Society
 So Long, Farewell, Goodbye|SSAA|Brent Graham
 So Long, Farewell, Goodbye|TTBB|Brent Graham
 So Long, It's Been Good To Know Yuh|TTBB|Nancy Bergman
@@ -16113,9 +19130,14 @@ So Long, Mother|TTBB|Thomas Gentry
 So Long, Mother|TTBB|Tom Gentry
 So Long, Sal|TTBB|Brent Graham
 So Lun Bushi|SSAA|Joan D 'Agostino
+So Many Voices (Sing America's Song)|TTBB|Tom Gentry
 So Many Voices Sing America's Song|TTBB|Tom Gentry
+So Much In Love|SATB|David Harrington
 So Much In Love|SSAA|David Harrington
 So Much In Love|TTBB|David Harrington
+So Much In Love|TTBB|Unspecified
+So Much In Love mini|SSAA|David Harrington
+So Much In Love mini|TTBB|David Harrington
 So Rare|TTBB|Robert Rund
 So This Is Love|TTBB|Gary Lewis
 So Tired|TTBB|Jesse Turner
@@ -16124,12 +19146,14 @@ So What's New|SSAA|Jean Shook
 So What's New|TTBB|Marvin Skupski
 So Wrong|TTBB|Robert Rund
 Soak Up The Sun|SATB|Deke Sharon
+Soft Shoe Song|SSAA|Leola Wright
 Soft Shoe Song|TTBB|SPEBSQSA
 Soft Shoe Song|TTBB|Unknown
 Soft Summer Breeze|SSAA|Wilma Williams
 Soft Summer Breeze|TTBB|Todd Troutman
 Softly|SATB|Dennis Driscoll
 Softly|TTBB|Joe Mannherz
+Softly (I Will Leave You)|SSAA|Nigel Williams
 Softly And Tenderly|TTBB|Edward Berg
 Softly As I Leave You|SATB|Larry Triplett
 Softly As I Leave You|SSAA|Brent Graham
@@ -16139,15 +19163,21 @@ Softly As I Leave You|TTBB|Bob Weiss
 Softly As I Leave You|TTBB|Brent Graham
 Softly As I Leave You|TTBB|Larry Newth
 Softly As I Leave You|TTBB|Larry Triplett
+Softly As I Leave You|TTBB|Terry Phillips
 Sold|SSAA|Aaron Dale
 Sold|TTBB|Aaron Dale
 Sold|TTBB|Deke Sharon
+Sold (At the Grundy County Auction)|TTBB|Aaron Dale
+Sold (The Grundy County Auction Incident)|SSAA|Aaron Dale
+Sold (The Grundy County Auction Incident)|TTBB|Aaron Dale
 Soldier Soldier Will You Marry Me|TTBB|Larry Wright
 Solid As A Rock|SATB|Adam Bock
+Soliloquy|TTBB|David Wright
 Soliloquy|TTBB|Jay Giallombardo
 Solitaire|SSAA|Tom Gentry
 Solitaire|TTBB|Tom Gentry
 Some Children See Him|SSAA|Kay Bromert
+Some Children See Him|TTBB|Brian Beck
 Some Children See Him|TTBB|Derric Johnson
 Some Children See Him|TTBB|James Henry
 Some Children See Him|TTBB|Jim West
@@ -16162,6 +19192,7 @@ Some Enchanted Evening|SSAA|Larry Wright
 Some Enchanted Evening|TTBB|David Wright
 Some Enchanted Evening|TTBB|Larry Wright
 Some Enchanted Evening|TTBB|Simon Arnott
+Some Enchanted Evening|TTBB|Steve Jamison
 Some Girls Do|TTBB|Ed Howard
 Some Girls Do And Some Girls Don't|TTBB|Steve Jamison
 Some Like It Hot|TTBB|Dan Wessler
@@ -16172,19 +19203,23 @@ Some Nights|SSAA|Kevin Keller
 Some Nights|TTBB|Deke Sharon
 Some Nights|TTBB|Dom Finetti
 Some Nights|TTBB|Nicholas Wright
+Some Nights|TTBB|Tom Anderson
 Some Of These Days|SSAA|Walter Latzko
 Some Of These Days|TTBB|Ed Waesche
 Some Of These Days|TTBB|Jack Baird
+Some Sunny Day|SSAA|Lynnell Diamond
 Some Things Are Meant To Be|SATB|Kevin Keller
 Some Things Are Meant To Be|SSAA|Kevin Keller
 Some Things Are Meant To Be|TTBB|Greg Mallett
 Some Things Are Meant To Be|TTBB|Kevin Keller
 Somebody|SATB|Mark Stevens
 Somebody Bigger Than You And I|TTBB|Joe Browne
+Somebody Done Somebody Wrong Song/Cheatin On Me|SSAA|Bev Sellers
 Somebody Else - Not Me|TTBB|David Briner
 Somebody Else Is Taking My Place|SSAA|David Briner
 Somebody Else Is Taking My Place|SSAA|Walter Latzko
 Somebody Else Is Taking My Place|TTBB|Mark Goodney
+Somebody Else Is Taking My Place|TTBB|Roger Craig
 Somebody Else Is Taking My Place|TTBB|Walter Latzko
 Somebody Else Took You Out of My Arms|TTBB|Jay Giallombardo
 Somebody Knows|SSAA|Lyndal Thorburn
@@ -16197,6 +19232,7 @@ Somebody Knows|TTBB|SPEBSQSA
 Somebody Lied About Me|SSAA|Diana Franceschi
 Somebody Like You|SATB|Deke Sharon
 Somebody Loves Me|SSAA|Charlene Yazurlo
+Somebody Loves Me|SSAA|Clay Hine
 Somebody Loves Me|SSAA|Sheryl Neal
 Somebody Loves Me|SSAA|Walter Latzko
 Somebody Loves Me|TTBB|Clay Hine
@@ -16204,6 +19240,7 @@ Somebody Loves Me|TTBB|Jim Shubert
 Somebody Loves Me/Let's Talk About My Sweetie|SSAA|Sheryl Neal
 Somebody Loves You|SSAA|Diana Franceschi
 Somebody Loves You|SSAA|Dorothy Short
+Somebody Loves You|SSAA|Dot Short
 Somebody Loves You|SSAA|Janice Wheeler
 Somebody Loves You|TTBB|F. W. Thom
 Somebody New Is Breaking Your Heart|TTBB|Jim Shubert
@@ -16214,10 +19251,14 @@ Somebody Stole My Gal|TTBB|George Hulst
 Somebody Stole My Gal|TTBB|Jack Baird
 Somebody Stole My Gal|TTBB|R. B. Easterlin
 Somebody Stole My Gal|TTBB|Rob Hopkins
+Somebody Stole My Gal / Five Foot Two (Medley)|TTBB|Ed Waesche
 Somebody Stole My Gal / Five Foot Two Medley|TTBB|Ed Waesche
 Somebody Stole My Gal Medley|TTBB|J Rae Jamieson
 Somebody Stole My Gal Medley|TTBB|John Hohl
+Somebody Stole My Gal Medley|TTBB|Rae Jamieson
 Somebody Stole the Church Bell|SSAA|Jan Meyer
+Somebody That I Used To Know|SATB|H Zimmerman
+Somebody That I Used To Know|SSAA|H Zimmerman
 Somebody to Love|SATB|Deke Sharon
 Somebody to Love|SATB|Joe Mannherz
 Somebody to Love|SATB|Kevin Keller
@@ -16236,9 +19277,13 @@ Somebody to Love|TTBB|Kevin Keller
 Somebody to Love|TTBB|Nicholas Wright
 Somebody to Love|TTBB|Patrick McAlexander
 Somebody to Love|TTBB|Richard Curtis
+Somebody To Love|SATB|Adam Anders, Tim Davis, Roger Emerson
+Somebody To Love|SATB|Queen
+Somebody To Love|SSAA|Joe Spiecker
 Somebody Touched Me|TTBB|Paul Jorg
 Somebody's Coming To My House|TTBB|Lloyd Steinkamp
 Somebody's Darlin'|TTBB|Tom Gentry
+Somebody's Talkin' 'Bout Jesus|TTBB|Jon Nicholas
 Someday|SATB|Kevin Koehl
 Someday|SSAA|Jo Lund
 Someday|SSAA|June Dale
@@ -16250,6 +19295,8 @@ Someday (You'll Want Me To Want You)|SSAA|Greta Somers
 Someday (You'll Want Me To Want You)|TTBB|Brent Graham
 Someday I'll Make You Glad|SSAA|Kay Bromert
 Someday My Prince Will Come|SSAA|Nancy Bergman
+Someday My Prince Will Come|SSAA|Renee Craig
+Someday You'll Want Me to Want You|SSAA|Vicki Uhr
 Someobdy's Talkin' 'Bout Jesus|TTBB|Jon Nicholas
 Someone Else's Star|SSAA|Tedda Lippincott
 Someone In The Crowd|TTBB|Simon Arnott
@@ -16257,6 +19304,7 @@ Someone Is Waiting At Home, Sweet Home|TTBB|Tom Gentry
 Someone Like You|SATB|Chris Arnold
 Someone Like You|SATB|Jay Krumbholz
 Someone Like You|SATB|Kohl Kitzmiller
+Someone Like You|SSAA|Alex Kaiserman
 Someone Like You|SSAA|Glenda Lloyd
 Someone Like You|SSAA|Joe Mannherz
 Someone Like You|SSAA|Kevin Keller
@@ -16271,6 +19319,7 @@ Someone Like You|TTBB|Rob Hopkins
 Someone Like You|TTBB|Simon Arnott
 Someone Like You|TTBB|Steve Tramack
 Someone Like You (from Jekyll And Hyde)|TTBB|Steve Tramack
+Someone Sorry Medley (I Had Someone Else/Who's Sorry Now)|SSAA|Tom Gentry
 Someone That I Used To Love|SSAA|Jean McFadyen
 Someone To Watch Over Me|SSAA|Carolyn Schmidt
 Someone To Watch Over Me|SSAA|David Briner
@@ -16288,10 +19337,12 @@ Someone To Watch Over Me|SSAA|Tedda Lippincott
 Someone To Watch Over Me|TTBB|Jay Giallombardo
 Someone To Watch Over Me|TTBB|Joe Mannherz
 Someone To Watch Over Me|TTBB|Walter Latzko
+Someone To Watch Over Me (Linda Ronstadt)|TTBB|Steve Tramack
 Someone You Loved|SSAA|Larry Wright
 Someone You Loved|TTBB|Rob Hopkins
 Someone's Always After My Baby|TTBB|Jon Nicholas
 Someone's Been Sending Me Flowers|SSAA|Patsee Parker
+Someone'S Stuck In The Chimney|SSAA|Lorraine Rochefort
 Someone's Waiting For You|SSAA|Eric Ruthenberg
 Someone's Waiting For You|SSAA|Jake Bavarsky
 Someone's Waiting For You|SSAA|Theodore Hicks
@@ -16299,17 +19350,27 @@ Someone's Waiting For You|TTBB|Dan Wessler
 Someone's Waiting For You|TTBB|Eric Ruthenberg
 Someone's Waiting For You|TTBB|Jeremey Johnson
 Somethin' About December|SSAA|Matt Parks
+Somethin' About Ya|SSAA|Joe Liles
 Somethin' About Ya|TTBB|Joe Liles
 Somethin' Stupid|SATB|Kyle Snook
 Somethin' Stupid|TTBB|Kevin Koehl
 Something|SATB|Joe Mannherz
 Something|SSAA|Carolyn Schmidt
 Something|SSAA|George Avener
+Something|SSAA|Jim Kahlke
 Something|SSAA|Larry Wright
+Something|TTBB|George Avener
+Something|TTBB|Jim Kahlke
 Something|TTBB|Jimbob Kahlke
 Something|TTBB|Jon Nicholas
+Something|TTBB|Steven Armstrong
 Something|TTBB|Tom Gentry
+Something|TTBB|Unspecified
+Something (Beatles)|TTBB|Jim Kahlke
+Something (In The Way He Moves)|SSAA|George Avener
+Something About a Soldier|SSAA|Jay Giallombardo
 Something About Ya|SSAA|Joe Liles
+Something Big|TTBB|Adam Reimnitz
 Something Good|TTBB|David Wright
 Something I Need|SATB|Nicholas Wright
 Something In Red|SSAA|Tedda Lippincott
@@ -16321,6 +19382,7 @@ Something Inside So Strong|SSAA|Fran Carter
 Something Inside So Strong|SSAA|Tom Gentry
 Something Inside So Strong|TTBB|Hilary Allen
 Something Inside So Strong|TTBB|Tom Gentry
+Something Inside So Strong|TTBB|Tom Gentry / tag - Dale Kynaston
 Something Sort of Grandish|TTBB|Mark Goodney
 Something Tells Me You Will Break My Heart|TTBB|Tom Campbell
 Something Tells Me You're The Girl|TTBB|Kevin Keller
@@ -16333,6 +19395,8 @@ Something to Talk About|SSAA|Carole Prietto
 Something to Talk About|SSAA|Jon Nicholas
 Something to Talk About|SSAA|Nicholas Wright
 Something To Write The Folks About|TTBB|Dennis Driscoll
+Something's Comin'|SSAA|Bev Sellers
+Something's Comin'-Tonight Medley|TTBB|Jay Giallombardo
 Something's Coming|SSAA|Bev Sellers
 Something's Coming|SSAA|David Wright
 Something's Coming|TTBB|David Wright
@@ -16359,10 +19423,14 @@ Somewhere|SSAA|Carolyn Schmidt
 Somewhere|SSAA|Tedda Lippincott
 Somewhere|TTBB|Deke Sharon
 Somewhere|TTBB|Dennis Driscoll
+Somewhere|TTBB|Fred King
 Somewhere|TTBB|Jim West
 Somewhere|TTBB|Mark Burnip
 Somewhere|TTBB|Rob Campbell
 Somewhere|TTBB|Walter Latzko
+Somewhere (West Side Story)|SSAA|Gina Ogden
+Somewhere (West Side Story)|SSAA|Tedda Lippincott
+Somewhere [A Broken Heart]|TTBB|Wayne Grimmer
 Somewhere Along The Way|SSAA|Jeanne Elmuccio
 Somewhere Down The Road|SSAA|Jay Giallombardo
 Somewhere Down The Road|TTBB|Jay Giallombardo
@@ -16378,7 +19446,9 @@ Somewhere Only We Know|SSAA|Alex Morris
 Somewhere Only We Know|SSAA|Liz Garnett
 Somewhere Only We Know|SSAA|Rowena Harper
 Somewhere Only We Know|SSAA|Sam Hubbard
+Somewhere Only We Know|SSAA|Tom West
 Somewhere Only We Know|TTBB|Sam Hubbard
+Somewhere Only We Know (Keene)|SSAA|Peter Nugent
 Somewhere Out There|SATB|Kohl Kitzmiller
 Somewhere Out There|SATB|Theodore Hicks
 Somewhere Out There|SSAA|Brent Graham
@@ -16399,6 +19469,9 @@ Somewhere Out There|TTBB|Kevin Keller
 Somewhere Out There|TTBB|Kim Brittain
 Somewhere Out There|TTBB|Kohl Kitzmiller
 Somewhere Out There|TTBB|Todd Troutman
+Somewhere Over the Rainbow|SSAA|Andy Beck
+Somewhere Over the Rainbow|SSAA|Joni Bescos
+Somewhere Over the Rainbow|TTBB|Ed Waesche
 Somewhere That's Green|TTBB|Kevin Keller
 Sommersprossen|TTBB|Tom Gentry
 Son of a Preacherman|TTBB|Deke Sharon
@@ -16408,10 +19481,13 @@ Song for Ireland|SSAA|Liz Garnett
 Song for Irene|SSAA|Joey Minshall
 Song for Late Summer|SATB|David Avshalomov
 Song For Mary|TTBB|Jay Giallombardo
+Song For The Little Guy, A (version 2)|TTBB|David Wright, Steven Armstrong
 Song For the Mira|SSAA|Joey Minshall
+Song For The Mira|TTBB|Roy Keys, Bob Pyper, Doug McLellan
 Song from Moulin Rouge|TTBB|Howard Dale
 Song I Love|SSAA|Darwin Scheel
 Song of America|TTBB|Jay Giallombardo
+Song Of Blessing|TTBB|Brian Beck
 Song Of Change|SATB|Mike Menefee
 Song Sung Blue|TTBB|Hilary Allen
 Song Without An Ending|TTBB|Louis Perry
@@ -16429,14 +19505,18 @@ Songbird|SSAA|Deke Sharon
 Songbird|SSAA|Fran Carter
 Songbird|SSAA|Jon Nicholas
 Songbird|SSAA|Sharon Holmes
+Songbird|TTBB|Deke Sharon
 Songs|SSAA|June Berg
 Songs|TTBB|Kevin Keller
 Songs for Hanukkah|SSAA|Anna Maria Parker
+Songs of Christmas|SSAA|Jim Clancy
+Songs Of Christmas|TTBB|Jim Clancy
 Songs of Christmas Medley|SSAA|Jim Clancy
 Songs of Christmas Medley|TTBB|Jim Clancy
 Songs of Love|TTBB|Deke Sharon
 Songs Of The West|TTBB|Derric Johnson
 Songs Of Wonder|TTBB|Matt Gallagher
+Sonny Boy|SSAA|Nancy Bergman
 Sonny Boy|TTBB|Al Baker
 Sonny Boy|TTBB|Bruce Wenner
 Sonny Boy|TTBB|Burt Szabo
@@ -16447,6 +19527,7 @@ Sonny Boy|TTBB|Tom Gentry
 Soon|SSAA|Suzy Lobaugh
 Soon|TTBB|Ed Waesche
 Soon Ah Will Be Done|TTBB|David Wright
+Soon Ah Will Be Done|TTBB|William L. Dawson
 Soon And Very Soon|TTBB|Chris Arnold
 Soon And Very Soon|TTBB|Derric Johnson
 Soon It's Gonna Rain|SATB|Joe Mannherz
@@ -16454,11 +19535,14 @@ Sooner or Later|SATB|Joe Mannherz
 Sooner or Later|SSAA|Dan Naumann
 Sooner or Later|SSAA|Joe Mannherz
 Sooner or Later|TTBB|Dan Naumann
+Sooner Or Later-Ask Me Medley|TTBB|Alan Gordon
 Sophie|TTBB|Al Baker
 Sophisticated Ladies Medley|SSAA|Jo Lund
 Sophisticated Lady|SATB|Joe Mannherz
+Sophisticated Lady|TTBB|Stash Rossi
 Sorry|TTBB|Nicholas Wright
 Sorry Seems To Be The Hardest Word|TTBB|Jackson Pinder
+SOS|SSAA|Chris MacMartin
 Soul Man|TTBB|Jay Giallombardo
 Soul Man|TTBB|Melody Hine
 Soulful Hallelujah|TTBB|Deke Sharon
@@ -16475,16 +19559,23 @@ Sound Of Music|TTBB|Harold Johnston
 Sound Of Music|TTBB|Harry Mays
 Sound Of Music / Climb Ev'ry Mountain Medley|TTBB|Joe Liles
 Sound of Music Medley|SSAA|Larry Wright
+Sound of Music Medley|SSAA|Unspecified
 Sound of Music Medley|TTBB|Jeremey Johnson
 Sound of Music Medley|TTBB|Joe Mannherz
 Sound of Music Medley|TTBB|Larry Wright
+Sound Of Music Medley|SSAA|Nancy Bergman
+Sound Of Music Medley|TTBB|Joe Liles
 Sound Off|TTBB|Tom Gentry
 South|TTBB|Gene Cokeroft
 South|TTBB|Gene Cokeroft and Matt Gallagher
+South America, Take It Away|SSAA|Carolyn Schmidt
 South America, Take It Away!|SSAA|Nancy Bergman
 South America, Take It Away!|TTBB|Jim Shubert
 South American Way|SSAA|Carolyn Schmidt
 South Pacific Medley|TTBB|Jay Giallombardo
+South Pacific Medley 1|TTBB|Jay Giallombardo
+South Pacific Medley 2|TTBB|Jay Giallombardo
+South Rampart Street Parade|SSAA|Brian Beck
 South Rampart Street Parade|SSAA|David Wright
 South Rampart Street Parade|TTBB|Charles White
 South Rampart Street Parade|TTBB|David Wright
@@ -16497,6 +19588,7 @@ Southern Cross|TTBB|Mark Stevens
 Southern Medley|TTBB|Barbershop Harmony Society
 Southern Medley|TTBB|Robert Rund
 Southern Medley|TTBB|SPEBSQSA
+Southern Nights|SSAA|Tedda Lippincott
 Southern Nights|TTBB|Mark Stevens
 Space Man|TTBB|Sam Hubbard
 Space Medley|TTBB|Deke Sharon
@@ -16523,6 +19615,7 @@ Spider-Man Theme|TTBB|Aaron Dale
 Spiderman Theme|SSAA|Sam Hubbard
 Spiderman Theme|TTBB|Aaron Dale
 Spiderman Theme|TTBB|Sam Hubbard
+Spiderman Theme Song|TTBB|Unspecified
 Spiderwebs|SSAA|Deke Sharon
 Spies in the Night|SSAA|Brent Graham
 Spinning Wheel|TTBB|Anders Lindqvist
@@ -16532,13 +19625,17 @@ Spiritual Medley|SSAA|Barbershop Harmony Society
 Spiritual Medley|SSAA|Unknown
 Spiritual Medley|TTBB|
 Spiritual Medley|TTBB|Barbershop Harmony Society
+Spiritual Medley|TTBB|The Imperials
+Spiritual Medley (Nobody Knows the trouble/Wade in the Water/Climbin Up the Mountain)|TTBB|Jay Giallombardo
 Splanky|SATB|Joe Mannherz
 Splish Splash|SSAA|Tom Gentry
 Splish Splash|TTBB|Cay Outerbridge
 Spongebob Medley|TTBB|Kohl Kitzmiller
 Spooky Scary Skeletons|TTBB|Kyle Hottel
+Spoonful Of Sugar|TTBB|Russ Foris
 Spoonful of Sugar/Jolly Holiday Medley|TTBB|Liz Garnett
 Sposin|SSAA|Diana Franceschi
+Spread A Little Happiness|SSAA|Joan Adler
 Spread The Love Around|SATB|David Wright
 Spread The Love Around|SSAA|Michael Gellert
 Spreadin' Rhythm Around|SSAA|Tom Gentry
@@ -16546,14 +19643,20 @@ Spreadin' Rhythm Around|TTBB|Tom Gentry
 Spring|SATB|David Avshalomov
 Spring|TTBB|SPEBSQSA
 Spring Can Really Hang You Up The Most|SATB|Scott Kitzmiller
+Spring Can Really Hang You Up The Most (modified)|SSAA|Brian Beck and Mike Barrett
 Springtime|TTBB|Walter Latzko
+Squeeze Box|TTBB|Steve Delehanty
 St Louis Blues|SSAA|Nancy Bergman
 St Louis Blues|SSAA|Walter Latzko
 St Louis Blues|TTBB|Jim Shubert
 St. James Infirmary|TTBB|Dan Wessler
+St. Louis Blues|SSAA|Jim Massey
+St. Patrick's Day Medley|TTBB|Steve Jamison
 St. Patrick's Day Parade Medley|TTBB|Don Gray
+St. Pattie's Day Parade Medley|TTBB|Unspecified
 Stacy's Mom|SATB|Deke Sharon
 Stacy's Mom|TTBB|Nicholas Wright
+Stairway to Heaven|SSAA|Lorraine Rochefort
 Stairway To Paradise|TTBB|Dan Wessler
 Stairway To The Stars|TTBB|Walter Latzko
 Stand A Little Rain|TTBB|Mark Stevens
@@ -16562,21 +19665,25 @@ Stand By Me|SATB|Joe Mannherz
 Stand By Me|SATB|Steve Delehanty
 Stand By Me|SSAA|Chris Arnold
 Stand By Me|SSAA|Dianne Goldrick
+Stand By Me|SSAA|Lorraine Rochefort
 Stand By Me|SSAA|Steve Delehanty
 Stand By Me|TTBB|David Wright
 Stand By Me|TTBB|Deke Sharon
 Stand By Me|TTBB|Dianne Goldrick
 Stand By Me|TTBB|Steve Delehanty
+Stand By Your Man|SSAA|Tedda Lippincott
 Stand Out|TTBB|Aaron Dale
 Stand Up And Sing For Your Father|TTBB|Jack Baird
 Standing In The Need Of Prayer|TTBB|Burt Szabo
 Standing On The Corner|SSAA|Dennis Driscoll
 Standing On The Corner|SSAA|Kevin Keller
+Standing On The Corner|TTBB|Burt Szabo
 Standing On The Corner|TTBB|Kevin Keller
 Standing On The Corner|TTBB|Mark Goodney
 Standing On The Corner|TTBB|Walter Latzko
 Standing Outside The Fire|SSAA|Joey Minshall
 Standing/Leaning Medley|TTBB|Tom Gentry
+Star|SSAA|Steve Delehanty
 Star Medley|TTBB|Steve Delehanty
 Star Medley (You Oughta Be In Pictures/Over The Rainbow)|SSAA|Steve Delehanty
 Star Of Bethlehem|SSAA|Avis Fellows
@@ -16592,6 +19699,7 @@ Star Spangled Banner|SSAA|Dianne Goldrick
 Star Spangled Banner|SSAA|Jim Clancy
 Star Spangled Banner|SSAA|Joni Bescos
 Star Spangled Banner|SSAA|Nancy Bergman
+Star Spangled Banner|SSAA|Unspecified
 Star Spangled Banner|SSAA|Val Hicks
 Star Spangled Banner|TTBB|Aaron Dale
 Star Spangled Banner|TTBB|Brent Graham
@@ -16609,7 +19717,10 @@ Star Spangled Banner|TTBB|Nancy Bergman
 Star Spangled Banner|TTBB|Steve Jamison
 Star Spangled Banner|TTBB|Tom Campbell
 Star Spangled Banner|TTBB|Val Hicks
+Star Spangled Banner Medley|TTBB|Clay Hine
 Star Trek: The Next Generation - Main Title|SATB|Joey Minshall
+Star Wars (John Williams is the Man)|TTBB|Mister Tim
+Star Wars (John Williams Is The Man)|TTBB|Moosebutter
 Star Wars Medley|TTBB|Patrick McAlexander
 Starboy|TTBB|Nicholas Wright
 Stardust|SATB|Joe Mannherz
@@ -16626,6 +19737,7 @@ Stars Are The Windows Of Heaven|TTBB|Jim Hickman
 Stars Fell On Alabama|SSAA|David Wright
 Stars Fell On Alabama|SSAA|Joey Minshall
 Stars Fell On Alabama|SSAA|Larry Wright
+Stars Fell On Alabama|SSAA|Mary Coffman
 Stars Fell On Alabama|SSAA|Mary K. Coffman Music Fund
 Stars Fell On Alabama|SSAA|Walter Latzko
 Stars Fell On Alabama|TTBB|Bill Packard
@@ -16633,6 +19745,7 @@ Stars Fell On Alabama|TTBB|Brent Graham
 Stars Fell On Alabama|TTBB|David Wright
 Stars Fell On Alabama|TTBB|Jon Nicholas
 Stars Fell On Alabama|TTBB|Walter Latzko
+Stars Over Texas|TTBB|Steve Jamison
 Statue of Liberty|SSAA|Jo Lund
 Statue of Liberty|TTBB|Steve Delehanty
 Stay|SATB|Deke Sharon
@@ -16646,7 +19759,9 @@ Stay Awake|SSAA|Kohl Kitzmiller
 Stay Awake|SSAA|Michael Hengelsberg
 Stay Awake|TTBB|Brent Graham
 Stay Awake|TTBB|Kohl Kitzmiller
+Stay With Me|SATB|Henrik Rosenberg
 Stay With Me|TTBB|III Eddie Holmes
+Stay With Me|TTBB|Val Hicks, Shaun Agnew
 Stayin' Alive|SATB|Manoj Padki
 Stayin' Alive|SSAA|Deke Sharon
 Stayin' Alive|SSAA|Emily Moriarty
@@ -16659,6 +19774,8 @@ Steal Away|TTBB|Patrick McAlexander
 Steal Away To Jesus|TTBB|Derric Johnson
 Steal My Kisses|SATB|Deke Sharon
 Steal My Kisses|TTBB|Deke Sharon
+Steam Heat|SSAA|Anita Barzilla
+Steam Heat|SSAA|Bev Sellers
 Steam Heat|SSAA|Tedda Lippincott
 Steam Heat|SSAA|Tom Gentry
 Steam Heat|TTBB|Craig Minor
@@ -16678,25 +19795,34 @@ Step To The Rear|SSAA|Larry Wright
 Step To The Rear|TTBB|Archie Steen
 Step To The Rear|TTBB|Gary Sparks
 Step To The Rear|TTBB|Jack Baird
+Step To The Rear|TTBB|Jim Clancy
 Step To The Rear|TTBB|Larry Wright
 Step To The Rear|TTBB|Mo Rector
 Step To The Rear / See Me Now Medley|TTBB|Joe Liles
+Step to the Rear/Hey, Look Me Over Medley|SSAA|Joe Liles
+Step to the Rear/See Me Now Medley|SSAA|Joe Liles
 Stephen Foster Medley|TTBB|Derric Johnson
 Stephen Foster Medley|TTBB|Jack Baird
 Stephen Foster Medley|TTBB|Phil Embury
 Steppin' On The Clouds|TTBB|Larry Wright
 Steppin' Out Medley|SSAA|Jo Lund
 Steppin' Out Medley|TTBB|Ed Waesche
+Steppin' Out with My Baby|TTBB|Clay Hine
 Steppin' Out With My Baby|SATB|Deke Sharon
 Steppin' Out With My Baby|SSAA|Dorothy Short
+Steppin' Out With My Baby|SSAA|Dot Short
 Steppin' Out With My Baby|SSAA|Larry Wright
+Steppin' Out With My Baby|SSAA|Mark Hale
 Steppin' Out With My Baby|SSAA|Nancy Bergman
 Steppin' Out With My Baby|SSAA|Sylvia Alsbury
 Steppin' Out With My Baby|TTBB|Deke Sharon
 Steppin' Out With My Baby|TTBB|Lance Fisher
 Steppin' Out With My Baby|TTBB|Rob Hopkins
+Steppin' Out-Puttin' On The Ritz|TTBB|Darin Drown
+Steppin' Out/Every Body Loves My Baby Medley|TTBB|Ed Waesche
 Stepping Around|TTBB|Rob Campbell
 Stepping Out With A Star|TTBB|Jackson Pinder
+Stepsisters' Lament|SSAA|Lynnell Diamond
 Stick To The Status Quo|SATB|Soren Detlefsen
 Stickshifts and Safety Belts|TTBB|Aaron Dale
 Still Crazy After All These Years|TTBB|Deke Sharon
@@ -16736,10 +19862,12 @@ Stitches|SATB|Nicholas Wright
 Stitches|SSAA|Deke Sharon
 Stitches|TTBB|Nicholas Wright
 Stolen Moments|SSAA|Jeanette Hawkenson
+Stompin' at the Savoy|TTBB|Bob O'Connell
 Stompin' At The Savoy|SSAA|Darwin Scheel
 Stompin' At The Savoy|TTBB|Kevin Keller
 Stompin' At The Savoy|TTBB|Todd Troutman
 Stop And Smell The Roses|TTBB|Mel Knight
+Stop Callin' Me Baby|SSAA|Lynnell Diamond
 Stop In The Name of Love|SSAA|Larry Wright
 Stop Thinkin'|TTBB|Deke Sharon
 Stop This Train|TTBB|Adam Scott
@@ -16752,16 +19880,20 @@ Stormy Weather|SSAA|Tedda Lippincott
 Stormy Weather|TTBB|Aaron Dale
 Stormy Weather|TTBB|Brian Doepke
 Stormy Weather|TTBB|David Wright
+Stormy Weather|TTBB|Jay Giallombardo
 Stormy Weather|TTBB|Mike Taylor
 Stormy Weather (Keeps Rainin' All The Time)|SSAA|Aaron Dale
 Stormy Weather (Keeps Rainin' All The Time)|TTBB|Aaron Dale
 Story of My Life|TTBB|Nicholas Wright
+Story of the Rose|TTBB|Brian Beck
 Story Of The Rose|SSAA|Brent Graham
 Story Of The Rose|SSAA|Jon Nicholas
 Story Of The Rose|TTBB|Barbershop Harmony Society
 Story Of The Rose|TTBB|Brent Graham
 Story Of The Rose|TTBB|Jon Nicholas
+Story of the Rose (Heart of My Heart)|TTBB|Brent Graham
 Storybook|SATB|Robert Rund
+Stout-Hearted Men|TTBB|Dick Stuart
 Stouthearted Men|TTBB|David Wright
 Stouthearted Men|TTBB|Dick Stuart
 Stouthearted Men|TTBB|Don Gray
@@ -16769,17 +19901,22 @@ Stouthearted Men|TTBB|Jim West
 Stouthearted Men|TTBB|Ray Buntaine
 Stouthearted Men|TTBB|Walter Latzko
 Straight Street|TTBB|Jeremey Johnson
+Straighten Up and Fly Right|SSAA|Brian Beck
+Straighten Up and Fly Right|SSAA|Mary Coffman
 Straighten Up And Fly Right|SATB|Andrew Carolan
 Straighten Up And Fly Right|SATB|Joe Mannherz
 Straighten Up And Fly Right|SSAA|Andrew Carolan
 Straighten Up And Fly Right|SSAA|Liz Garnett
 Straighten Up And Fly Right|SSAA|Mary K. Coffman Music Fund
+Straighten Up And Fly Right|TTBB|Greg Volk
 Straighten Up And Fly Right|TTBB|Jim Shubert
 Straighten Up And Fly Right|TTBB|Liz Garnett
 Strange Sight|TTBB|Ken Potter
 Stranger in Paradise|TTBB|Rob Campbell and Mark Hale
+Stranger In Paradise|TTBB|Mark Hale
 Stranger on the Shore|SSAA|Joe Mannherz
 Strangers|SSAA|Audrey Oakley
+Strangers|SSAA|Bergman/Oakley
 Strangers|SSAA|Nancy Bergman
 Strangers In The Night|TTBB|Dan Wessler
 Strangers In The Night|TTBB|Todd Troutman
@@ -16800,6 +19937,7 @@ Streets Of Edinburgh|SSAA|Liz Garnett
 Streets Of Laredo|TTBB|William Redmon
 Streets Of London|TTBB|Joey Minshall
 Stretchy Pants|SSAA|Erica Kelch-Slesnick
+Strike Up the Band|SSAA|George Avener
 Strike Up The Band|SSAA|David Wright
 Strike Up The Band|TTBB|David Wright
 Strike Up The Band|TTBB|George Avener
@@ -16808,8 +19946,12 @@ Strike Up The Band|TTBB|Mel Knight
 Strike Up The Band|TTBB|Steve Delehanty
 Strike Up The Band / Alexander's Ragtime Band Medley|SSAA|David Harrington
 Strike Up The Band / Alexander's Ragtime Band Medley|TTBB|David Harrington
+Strike Up The Band / Everybody Step Medley|SSAA|Aaron Dale
+Strike Up The Band / Everybody Step Medley|TTBB|Aaron Dale
 Strike Up The Band / I Love A Parade Medley|TTBB|Hal Snyder
 Strike Up The Band / Mardi Gras March/Drummer's Beat Medley|TTBB|Terry Shannon
+Strike Up the Band Medley|TTBB|David Harrington
+Strike Up the Band/Alexander's Ragtime Band Medley|TTBB|David Harrington
 Strike Up The Band/Everybody Step Medley|SSAA|Aaron Dale
 Strike Up The Band/Everybody Step Medley|TTBB|Aaron Dale
 Strip Polka|TTBB|Dennis Driscoll
@@ -16822,6 +19964,7 @@ Stuck Like Glue|SATB|Matt Astle
 Stuck Like Glue|SSAA|Matt Astle
 Stuck Like Glue|TTBB|Matt Astle
 Student Marching Song|TTBB|Don Gray
+Stuff Like That There|SSAA|Dave Briner
 Stuff Like That There|SSAA|David Briner
 Stuff Like That There|SSAA|Scott Kitzmiller
 Stuff Like That There|TTBB|Dennis Driscoll
@@ -16843,8 +19986,10 @@ Sudbury Saturday Night|TTBB|Tom Gentry
 Sudden Love|TTBB|David Wright
 Suddenly|TTBB|Rob Hopkins
 Suddenly I See|SSAA|Robert Rund
+Suddenly There's A Valley|SSAA|Bergman/Wright
 Suddenly There's A Valley|TTBB|Adam Reimnitz
 Suddenly There's A Valley|TTBB|Nancy Bergman
+Sue Me|SATB|Don Gray
 Sugar|SATB|Nicholas Wright
 Sugar|SATB|Wayne Grimmer
 Sugar|SSAA|Wayne Grimmer
@@ -16854,9 +19999,14 @@ Sugar (That Sugar Baby O'Mine)|SSAA|Wayne Grimmer
 Sugar (That Sugar Baby O'Mine)|TTBB|Adam Reimnitz
 Sugar (That Sugar Baby O'Mine)|TTBB|Walter Latzko
 Sugar (That Sugar Baby O'Mine)|TTBB|Wayne Grimmer
+Sugar (That Sugar Baby Of Mine)|TTBB|Adam Reimnitz
 Sugar Blues|SSAA|Anna Maria Parker
+Sugar Medley|SSAA|Nancy Bergman
 Sugar Medley|TTBB|Aaron Dale
+Sugar Medley|TTBB|Jay Giallombardo
+Sugar Medley|TTBB|Walter Latzko
 Sugar on the Side|SSAA|Joe Mannherz
+Sugarcane Jubilee|TTBB|Buzz Haeger
 Sugarcane Jubilee|TTBB|David Wright
 Sugarcane Jubilee|TTBB|Ozzie Westley
 Sugarcane Jubilee|TTBB|Ozzie Westley and Buzz Haeger
@@ -16884,10 +20034,12 @@ Summer Nights|SATB|Liz Garnett
 Summer Of 42|SSAA|Emily Moriarty
 Summer Of 42|SSAA|Joey Minshall
 Summer Samba|SATB|Joe Mannherz
+Summer Sounds|SSAA|Mary Grace Lodico
 Summer Sounds|TTBB|David Briner
 Summer Sounds|TTBB|E. Douglas Adams
 Summer Sounds|TTBB|Rob Hopkins
 Summer Sounds|TTBB|Val Hicks
+Summer Sounds|TTBB|Val Hicks, Rob Hopkins
 Summer Sunshine Medley|SSAA|Tom Gentry
 Summer Sunshine Medley|TTBB|Tom Gentry
 Summer Wind|TTBB|James Halvorson
@@ -16895,8 +20047,12 @@ Summer Wind|TTBB|Jon Nicholas
 Summer Wind|TTBB|Patrick McAlexander
 Summer's Gone|TTBB|Michael Webber
 Summer's Over|TTBB|Ralph Urquhart
+Summertime|SSAA|Avis Fellows
 Summertime|SSAA|Jan-Ake Westin
+Summertime|SSAA|Nancy Bergman
+Summertime|SSAA|Renee Craig
 Summertime|TTBB|Deke Sharon
+Summertime|TTBB|Hugh C. Hodgson
 Summertime|TTBB|Jay Giallombardo
 Summertime|TTBB|Steve Jamison
 Summertime in the Park|TTBB|Charles Rose
@@ -16923,37 +20079,49 @@ Sunny|SATB|Joe Mannherz
 Sunny|SSAA|Sam Hubbard
 Sunny|TTBB|Sam Hubbard
 Sunny|TTBB|Walter Latzko
+Sunny (SATB)|SATB|Dave King
 Sunny Afternoon|TTBB|Hilary Allen
 Sunny Came Home|SSAA|Deke Sharon
 Sunny In Seattle|TTBB|Patrick McAlexander
+Sunny Side Medley|SSAA|Avis Fellows
 Sunny Side Medley|SSAA|Nancy Bergman
+Sunny Side of the Street|SSAA|Nancy Bergman
 Sunny Side Up|SSAA|Nancy Bergman
 Sunny Side Up|TTBB|Ed Waesche
 Sunny Side Up|TTBB|Greg Volk
 Sunny Side Up/When You're Smiling Medley|TTBB|John Fortino
 Sunny Southern Smiles|TTBB|Russ Foris
+Sunnyside Up|SSAA|Nancy Bergman
+Sunnyside Up Medley|SSAA|Nancy Bergman
 Sunrise, Sunset|SSAA|Carolyn Johnson
 Sunrise, Sunset|SSAA|Connie Nickel
+Sunrise, Sunset|SSAA|George Avener
+Sunrise, Sunset|SSAA|Nancy Bergman
 Sunrise, Sunset|TTBB|David Harrington
 Sunrise, Sunset|TTBB|Jim West
 Sunrise, Sunset|TTBB|Joe Mannherz
+Sunrise, Sunset|TTBB|Unspecified
 Sunrise, Sunset|TTBB|Walter Latzko
 Sunshine And Roses|TTBB|Toban Dvoretsky
 Sunshine Lollipops And Rainbows|SSAA|Larry Wright
 Sunshine Lollipops And Rainbows|TTBB|Jay Giallombardo
 Sunshine Lollipops And Rainbows|TTBB|Larry Wright
+Sunshine of Your Smile|TTBB|Tom Gentry
 Sunshine On My Shoulders|SSAA|Deke Sharon
 Sunshine On My Shoulders|TTBB|Steve Jamison
 Sunshine On My Shoulders|TTBB|Todd Troutman
 Sunshine, I Can Fly|SATB|Joe Mannherz
 Super Heroes|TTBB|Ray Buntaine
+Super Star Medley|SSAA|June Berg
 Super Trouper|SSAA|Deke Sharon
+Super Trouper|SSAA|Elaine Gain
 Super Trouper|SSAA|Takako Fuke
 Supercalifragilisticexpialidocious|SATB|Deke Sharon
 Supercalifragilisticexpialidocious|SSAA|Takako Fuke
 Supercalifragilisticexpialidocious|TTBB|Anthony Bartholomew
 Supercalifragilisticexpialidocious|TTBB|Robert Rund
 Supercalifragilisticexpialidocious (Parody)|TTBB|Anthony Bartholomew
+Supercalifragilisticexpialidocious/Step In Time|SSAA|June Dale
 Superhero Medley|TTBB|Patrick McAlexander
 Superman (It's Not Easy)|SATB|Deke Sharon
 Superman (It's Not Easy)|TTBB|Deke Sharon
@@ -16973,9 +20141,13 @@ Surface Pressure|TTBB|Nicholas Wright
 Surfer Girl|TTBB|Aaron Dale
 Surfer Girl|TTBB|Ethan Owens
 Surfin' Safari|TTBB|Jon Nicholas
+Surfin' Safari with a hungry bass singer|TTBB|Jon Nicholas
 Surfin' U.S.A.|SSAA|Carolyn Schmidt
 Surfin' U.S.A.|TTBB|Jon Nicholas
 Surfin' U.S.A.|TTBB|Steve Jamison
+Surfin' USA Medley|SSAA|Carolyn Schmidt
+Surfin' With the Beach Boys|SSAA|Lorraine Rochefort
+Surrey With A Fringe On Top|TTBB|Don Gray
 Surrey with the Fringe On the Top|TTBB|Jay Giallombardo
 Survivor|SSAA|Larry Wright
 Survivor|SSAA|Sheryl Neal
@@ -16988,19 +20160,34 @@ Suzanne|SATB|Vince Peterson
 Suzy Snowflake|TTBB|Mason Eubank
 Swan Song|TTBB|Rob Campbell
 Swan Song Medley|TTBB|Matt Astle
+Swanee|SSAA|Ed Waesche
+Swanee|SSAA|Ed Waesche/Joe Liles
 Swanee|TTBB|Burt Szabo
+Swanee|TTBB|Ed Waesche
+Swanee|TTBB|Scott Werner
+Swanee (Prestige Quartet Style Version)|TTBB|Ed Waesche
 Sway|SSAA|Carole Prietto
 Sway|SSAA|Larry Wright
+Sway|SSAA|Liz Garnet
 Sway|SSAA|Liz Garnett
 Sway|SSAA|Lyndal Thorburn
 Sway|SSAA|Takako Fuke
+Sway|TTBB|Ken Hatton
 Sway|TTBB|Larry Wright
 Sway|TTBB|Richard Floersheimer
+Sway (Quien Sera)|SSAA|Neil Watkins
+Sway (YWIH)|SSAA|Larry Wright
+Swedish House Mafia Medley|SATB|Emmanuel Roll
 Sweet 16 Medley|TTBB|Jay Giallombardo
 Sweet Adeline|SSAA|Floyd Connett
+Sweet Adeline|SSAA|Jay Giallombardo
 Sweet Adeline|SSAA|Joey Minshall
 Sweet Adeline|SSAA|Nancy Bergman
+Sweet Adeline|TTBB|Dick Johnson
+Sweet Adeline|TTBB|Jay Giallombardo
+Sweet Adeline [Doo-Wop]|TTBB|Will Hamblet
 Sweet Adelines Tapestry|SSAA|Jeanette Hawkenson
+Sweet and Lovely|SSAA|Mac Huff
 Sweet And Lovely|TTBB|Mac Huff
 Sweet And Low|SSAA|Carolyn Johnson
 Sweet And Low|SSAA|Walter Latzko
@@ -17010,7 +20197,9 @@ Sweet Blindness|TTBB|Rob Campbell
 Sweet Caroline|SATB|Dylan Oxford
 Sweet Caroline|SSAA|Dylan Oxford
 Sweet Caroline|SSAA|Glenda Lloyd
+Sweet Caroline|SSAA|Lorraine Rochefort
 Sweet Caroline|TTBB|Adam Bock
+Sweet Caroline|TTBB|Don Gray
 Sweet Caroline|TTBB|Dylan Oxford
 Sweet Caroline|TTBB|Gene Cokeroft
 Sweet Caroline|TTBB|Mark Goodney
@@ -17027,13 +20216,21 @@ Sweet Child O' Mine|TTBB|Kohl Kitzmiller
 Sweet Child O' Mine|TTBB|Matt Astle
 Sweet Cider Time When You Were Mine|TTBB|Jack Baird
 Sweet Cider Time When You Were Mine|TTBB|Munson Hinman
+Sweet Dreams|SSAA|Deke Sharon
+Sweet Dreams|SSAA|YWIH
 Sweet Dreams (Are Made of These)|SSAA|Deke Sharon
 Sweet Dreams (Are Made of These)|SSAA|Simon Arnott
 Sweet Genevieve|TTBB|J. Cecil Rowe
 Sweet Georgia Brown|SSAA|Carolyn Schmidt
+Sweet Georgia Brown|SSAA|George Avener
+Sweet Georgia Brown|SSAA|Jim Massey
 Sweet Georgia Brown|SSAA|Jo Lund
+Sweet Georgia Brown|SSAA|Joey Minshall
+Sweet Georgia Brown|SSAA|Joni Bescos
+Sweet Georgia Brown|SSAA|Mary Coffman
 Sweet Georgia Brown|TTBB|Aaron Dale
 Sweet Georgia Brown|TTBB|Carl Walters
+Sweet Georgia Brown|TTBB|Clay Hine
 Sweet Georgia Brown|TTBB|Derek Gilbert
 Sweet Georgia Brown|TTBB|Don Gray
 Sweet Georgia Brown|TTBB|Ed Waesche
@@ -17041,13 +20238,17 @@ Sweet Georgia Brown|TTBB|Jack Baird
 Sweet Georgia Brown|TTBB|Roy Keys
 Sweet Georgia Brown|TTBB|Vern Knapp
 Sweet Heaven Medley|TTBB|Adam Reimnitz
+Sweet Heaven Medley (Sweet Heaven/When My Baby Smiles at Me)|TTBB|Adam Reimnitz
 Sweet Home Chicago|TTBB|Deke Sharon
 Sweet Hour Of Prayer|SSAA|Jim Clancy
 Sweet Hour Of Prayer|SSAA|Tedda Lippincott
 Sweet Hour Of Prayer|TTBB|Derric Johnson
 Sweet Hour Of Prayer|TTBB|Jim Clancy
+Sweet Hour Of Prayer|TTBB|Joe Johnson
 Sweet Little Alice Blue Gown|SSAA|Bev Sellers
+Sweet Little Girl|TTBB|Kyle and Kohl Kitzmiller
 Sweet Little Jesus Boy|SSAA|Kay Bromert
+Sweet Little Jesus Boy|TTBB|David Wright
 Sweet Little Jesus Boy|TTBB|Derric Johnson
 Sweet Little Mother Of Mine|TTBB|Dennis Driscoll
 Sweet Lorraine|TTBB|David Wright
@@ -17055,6 +20256,7 @@ Sweet Lorraine|TTBB|Ed Waesche
 Sweet Lorraine|TTBB|J Rae Jamieson
 Sweet Lorraine|TTBB|Larry Wright
 Sweet Lorraine|TTBB|Mark Hale/David Wright
+Sweet Lucy Brown|TTBB|Adam Reimnitz
 Sweet Mae|TTBB|Bob Jones
 Sweet Man|TTBB|Todd Troutman
 Sweet Nothing|SATB|Nicholas Wright
@@ -17069,6 +20271,7 @@ Sweet She (He) Ain't|SSAA|Tom Gentry
 Sweet She (He) Ain't|TTBB|Tom Gentry
 Sweet Sugar Baby Medley|TTBB|David Wright
 Sweet Sweet Smile|SSAA|Sheryl Neal
+Sweet Sweet Spirit|SSAA|The Idea of North
 Sweet Talkin' Guy|SSAA|Linda Edmondson
 Sweet Violets|SSAA|Kathy Barnett
 Sweet Violets|SSAA|Tom Gentry
@@ -17078,11 +20281,13 @@ Sweet Violets|TTBB|Jeff Pipkins
 Sweet Violets|TTBB|Jim West
 Sweet Violets|TTBB|Mark Goodney
 Sweet Violets|TTBB|Tom Gentry
+Sweet, Sweet Roses Of Morn|TTBB|Floyd Connett
 Sweet, Sweet Spirit|TTBB|John Hale
 Sweet, Sweet Spirit|TTBB|Mark Smith
 Sweetest Story Ever Told, The|TTBB|Burt Szabo
 Sweetest Thing, The (I've Ever Known)|SSAA|Dianne Goldrick
 Sweetheart Of All My Dreams|TTBB|Roy Keys
+Sweetheart of Sigma Chi|TTBB|Barbershop Harmony Society
 Sweetheart of Sigma Nu, The|TTBB|Frank Thorne
 Sweetheart Tree|SSAA|Becky Cartine
 Sweetheart Tree|TTBB|Alan C. Gasper
@@ -17092,26 +20297,46 @@ Sweetheart Tree|TTBB|Todd Troutman
 Sweetheart, I'm Sorry|SSAA|Tom Gentry
 Sweetheart, I'm Sorry|TTBB|Tom Gentry
 Swept Away|SSAA|Brent Graham
+Swing Down Chario|SSAA|Traditional
 Swing Down Chariot|SATB|The Vagabonds
 Swing Down Chariot|SSAA|Anastasio Rossi
+Swing Down Chariot|SSAA|Barbershop Harmony Society
 Swing Down Chariot|SSAA|Karen McCarville
+Swing Down Chariot|SSAA|Sharon Holmes
 Swing Down Chariot|SSAA|SPEBSQSA
+Swing Down Chariot|SSAA|Sweet Adelines International
 Swing Down Chariot|SSAA|The Vagabonds
+Swing Down Chariot|SSAA|Vagabonds
+Swing Down Chariot|TTBB|Barbershop Harmony Society
 Swing Down Chariot|TTBB|The Vagabonds
+Swing Down Chariot|TTBB|Unspecified
+Swing Down Chariot|TTBB|Vagabonds
 Swing Low|TTBB|Jim West
 Swing Low, Sweet Chariot|TTBB|Maurice Reagan
 Swing Low, Sweet Chariot|TTBB|Peter Knight
+Swing Low, Sweet Chariot|TTBB|Unspecified
+Swing Low, Sweet Chariot Medley|SSAA|Nancy Bergman
 Swing Low, Swing Down Medley|TTBB|Paul Jorg
+Swing Medley|SSAA|Dave Briner
+Swing Medley|SSAA|Walter Latzko
+Swing Medley - Somebody Else/Slow Boat to China|SSAA|Dave Briner
 Swingin' Down The Lane|SSAA|Marsha Zwicker
 Swingin' Down The Lane|TTBB|Burt Szabo
 Swingin' On A Rainbow|TTBB|Adam Bock
+Swingin' on a Star|TTBB|Clay Hine
+Swingin' On a Star|SSAA|Walter Latzko
 Swingin' On A Star|SATB|Joe Mannherz
 Swingin' On A Star|SATB|Kevin Keller
 Swingin' On A Star|SATB|Tom Gentry
+Swingin' On A Star|SSAA|Bev Sellers
 Swingin' On A Star|SSAA|Tom Gentry
 Swingin' On A Star|TTBB|David Harrington
 Swingin' On A Star|TTBB|Kevin Keller
 Swingin' On A Star|TTBB|Tom Gentry
+Swinging on a Star|SSAA|Nancy Bergman
+Swinging On a Star|TTBB|David Harrington
+Swinging On A Star|TTBB|Tom Gentry
+Swingle Song|SATB|Darmon Meader
 Symphony|SSAA|Simon Arnott
 Ta-Ra-Ra Boom-De-Ay / Hot Time Medley|TTBB|SPEBSQSA
 Ta-Ra-Ra Boom-De-Ay and A Hot Time In The Old Town|TTBB|SPEBSQSA, Inc.
@@ -17126,10 +20351,14 @@ Tain't No Sin|TTBB|Dennis Driscoll
 Tain't Nobody's Business If I Do|SATB|Melody Hine
 Tain't Nobody's Business If I Do|SSAA|Melody Hine
 Tain't Nobody's Business If I Do|TTBB|Dan Wessler
+Taint No Sin|SSAA|Penketh
 Tainted Love|SATB|Deke Sharon
 Take A Bow|TTBB|Wayne Grimmer
+Take A Chance|SSAA|Joey Minshall
 Take A Chance On Me|SATB|Joey Minshall
 Take A Chance On Me|SSAA|Joey Minshall
+Take a Chance on Me (4 part)|SSAA|Joey Minshall
+Take A Chance on Me (7 part)|SSAA|Joey Minshall
 Take A Little Time|TTBB|Greg Lyne
 Take A Little Time|TTBB|Gregory Lyne
 Take A Look At Us Now|SSAA|Adam Bock
@@ -17144,6 +20373,7 @@ Take Another Guess|TTBB|Walter Latzko
 Take Back The Night|SATB|Kevin Keller
 Take Five|TTBB|David Wright
 Take Good Care Of My Baby|TTBB|Kevin Koehl
+Take Good Care of My Baby/Bye Bye Love Medley|TTBB|Zac Booles
 Take It Easy|TTBB|Andrew Wittenberg
 Take It On The Run|TTBB|Ed Howard
 Take It To The Limit|SATB|Melody Hine
@@ -17155,19 +20385,23 @@ Take It Up A Step|SSAA|Michael Gellert
 Take Me Along|SSAA|Becky Cartine
 Take Me As I Am|TTBB|Theo Hicks
 Take Me As I Am|TTBB|Theodore Hicks
+Take Me Back to the 1920's|SSAA|Gwen Schweitzer
 Take Me Back To Toyland|SSAA|DeDe Crow
 Take Me Home|TTBB|Mark Stevens
 Take Me Home|TTBB|Nicholas Wright
 Take Me Home Tonight|TTBB|Deke Sharon
 Take Me Home, Country Roads|SATB|Deke Sharon
 Take Me Home, Country Roads|SSAA|Lauren Kahn
+Take Me Home, Country Roads|SSAA|Sonny Steffan
 Take Me Home, Country Roads|TTBB|Jim West
 Take Me Home, Country Roads|TTBB|Kevin Koehl
 Take Me Home, Country Roads|TTBB|Marilyn Penketh
 Take Me Home, Country Roads|TTBB|Mark Goodney
+Take Me Home, Country Roads|TTBB|Renee Craig
 Take Me Or Leave Me|SATB|Kohl Kitzmiller
 Take Me Or Leave Me|SSAA|Simon Arnott
 Take Me Out|SATB|Deke Sharon
+Take Me Out to the Ball Game|TTBB|Unspecified
 Take Me Out To The Ball Game|SATB|Deke Sharon
 Take Me Out To The Ball Game|SATB|Marshall Webb
 Take Me Out To The Ball Game|SATB|Thomas Degan
@@ -17186,13 +20420,18 @@ Take Me Out To The Ball Game|TTBB|Jim West
 Take Me Out To The Ball Game|TTBB|SPEBSQSA
 Take Me Out To The Ball Game|TTBB|Steve Jamison
 Take Me Out To The Ball Game|TTBB|Tom Gentry
+Take Me Out to the Ballgame|SSAA|Nancy Bergman
 Take Me Out To The Ballgame|TTBB|BHS
 Take Me There|SSAA|Tom Gentry
 Take Me There|TTBB|Tom Gentry
 Take Me To Church|SATB|Nicholas Wright
 Take Me To Church|TTBB|Nicholas Wright
+Take Me To Exotic Lands|TTBB|Unspecified
 Take Me To My Alabam'|TTBB|Burt Szabo
 Take Me To My Alabam'|TTBB|J Rae Jamieson
+Take Me to the Land of Jazz|SSAA|Pete Wendling
+Take Me To The Land of Jazz|SSAA|Ann Minihane
+Take Me To The Land of Jazz|SSAA|Mary Coffman
 Take Me To The Land Of Jazz|SSAA|Ed Waesche
 Take Me To The Land Of Jazz|SSAA|Mary K. Coffman Music Fund
 Take Me To The Land Of Jazz|SSAA|Molly Rowland
@@ -17209,13 +20448,20 @@ Take On Me|TTBB|Dan Wessler
 Take On Me|TTBB|Deke Sharon
 Take On Me|TTBB|Mark Stevens
 Take On Me|TTBB|Nicholas Wright
+Take The 'A' Train|TTBB|Joe Johnson
 Take The Moon|SATB|Jay Dougherty
+Take These Wings|SSAA|Vicki Uhr
 Take Your Girlie To The Movies|SSAA|Nancy Bergman
 Take Your Girlie To The Movies|TTBB|Burt Szabo
+Take Your Girlie to the Movies!|SSAA|Nancy Bergman
+Takin' A Chance|SSAA|Dot Calvin
+Takin' a Chance on Love|TTBB|Jay Giallombardo
 Takin' Care of Business|SSAA|Corinna Garriock
 Takin' It To The Streets|TTBB|Patrick McAlexander
+Taking A Chance on Love|SSAA|Ruby Rhea
 Taking A Chance On Love|SATB|Steve Jamison
 Taking A Chance On Love|SATB|Tom Gentry
+Taking A Chance On Love|SSAA|Ann Minihane
 Taking A Chance On Love|SSAA|Avis Fellows
 Taking A Chance On Love|SSAA|Ed Waesche
 Taking A Chance On Love|SSAA|Jay Giallombardo
@@ -17231,6 +20477,9 @@ Taking A Chance On Love|TTBB|John Hohl
 Taking A Chance On Love|TTBB|Mark Goodney
 Taking A Chance On Love|TTBB|Steve Jamison
 Taking A Chance On Love|TTBB|Tom Gentry
+Taking A Chance On Love|TTBB|Walter Latzko
+Taking Care of Business|SSAA|Corinna Garriock
+Talk to the Animals|TTBB|Al Parker
 Talk To The Animals|TTBB|Alden Parker
 Talk To The Animals|TTBB|Walter Latzko
 Talking to the Moon|SATB|Nicholas Wright
@@ -17238,6 +20487,7 @@ Taller Stronger Better|SATB|Dan Wessler
 Tammy|SSAA|Steve Jamison
 Tangerine|SSAA|Joey Minshall
 Tangerine|TTBB|Mark Hale
+Taps|TTBB|R. Partin
 TAPS|TTBB|Derric Johnson
 TAPS|TTBB|Ed Waesche
 TAPS|TTBB|Tom Gentry
@@ -17251,9 +20501,11 @@ Taylor The Latte Boy|SSAA|Michael Gellert
 Taylor The Latte Boy|SSAA|Simon Arnott
 Taylor The Latte Boy|SSAA|Steve Tramack
 Taylor The Latte Boy|TTBB|Tom Gentry
+Tea For Two|SSAA|Lynnell Diamond
 Tea For Two|TTBB|Mark Hale
 Tea For Two|TTBB|Walter Latzko
 Teach Everybody To Sing|SSAA|Joe Liles
+Teach Everybody To Sing|TTBB|Joe Liles
 Teach Me Tonight|SSAA|Sam Hubbard
 Teach The Children To Sing|TTBB|Joe Liles
 Teach Your Children|SSAA|Deke Sharon
@@ -17269,15 +20521,21 @@ Tears|TTBB|Burt Szabo
 Tears (For Souvenirs)|TTBB|Joe Mannherz
 Tears (For Souvenirs)|TTBB|Rick Witte
 Tears (For Souvenirs)|TTBB|Tom Gentry
+Tears For Souvenirs|SSAA|Nancy Bergman
 Tears Hit The Ground|SATB|Deke Sharon
+Tears In Heaven|SSAA|Tedda Lippincott
 Tears In Heaven|TTBB|Brent Graham
+Tears In Heaven|TTBB|Nick Schurmann
+Tears In Heaven|TTBB|Steve Delehanty
 Tears On My Pillow|SSAA|Marge Bailey
 Tears On My Pillow|SSAA|Marsha Zwicker
 Teasin' Medley|TTBB|Kirk Roose
 Teasing|TTBB|Toban Dvoretsky
 Teddy Bear|SSAA|Jon Nicholas
 Teddy Bear|TTBB|Aaron Dale
+Teddy Bear|TTBB|Will Hamblet
 Teddy Bears' Picnic|SSAA|Jay Dougherty
+Teddy Bears' Picnic|SSAA|Joey Minshall
 Teddy Bears' Picnic|SSAA|Steve Jamison
 Teddy Bears' Picnic|TTBB|C. J. Spatafora
 Teddy Bears' Picnic|TTBB|David Briner
@@ -17299,6 +20557,7 @@ Tell Me Why|SSAA|Emily Moriarty
 Tell Me Why|SSAA|Floyd Connett
 Tell Me Why|SSAA|Joey Minshall
 Tell Me Why|TTBB|Dennis Driscoll
+Tell Me Why (Parody)|TTBB|Burt Szabo
 Tell Me With Your Eyes|TTBB|John Fortino
 Tell Me You'll Forgive Me|SSAA|Walter Latzko
 Tell Me You'll Forgive Me|TTBB|Jack Baird
@@ -17311,6 +20570,7 @@ Telling It To The Daisies|SSAA|Walter Latzko
 Temptation|SATB|Vince Peterson
 Temptation (parody)|TTBB|Richard Lengel
 Tempted|TTBB|Deke Sharon
+Ten Feet Off the Ground|SSAA|Vicki Uhr
 Ten Feet Off The Ground|SSAA|Barbara Bianchi
 Ten Feet Off The Ground|SSAA|Marsha Zwicker
 Ten Feet Off The Ground|SSAA|Molly Clark
@@ -17331,8 +20591,12 @@ Tenderly|SATB|Joe Mannherz
 Tenderly|SATB|Jon Nicholas
 Tenderly|TTBB|Jim Shubert
 Tenderly|TTBB|Jon Nicholas
+Tenebrae Factae Sunt|TTBB|G.P. Palestrina
+Tennessee Christmas|SSAA|June Berg
+Tennessee Christmas|TTBB|J Stanbery
 Tennessee River Runs Low|SSAA|Mason Eubank
 Tennessee Waltz|SSAA|Aaron Dale
+Tennessee Waltz|SSAA|Linda Masterson
 Tennessee Waltz|SSAA|Walter Latzko
 Tennessee Waltz|TTBB|Aaron Dale
 Tennessee Waltz|TTBB|Dan Wessler
@@ -17347,12 +20611,16 @@ Texas A&M Aggie War Hymn|SSAA|Kevin Keller
 Texas A&M Aggie War Hymn|TTBB|Kevin Keller
 Texas Hold 'em|SSAA|Liz Garnett
 Texas Hold 'em|TTBB|Nicholas Wright
+Texas Medley|SATB|Brian Beck
+Texas Medley|TTBB|Jim Clancy
 Texas, My Texas Medley|TTBB|Mac Huff
 Text Me Merry Christmas|SATB|Adam Scott
+Text Me Merry Christmas|SATB|Henrik Rosenberg
 Text Me Merry Christmas|SSAA|Adam Scott
 Text Me Merry Christmas|SSAA|Larry Wright
 Text Me Merry Christmas|TTBB|Adam Scott
 Thank God And Greyhound|SSAA|Tedda Lippincott
+Thank God for Kids|TTBB|Dick Carr
 Thank God For Kids|TTBB|Richard Carr
 Thank God I'm a Country Boy|TTBB|Jim West
 Thank God I'm a Country Boy|TTBB|Tom Gentry
@@ -17363,22 +20631,31 @@ Thank Heaven For Little Girls|SSAA|Jo Lund
 Thank You|SATB|Deke Sharon
 Thank You|TTBB|Dave Briner
 Thank You|TTBB|David Briner
+Thank You Dear Lord For Music|SSAA|Mary Coffman
 Thank You for being a Friend|SATB|Joe Mannherz
 Thank You for being a Friend|SSAA|Patrick McAlexander
 Thank You for being a Friend|SSAA|Tedda Lippincott
 Thank You for being a Friend|TTBB|Ed Howard
 Thank You for being a Friend|TTBB|Patrick McAlexander
+Thank You For Being A Friend (8 parts, chorus and quartet solo)|TTBB|Zac Booles
 Thank You For Being My Dad|TTBB|Theodore Hicks
 Thank You For Letting Us Entertain You|TTBB|Walter Latzko
+Thank You For the Music|SSAA|Barbara McNeill
+Thank You For the Music|SSAA|Carolyn Healey
+Thank You For the Music|SSAA|Tedda Lippincott
+Thank You For the Music|SSAA|Unspecified
 Thank You For The Music|SATB|Karen Penketh
 Thank You For The Music|SSAA|David Wright
 Thank You For The Music|SSAA|Deke Sharon
 Thank You For The Music|SSAA|Larry Wright
+Thank You For The Music|SSAA|Nathan Peplinski
 Thank You For The Music|SSAA|Takako Fuke
 Thank You For The Music|SSAA|Tom Gentry
+Thank You For The Music|TTBB|Kirk Young
 Thank You For The Music|TTBB|Larry Wright
 Thank You For The Music|TTBB|Tom Gentry
 Thank You For The Music|TTBB|Walter Latzko
+Thank You Lord|TTBB|Bob Dowma
 Thank You Soldiers|SSAA|Tedda Lippincott
 Thank You Very Much|SSAA|Sonny Steffan
 Thank You Very Much|SSAA|Suzy Lobaugh
@@ -17386,18 +20663,24 @@ Thank You Very Much|SSAA|Tom Gentry
 Thank You Very Much|TTBB|Dennis Driscoll
 Thank You Very Much|TTBB|Joe Mannherz
 Thank You Very Much|TTBB|Tom Gentry
+Thank You Very Much|TTBB|Unspecified
 Thank You World|SSAA|Charlene Yazurlo
 Thank You World|SSAA|Diana DeBruycker
+Thank You World|SSAA|Joni Bescos
+Thank You World|SSAA|Kraft/Debruycker
 Thank You World|SSAA|Larry Wright
 Thank You World|TTBB|Dennis Driscoll
 Thank You World|TTBB|Tom Gentry
 Thank You World|TTBB|Walter Latzko
 Thank You, Dear Lord, For Music|SSAA|Mary K. Coffman Music Fund
+Thank You, Lord|TTBB|Fred King
+Thankful|SATB|Gary Lewis
 Thankful|SSAA|Joan D 'Agostino
 Thankful|TTBB|Kohl Kitzmiller
 Thankful Heart|TTBB|Brian Mastrull
 Thanks Again|SSAA|David Wright
 Thanks For The Buggy Ride|TTBB|Val Hicks
+Thanks for the Memory|TTBB|Chuck Brooks
 Thanks For The Memory|SSAA|Jo Lund
 Thanks For The Memory|SSAA|Marie Johnson
 Thanks For The Memory|SSAA|Marsha Zwicker
@@ -17405,6 +20688,7 @@ Thanks For The Memory|SSAA|Tom Gentry
 Thanks For The Memory|TTBB|Dick Rode
 Thanks For The Memory|TTBB|I.I. Ellis
 Thanks For The Memory|TTBB|K. Mast
+Thanks For The Memory|TTBB|Mel Knight
 Thanks For The Memory|TTBB|Melvin Knight
 Thanks For The Memory|TTBB|Ray Buntaine
 Thanks For The Memory|TTBB|Tom Gentry
@@ -17424,33 +20708,50 @@ That Golden Stair|TTBB|Derric Johnson
 That Great Come And Get It Day|SSAA|Jarmela Speta
 That Little Boy Of Mine|SSAA|Dave Wilkinson
 That Little Boy Of Mine|TTBB|Joe Mannherz
+That Lonesome Road|SATB|Simon Carrington
+That Lonesome Road|SSAA|Steve Jamison
 That Lonesome Road|TTBB|Dan Naumann
 That Lonesome Road|TTBB|Gary Thiel
 That Lonesome Road|TTBB|L. M. Coyle
+That Lonesome Road|TTBB|Simon Carrington
 That Lonesome Road|TTBB|Steve Jamison
+That Lonesome Road (James Taylor)|SATB|Simon Carrington
+That Lonesome Road (SATB)|SATB|Simon Carrington
 That Lovely Weekend|SSAA|Tom Gentry
 That Lovely Weekend|TTBB|Roy Keys
 That Lovely Weekend|TTBB|Tom Gentry
 That Lucky Old Sun|TTBB|David Wright
+That Lucky Old Sun|TTBB|Roy Keys
 That Lucky Old Sun|TTBB|Walter Latzko
 That Man|SSAA|Carole Prietto
 That Man|SSAA|Melody Hine
+That Man (Caro Emerald) A Cappella|SSAA|Peter Nugent
+That Man (Caro Emerald) Backing Track|SSAA|Hans Reintjes
 That Old Bible On The Bookcase|TTBB|Jim West
 That Old Black Magic|SSAA|Dede Nibler
+That Old Black Magic|SSAA|June Berg
 That Old Black Magic|SSAA|June Dale
 That Old Black Magic|SSAA|Marge Bailey
 That Old Black Magic|SSAA|Tedda Lippincott
+That Old Black Magic|TTBB|Bill Wyatt
+That Old Black Magic|TTBB|Bob Wyatt
 That Old Black Magic|TTBB|Patrick McAlexander
+That Old Black Magic|TTBB|Suntones
 That Old Black Magic|TTBB|W. A. Wyatt
+That Old Black Magic|TTBB|William Wyatt
+That Old Boar Pet of Mine|TTBB|Unspecified
 That Old Dominion Line|TTBB|Burt Szabo
 That Old Fashioned Mother Of Mine|SSAA|Tedda Lippincott
 That Old Fashioned Mother Of Mine|TTBB|Barbershop Harmony Society
 That Old Fashioned Mother Of Mine|TTBB|Unknown
 That Old Fashioned Sweeetheart Of Mine|TTBB|Dave Stevens
 That Old Feeling|SATB|Kevin Keller
+That Old Feeling|SSAA|Ann Minihane
 That Old Feeling|SSAA|Dot Calvin
 That Old Feeling|SSAA|Kevin Keller
 That Old Feeling|SSAA|Michael Gellert
+That Old Feeling|SSAA|Nancy Bergman
+That Old Feeling|SSAA|Unspecified
 That Old Feeling|TTBB|David Wright
 That Old Feeling|TTBB|Dennis Driscoll
 That Old Feeling|TTBB|Fred King
@@ -17469,6 +20770,9 @@ That Old Irish Mother Of Mine|SSAA|Marsha Zwicker
 That Old Irish Mother Of Mine|TTBB|Larry Wright
 That Old Irish Mother Of Mine|TTBB|Louis Perry
 That Old Irish Mother Of Mine|TTBB|Rob Hopkins
+That Old Quartet of Mine|SSAA|Joni Bescos
+That Old Quartet of Mine|SSAA|Lou Perry
+That Old Quartet of Mine|TTBB|Lou Perry
 That Old Quartet Of Mine|TTBB|Louis Perry
 That Railroad Rag|TTBB|Kirk Roose
 That Rhythm Man|TTBB|Ed Waesche
@@ -17477,9 +20781,12 @@ That Silver Haired Daddy Of Mine|TTBB|Tom Gentry
 That Slippery Slide Trombone|TTBB|Tom Campbell
 That Slippery Slide Trombone|TTBB|Unknown
 That Smile|SSAA|Joan D 'Agostino
+That Song Is Driving Me Crazy|SSAA|Bev Sellers
 That Song My Mother Sang|TTBB|Tom Gentry
 That Summer When We Were Young|SSAA|Brent Graham
 That Summer When We Were Young|SSAA|Jo Lund
+That Summer When We Were Young|SSAA|Val Hicks
+That Summer When We Were Young|TTBB|Val Hicks
 That Sunday, That Summer|SSAA|Avis Fellows
 That Tumble Down Shack In Athlone|SSAA|Joe Liles
 That Tumble Down Shack In Athlone|SSAA|Larry Wright
@@ -17492,17 +20799,22 @@ That Tumble Down Shack In Athlone|TTBB|Larry Wright
 That Tumble Down Shack In Athlone|TTBB|Louis Perry
 That Tumble Down Shack In Athlone|TTBB|Paul Bowman
 That Tumble Down Shack In Athlone|TTBB|SPEBSQSA
+That Tumble-down Shack in Athlone|SSAA|Joni Bescos
+That Tumble-down Shack in Athlone|SSAA|Renee Craig
 That Tumble-Down Shack in Athlone|TTBB|SPEBSQSA (Barbershop Harmony Society)
+That Tumble-Down Shack In Athlone|SSAA|Joe Liles
 That Wonderful Mother Of Mine|SSAA|Ann Minihane
 That Wonderful Mother Of Mine|SSAA|Nancy Bergman
 That Wonderful Mother Of Mine|TTBB|Bob Graham
 That Wonderful Mother Of Mine|TTBB|Burt Szabo
+That Wonderful Mother Of Mine|TTBB|Jim Clancy
 That Wonderful Mother Of Mine|TTBB|Lou Perry, Bob Graham
 That Wonderful Mother Of Mine|TTBB|Louis Perry
 That Wonderful Mother Of Mine|TTBB|Norm Duggan
 That Wonderful Mother Of Mine|TTBB|Roy Keys
 That Wonderful Mother Of Mine|TTBB|Tom Gentry
 That'll Be the Day|SSAA|Thomas Gentry
+That'll Be the Day|SSAA|Tom Gentry
 That'll Be the Day|TTBB|Thomas Gentry
 That'll Be The Day|SSAA|Carole Prietto
 That'll Be The Day|TTBB|Deke Sharon
@@ -17510,9 +20822,11 @@ That'll Be The Day|TTBB|Tom Gentry
 That'll Do|TTBB|John Hohl
 That's A Plenty|TTBB|Burt Szabo
 That's A Plenty|TTBB|Chris Arnold
+That's A Plenty|TTBB|Greg Volk
 That's All|SATB|Kevin Keller
 That's All|SSAA|Nancy Bergman
 That's All|TTBB|Aaron Dale
+That's All|TTBB|Joe Johnson
 That's All|TTBB|Kohl Kitzmiller
 That's All|TTBB|Kyle Kitzmiller
 That's America to Me|TTBB|Todd Troutman
@@ -17521,8 +20835,10 @@ That's Amore|SSAA|Tedda Lippincott
 That's Amore|TTBB|John Fortino
 That's Amore|TTBB|Richard Floersheimer
 That's An Irish Lullaby|SSAA|Carolyn Johnson
+That's An Irish Lullaby|SSAA|Ed Waesche
 That's An Irish Lullaby|TTBB|Ed Waesche
 That's An Irish Lullaby|TTBB|Paul Bowman
+That's An Irish Lullabye|SSAA|Nancy Bergman
 That's Christmas To Me|SATB|Kohl Kitzmiller
 That's Christmas To Me|SSAA|Dawn Haggerty
 That's Christmas To Me|SSAA|Kay Bromert
@@ -17536,12 +20852,16 @@ That's Entertainment|SSAA|Renee Craig
 That's Entertainment|SSAA|Tom Gentry
 That's Entertainment|TTBB|Jay Giallombardo
 That's Entertainment|TTBB|Joe Mannherz
+That's Entertainment|TTBB|Ray Danley
 That's Entertainment|TTBB|Rob Ozman
 That's Entertainment|TTBB|Tom Gentry
+That's Entertainment|TTBB|Unspecified
 That's How I Spell Ireland|TTBB|Dave Wilkinson
 That's How Rhythm Was Born|TTBB|David Wright
 That's How The Yodel Was Born|TTBB|Jon Nicholas
 That's How You Jazz|SSAA|Jo Lund
+That's How You Jazz & The Jam Medley|SSAA|Jo Lund
+That's How You Jazz Medley|SSAA|Jo Lund
 That's How You Jazz/The Jam Medley|SSAA|Jo Lund
 That's How You Know|SSAA|Kohl Kitzmiller
 That's Life|SATB|Barbershop Harmony Society
@@ -17551,18 +20871,22 @@ That's Life|SSAA|Jarmela Speta
 That's Life|SSAA|Joe Mannherz
 That's Life|SSAA|Kevin Keller
 That's Life|SSAA|Mo Rector
+That's Life|SSAA|Steve Wolf
 That's Life|TTBB|Barbershop Harmony Society
 That's Life|TTBB|BHS
 That's Life|TTBB|David Harrington
 That's Life|TTBB|Joe Mannherz
 That's Life|TTBB|Kevin Keller
 That's Life|TTBB|Mo Rector
+That's Life|TTBB|Mo Rector, Steve Tramack
+That's Life|TTBB|Roger Payne
 That's My Girl|SSAA|Aaron Dale
 That's My Girl|TTBB|Aaron Dale
 That's My Weakness Now|SSAA|Norma Andersen
 That's My Weakness Now|SSAA|Tom Gentry
 That's My Weakness Now|SSAA|Walter Latzko
 That's My Weakness Now|TTBB|Tom Gentry
+That's My Weakness Now / That Certain Party|TTBB|Tom Gentry
 That's My Weakness Now/That Certain Party|SSAA|Tom Gentry
 That's My Weakness Now/That Certain Party|TTBB|Tom Gentry
 That's Our Renee|SSAA|Jo Lund
@@ -17572,6 +20896,7 @@ That's The One Thing That I Didn't Get From You|SSAA|Brent Graham
 That's The One Thing That I Didn't Get From You|TTBB|Brent Graham
 That's The Way Love Is|TTBB|Kyle Snook
 That's What Dreams Are For|TTBB|Jay Giallombardo
+That's What Dreams Are For|TTBB|Joe Liles
 That's What Friends Are For|SATB|Burt Szabo
 That's What Friends Are For|SSAA|Bev Sellers
 That's What Friends Are For|SSAA|Jo Lund
@@ -17585,12 +20910,15 @@ That's What I Call A Pal|TTBB|Ed Waesche
 That's What I Want For Christmas|SSAA|Avis Fellows
 That's What We Love About Christmas|SSAA|Avis Fellows
 That's When Life Is Worth Living|SSAA|Tedda Lippincott
+The 12 Days After Christmas|TTBB|Dennis Driscoll
+The 20s Dance Medley|TTBB|Ray Danley
 The 59th Street Bridge Song (Feelin' Groovy)|SATB|Tamra Perez
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Bev Sellers
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Julie Gaulke
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Marge Bailey
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Patsee Parker
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Deke Sharon
+The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Don Gray
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Jon Nicholas
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Mark Goodney
 The Ace In The Hole|TTBB|Kohl Kitzmiller
@@ -17607,11 +20935,20 @@ The Auctioneer|TTBB|Greg Backwell
 The Ballad Of Bonnie And Clyde|SSAA|Larry Wright
 The Ballad Of Bonnie And Clyde|TTBB|Larry Wright
 The Ballad Of Bonnie And Clyde|TTBB|Nick Bryant
+The Ballad Of Springhill|TTBB|Steve Tramack
 The Banana Boat Song|TTBB|Don Gray
 The Band Played On|SSAA|Nancy Bergman
 The Band Played On|SSAA|Renee Craig
 The Band Played On|TTBB|Rob Hopkins
+The Band Played On|TTBB|Yesteryear
+The Barbershop Strut|SSAA|Earl Moon
 The Barbershop Strut|TTBB|Earl Moon
+The Bare Necessities|SSAA|Carolyn Healey
+The Bare Necessities|TTBB|Bill Eberius
+The Bare Necessities|TTBB|Don Rose
+The Baritone Blues|SSAA|Joe Liles
+The Baritone Blues|TTBB|Larry Bean
+The Baritone Blues|TTBB|The Management
 The Bear|TTBB|David Avshalomov
 The Begat|TTBB|Mark Goodney
 The Bell Carol|SSAA|Rowena Harper
@@ -17625,6 +20962,7 @@ The Best Is Yet To Come|TTBB|Brent Graham
 The Best Is Yet To Come|TTBB|Joe Grimme
 The Best Man|TTBB|Matt Astle
 The Best of Days|SSAA|Joey Minshall
+The Best Of Doo Wop|TTBB|Unspecified
 The Best Of Me|TTBB|Rasmus Krigström
 The Best Thing For You|SSAA|Kohl Kitzmiller
 The Best Thing For You|TTBB|Kohl Kitzmiller
@@ -17633,14 +20971,22 @@ The Best Things Happen While You're Dancing|SSAA|Steve Tramack
 The Best Things Happen While You're Dancing|SSAA|Tom Gentry
 The Best Things Happen While You're Dancing|TTBB|Tom Gentry
 The Best Things Happen While You're Dancing (from White Christmas)|TTBB|Steve Tramack
+The Best Things Happen While You're Dancing(Steve Tra|TTBB|Steve Tramack
+The Best Things In Life Are Free|TTBB|Marie Johnson
 The Best Time Of Your Life|SSAA|Marie Johnson
 The Best Times I Ever Had|SSAA|Larry Wright
 The Best Times I Ever Had|TTBB|Larry Wright
 The Big Bang Theory|SSAA|Patricia Godfrey
+The Big Brass Band From Brazil|TTBB|Dick Floersheimer
 The Big Parade|SSAA|Michael Gellert
 The Biggest Parakeets in Town|TTBB|Tom Gentry
 The Birds And The Bees|TTBB|TJ Barranger
+The Birth of the Blues|SSAA|Carolyn Schmidt
+The Birth of the Blues|TTBB|Tony Searle
+The Birth Of The Blues|TTBB|Buzz Haeger
 The Birth Of The Blues|TTBB|David Wright
+The Birth Of The Blues|TTBB|Don Gray
+The Birth Of The Blues|TTBB|Steve Jamison
 The Birthday Of A King|SSAA|Jay Giallombardo
 The Birthday Of A King|SSAA|Nancy Bergman
 The Birthday Of A King|TTBB|David Wright
@@ -17666,6 +21012,7 @@ The Broadway Blues|TTBB|Burt Szabo
 The Brooklyn Bridge|SSAA|Sonny Steffan
 The Brotherhood Of Man (Parody)|TTBB|Jay Giallombardo
 The Bunny Hug|TTBB|Jim Shubert
+The Candy Man|TTBB|Joe Johnson
 The Candy Man|TTBB|Kevin Keller
 The Captain Of The Toy Brigade|SSAA|Jay Giallombardo
 The Captain Of The Toy Brigade|TTBB|Burt Szabo
@@ -17680,13 +21027,18 @@ The Chapters Of Life|TTBB|Walter Latzko
 The Chicken Dance|SSAA|Asuka Ichikawa
 The Chipmunk Song|SSAA|Carole Prietto
 The Chipmunk Song|SSAA|Debbie Keretz
+The Chipmunks Christmas Song|TTBB|The Grand Tradition/Reveille
 The Chocolate Carol|SATB|David Avshalomov
 The Chordbuster March|SATB|W. A. Wyatt
 The Chordbuster March|SSAA|Becky Wilkins
 The Chordbuster March|SSAA|Joe Liles
 The Chordbuster March|SSAA|W. A. Wyatt
 The Chordbuster March|TTBB|W. A. Wyatt
+The Chordbuster March|TTBB|WA Wyatt
+The Chordbuster's March|SSAA|Joe Liles
+The Christmas Blues|TTBB|Steven Armstrong
 The Christmas Rag|TTBB|Jay Giallombardo
+The Christmas Rap|SSAA|Judy Vidal
 The Christmas Savior|TTBB|Anthony Bartholomew
 The Christmas Shoes|SSAA|Tom Gentry
 The Christmas Shoes|TTBB|Tom Gentry
@@ -17696,12 +21048,16 @@ The Christmas Song|SATB|Nick Bryant
 The Christmas Song|SATB|Simon Lubkowski
 The Christmas Song|SSAA|Bev Sellers
 The Christmas Song|SSAA|Brent Graham
+The Christmas Song|SSAA|Dot Calvin
 The Christmas Song|SSAA|Jay Giallombardo
 The Christmas Song|SSAA|Jo Lund
+The Christmas Song|SSAA|Joe Liles
 The Christmas Song|SSAA|Judith Riley
 The Christmas Song|SSAA|June Berg
 The Christmas Song|SSAA|Kohl Kitzmiller
 The Christmas Song|SSAA|Larry Wright
+The Christmas Song|SSAA|R. Emley
+The Christmas Song|SSAA|Ruth Emley
 The Christmas Song|SSAA|Susan Kegley
 The Christmas Song|TTBB|Aaron Dale
 The Christmas Song|TTBB|Al Fisk
@@ -17715,9 +21071,13 @@ The Christmas Song|TTBB|Jay Giallombardo
 The Christmas Song|TTBB|Joe Liles
 The Christmas Song|TTBB|Joe Mannherz
 The Christmas Song|TTBB|Larry Wright
+The Christmas Song|TTBB|Pete Rupay
 The Christmas Song|TTBB|Robert Rund
 The Christmas Song|TTBB|Walter Latzko
 The Christmas Song (Chestnuts Roasting on an Open Fire)|TTBB|Aaron Dale
+The Christmas Waltz|SSAA|Anastasio Rossi
+The Christmas Waltz|SSAA|Jo Lund
+The Christmas Waltz|TTBB|Joe Johnson
 The Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
 The Church Bells Are Ringing For Mary|TTBB|Ed Waesche
 The Church Bells Are Ringing For Mary|TTBB|Greg Lapp
@@ -17741,6 +21101,7 @@ The Climb|TTBB|Cay Outerbridge
 The Climb|TTBB|Deke Sharon
 The Climb|TTBB|Larry Wright
 The Climb|TTBB|Melody Hine
+The Climb/Go The Distance|SSAA|Nick Girard
 The Clod & the Pebble|SATB|David Avshalomov
 The Closest Thing To Crazy|TTBB|Hilary Allen
 The Clouds Will Soon Roll By|SSAA|Zona Snyder
@@ -17759,17 +21120,22 @@ The Cross, The Crown, The Nail|TTBB|Derric Johnson
 The Curtain Falls|SSAA|Tom Gentry
 The Curtain Falls|TTBB|Clay Hine
 The Curtain Falls|TTBB|Tom Gentry
+The Curtain Falls|TTBB|Will Hamblet
 The Dance|SSAA|Jeanne Elmuccio
+The Dance|SSAA|Tedda Lippincott
 The Dance|TTBB|Patrick McAlexander
 The Darktown Strutters' Ball|TTBB|Ed Waesche
+The Darktown Strutters' Ball|TTBB|Steve Jamison
 The Daughter of Sweet Adeline|TTBB|John Minsker
 The Day After Thanksgiving|SATB|Kay Bromert
 The Day After Thanksgiving|TTBB|Eric Ruthenberg
+The Day that the Circus Left Town|TTBB|Fred King
 The Days Back When|TTBB|Theodore Hicks
 The Days Back When|TTBB|Val Hicks
 The Desert Song|TTBB|Jon Nicholas
 The Devil Ain't Lazy|TTBB|Aaron Dale
 The Devil Went Down to Georgia|SSAA|Carole Prietto
+The Dinosaur Strut|TTBB|Unspecified
 The Distance|SATB|Deke Sharon
 The Divine Image|SATB|David Avshalomov
 The Dogs|TTBB|Tom Gentry
@@ -17805,10 +21171,12 @@ The First Noel|SATB|Deke Sharon
 The First Noel|SATB|Derric Johnson
 The First Noel|SATB|Wayne Grimmer
 The First Noel|SSAA|Carolyn Johnson
+The First Noel|SSAA|David Harrington
 The First Noel|SSAA|Nancy Bergman
 The First Noel|SSAA|Wayne Grimmer
 The First Noel|TTBB|David Harrington
 The First Noel|TTBB|Deke Sharon
+The First Noel|TTBB|Joe Johnson
 The First Noel|TTBB|Jon Nicholas
 The First Noel|TTBB|Matt Astle
 The First Noel|TTBB|Nick Bryant
@@ -17821,6 +21189,7 @@ The First Toymaker To The King|SATB|Steve Tramack
 The Flame|TTBB|Mark Stevens
 The Flirt|TTBB|Walter Latzko
 The Fly|SATB|David Avshalomov
+The Fool On The Hill|TTBB|Jon Nicholas
 The Fourth of July Parade|TTBB|Dan Naumann
 The Fox|TTBB|Kevin Koehl
 The Friendly Beasts|SATB|Kay Bromert
@@ -17837,10 +21206,13 @@ The Gambler|TTBB|Walter Latzko
 The Game|TTBB|Andy Wolf
 The Gang That Sang Heart Of My Heart|TTBB|Bob Graham
 The Garden of Love|SATB|David Avshalomov
+The Gift Carol|TTBB|Greg Lyne
 The Gift Of Harmony|TTBB|Paul C. Olguin
 The Gift of Harmony (TTBB) (Olguin)|TTBB|Paul Olguin
 The Gift of Song|SSAA|Kay Bromert
 The Gift To Be Simple|SSAA|Chris Moyer
+The Gift To Be Simple|TTBB|Bob Chilcott
+The Girl From Ipanema|SATB|Joanna Forbes
 The Girl From Ipanema|SATB|Joe Mannherz
 The Girl From Ipanema|SSAA|Gloria Kuchenbecker
 The Girl From Ipanema|TTBB|Deke Sharon
@@ -17855,11 +21227,17 @@ The Girl In My Fantasy|TTBB|Joe Liles
 The Girl In My Memory|TTBB|Dave Stevens
 The Girl In Noman's Land|SSAA|Joe Mannherz
 The Girl on the Magazine Cover|TTBB|Burt Szabo
+The Girl that I Marry|TTBB|Unspecified
 The Girl That I Marry|TTBB|Dennis Driscoll
 The Girl That I Marry|TTBB|Rob Hopkins
 The Glendy Burke|TTBB|Bryan Olson
 The Glory Days|SATB|Deke Sharon
+The Glory of Love|SSAA|Region 21
+The Glory of Love|SSAA|Region 21 Arr. Dev. Program
+The Glory of Love|TTBB|Clay Hine
 The Glory of Love|TTBB|Dennis Driscoll
+The Gloryland Way|TTBB|Mo Rector
+The Gold-Minin' Gang|SSAA|June Dale
 The Good Book Song|TTBB|Tom Gentry
 The Goodbye Song|SATB|Dan Mulligan
 The Goodbye Song|TTBB|Allyson Lotz
@@ -17874,6 +21252,7 @@ The Great War Era Medley|SSAA|Mark Rusch
 The Great War Era Medley|TTBB|Mark Rusch
 The Greatest|SATB|Nicholas Wright
 The Greatest|TTBB|Tom Gentry
+The Greatest Barbershop Chart|TTBB|Adam Reimnitz
 The Greatest Gift of All|SSAA|Carole Prietto
 The Greatest Gift of All|SSAA|Tom Gentry
 The Greatest Gift of All|TTBB|Matthew Gallagher
@@ -17896,6 +21275,7 @@ The Hands of Time|SSAA|Joe Mannherz
 The Hands of Time|TTBB|Joe Mannherz
 The Headless Horseman|SATB|Kohl Kitzmiller
 The Headless Horseman|TTBB|Aaron Dale
+The Headless Horseman|TTBB|David Wright
 The Headless Horseman|TTBB|Larry Triplett
 The Heart of a Girl|SSAA|Tom Gentry
 The Heart of a Girl|TTBB|Tom Gentry
@@ -17910,8 +21290,11 @@ The Holly And The Ivy|SATB|Deke Sharon
 The Holly And The Ivy|SSAA|Carolyn Johnson
 The Holly And The Ivy|SSAA|Diane Clark
 The Holly And The Ivy|SSAA|Tedda Lippincott
+The Holly And The Ivy|TTBB|Darin Drown
 The Holy City|TTBB|Walter Latzko
 The House At The End Of The Lane|TTBB|Burt Szabo
+The House I Live In|SSAA|Marge Bailey
+The House I Live In|SSAA|Sandy Sharpe
 The House Is Haunted|SSAA|Kristina Roper
 The Human Abstract|SATB|David Avshalomov
 The Hut-Sut Song|TTBB|Rasmus Krigström
@@ -17919,14 +21302,18 @@ The Impossible Dream|SATB|Manoj Padki
 The Impossible Dream|SSAA|Clay Hine
 The Impossible Dream|SSAA|Jay Giallombardo
 The Impossible Dream|SSAA|Larry Wright
+The Impossible Dream|TTBB|Bob Bohn
 The Impossible Dream|TTBB|David Wright
 The Impossible Dream|TTBB|Jay Giallombardo
 The Impossible Dream|TTBB|Larry Wright
+The Impossible Dream|TTBB|Pete Rupay
 The Impossible Dream|TTBB|Scott Kitzmiller
 The Impossible Dream|TTBB|Steven Armstrong
 The Impossible Dream|TTBB|Theodore Hicks
+The Impossible Dream (The Quest)|TTBB|Ed Waesche
 The Impossible Dream Medley|TTBB|Matt Astle/Ken Potter
 The Impression That I Get|TTBB|Kari Francis
+The Infant King|TTBB|Steven Armstrong
 The International Rag|SSAA|Kevin Keller
 The International Rag|TTBB|Kevin Keller
 The International Rag|TTBB|Walter Latzko
@@ -17934,14 +21321,20 @@ The Internationale for Remainers|SATB|Liz Garnett
 The Isle of Inisfree|SSAA|Tom Gentry
 The Isle of Inisfree|TTBB|Tom Gentry
 The Japanese Sandman|TTBB|Mark Goodney
+The Jazz Me Blues|SSAA|Carolyn Schmidt
 The Jogging Song|SSAA|Liz Garnett
+The Joint Is Jumpin'|SSAA|Greg Volk
+The Joint Is Jumpin'|SSAA|Lorraine Rochefort
+The Joint Is Jumpin'|SSAA|Nancy Bergman
 The Joke|SSAA|Lauren Kahn
 The Jones Boy|TTBB|Tom Gentry
 The Joy of Life|SSAA|Joe Mannherz
 The Joy of Life|TTBB|Joe Mannherz
 The Jumpin' Jive|TTBB|Aaron Dale
+The Kazoo Concerto|TTBB|Tom Gentry
 The Key To Success With The Beautiful Girls|TTBB|John Hohl
 The King Is Coming|TTBB|Derric Johnson
+The King Medley|TTBB|Webb Comfort
 The Kingdom of Shy|SATB|Joe Mannherz
 The Lady Down the Hall|SSAA|Michael Gellert
 The Lady From 29 Palms|SSAA|Marie Johnson
@@ -17962,6 +21355,7 @@ The Lemonade Song|SSAA|Emily Moriarty
 The Letter|SSAA|Jon Nicholas
 The Letter|TTBB|Burt Szabo
 The Letter|TTBB|Jon Nicholas
+The Letter (Women)|SSAA|Jon Nicholas
 The Life of a Showgirl|SATB|Mark Stevens
 The Life Of The Party|SATB|Dan Wessler
 The Life Of The Party|TTBB|Dan Wessler
@@ -17972,12 +21366,20 @@ The Lighthouse Keeper|SSAA|Joey Minshall
 The Lilly|SATB|David Avshalomov
 The Lion Sleeps Tonight|SATB|Scott Turnbull
 The Lion Sleeps Tonight|SSAA|Scott Turnbull
+The Lion Sleeps Tonight|SSAA|Tedda Lippincott
+The Lion Sleeps Tonight|TTBB|Jon Nicholas
 The Lion Sleeps Tonight|TTBB|Scott Turnbull
+The Lion Sleeps Tonight|TTBB|Unspecified
 The Little Bitty Baby|TTBB|Derric Johnson
 The Little Boy|SSAA|Tom Gentry
 The Little Boy|TTBB|Thomas Gentry
 The Little Boy|TTBB|Tom Gentry
 The Little Child|SSAA|Nancy Bergman
+The Little Drummer Boy|SSAA|Tedda Lippincott
+The Little Drummer Boy|TTBB|David Wright
+The Little Drummer Boy|TTBB|Jon Nicholas
+The Little Drummer Boy|TTBB|Tracy Shirk
+The Little Girl|SSAA|Tom Gentry
 The Little Man Who Wasn't There|SSAA|Nancy Bergman
 The Little Things|SSAA|Glenda Lloyd
 The Little Things|TTBB|Simon Arnott
@@ -17993,6 +21395,7 @@ The Lonesomest Girl In Town|TTBB|Unknown
 The Long and Winding Road|SATB|Simon Lubkowski
 The Long and Winding Road|TTBB|Anders Lindqvist
 The Long and Winding Road|TTBB|Jay Giallombardo
+The Long Day Closes|TTBB|Arthur Sullivan
 The Long Word Song|TTBB|Tom Gentry
 The Longest Time|SATB|Deke Sharon
 The Longest Time|SATB|Tom Gentry
@@ -18002,9 +21405,12 @@ The Longest Time|SSAA|Karen Procter
 The Longest Time|SSAA|Kay Bromert
 The Longest Time|SSAA|Mark Burnip
 The Longest Time|SSAA|Tom Gentry
+The Longest Time|TTBB|Darwin Scheel
 The Longest Time|TTBB|Mark Burnip
 The Longest Time|TTBB|Thomas Gentry
 The Longest Time|TTBB|Tom Gentry
+The Lord Bless You and Keep You|SSAA|Avis Fellows
+The Lord Bless You and Keep You|SSAA|Fellows
 The Lord Is Good To Me|SATB|Kevin Keller
 The Lord Is Good To Me|SSAA|Kevin Keller
 The Lord Is Good To Me|SSAA|Ron Mason
@@ -18013,18 +21419,25 @@ The Lord Is Good To Me|TTBB|Kevin Keller
 The Lord's Prayer|SATB|Tom Gentry
 The Lord's Prayer|SSAA|Anna Maria Parker
 The Lord's Prayer|SSAA|Diana DeBruycker
+The Lord's Prayer|SSAA|Jim Clancy
+The Lord's Prayer|SSAA|June Dale
 The Lord's Prayer|SSAA|Kay Bromert
 The Lord's Prayer|SSAA|Marie Johnson
 The Lord's Prayer|SSAA|Nancy Bergman
+The Lord's Prayer|SSAA|Nigel Williams
 The Lord's Prayer|SSAA|Peg Millard
 The Lord's Prayer|SSAA|Sharon Holmes
 The Lord's Prayer|SSAA|Sylvia Alsbury
+The Lord's Prayer|TTBB|Barbershop Harmony Society
 The Lord's Prayer|TTBB|Derric Johnson
+The Lord's Prayer|TTBB|Jim Clancy
 The Lord's Prayer|TTBB|Joe Liles
 The Lord's Prayer|TTBB|Joe Liles and Tom Gentry
 The Lord's Prayer|TTBB|Joe Mannherz
 The Lord's Prayer|TTBB|Richard Curtis
 The Lord's Prayer|TTBB|Tom Gentry
+The Lords prayer|TTBB|Tom Gentry and Joe Liles
+The Love Bug|TTBB|Kirk Young
 The Love Bug Will Bite You|TTBB|Kyle Snook
 The Love I Meant To Say|TTBB|Brent Graham
 The Loveliest Night Of The Year|TTBB|Walter Latzko
@@ -18048,28 +21461,44 @@ The Man In the Looking Glass|TTBB|Brian Mastrull
 The Man In the Looking Glass|TTBB|Larry Triplett
 The Man That Got Away|TTBB|Greg Mallett
 The Man Who Can't Be Moved|SATB|Nicholas Wright
+The Man With the Bag|SSAA|Marge Bailey
+The Man With the Bag|SSAA|Nancy Bergman
+The Man With The Bag|SSAA|Lorraine Rochefort
+The Man With The Bag|TTBB|Jon Nicholas
+The Man With The Bag|TTBB|Tom Gentry and Lorraine Rochefort
+The Mansions Of The Lord|TTBB|Jon Nicholas
+The Maple Leaf Forever|TTBB|Chris Arnold
 The Maple Leaf Forever|TTBB|Phil Embury
+The Mardi Gras March|SATB|Aaron Dale
+The Mardi Gras March|SSAA|Aaron Dale
+The Mardi Gras March|TTBB|Aaron Dale
 The Martian Hop|SSAA|June Dale
 The Marvelous Toy|SSAA|Connie Nickel
+The Marvelous Toy|SSAA|Twardowsky
 The Marx Brothers Opener|TTBB|Jay Giallombardo
+The Masquerade is Over|SSAA|Tedda Lippincott
 The Masquerade Is Over|SSAA|Ed Waesche
 The Masquerade Is Over|SSAA|Jay Giallombardo
 The Masquerade Is Over|TTBB|Ed Waesche
 The Masquerade Is Over|TTBB|Jay Giallombardo
 The Masquerade Is Over|TTBB|Joe Mannherz
+The Masquerade is Over (as performed by Hillfoot Harmony)|SSAA|Arr Tedda Lippincot
 The Masquerade Is Over (I'm Afraid)|TTBB|Ed Waesche
 The Meeting In The Air|TTBB|Derric Johnson
 The Memory Of You Lives On|SSAA|Marie Johnson
 The Merry Christmas Polka|SATB|Tom Gentry
 The Merry Christmas Polka|TTBB|Tom Gentry
 The Middle|SATB|Nicholas Wright
+The Mississippi Squirrel Revival|TTBB|Archie Steen
 The Moment I Saw Your Eyes|SATB|Joe Liles
 The Moment I Saw Your Eyes|SSAA|Joe Liles
 The Moment I Saw Your Eyes|TTBB|Joe Liles
+The Money Song|TTBB|Gene Cokeroft
 The More I See You|SSAA|Brent Graham
 The More I See You|SSAA|Carolyn Schmidt
 The More I See You|SSAA|Joe Mannherz
 The More I See You|SSAA|Kevin Keller
+The More I See You|SSAA|Ruby Rhea
 The More I See You|TTBB|Brent Graham
 The More I See You|TTBB|Joe Mannherz
 The More I See You|TTBB|John Brockman
@@ -18077,6 +21506,9 @@ The More I See You|TTBB|Kevin Keller
 The More I See You|TTBB|Walter Latzko
 The Most Beautiful Girl|TTBB|Jon Nicholas
 The Most Wonderful Day Of The Year|TTBB|Mark Goodney
+The Most Wonderful Time Of The Year|SSAA|Nancy Bergman
+The Most Wonderful Time Of The Year|TTBB|Dave Plette
+The Most Wonderful Time Of The Year|TTBB|Jay Giallombardo
 The Movies|TTBB|Earl Moon
 The Movies|TTBB|Mark Goodney
 The Movies|TTBB|Walter Latzko
@@ -18090,8 +21522,16 @@ The Muppet Show Theme|TTBB|Larry Wright
 The Muppet Show Theme|TTBB|Michael Webber
 The Music and the Mirror|SSAA|Mary Ann Wydra
 The Music of the Night|SSAA|David Wright
+The Music of the Night|SSAA|Tedda Lippincott
 The Music of the Night|TTBB|David Wright
+The Music of the Night|TTBB|Ed Boehm
 The Musics Always There With You|SSAA|Kay Bromert
+The Naughty Lady Of Shady Lane|TTBB|Joe Johnson
+The Naughty Lady Of Shady Lane|TTBB|Unspecified
+The Nearness of You|SSAA|John Brockman
+The Nearness of You|SSAA|Rob Hopkins
+The Nearness of You|SSAA|Susan Lamb Kegley
+The Nearness of You|TTBB|Kirby Shaw
 The Nearness Of You|SATB|Kevin Keller
 The Nearness Of You|SSAA|Adam Reimnitz
 The Nearness Of You|SSAA|Carolyn Healey
@@ -18121,6 +21561,7 @@ The Night Has a Thousand Eyes|SSAA|David Wright
 The Night Has a Thousand Eyes|SSAA|Mark Burnip
 The Night Has a Thousand Eyes|TTBB|David Wright
 The Night Has a Thousand Eyes|TTBB|Mark Burnip
+The Night We Called It A Day|SSAA|Ruby Rhea
 The Night We Met|SATB|Lance Fisher
 The Nightmare Before Chrismas Medley|TTBB|Deke Sharon
 The Nittany Lion|TTBB|Jim West
@@ -18137,44 +21578,61 @@ The Old Maids Ball|SSAA|Barbara McNeill
 The Old Maids Ball|SSAA|Carolyn Schmidt
 The Old Man|TTBB|Jay Giallombardo
 The Old Man|TTBB|Larry Wright
+The Old Man's Back In Town|SSAA|Brian Beck
 The Old Man's Back In Town|SSAA|Joe Liles
 The Old North State|TTBB|Jeremey Johnson
+The Old Piano Roll Blues|SSAA|Joni Bescos
+The Old Piano Roll Blues|TTBB|David Wright
 The Old Piano Roll Blues|TTBB|Mo Rector
 The Old Songs|SSAA|Jo Lund
 The Old Songs|TTBB|Jay Giallombardo
+The Old Songs Medley|TTBB|David Zimmerman
 The Old Spinning Wheel|SSAA|Tom Gentry
 The Old Spinning Wheel|TTBB|Earl Moon
 The Old Spinning Wheel|TTBB|Tom Gentry
 The Older I Get|SSAA|Sheryl Neal
+The Oldest Established|TTBB|Don Gray
 The One I Love (Belongs To Somebody Else)|TTBB|Clay Hine
+The One I Love Belongs to Somebody Else|TTBB|Clay Hine
 The One I Love Belongs to Somebody Else|TTBB|Jim Shubert
 The One I Love Belongs To Somebody Else|SATB|Joe Mannherz
 The One I Love Belongs To Somebody Else|SSAA|Joe Mannherz
 The One on the Right is On the Left|SSAA|Kay Bromert
 The One That You Love|TTBB|Gary Thiel
 The Only Guy Can Make Me Cry|SSAA|Carolyn Johnson
+The Original Dixieland One Step|SSAA|Greg Volk
+The Original Dixieland One Step|SSAA|Renee Craig
+The Original Dixieland One-Step|TTBB|Renee Craig
 The Out of Tune Song|TTBB|Michael Webber
+The Over 40 Waltz|TTBB|Chuck Brooks
 The Pal That I Loved Stole The Gal That I Loved|TTBB|Dennis Driscoll
 The Pal That I Loved Stole The Gal That I Loved|TTBB|Harry Mays
 The Pal That I Loved Stole The Gal That I Loved|TTBB|Louis Perry
 The Parting Glass|SATB|Liz Garnett
 The Parting Glass|SSAA|Liz Garnett
 The Parting Glass|SSAA|Mike Taylor
+The Parting Glass|SSAA|The Wailin' Jennys
 The Parting Glass|TTBB|Adam Scott
 The Parting Glass|TTBB|Anders Lindqvist
+The Parting Glass|TTBB|Chris Arnold
 The Parting Glass|TTBB|Ken Potter
 The Parting Glass|TTBB|Liz Garnett
 The Parting Glass|TTBB|Manoj Padki
+The Parting Glass|TTBB|Nathan Peplinski
 The Parting Glass|TTBB|Nicholas Wright
 The Parting Glass|TTBB|Thomas Degan
 The Party's Over|TTBB|Brent Graham
 The Party's Over|TTBB|Steve Armstrong
 The Party's Over|TTBB|Steven Armstrong
+The Party's Over/Send In The Clowns Medley|TTBB|Ralph Warman
 The Peace Carol|SSAA|David Wallace
 The Peace Carol|SSAA|June Berg
+The Perfect Barbershop Song|SSAA|Lynnell Diamond
 The Perfect Fan|TTBB|Nicholas Wright
 The Perfect Fan|TTBB|Theodore Hicks
 The Picture That I Love the Best of All|TTBB|Dennis Driscoll
+The Pirate Song|TTBB|Darin Drown
+The Pirate's Life|TTBB|Mel Knight
 The Place Where the Lost Things Go|SSAA|Carole Prietto
 The Place Where the Lost Things Go|SSAA|Glenda Lloyd
 The Place Where the Lost Things Go|SSAA|Joey Minshall
@@ -18186,20 +21644,30 @@ The Place Where the Lost Things Go|TTBB|Mark Goodney
 The Place Where the Lost Things Go|TTBB|Theodore Hicks
 The Pledge of Allegiance|TTBB|Jim Clancy
 The Polar Express|SSAA|Jan Meyer
+The Polar Express|TTBB|Joe Johnson
 The Popcorn Song|SSAA|Judith Riley
 The Power of Love|SATB|Matthew Spinner
 The Power of Love|TTBB|Dan Wessler
+The Power of the Dream|SSAA|Brian Beck
+The Power of the Dream|SSAA|Tedda Lippincott
 The Prayer|SATB|Deke Sharon
 The Prayer|SSAA|Jay Giallombardo
 The Prayer|SSAA|Joan D 'Agostino
+The Prayer|SSAA|Joan D'Agostino
+The Prayer|SSAA|Joe Liles
 The Prayer|TTBB|Jay Giallombardo
+The Prayer|TTBB|Kenny Ray Hatton
 The Prayer|TTBB|Steven Armstrong
 The Preacher And The Bear|SSAA|Walter Latzko
 The Preacher And The Bear|TTBB|Bud Leabo
 The Preacher And The Bear|TTBB|Walter Latzko
 The Proposal Song|TTBB|Jeremey Johnson
+The Quest (Impossible Dream)|SSAA|Ed Waesche
+The Rainbow Connection|SSAA|Joey Minshall
+The Rainbow Connection|SSAA|Judy Vidal
 The Rains of Castamere|TTBB|Nicholas Wright
 The Rattlin' Bog|TTBB|Dan Wessler
+The Reason/Everybody's Changing (Medley)|TTBB|Henrik Rosenberg
 The Red Rose Rag|SSAA|Margaret Raeside
 The Red Rose Rag|TTBB|Mel Knight
 The Red, White And Blue|TTBB|Derric Johnson
@@ -18208,12 +21676,16 @@ The Restroom song|SATB|Joe Mannherz
 The Rhythm Of Life|SSAA|David Wallace
 The Rhythm Of Life|SSAA|Jim Massey
 The Rhythm Of Life|SSAA|Jo Kraut
+The Rhythm Of Life|TTBB|Greg Volk
+The Rhythm of Life (SATB)|SATB|Roger Emerson
+The Rhythm of Love|TTBB|Jeremey Johnson
 The Riff Song|TTBB|Jon Nicholas
 The Right Girl for Me|TTBB|Brent Graham
 The River|SSAA|Carole Prietto
 The River|SSAA|Emily Moriarty
 The River|SSAA|Joey Minshall
 The River|SSAA|June Berg
+The River|TTBB|Rob Hopkins
 The River Of Dreams|SATB|Deke Sharon
 The River Of Dreams|SSAA|Becky Wilkins
 The River Of Dreams|SSAA|Charlene Yazurlo
@@ -18223,34 +21695,54 @@ The River Of Dreams|TTBB|Jay Giallombardo
 The River Of No Return|TTBB|Gene Cokeroft
 The River Seine|SSAA|Walter Latzko
 The Roast Beef of Old England|SATB|Matthew Spinner
+The Rooster Song|SSAA|Doris Twardosky
 The Rose|SATB|Deke Sharon
 The Rose|SSAA|Carole Prietto
 The Rose|SSAA|Dick Keirstead
 The Rose|SSAA|Jo Lund
 The Rose|SSAA|Joanne Dockrell
+The Rose|SSAA|Joni Bescos
 The Rose|SSAA|Kay Bromert
+The Rose|SSAA|Kirby Shaw
+The Rose|SSAA|Unspecified
+The Rose|TTBB|B. Doepke
 The Rose|TTBB|Brian Doepke
+The Rose|TTBB|The Old Vic
 The Rose|TTBB|Todd Troutman
+The Rose (SSAA)|SSAA|Kirby Shaw
 The Rose Of No Man's Land|TTBB|the Barbershop Harmony Society
 The Rose of Tralee|TTBB|Dennis Driscoll
 The Rose of Tralee|TTBB|Floyd Connett
+The Rose Of Tralee|TTBB|Leo Larivee
+The Sadder But Wiser Girl|TTBB|Walter Latzko
 The Safety Dance|SATB|Mark Stevens
 The Safety Dance|TTBB|Mark Stevens
+The Sally Gardens|TTBB|Philip Serino
 The Saltwater Room|SATB|Deke Sharon
 The Santa Claus Express|TTBB|SPEBSQSA
 The School Boy|SATB|David Avshalomov
 The Scientist|TTBB|Deke Sharon
 The Sears Christmas Catalog|TTBB|Jim Shubert
+The Second Star From The Right|SSAA|Tom Gentry
+The Second Star To The Right|TTBB|Tom Gentry
+The Second Time Around|TTBB|Steve Delehanty
+The Secret of Christmas|SATB|Ruby Rhea
+The Secret of Christmas|SSAA|Nancy Bergman
+The Secret of Christmas|TTBB|James Van Heusen
 The Secret Of Christmas|SATB|Joe Mannherz
 The Secret Of Christmas|SSAA|Carolyn Schmidt
 The Secret Of Christmas|SSAA|Dianne Goldrick
 The Secret Of Christmas|SSAA|Jarmela Speta
+The Secret Of Christmas|SSAA|Jim Clancy
 The Secret Of Christmas|SSAA|Joe Mannherz
 The Secret Of Christmas|SSAA|Russ Foris
 The Secret Of Christmas|TTBB|Dianne Goldrick
+The Secret Of Christmas|TTBB|Jim Clancy
 The Secret Of Christmas|TTBB|Joe Mannherz
 The Secret Of Christmas|TTBB|Russ Foris
+The Secret of Christmas Medley|TTBB|Jim Clancy
 The Seed|SSAA|Adam Bock
+The Shadow of Your Smile|TTBB|Jeff Taylor
 The Shadow Of Your Smile|SSAA|Brent Graham
 The Shadow Of Your Smile|SSAA|Kevin Keller
 The Shadow Of Your Smile|SSAA|Larry Wright
@@ -18263,15 +21755,19 @@ The Shadow Of Your Smile|TTBB|Mark Burnip
 The Shadow Of Your Smile|TTBB|Simon Arnott
 The Shepherd|SATB|David Avshalomov
 The Shifting Whispering Sands|TTBB|Paul Jorg
+The Shoop Shoop Song|SSAA|Jo Lund
 The Show Must Go On|SATB|David Wright
 The Show Must Go On|SATB|Nicholas Wright
 The Showboat Came to Town|TTBB|Val Hicks
 The Sick Rose|SATB|David Avshalomov
 The Sign|SATB|Deke Sharon
 The Sky, The Dawn And The Sun|SSAA|June Dale
+The Skye Boat Song|TTBB|Paul Davies
 The Sleigh|SATB|Deke Sharon
 The Sleigh|TTBB|Derric Johnson
+The Song is Ended|TTBB|Jay Giallombardo
 The Song Is Ended|SSAA|Anna Maria Parker
+The Song Is Ended|SSAA|Joni Bescos
 The Song Is Ended|SSAA|Larry Wright
 The Song Is Ended|TTBB|Ed Waesche
 The Song Is Ended|TTBB|Larry Wright
@@ -18281,14 +21777,20 @@ The Song Is Ended (But the Melody Lingers On)|TTBB|Ed Waesche
 The Song Is Ended (But the Melody Lingers On)|TTBB|Russ Foris, Tom Gentry, Burt Szabo
 The Song Is You|SSAA|Melody Hine
 The Song Is You|SSAA|Sharon Holmes
+The Song Is You|TTBB|Joe Johnson
 The Song Is You|TTBB|Matthew Gallagher
 The Song Is You|TTBB|Walter Latzko
 The Song Remembers When|SSAA|Tedda Lippincott
 The Song that Doesn't End|TTBB|Jim Emery
 The Song That Goes Like This|SSAA|Carole Prietto
+The Song That Goes Like This|SSAA|Lorraine Rochefort
+The Song's Gotta Come From the Heart|TTBB|David Wright
 The Songs We Sang Together|TTBB|Steve Tramack
 The Sound|TTBB|Nicholas Wright
+The Sound of Music|SSAA|Nancy Bergman
 The Sound Of Music|TTBB|David Wright
+The Sound of Music Medley|SSAA|Nancy Bergman
+The Sound of Music Medley|TTBB|Clay Hine
 The Sound of Music with Climb Every Mountain|TTBB|Joe Liles
 The Sound Of Silence|SATB|Deke Sharon
 The Sound Of Silence|SATB|Marilyn Penketh
@@ -18302,6 +21804,8 @@ The Sound Of Silence|TTBB|Mark Goodney
 The Spaniard That Blighted My Life|TTBB|Burt Szabo
 The Spinning Song|TTBB|Jay Giallombardo
 The Spirit Of Adventure|TTBB|Adam Bock
+The Star Spangled Banner|TTBB|Aaron Dale
+The Star Spangled Banner|TTBB|Jim Clancy
 The Star-Spangled Banner|TTBB|Val Hicks
 The Stars and Stripes Forever|SATB|David Wright
 The Stars and Stripes Forever|SSAA|David Wright
@@ -18309,7 +21813,9 @@ The Stars and Stripes Forever|TTBB|David Wright
 The Stars Will Remember|SSAA|Ann Minihane
 The Stars Will Remember|TTBB|Kyle Kitzmiller
 The Story|SSAA|Brent Graham
+The Story Of The Rose|TTBB|Jon Nicholas
 The Story of the Rose (Heart of My Heart)|TTBB|Barbershop Harmony Society
+The Story Of The Rose (Women)|SSAA|Jon Nicholas
 The Story of the Sparrows|TTBB|Jay Giallombardo
 The Streets Of New York|TTBB|Burt Szabo
 The Subway|SATB|Mark Stevens
@@ -18322,13 +21828,16 @@ The Sunshine Of Your Smile|TTBB|Ed Waesche
 The Sunshine Of Your Smile|TTBB|Jay Giallombardo
 The Sunshine Of Your Smile|TTBB|Tom Gentry
 The Super Supper March|SSAA|Dede Nibler
+The Supreme Supremes Medley|SSAA|Kevin Keller
 The Sweet Escape|SATB|Deke Sharon
 The Sweet Escape|SSAA|Nicholas Wright
+The Sweetest Song in the World|SSAA|Walter Latzko/Gene Cokeroft
 The Sweetest Song In The World|TTBB|Dennis Driscoll
 The Sweetest Song In The World|TTBB|Louis Perry
 The Sweetest Sounds|SSAA|Dianne Goldrick
 The Sweetest Sounds|SSAA|Patrick McAlexander
 The Sweetest Story Ever Told|TTBB|Burt Szabo
+The Sweetest Story Ever Told|TTBB|Unspecified
 The Sweetheart Of Sigma Chi|TTBB|Barbershop Harmony Society
 The Sweetheart Of Sigma Chi|TTBB|Dave Richards
 The Sweetheart Of Sigma Chi|TTBB|Ed Waesche
@@ -18338,6 +21847,7 @@ The Sweetheart Of Sigma Chi|TTBB|Jack Baird
 The Sweetheart Of Sigma Chi|TTBB|Jay Giallombardo
 The Sweetheart Of Sigma Chi|TTBB|Jim Clancy
 The Sweetheart Of Sigma Chi|TTBB|Kirk Roose
+The Sweetheart Of Sigma Chi|TTBB|Lou Perry
 The Sweetheart Of Sigma Chi|TTBB|Louis Perry
 The Sweetheart Of Sigma Chi|TTBB|Rob Campbell
 The Sweetheart Of Sigma Chi|TTBB|SPEBSQSA
@@ -18345,11 +21855,16 @@ The Sweetheart Of Sigma Chi|TTBB|Steve Jamison
 The Sweetheart Of Sigma Chi|TTBB|Steve Tramack
 The Sweetheart Of Sigma Chi|TTBB|Walter Latzko
 The Sweetheart of Sigma Nu|TTBB|Frank Thorne
+The Sweetheart Tree|TTBB|Mancini
 The Swingin' Shepherd Blues|SSAA|Joey Minshall
 The Syncopated Clock|SSAA|Cheryl Suhr
 The Syncopated Walk|TTBB|Walter Latzko
 The Tag|TTBB|Ray Buntaine
 The Tears of a Clown|SATB|Nicholas Wright
+The Teddy Bear's Picnic|TTBB|Dave Briner
+The Telephone Song (Mixed Jazz)|SATB|Brian Beck
+The Tender Trap|TTBB|Steve Tramack
+The Themes of 007|SSAA|Joey Minshall
 The Thing|TTBB|Andy Wolf
 The Thing|TTBB|Thomas Degan
 The Things We Did Last Summer|SSAA|Larry Wright
@@ -18380,13 +21895,16 @@ The Trolley Song|TTBB|Kohl Kitzmiller
 The Trolley Song|TTBB|Mark Goodney
 The Trolley Song|TTBB|Patrick McAlexander
 The Trolley Song|TTBB|Renee Craig
+The Trolley Song|TTBB|Unspecified
 The Trouble With Me Is You|TTBB|Patrick McAlexander
 The Truth About Men|TTBB|Dennis Malone
+The Truth About Men|TTBB|Dennis Malone and Matt Swann
 The Twelfth Of Never|SSAA|Brent Graham
 The Twelfth Of Never|TTBB|Brent Graham
 The Twelfth Of Never|TTBB|Todd Troutman
 The Twelfth Of Never|TTBB|Walter Latzko
 The Twelve Days After Christmas|SSAA|Joan Melling
+The Twelve Days After Christmas|SSAA|Tedda Lippincott
 The Twelve Days After Christmas|TTBB|Archie Steen
 The Twelve Days After Christmas|TTBB|Dennis Driscoll
 The Twelve Days After Christmas|TTBB|Paul Engel
@@ -18405,6 +21923,7 @@ The U. S. Air Force|TTBB|David Avshalomov
 The U. S. Air Force|TTBB|Nancy Bergman
 The U. S. Air Force|TTBB|Todd Troutman
 The Ugly Bug Ball|SSAA|Betty Grant
+The Ugly Bug Ball|SSAA|Suzy Lobaugh
 The Unbirthday Song|SSAA|Debbie Porter
 The Unicorn|TTBB|Jim West
 The Unicorn|TTBB|Todd Troutman
@@ -18431,17 +21950,23 @@ The Voyage|TTBB|Kevin Keller
 The Walk|TTBB|Deke Sharon
 The Water Is Wide|SATB|Deke Sharon
 The Water Is Wide|SSAA|Rick Spencer
+The Water Is Wide|TTBB|Joe Johnson
 The Water Is Wide|TTBB|Jon Nicholas
+The Water Is Wide|TTBB|Rick Spencer
 The Water Is Wide|TTBB|Vince Peterson
 The Way|TTBB|Eric Ruthenberg
+The Way|TTBB|Josh Ehrlich
 The Way I Am|SSAA|Patrick McAlexander
+The Way We Were|SSAA|Brian Beck
 The Way We Were|SSAA|Joe Mannherz
 The Way We Were|SSAA|Marge Bailey
 The Way We Were|SSAA|Molly Rowland
 The Way We Were|TTBB|Anders Lindqvist
+The Way We Were|TTBB|Brian Beck
 The Way We Were|TTBB|Jay Giallombardo
 The Way We Were|TTBB|Jim West
 The Way We Were|TTBB|Joe Mannherz
+The Way We Were|TTBB|Roy Keys
 The Way You Do|TTBB|Deke Sharon
 The Way You Look Tonight|SSAA|Diane Clark
 The Way You Look Tonight|SSAA|Joey Minshall
@@ -18451,12 +21976,19 @@ The Way You Look Tonight|SSAA|Tom Gentry
 The Way You Look Tonight|TTBB|Deke Sharon
 The Way You Look Tonight|TTBB|Larry Wright
 The Way You Look Tonight|TTBB|Mark Hale
+The Way You Look Tonight|TTBB|Renee Craig
 The Way You Look Tonight|TTBB|Tom Gentry
 The Way You Look Tonight|TTBB|Walter Latzko
 The Weekend|TTBB|Nicholas Wright
 The Wells Fargo Wagon|TTBB|Howard Jones
 The Wells Fargo Wagon (Parody)|TTBB|Patrick McAlexander
+The Whiffenpoof Song|TTBB|Blaine Mack
 The Whiffenpoof Song|TTBB|Louis Perry
+The Whiffenpoof Song|TTBB|The Ritz
+The White Cliffs of Dover|SSAA|Renee Craig
+The White Cliffs Of Dover|TTBB|Don Gray
+The Wind Beneath My Wings|SSAA|Julie Starr
+The Wind Beneath My Wings|TTBB|Tom Gentry
 The Windmills of your Mind|SATB|Dennis Driscoll
 The Windmills of your Mind|SATB|Joe Mannherz
 The Winner Takes It All|SATB|Kyle Snook
@@ -18473,15 +22005,20 @@ The World is Waiting For The Sunrise|TTBB|Burt Szabo
 The World is Waiting For The Sunrise|TTBB|Dennis Driscoll
 The World is Waiting For The Sunrise|TTBB|Ellsworth Morey
 The World is Waiting For The Sunrise|TTBB|Walter Latzko
+The World Is Waiting For The Sunrise|TTBB|Roy Keys
+The World Is Waiting For The Sunrise|TTBB|Steven Armstrong
 The World This Way|SATB|Melody Hine
+The Yankee Doodle Boy|TTBB|Unspecified
 Their Hearts Were Full Of Spring|SATB|Joe Mannherz
 Their Hearts Were Full Of Spring|SSAA|Aaron Dale
 Their Hearts Were Full Of Spring|SSAA|Tom Gentry
 Their Hearts Were Full Of Spring|TTBB|Aaron Dale
 Their Hearts Were Full Of Spring|TTBB|Joe Mannherz
+Their Hearts Were Full Of Spring|TTBB|Kirby Shaw
 Their Hearts Were Full Of Spring|TTBB|Todd Troutman
 Their Hearts Were Full Of Spring|TTBB|Tom Gentry
 Them There Eyes|SSAA|Dave Stevens
+Them There Eyes|SSAA|Stevens
 Them Was The Good Old Days|SSAA|Larry Wright
 Them Was The Good Old Days|TTBB|Larry Wright
 Theme From "New York, New York"|TTBB|Patrick McAlexander
@@ -18498,12 +22035,15 @@ There Are Worse Things I Could Do|SSAA|Patrick McAlexander
 There goes My Everything|TTBB|Jim West
 There Goes My Heart|SSAA|Ed Waesche
 There Goes My Heart|SSAA|Joe Mannherz
+There Goes My Heart|SSAA|Lloyd Steinkamp/Nancy Bergman
 There Goes My Heart|SSAA|Nancy Bergman
 There Goes My Heart|TTBB|Ed Waesche
 There Goes My Heart|TTBB|Joe Mannherz
+There Goes My Heart|TTBB|Lloyd Steinkamp
 There Goes My Heart|TTBB|Scott Kitzmiller
 There Goes That Song Again|TTBB|Todd Troutman
 There He Goes|TTBB|Walter Latzko
+There I've Said it Again|TTBB|Not Specified
 There I've Said It Again|SATB|Don Gray
 There I've Said It Again|SSAA|Don Gray
 There I've Said It Again|SSAA|Doris Twardosky
@@ -18525,13 +22065,20 @@ There Is Love Wherever There Is Song|TTBB|Steve Delehanty
 There Is No Greater Love|SSAA|Nancy Bergman
 There Is No Greater Love|SSAA|Rebecca J. Wood
 There Is No Greater Love|TTBB|John Hohl
+There Is Nothin' Like A Dame|TTBB|Don Gray
 There Is Nothin' Like A Dame|TTBB|Jarmela Speta
+There is Nothing Like a Dame|TTBB|Dennis Morrisey
+There is Nothing Like a Dame|TTBB|J. Speta
+There is Nothing Like a Dame|TTBB|Unspecified
 There Is Nothing Like A Dame|SSAA|Tedda Lippincott
 There Is Nothing Like A Dame|TTBB|Jarmela Speta
 There Is Nothing Like A Dame|TTBB|Jay Giallombardo
 There Is Nothing Like A Dame|TTBB|Larry Wright
+There Is Nothing Like A Dame|TTBB|Pete Rupay
 There Is Only One of You|TTBB|Tom Gentry
 There Is Room In The World|SSAA|Dede Nibler
+There Never Was A Gang Like Mine|SSAA|Brian Beck
+There Never Was A Gang Like Mine|SSAA|Buzz Haeger
 There Never Was A Gang Like Mine|TTBB|Warren 'Buzz' Haeger
 There Never Was A Gang Like Mine|TTBB|Warren Haeger
 There Never Was A Girl Like You|TTBB|Walter Latzko
@@ -18540,7 +22087,11 @@ There Used To Be A Ball Park|SSAA|Jay Giallombardo
 There Used To Be A Ball Park|TTBB|Brent Graham
 There Used To Be A Ball Park|TTBB|Jay Giallombardo
 There Used To Be A Ball Park|TTBB|Kevin Keller
+There Used to Be a Ballpark|SSAA|Rich Hasty
+There Used to Be a Ballpark|TTBB|Ken Potter
 There Used To Be A Ballpark|TTBB|Roger Payne
+There Used To Be A Ballpark|TTBB|Val Hicks
+There Used to Be a Ballpark Here|SSAA|Doris Twardosky
 There Used To Be A Ballpark Right Here|SSAA|Doris Twardosky
 There Used To Be A Ballpark Right Here|SSAA|Val Hicks
 There Used To Be A Ballpark Right Here|TTBB|Doris Twardosky
@@ -18556,25 +22107,35 @@ There Will Never Be Another You|TTBB|Walter Latzko
 There You'll Be|SATB|Mike Menefee
 There You'll Be|SSAA|David Briner
 There You'll Be|SSAA|Larry Wright
+There, I've Said It Again|SSAA|Nancy Bergman
+There, I've Said It Again|TTBB|Bob Mattes
+There, I've Said It Again|TTBB|Rob Hopkins
+There, I've Said it Again (different tag)|SSAA|Nancy Bergman
 There'll Be Jubilation Bye And Bye|SSAA|Diana Franceschi
 There'll Be No New Tunes On This Old Piano|SSAA|June Berg
 There'll Be No New Tunes On This Old Piano|TTBB|Gene Cokeroft
 There'll Be No New Tunes On This Old Piano|TTBB|Tom Gentry
+There'll Be Now New Tunes On This Old Piano|SSAA|June Berg
 There'll Be Some Changes Made|SSAA|David Wallace
 There'll Be Some Changes Made|SSAA|Ed Waesche
 There'll Be Some Changes Made|SSAA|Nancy Bergman
+There'll Be Some Changes Made|TTBB|Charles E. Brooks
 There'll Be Some Changes Made|TTBB|Chuck Brooks
+There'll Be Some Changes Made|TTBB|Classic Collection
 There'll Be Some Changes Made|TTBB|Ed Waesche
 There'll Be Some Changes Made|TTBB|Richard Peterson
 There'll Be Some Changes Made / So Long, Dearie|SSAA|Nancy Bergman
 There'll Be Some Changes Made / Who's Sorry Now?|SSAA|Nancy Bergman
+There'll Be Some Changes Made/So Long Dearie Medley|SSAA|Nancy Bergman
 There'll Be Some Changes/Running Wild Medley|SSAA|Jo Lund
+There'll No New Tunes On This Old Piano|TTBB|Rob Hopkins (mod. Larry Lane)
 There's A Beautiful Star|SSAA|Carolyn Johnson
 There's A Boat Dat's Leavin' Soon for New York|SATB|Kohl Kitzmiller
 There's A Boat Dat's Leavin' Soon for New York|SSAA|Kohl Kitzmiller
 There's A Boat Dat's Leavin' Soon for New York|TTBB|Kohl Kitzmiller
 There's a Boat That's Leaving Soon/Bess You Is Ma Woman Now|SSAA|Jay Giallombardo
 There's a Boat That's Leaving Soon/Bess You Is Ma Woman Now|TTBB|Jay Giallombardo
+There's A Brand New Gang On The Corner|TTBB|Gene Cokeroft
 There's A Broken Heart For Every Light On Broadway|TTBB|Ed Waesche
 There's A Broken Heart For Every Light On Broadway|TTBB|Joni Bescos
 There's a Fine Fine Line|SATB|Cay Outerbridge
@@ -18587,7 +22148,9 @@ There's A Frost On The Moon|SSAA|Lauren Kahn
 There's A Full Moon Tonight|TTBB|Walter Latzko
 There's A Girl In The Heart Of Maryland|TTBB|Jack Baird
 There's A Goldmine in the Sky|TTBB|Rob Campbell
+There'S A Great Day Coming, Manana|SSAA|Judy Vidal
 There's A Hero|SSAA|Jim Arns
+There's a Kind of Hush|SSAA|Tedda Lippincott
 There's A Kind Of Hush (All Over The World)|SSAA|Diana DeBruycker
 There's A Kind Of Hush (All Over The World)|SSAA|Tedda Lippincott
 There's A Little Spark Of Love Still Burning|TTBB|Tom Gentry
@@ -18603,6 +22166,7 @@ There's A New Gang On The Corner|TTBB|Floyd Connett
 There's A New Gang On The Corner|TTBB|Gene Cokeroft
 There's A Place|SSAA|Emily Moriarty
 There's A Place For Us|TTBB|Greg Mallett
+There's A Rainbow 'Round My Shoulder|TTBB|Barbershop Harmony Society
 There's A Rainbow 'Round My Shoulder|TTBB|Jeff Marks
 There's A Rainbow 'Round My Shoulder|TTBB|Kyle Snook
 There's A Rainbow 'Round My Shoulder|TTBB|SPEBSQSA
@@ -18612,9 +22176,11 @@ There's a Rose On Your Cheek|TTBB|Tom Gentry
 There's A Rose That Is Blooming In Ireland|TTBB|Dick Ellenberger
 There's A Rose That Is Blooming In Ireland|TTBB|Louis Perry
 There's A Small Hotel|TTBB|Walter Latzko
+There's A Song in the Air|SSAA|Aileen Nightingale
 There's A Song In The Air|SSAA|Aileen Nightingale Music
 There's A Song In The Air|SSAA|Carolyn Johnson
 There's A Star Spangled Banner Waving Somewhere|TTBB|Marie Johnson
+There's A Tag In The Old Quartet|SSAA|Lynnell Diamond
 There's a Vacant Chair at Home|TTBB|Louis Perry
 There's A Vacant Chair At Home Sweet Home|SSAA|Kay Bromert
 There's A Vacant Chair At Home Sweet Home|TTBB|Dick Welsh
@@ -18623,13 +22189,19 @@ There's a Wind|TTBB|David Avshalomov
 There's Always Tomorrow|SSAA|Kevin Keller
 There's Always Tomorrow|TTBB|Kevin Keller
 There's An Old Easy Chair By The Fireplace|TTBB|Jim Stenson
+There's Gonna Be the Devil to Pay|SSAA|Greg Volk
+There's Gotta Be Something Better Than This|SSAA|Renee Craig
 There's More To Me Than You|SSAA|Deke Sharon
+There's No Business Like Show Business|SSAA|Dot Calvin
+There's No Business Like Show Business|SSAA|Joni Bescos
 There's No Business Like Show Business|SSAA|Nancy Bergman
 There's No Business Like Show Business|TTBB|Dennis Driscoll
 There's No Business Like Show Business|TTBB|Derric Johnson
 There's No Business Like Show Business|TTBB|Kevin Koehl
 There's No Business Like Show Business|TTBB|Russ Foris
+There's No Business Like Show Business|TTBB|Steve Jamison - Tag Randy Rogers
 There's No One But You|TTBB|Joe Liles
+There'S No Place Like Home 4 Holidays|SSAA|Carolyn Schmidt
 There's No Way|TTBB|Nicholas Wright
 There's No You|TTBB|Dennis Driscoll
 There's Nobody Else But You|SSAA|Suzy Lobaugh
@@ -18637,6 +22209,7 @@ There's Nobody Else But You|TTBB|Louis Perry
 There's Nobody Just Like You|TTBB|Jack Baird
 There's Nothing I Wouldn't Do|SSAA|Dianne Goldrick
 There's Nothing That I Haven't Sung About|TTBB|Clay Hine
+There's Something About A Soldier|SSAA|George Avener
 There's Something About A Soldier|SSAA|Jay Giallombardo
 There's Something About A Soldier|SSAA|Joe Mannherz
 There's Something About A Soldier|SSAA|Judy Vidal
@@ -18646,7 +22219,9 @@ There's Something About A Soldier|TTBB|Joe Mannherz
 There's Something About An Old-Fashioned Girl|TTBB|Louis Perry
 There's Something About That Name|TTBB|John Hale
 There's Something About That Name|TTBB|Randall Weir
+There's Something I Like About Broadway|TTBB|Lou Perry
 There's Something I Like About Broadway|TTBB|Louis Perry
+There's Still A Touch of Texas in My Heart|SSAA|Lynnell Diamond
 There's Yes Yes In Your Eyes|TTBB|Tim Wheeler
 These Are The Days|TTBB|Stefan Pugliese
 These Are the Days of Our Lives|SATB|Liz Garnett
@@ -18663,26 +22238,36 @@ They|SATB|Deke Sharon
 They All Call It Canada|SATB|Beverly Kennedy
 They All Call It Canada|SSAA|Beverly Kennedy
 They All Call It Canada|TTBB|Beverly Kennedy
+They All Call It Canada|TTBB|M. Polis
 They All Laughed|SATB|Joe Mannherz
 They All Laughed|SSAA|Jay Giallombardo
 They All Laughed|SSAA|Joe Mannherz
 They All Laughed|SSAA|Sheryl Neal
 They All Laughed|SSAA|Walter Latzko
+They All Laughed|TTBB|David Wright
 They All Laughed|TTBB|Don Gray
+They All Laughed|TTBB|Ed Waesche
 They All Laughed|TTBB|Jay Giallombardo
 They All Laughed|TTBB|Joe Mannherz
 They All Laughed|TTBB|Rob Hopkins
 They All Laughed|TTBB|Walter Latzko
+They All Laughed|TTBB|Will Hamblet
 They Always Pick On Me|SSAA|Tedda Lippincott
 They Always Pick On Me|TTBB|Jack Baird
 They Are Gone|TTBB|Tom Gentry
 They Call it Canada but I Call it Home|SATB|Beverly Kennedy
 They Call it Canada but I Call it Home|SSAA|Beverly Kennedy
+They Call It Dancing|SSAA|Judy Vidal
 They Call It Dancing|TTBB|Tom Gentry
+They Call The Wind 'Mariah'|TTBB|Joe Johnson
 They Call The Wind Maria|TTBB|Jay Giallombardo
 They Call The Wind Maria|TTBB|Jim West
 They Call The Wind Maria|TTBB|Jon Nicholas
 They Call The Wind Maria|TTBB|Kevin Keller
+They Call The Wind Mariah|TTBB|Don Thomson
+They Call The Wind Mariah|TTBB|Kevin Keller
+They Call The Wind Mariah|TTBB|Steve Jamison
+They Can't Take That Away from Me|TTBB|Mark Hale
 They Can't Take That Away From Me|SATB|Deke Sharon
 They Can't Take That Away From Me|SATB|Larry Triplett
 They Can't Take That Away From Me|SSAA|Aaron Dale
@@ -18690,6 +22275,7 @@ They Can't Take That Away From Me|SSAA|Joe Mannherz
 They Can't Take That Away From Me|SSAA|Larry Triplett
 They Can't Take That Away From Me|SSAA|Melody Hine
 They Can't Take That Away From Me|TTBB|Aaron Dale
+They Can't Take That Away From Me|TTBB|Aaron Dale, Mark Hale
 They Can't Take That Away From Me|TTBB|Joe Mannherz
 They Can't Take That Away From Me|TTBB|Larry Triplett
 They Can't Take That Away From Me|TTBB|Walter Latzko
@@ -18700,16 +22286,20 @@ They Didn't Believe Me|SSAA|Jay Giallombardo
 They Didn't Believe Me|TTBB|Adam Scott
 They Didn't Believe Me|TTBB|Burt Szabo
 They Didn't Believe Me|TTBB|David Wright
+They Didn't Believe Me|TTBB|Dick Floersheimer
 They Didn't Believe Me|TTBB|Jay Giallombardo
 They Didn't Believe Me|TTBB|Jim Shubert
 They Didn't Believe Me|TTBB|Walter Latzko
 They Didn't Believe Me / Smoke Gets In Your Eyes Medley|TTBB|David Briner
 They Don't Know (About Us)|TTBB|Mark Stevens
 They Don't Let You In The Opera|SSAA|Melody Hine
+They Go Wild Over Me|SSAA|June Berg
+They Go Wild Simply Wild Over Me|SSAA|June Berg
 They Go Wild, Simply Over Me|TTBB|SPEBSQSA
 They Go Wild, Simply Wild Over Me|SSAA|Jay Giallombardo
 They Go Wild, Simply Wild Over Me|SSAA|Jo Kraut
 They Go Wild, Simply Wild Over Me|SSAA|June Berg
+They Go Wild, Simply Wild Over Me|SSAA|June Berg/Jo Kraut
 They Go Wild, Simply Wild Over Me|SSAA|Mark Rusch
 They Go Wild, Simply Wild Over Me|SSAA|Tom Gentry
 They Go Wild, Simply Wild Over Me|TTBB|Barbershop Harmony Society
@@ -18720,6 +22310,7 @@ They Go Wild, Simply Wild Over Me|TTBB|Mark Rusch
 They Go Wild, Simply Wild Over Me|TTBB|SPEBSQSA
 They Go Wild, Simply Wild Over Me|TTBB|Tom Gentry
 They Go Wild, Simply Wild Over Me/Running Wild medley|SSAA|Jo Lund
+They Go Wild, Simply Wild, Over Me|TTBB|Barbershop Harmony Society
 They Just Keep Moving the Line|SATB|Kohl Kitzmiller
 They Just Keep Moving the Line|SSAA|Kevin Keller
 They Just Keep Moving the Line|SSAA|Kohl Kitzmiller
@@ -18744,14 +22335,20 @@ They Say It's Wonderful|SSAA|Diane Clark
 They Say It's Wonderful|SSAA|Katie Farrell
 They Say It's Wonderful|SSAA|Walter Latzko
 They Say It's Wonderful|TTBB|Dennis Driscoll
+They Say It's Wonderful|TTBB|Ed Waesche
 They Say It's Wonderful|TTBB|Katie Farrell
+They Were All Out of Step But Jim|TTBB|Barbershop Harmony Society
 They Were All Out Of Step But Jim|TTBB|Jay Giallombardo
 They Were All Out Of Step But Jim|TTBB|Paul Engel
 They Wrote 'Em in the Good Ol' Days|TTBB|Gene Cokeroft
 They Wrote 'Em In The Good Old Days|TTBB|Gene Cokeroft
+They Wrote Em' in the Good Old Days|TTBB|Gene Cokeroft
+They'll Be Seeing You|TTBB|Unspecified
+They'll Be Seeing You (Hospital Gown)|TTBB|Chordiac Arrest
 They'll Never Believe Me|TTBB|George Davidson
 They're All Sweeties|TTBB|Burt Szabo
 They're Either Too Young Or Too Old|SSAA|Carolyn Schmidt
+They're Gonna Fight, Fight, Fight Over There|SSAA|June Dale
 They're Off|TTBB|Denny Stiers
 They're Wearing 'Em Higher In Hawaii|TTBB|Paul Engel
 Things Are Looking Up|SSAA|David Briner
@@ -18771,17 +22368,22 @@ Think Of Me|SSAA|Sheila Cope
 Thinking Of You|TTBB|Bob Weiss
 Thinking Out Loud|SATB|Deke Sharon
 Thinking Out Loud|SSAA|Kirby Shaw
+Thinking Out Loud|TTBB|Henrik Rosenberg
 Thinking Out Loud|TTBB|Kirby Shaw
+Third Wheel|TTBB|Steve Delehanty
 Thirty-Five Years Ago|TTBB|Unknown
 This Boy|SSAA|David Harrington
 This Boy|TTBB|David Harrington
+This Boy|TTBB|James Porter
 This Boy or This Girl|SSAA|Joe Mannherz
 This Boy or This Girl|TTBB|Joe Mannherz
+This Can't Be Love|SATB|Ruby Rhea
 This Can't Be Love|SSAA|David Wright
 This Can't Be Love|SSAA|George Avener
 This Can't Be Love|TTBB|Aaron Dale
 This Can't Be Love|TTBB|David Wright
 This Can't Be Love|TTBB|Eric Ruthenberg
+This Can't Be Love|TTBB|Jim Clancy
 This Can't Be Love (from The Boys From Syracuse)|TTBB|Aaron Dale
 This Can't Be Love (from The Boys From Syracuse)|TTBB|David Wright
 This Can't Be Love (from The Boys From Syracuse)|TTBB|Wayne Grimmer
@@ -18803,6 +22405,7 @@ This Could be the Start of Something Big|TTBB|Walter Latzko
 This Frog|TTBB|Cay Outerbridge
 This Grill Is Not A Home|TTBB|Ben Lewin
 This Guy's In Love With You|TTBB|Dan Wessler
+This Heart of Mine|SSAA|Anita Barzilla
 This Heart of Mine|SSAA|David Harrington
 This Heart of Mine|SSAA|Kevin Keller
 This Heart of Mine|SSAA|Walter Latzko
@@ -18811,12 +22414,15 @@ This Heart of Mine|TTBB|David Harrington
 This Heart of Mine|TTBB|Kevin Keller
 This Is A Great Country|SSAA|Carolyn Schmidt
 This Is A Very Special Day|TTBB|Eric Ruthenberg
+This Is All I Ask|TTBB|Buzz Haeger
 This Is All I Ask|TTBB|Dennis Driscoll
 This Is All I Ask|TTBB|Jim Shubert
 This Is All I Ask|TTBB|Tom Gentry
 This Is All I Ask|TTBB|Warren 'Buzz' Haeger
 This Is All I Ask|TTBB|Warren Haeger
 This Is Halloween|SATB|David Wright
+This Is It|TTBB|Brent Graham (Tag Mods Randy Rogers)
+This Is It (Bugs Bunny Overture)|TTBB|Unspecified
 This Is It!|SSAA|Brent Graham
 This Is It!|SSAA|Corinna Garriock
 This Is It!|SSAA|Debbie Keretz
@@ -18826,6 +22432,7 @@ This Is It!|SSAA|Nancy Bergman
 This Is It!|SSAA|Patricia Godfrey
 This Is It!|TTBB|Brent Graham
 This Is It!|TTBB|Larry Wright
+This Is It! (Theme from Bugs Bunny)|SSAA|Corinna Garriock
 This Is Me|SATB|Deke Sharon
 This Is Me|SATB|Dianne Goldrick
 This Is Me|SATB|Melody Hine
@@ -18840,27 +22447,35 @@ This Is Me|TTBB|Anders Lindqvist
 This Is Me|TTBB|Dianne Goldrick
 This Is Me|TTBB|Liz Garnett
 This Is Me|TTBB|Matt Astle
+This is My Country|TTBB|Barbershop Harmony Society
 This Is My Country|SSAA|Nancy Bergman
 This Is My Country|SSAA|Sharon Holmes
+This Is My Country|TTBB|Al Jacobs
 This Is My Country|TTBB|Derric Johnson
 This Is My Country|TTBB|Gene Cokeroft
 This Is My Country|TTBB|Larry Jackson
 This is My Country / America the Beautiful|SSAA|Nancy Bergman
 This Is My Lucky Day/Sing Hallelujah|TTBB|Jay Giallombardo
 This Is My Night|SSAA|Nancy Bergman
+This is Some Lucky Day|SSAA|Greg Volk
+This is Some Lucky Day|TTBB|Greg Volk
 This Is The Army, Mr. Jones|SSAA|Nancy Bergman
 This Is The Army, Mr. Jones|SSAA|Tedda Lippincott
+This Is The Army, Mr. Jones|TTBB|John Bober
 This Is The Army, Mr. Jones|TTBB|Nancy Bergman
 This Is The Life|SSAA|Jo Lund
 This Is The Life|TTBB|Michael Webber
+This is the Moment|TTBB|Jeff Oxley
 This Is The Moment|SATB|Jay Dougherty
 This Is The Moment|SSAA|Brent Graham
+This Is The Moment|SSAA|Fred King
 This Is The Moment|SSAA|Gene Bender
 This Is The Moment|SSAA|Jay Dougherty
 This Is The Moment|SSAA|Jim Arns
 This Is The Moment|SSAA|Marie Johnson
 This Is The Moment|SSAA|Tedda Lippincott
 This Is The Moment|TTBB|Brent Graham
+This Is The Moment|TTBB|Fred King
 This Is The Moment|TTBB|Jay Dougherty
 This Is The Moment|TTBB|Nick Bryant
 This Is The Moment|TTBB|Simon Arnott
@@ -18870,8 +22485,13 @@ This Is The Moment (from Jekyll & Hyde)|TTBB|Steve Armstrong
 This Is Why I Sing|SATB|Melody Hine
 This Is Worth Fighting For|TTBB|Bernie Pitkin
 This Joint is Jumpin'|TTBB|Clay Hine
+This Joint Is Jumpin'|SSAA|Nancy Bergman
+This Joint Is Jumpin'|TTBB|David Wright
+This Joint is Jumpin' Medley|TTBB|Jay Giallombardo
 This Kiss|SSAA|Dianne Goldrick
 This Land is Home|TTBB|Todd Troutman
+This Land is My Land|SSAA|Lorraine Rochefort
+This Land is Your Land|TTBB|Unspecified
 This Land Is Your Land|SATB|Manoj Padki
 This Land Is Your Land|SSAA|Jay Giallombardo
 This Land Is Your Land|SSAA|Jo Lund
@@ -18881,20 +22501,31 @@ This Land Is Your Land|TTBB|Derric Johnson
 This Land Is Your Land|TTBB|Dick Whitehouse
 This Land Is Your Land|TTBB|Jay Giallombardo
 This Land Is Your Land|TTBB|Jim West
+This Land Is Your Land Canadian|TTBB|Richard E. Whitehouse
 This Life|SATB|Nicholas Wright
+This Little Light / Do Lord Medley|TTBB|Val Hicks
 This Little Light Of Mine|SSAA|Karen McCarville
 This Little Light Of Mine|TTBB|Dennis Driscoll
+This Little Light Of Mine|TTBB|John Leavitt
 This Little Light Of Mine|TTBB|Val Hicks
 This Little Light Of Mine / Do Lord Medley|SSAA|Val Hicks
 This Little Light Of Mine / Do Lord Medley|TTBB|Val Hicks
+This Little Light of Mine/Do Lord|TTBB|Val Hicks
+This Little Light Of Mine/Do Lord Medley|SSAA|Val Hicks
+This Little Light Of Mine/Do Lord Medley (Val H|TTBB|Val Hicks
+This Little Piggy|SSAA|George Avener
 This Love|TTBB|Deke Sharon
 This Love|TTBB|Kyle Kitzmiller
+This Love of Mine|SSAA|Anita Barzilla
+This Masquerade|SSAA|Ase Hagerman
 This May Be The Night|TTBB|Rob Hopkins
 This Nearly Was Mine|SATB|Deke Sharon
 This Nearly Was Mine|SSAA|Debbie Keretz
 This Nearly Was Mine|TTBB|Jay Giallombardo
 This Nearly Was Mine|TTBB|Kevin Keller
 This Night|SSAA|Jen Squires
+This Old House|SSAA|Carolyn Healey
+This Old House|TTBB|David Wright
 This Ole House|SSAA|Carolyn Healey
 This Ole House|SSAA|Jean McFadyen
 This Ole House|TTBB|David Wright
@@ -18902,6 +22533,7 @@ This Ole House|TTBB|Kevin Keller
 This Ole House|TTBB|Kevin Koehl
 This Ole House|TTBB|Larry Triplett
 This Ole House|TTBB|Walter Latzko
+This Ole House/When the Saints Go Marching In Medley|TTBB|Jay Giallombardo
 This One's For The Girls|SSAA|Larry Wright
 This Time Around|SATB|Kohl Kitzmiller
 This Time Around|SSAA|David Briner
@@ -18911,14 +22543,19 @@ This Train/When the Saints Go Marching In|TTBB|Tom Gentry
 This World|SSAA|Tedda Lippincott
 Thong Song/Shake Your booty/Low/Bootylicious/ Baby Got Back Medley|SATB|Deke Sharon
 Thoroughly Modern Millie|SSAA|Nancy Bergman
+Thoroughly Modern Millie / Charleston|SSAA|Nancy Bergman
 Those Chords Will Ring Forever|TTBB|Jim Clancy
+Those Days Are Over|TTBB|Joe Johnson
 Those Good Old Fluffy Ruffle Days|TTBB|Gregory Lyne
 Those Lazy Hazy Crazy Days Of Summer|SATB|David Briner
 Those Lazy Hazy Crazy Days Of Summer|SSAA|Marge Bailey
 Those Lazy Hazy Crazy Days Of Summer|TTBB|Jim Shubert
 Those Lazy Hazy Crazy Days Of Summer|TTBB|Mark Goodney
+Those Lazy, Hazy, Crazy Days of Summer|SSAA|Marge Bailey
+Those Magnificent Men in Their Flying Machines|SSAA|Ann Minihane
 Those Magnificent Men In Their Flying Machines|TTBB|Todd Troutman
 Those Magnificent Men In Their Flying Machines|TTBB|Tom Roberts
+Those Magnificent Men in There Flying Machines|TTBB|Tony Searle
 Those Old Fashioned Songs|TTBB|Ernie Johansen
 Those Old Midnight Blues|TTBB|Dan Wilson
 Those Old-Time Sing-Along Songs|TTBB|Tom Gentry
@@ -18943,6 +22580,7 @@ Three Cigarettes In An Ashtray|SATB|Kevin Koehl
 Three Coins In The Fountain|SSAA|Walter Latzko
 Three Coins In The Fountain|TTBB|David Ebersole
 Three Coins In The Fountain|TTBB|Walter Latzko
+Three Guy Medley|SSAA|Tom Gentil
 Three Lions (Football's Coming Home)|TTBB|Liz Garnett
 Three Little Birds|SATB|Manoj Padki
 Three Little Words|TTBB|Dan Wessler
@@ -18950,6 +22588,7 @@ Three Little Words|TTBB|Walter Latzko
 Three O'Clock In The Morning|TTBB|Walter Latzko
 Three Plays For A Quarter Medley|TTBB|Steve Jamison
 Three Plays For A Quarter Show Opener Medley|TTBB|Marty Israel
+Three Steps To Heaven|TTBB|Steve Hall
 Three Times A Lady|TTBB|Rob Hopkins
 Three Wonderful Letters from Home|TTBB|Kirk Roose
 Thriller|SATB|Deke Sharon
@@ -18961,9 +22600,12 @@ Thriller|TTBB|Dan Naumann
 Throne of Grace|TTBB|Tom Gentry
 Through a Long and Sleepless Night|TTBB|Kevin Keller
 Through the Eyes of Love|TTBB|Jay Giallombardo
+Through The Eyes Of Love|TTBB|John Hohl
 Through The Years|SSAA|Diana DeBruycker
 Through The Years|SSAA|Judy Vidal
 Through The Years|SSAA|Tedda Lippincott
+Through The Years|TTBB|Adam Reimnitz
+Through The Years|TTBB|Gene Puerling
 Through The Years|TTBB|Jay Giallombardo
 Through The Years|TTBB|Joe Liles
 Throw Me Something, Mister|TTBB|Ed Waesche
@@ -18974,8 +22616,10 @@ Thunder And Lightning|SSAA|Ã…se Hagerman
 Thunderball|TTBB|Anders Lindqvist
 Thunderball|TTBB|Manoj Padki
 Thursday|SSAA|Fran Carter
+Ticket to Ride|SSAA|Lynnell Diamond
 Ticket To Ride|SSAA|Kevin Keller
 Ticklish Reuben (The Laughing Song)|TTBB|Mason Eubank
+Tico Tico|SSAA|Cheryl Dick
 Tico-Tico|SSAA|Cheryl Suhr
 Tie a Yellow Ribbon 'Round The Ole Oak Tree|SSAA|Tedda Lippincott
 Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Douglas Smith
@@ -18991,14 +22635,19 @@ Tie Me To Your Apron Strings Again|TTBB|Tom Gentry
 Tiger Rag|SSAA|Nancy Bergman
 Tiger Rag|TTBB|Al Downey
 Tiger Rag|TTBB|Stan Harris
+Tiger Rag|TTBB|Will Hamblet
 Tightrope|SSAA|Sheryl Neal
 Tijuana Jail|TTBB|Donn Updegrove
+Tijuana Taxi|SSAA|Renee Craig
 Til I Hear You Sing|SATB|Theo Hicks
+Til I Hear You Sing|SSAA|June Berg
 Til I Hear You Sing|SSAA|Theo Hicks
 Til I Hear You Sing|TTBB|Theo Hicks
 Til The Season Comes Round Again|SSAA|June Berg
 Til The Season Comes Round Again|SSAA|Sylvia Alsbury
 Til The Season Comes Round Again|TTBB|Adam Reimnitz
+Til There Was You|SSAA|Roger Payne
+Til There Was You|TTBB|Bob Rund
 Til Tomorrow (from "Fiorello!")|TTBB|Bob Meyer
 Til Tomorrow Comes|SSAA|Jay Giallombardo
 Til Tomorrow Comes|TTBB|Jay Giallombardo
@@ -19016,11 +22665,13 @@ Till The Day|TTBB|Bill Diekema
 Till The End Of Time|TTBB|Walter Latzko
 Till Then|SSAA|Stephanie G. Gentry
 Till Then|SSAA|Walter Latzko
+Till Then|TTBB|Ig Jakovac
 Till Then|TTBB|Mark Goodney
 Till There Was You|SSAA|Debbie Keretz
 Till There Was You|SSAA|Diane Butler
 Till There Was You|SSAA|Mark Burnip
 Till There Was You|SSAA|Roger Payne
+Till There Was You|TTBB|Bob Rund
 Till There Was You|TTBB|David Naddor
 Till There Was You|TTBB|Ellsworth Morey
 Till There Was You|TTBB|Joe Mannherz
@@ -19032,6 +22683,7 @@ Till There Was You (from "The Music Man")|SSAA|Roger Payne
 Till There Was You (from "The Music Man")|TTBB|Roger Payne
 Till There Was You (from "The Music Man")|TTBB|Willis Diekema
 Till There Was You (from The Music Man)|TTBB|Robert Rund
+Till We Meet Again|SSAA|Ig Jakovac
 Till We Meet Again|TTBB|Louis Perry
 Timber|SSAA|Deke Sharon
 Time After Time|SATB|Deke Sharon
@@ -19039,10 +22691,12 @@ Time After Time|SSAA|David Wright
 Time After Time|SSAA|Deke Sharon
 Time After Time|SSAA|Ed Waesche
 Time After Time|SSAA|Jim Arns
+Time After Time|SSAA|Joan Adler
 Time After Time|SSAA|June Berg
 Time After Time|SSAA|Mark Jennings
 Time After Time|SSAA|Norma Andersen
 Time After Time|TTBB|Alex Morris
+Time After Time|TTBB|Buzz Haeger
 Time After Time|TTBB|David Wright
 Time After Time|TTBB|Ed Waesche
 Time After Time|TTBB|Mark Goodney
@@ -19052,7 +22706,10 @@ Time After Time|TTBB|the Barbershop Harmony Society
 Time After Time|TTBB|Tom Gentry
 Time After Time|TTBB|Tony Crain
 Time After Time|TTBB|Warren 'Buzz' Haeger
+Time After Time - Arns|SSAA|Jim Arns
+Time After Time - Berg|SSAA|June Berg
 Time For Livin'|TTBB|Larry Wright
+Time For You|SSAA|Joe Liles
 Time Heals Everything|SATB|Alexander Ronneburg
 Time Heals Everything|SATB|Joe Mannherz
 Time In A Bottle|SATB|Joey Minshall
@@ -19070,11 +22727,14 @@ Time Of My Life|SSAA|Debbie Keretz
 Time Of Our Lives|SATB|Nicholas Wright
 Time Of Season/What's Your Name|SATB|Deke Sharon
 Time To Dance|TTBB|SPEBSQSA
+Time To Say Goodbye|TTBB|Gary Lewis
+Time Waits for No One|SSAA|Nancy Bergman
 Time Warp (from The Rocky Horror Show)|TTBB|Melody Hine
 Time Was|SSAA|Brent Graham
 Time Was|SSAA|Debbie Keretz
 Time Was|SSAA|Tedda Lippincott
 Time Was|TTBB|Brent Graham
+Time Was|TTBB|Mark Hale
 Timeless To Me|SATB|Dan Mulligan
 Timeless To Me|SATB|Deke Sharon
 Timeless To Me|TTBB|Dom Finetti
@@ -19082,6 +22742,7 @@ Timeless To Me|TTBB|Steve Delehanty
 Timshel|SATB|Katie Gillis & Katie Macdonald
 Timshel|SSAA|Katie Gillis & Katie Macdonald
 Timshel|TTBB|Katie Gillis & Katie Macdonald
+Tin Roof Blues|SSAA|Renee Craig
 Tin Roof Blues|TTBB|Don Gray
 Tin Roof Blues (TTBB) (arr. Gray) - Old Version|TTBB|Don Gray
 Tiny Toons Around The World|TTBB|Elling Sagen
@@ -19089,6 +22750,7 @@ Tired Hands|TTBB|Dennis Driscoll
 Tired Of Me|SSAA|Burt Szabo
 Tired Of Me|TTBB|Burt Szabo
 Tired Of Me|TTBB|Dennis Driscoll
+Tired of the South|TTBB|Unspecified
 Titanium|SATB|Nicholas Wright
 Titanium|SSAA|David Wright
 Titanium|SSAA|Deke Sharon
@@ -19096,6 +22758,7 @@ Titanium|SSAA|Nicholas Wright
 Titanium|TTBB|David Wright
 Titanium|TTBB|Deke Sharon
 Titanium|TTBB|Nicholas Wright
+To a Swimmin' Hole with a Fishin' Pole|SSAA|Rich Hasty
 To Be Loved|SSAA|Jay Giallombardo
 To Be Loved|TTBB|Jay Giallombardo
 To Build A Home|TTBB|Nicholas Wright
@@ -19110,6 +22773,7 @@ To Let A Good Thing Die|TTBB|Gabriel Lawson
 To Let A Good Thing Die|TTBB|Kohl Kitzmiller
 To Love and to be Loved|TTBB|Kevin Keller
 To Make You Feel My Love|SSAA|Dianne Goldrick
+To Make You Feel My Love|SSAA|Hari Birtles
 To Make You Feel My Love|SSAA|Joey Minshall
 To Make You Feel My Love|SSAA|Liz Garnett
 To Make You Feel My Love|TTBB|Aaron Dale
@@ -19124,6 +22788,7 @@ To Tirzah|SATB|David Avshalomov
 To Where You Are|SSAA|Tom Gentry
 To Where You Are|TTBB|Simon Arnott
 To Where You Are|TTBB|Tom Gentry
+Today|SSAA|Jay Wright
 Today|TTBB|David Wright
 Today|TTBB|Gerald Wright
 Today|TTBB|Jim West
@@ -19138,16 +22803,21 @@ Together We Are One|SSAA|Glenda Lloyd
 Together Wherever We Go|SSAA|Betty Oliver
 Together Wherever We Go|SSAA|Jo Lund
 Together Wherever We Go|SSAA|Kevin Keller
+Together Wherever We Go|SSAA|Nancy Bergman
 Together Wherever We Go|TTBB|Dennis Driscoll
 Together Wherever We Go|TTBB|Kevin Keller
 Together Wherever We Go|TTBB|Kohl Kitzmiller
 Together Wherever We Go|TTBB|Rob Campbell
+Together Wherever We Go|TTBB|Walter Latzko
 Together, We Two|SSAA|Joan D 'Agostino
 TOGOM|TTBB|Joe Mannherz
 Tomboy|SSAA|Walter Latzko
 Tomorrow|SATB|Cay Outerbridge
 Tomorrow|SSAA|Michael Gellert
+Tomorrow|TTBB|Dick Floersheimer
+Tomorrow|TTBB|Richard Curtis, Mark Burnip, Zac Booles
 Tomorrow|TTBB|Rick Spencer
+Tomorrow Is Promised to No One|TTBB|Freddy King and Robert Rund
 Tomorrow Is Promised To No One|SSAA|Robert Rund
 Tomorrow Is Promised To No One|TTBB|Robert Rund
 Tomorrow Never Dies|SATB|Deke Sharon
@@ -19157,12 +22827,15 @@ Tomorrow Tonight|SATB|Larry Triplett
 Tomorrow Tonight|SSAA|Larry Triplett
 Tomorrow Tonight|TTBB|Larry Triplett
 Tonight|TTBB|Jay Giallombardo
+Tonight (West Side Story)|SSAA|Jay Giallombardo
+Tonight (West Side Story)|SSAA|Tedda Lippincott
 Tonight I Celebrate My Love|SATB|Liz Garnett
 Tonight We Love|SSAA|Jay Giallombardo
 Tonight We Love|TTBB|Jay Giallombardo
 Tonight You Belong To Me|SSAA|Brent Graham
 Tonight You Belong To Me|TTBB|Brent Graham
 Tonight You Belong To Me|TTBB|Walter Latzko
+Tonight, Tonight|TTBB|Jay Giallombardo
 Too Close For Comfort|SATB|Kohl Kitzmiller
 Too Close For Comfort|SSAA|Kohl Kitzmiller
 Too Close For Comfort|TTBB|Aaron Dale
@@ -19182,6 +22855,7 @@ Too Human|TTBB|Joe Mannherz
 Too Late Now (from ROYAL WEDDING)|SSAA|Becky Cartine
 Too Late Now (from ROYAL WEDDING)|TTBB|Adam Scott
 Too Late Now (from ROYAL WEDDING)|TTBB|Walter Latzko
+Too Long at the Fair|TTBB|Russ Foris
 Too Long At The Fair|TTBB|Bob Benson
 Too Many Fish in the Sea|SSAA|Michael Gellert
 Too Many Kisses In The Summer|TTBB|Paul Engel
@@ -19201,6 +22875,7 @@ Too Marvelous For Words|TTBB|Rob Hopkins
 Too Marvelous For Words|TTBB|Walter Latzko
 Too Much Love Will Kill You|TTBB|Kevin Keller
 Too Old|TTBB|Don Gray
+Too Old To Fall In Love|TTBB|Don Gray
 Too Soon|TTBB|Jim West
 Too Young|SATB|Larry Triplett
 Too Young|SSAA|Larry Triplett
@@ -19214,8 +22889,12 @@ Too Young|TTBB|Tom Gentry
 Too Young|TTBB|Walter Latzko
 Too Young for the Blues|TTBB|Aaron Dale
 Too Young To Go Steady|SATB|Andrew Carolan
+Toora Loora Loora|SSAA|Lynnell Diamond
 Toora Loora Loora|SSAA|Walter Latzko
 Toora Loora Loora|TTBB|David Wright
+Toot Toot Tootsie|SSAA|Carolyn Butler
+Toot Toot Tootsie|SSAA|Nancy Bergman
+Toot Toot Tootsie Goodbye|TTBB|Clay Hine
 Toot, Toot, Tootsie|SSAA|Nancy Bergman
 Toot, Toot, Tootsie|TTBB|Bill Biffle
 Toot, Toot, Tootsie|TTBB|Burt Szabo
@@ -19226,8 +22905,15 @@ Toot, Toot, Tootsie|TTBB|Dennis Burnett
 Toot, Toot, Tootsie|TTBB|Ed Waesche
 Toot, Toot, Tootsie|TTBB|Joe Mannherz
 Toot, Toot, Tootsie|TTBB|Walter Latzko
+Toot, Toot, Tootsie Goodbye/When the Midnight Choo Choo|TTBB|Pete Rupay
 Tootsie / Lady Love Medley|TTBB|Don Gray
+Tootsie/Lady Love Medley|TTBB|Don Gray
+Top Hat White Tie and Tails|TTBB|Ed Waesche
 Top Hat, White Tie And Tails|TTBB|Chris Arnold
+Top Hat, White Tie And Tails|TTBB|Ed Waesche, Chris Arnold
+Top of the World|SATB|Liz Garnett
+Top of the World|SSAA|Don Gray
+Top of the World|SSAA|Joni Bescos
 Top Of The World|SATB|Ken Potter
 Top Of The World|SATB|Vince Peterson
 Top Of The World|SSAA|Joey Minshall
@@ -19255,8 +22941,10 @@ Toxic|TTBB|Alex Morris
 Toxic|TTBB|Deke Sharon
 Toy Song|TTBB|David Wright
 Toyland|SATB|Mel Knight
+Toyland|SSAA|Judy Vidal Renee Craig
 Toyland|SSAA|Nancy Bergman
 Toyland|SSAA|Paul Grimm
+Toyland|SSAA|Renee Craig
 Toyland|TTBB|Burt Szabo
 Toyland|TTBB|Ed Waesche
 Toyland|TTBB|George Hulst
@@ -19268,15 +22956,19 @@ Toyland|TTBB|Joe Mannherz
 Toyland|TTBB|Nancy Bergman
 Traces|SSAA|Debbie Keretz
 Tradition|TTBB|Jay Giallombardo
+Traditional Carol Medley|SSAA|Carolyn Schmidt
 Traffic Jam|SATB|Melody Hine
 Traffic Jam|SSAA|Melody Hine
 Traffic Jam|TTBB|Michael Webber
 Trail Of The Lonesome Pine|TTBB|Jack Baird
+Train-Saints Medley|TTBB|Tom Gentry
 Trains and Boats and Planes|TTBB|Jon Nicholas
 Traitor|SATB|Nicholas Wright
+Tramp Medley|SSAA|Paul Davies
 Tramp! Tramp! Tramp!|SATB|Thomas Degan
 Trampoline|SSAA|Adam Bock
 Transport of Delight|TTBB|Tom Gentry
+Transylvania Mania|TTBB|Aaron Dale
 Transylvania Mania|TTBB|Simon Arnott
 Trashin' The Camp|SATB|Deke Sharon
 Trashin' The Camp|SSAA|Melody Hine
@@ -19300,24 +22992,34 @@ Tri-State Tribute|TTBB|Jim West
 Triangle Love Song|TTBB|Robert Rund
 Tribute|TTBB|Kevin Koehl
 Tribute To The U.S.A.|SSAA|Nancy Bergman
+Tribute to the USA|SSAA|Nancy Bergman
+Tribute To World Peace|TTBB|Jay Giallombardo
 Trick Or Treat|SSAA|Joan D 'Agostino
 Trick Or Treat|TTBB|Dick Floersheimer
+Trickle Trickle|SSAA|Dave Briner
+Trickle Trickle|SSAA|Lorraine Rochefort
 Trickle, Trickle|SSAA|David Briner
+Trickle, Trickle|TTBB|Mel Knight
+Trim Up The Tree|TTBB|Hal Maples
 Trip A Little Light Fantastic|TTBB|Dan Wessler
 Trip A Little Light Fantastic|TTBB|Simon Arnott
 Triplets|TTBB|Tom Gentry
+Trolley Song|SSAA|Renee Craig
 Troublemaker|SATB|Nicholas Wright
 Truckin'|TTBB|Walter Latzko
 True Colors|SATB|Deke Sharon
 True Colors|SATB|Tony Nasto
 True Colors|SSAA|Chris Arnold
 True Colors|SSAA|Deke Sharon
+True Colors|SSAA|Elaine Gain
 True Colors|SSAA|Julie Starr
 True Colors|SSAA|Staffan Paulson
 True Colors|TTBB|David Wright
 True Colors|TTBB|Deke Sharon
 True Colors|TTBB|Ken Potter
 True Colors|TTBB|Staffan Paulson
+True Colours|SSAA|Deke Sharon
+True Colours|TTBB|Bill Heigen
 True Love|SSAA|Val Hicks
 True Love|TTBB|Charles Powers
 True Love|TTBB|Dennis Driscoll
@@ -19333,6 +23035,7 @@ Try|SATB|Deke Sharon
 Try a Little Kindness|SATB|Ig Jakovac
 Try a Little Kindness|TTBB|Ig Jakovac
 Try A Little Tenderness|SSAA|Tom Gentry
+Try A Little Tenderness|SSAA|Unspecified
 Try A Little Tenderness|SSAA|Walter Latzko
 Try A Little Tenderness|TTBB|Ed Waesche
 Try A Little Tenderness|TTBB|Larry Wright
@@ -19353,6 +23056,7 @@ Tulip Medley|SSAA|Jay Giallombardo
 Tulip Medley|TTBB|Jay Giallombardo
 Tulou Tagaloa|SATB|Aaron Dale
 Tulsa Time|SSAA|Molly Clark
+Tumblin' Tumbleweeds|TTBB|Walter Latzko
 Tumbling Tumbleweeds|SSAA|Kay Bromert
 Tumbling Tumbleweeds|TTBB|Burt Szabo
 Tumbling Tumbleweeds|TTBB|Jim Clark
@@ -19360,9 +23064,12 @@ Tumbling Tumbleweeds|TTBB|Jim Hickman
 Tumbling Tumbleweeds|TTBB|Jim Shubert
 Tumbling Tumbleweeds|TTBB|Jon Nicholas
 Tumbling Tumbleweeds|TTBB|Max White
+Tumbling Tumbleweeds|TTBB|Unspecified
 Turn Around|SSAA|Jay Giallombardo
 Turn Around|SSAA|June Dale
 Turn Around|TTBB|Jay Giallombardo
+Turn Around|TTBB|Tom Gentil
+Turn Around, Look at Me|SSAA|Sylvia Alsbury
 Turn Around, Look At Me|TTBB|Gordon Haines
 Turn Back The Universe|TTBB|Jack Baird
 Turn Back The Universe|TTBB|Jay Giallombardo
@@ -19377,10 +23084,13 @@ Turn The Lights Back On|TTBB|Adam Scott
 Turn The Lights Back On|TTBB|Kyle Snook
 Turn Your Eyes Upon Jesus|TTBB|Brent Graham
 Turn Your Eyes Upon Jesus|TTBB|Jeremey Johnson
+Turn Your Radio On|SSAA|Joni Bescos
 Turn Your Radio On|SSAA|Larry Wright
 Turn Your Radio On|TTBB|Burt Staffen
 Turn Your Radio On|TTBB|Larry Wright
 Turn Your Radio On|TTBB|Paul Jorg
+Turn Your Radio On|TTBB|Unspecified
+Turn! Turn! Turn!|SSAA|Jonathan Wikeley
 Tuxedo Junction|SATB|Joe Mannherz
 Tuxedo Junction|SSAA|Carolyn Healey
 Tuxedo Junction|SSAA|Dede Nibler
@@ -19395,26 +23105,37 @@ Tuxedo Junction|TTBB|Jay Giallombardo
 Tuxedo Junction|TTBB|Joe Mannherz
 Tuxedo Junction|TTBB|Larry Wright
 Tuxedo Junction|TTBB|Tom Gentry
+Tuxedo Junction|TTBB|Tony Nasto
 Tuxedo Junction|TTBB|Walter Latzko
+TV Monster|TTBB|Greg Volk
+Twas Only an Irishman's Dream|TTBB|Rennie Cormack
 Twas Only An Irishman's Dream|TTBB|Jack Baird
 Twas Only An Irishman's Dream|TTBB|Sherry Brown
+Twas The Night Before Christmas|SSAA|Nancy Bergman
 Twas The Night Before Christmas|SSAA|Patsee Parker
+Twelve Days After Christmas|SSAA|Nancy Bergman
+Twelve Days After Christmas|SSAA|Sylvia Alsbury
 Twelve Days of Christmas Parody|SSAA|Kay Bromert
 Twenties Dance Medley|SSAA|Tom Gentry
 Twenties Dance Medley|TTBB|Tom Gentry
 Twenties Sing-A-Long|SSAA|Nancy Bergman
+Twenties Singalong|SSAA|Nancy Bergman
 Twentieth Century Baby's Lullaby, That's the|SSAA|Jay Giallombardo
 Twenty Nine Ways to My Baby's Door|SSAA|Deke Sharon
+Twenty Third Psalm|TTBB|Ted Hanna
 Twenty-Third Psalm|TTBB|Kevin Keller
 Twice As Much|TTBB|Mark Goodney
+Twilight Time|SSAA|Mark Hale
 Twilight Time|SSAA|Nancy Bergman
 Twilight Time|TTBB|Brent Graham
+Twilight Time|TTBB|Don Gray
 Twilight Time|TTBB|Jon Nicholas
 Twilight Tone|SSAA|Jo Lund
 Twilight Zone|TTBB|Walter Latzko
 Twinkle Twinkle Little Me|TTBB|Joe Grimme
 Twinkle Twinkle Little Star|SSAA|Tom Gentry
 Twinkle Twinkle Little Star|TTBB|Tom Gentry
+Twist Medley|SSAA|Carole Prietto
 Twisted|SSAA|Tom Gentry
 Twisted|TTBB|Jeremey Johnson
 Twisted|TTBB|Tom Gentry
@@ -19437,6 +23158,7 @@ Two Points For Honesty|TTBB|Deke Sharon
 Two Sleepy People|SATB|Mark Jennings
 Two Sleepy People|TTBB|Luke Stevenson
 Two Strong Hearts|TTBB|Michael Webber
+Two Tickets/Sentimental Gentleman|SSAA|Chari Pernert
 Two Ton Tessie|TTBB|Don Gray
 Two Weeks|SATB|Deke Sharon
 Two Weeks|TTBB|Emily Moriarty
@@ -19457,9 +23179,12 @@ Unchained Melody|SATB|Deke Sharon
 Unchained Melody|SSAA|Connie Nickel
 Unchained Melody|SSAA|Kevin Keller
 Unchained Melody|SSAA|Larry Wright
+Unchained Melody|SSAA|Mary Coffman
 Unchained Melody|SSAA|Mary K. Coffman Music Fund
 Unchained Melody|SSAA|Suzy Lobaugh
+Unchained Melody|TTBB|Dave Strachan
 Unchained Melody|TTBB|David Wright
+Unchained Melody|TTBB|Dennis Driscoll
 Unchained Melody|TTBB|Fran Wilson
 Unchained Melody|TTBB|Jay Giallombardo
 Unchained Melody|TTBB|Jim West
@@ -19472,11 +23197,15 @@ Uncharted|SATB|Nicholas Wright
 Uncle John's Band|TTBB|Deke Sharon
 Uncle Watt's Original Fantascinatin' Roadside Stand|SSAA|Tom Gentry
 Uncle Watt's Original Fantascinatin' Roadside Stand|TTBB|Tom Gentry
+Uncorked|SSAA|Donya Metzger
+Undecided|SATB|David Wright
 Undecided|SSAA|Carolyn Schmidt
 Undecided|SSAA|David Wright
 Undecided|SSAA|Fred King
+Undecided|SSAA|Joyce Stanbery
 Undecided|TTBB|David Wright
 Undecided|TTBB|Dennis Driscoll
+Undecided|TTBB|Ed Waesche
 Undecided|TTBB|Jim Shubert
 Undecided|TTBB|Jim West
 Undecided|TTBB|Scott Kitzmiller
@@ -19501,6 +23230,7 @@ Under The Boardwalk|TTBB|Tom Gentry
 Under The Bridge|SATB|Deke Sharon
 Under The Bridge|TTBB|Deke Sharon
 Under The Mistletoe|SATB|Scott Anderson
+Under the Sea|TTBB|Scott Turnbull
 Under The Sea|SATB|Deke Sharon
 Under The Sea|SATB|Melody Hine
 Under The Sea|SSAA|Jay Giallombardo
@@ -19518,12 +23248,16 @@ Underneath the Tree|SSAA|Joe Mannherz
 Underneath the Tree|SSAA|Simon Arnott
 Underneath the Tree|TTBB|Gabriel Lawson
 Undersea Medley|TTBB|Kirk Roose
+Unexpected Song|SATB|Michael Gellert
 Unfinished Songs|SSAA|June Berg
 Unforgettable|SATB|Deke Sharon
 Unforgettable|SATB|Larry Wright
 Unforgettable|SSAA|Larry Wright
+Unforgettable|SSAA|Lorraine Rochefort
+Unforgettable|SSAA|Mary Coffman
 Unforgettable|SSAA|Mary K. Coffman Music Fund
 Unforgettable|TTBB|Larry Wright
+Unintended|TTBB|Chris MacMartin
 Uninvited|SATB|Bryan W. Pulver
 United We Sing|TTBB|Einar Pedersen
 Unredeemable|SSAA|Melody Hine
@@ -19532,6 +23266,7 @@ Unredeemable|TTBB|Gabriel Lawson
 Unredeemable|TTBB|Kohl Kitzmiller
 Unsaid Things|TTBB|Kevin Keller
 Unstoppable|SSAA|Emily Moriarty
+Until|TTBB|Chris Arnold
 Until I Found You|SATB|Jay Dougherty
 Until I Found You|TTBB|Kevin Koehl
 Until It's Time For You To Go|TTBB|Joe Mannherz
@@ -19562,6 +23297,8 @@ Up On the House Top|SSAA|Carole Prietto
 Up On the House Top|SSAA|Jay Giallombardo
 Up On the House Top|TTBB|Jay Giallombardo
 Up On the House Top|TTBB|Jim West
+Up on the Housetop|SSAA|Nancy Bergman
+Up On the Roof|SSAA|Lorraine Rochefort
 Up On The Roof|SATB|Alex Kaiserman
 Up On The Roof|SATB|Deke Sharon
 Up On The Roof|SATB|Joe Mannherz
@@ -19573,8 +23310,10 @@ Up On The Roof|TTBB|Walter Latzko
 Up Over The Hill|TTBB|Rex Jamieson
 Up the Ladder to the Roof|SATB|Kari Francis
 Up the Ladder to the Roof|SSAA|Michael Gellert
+Up The Ladder To The Roof|SSAA|Mo Field
 Up Where We Belong|SSAA|Walter Latzko
 Up Where We Belong|TTBB|Sam Dabrusin
+Up, Up and Away|SSAA|Marge Bailey
 Up, Up And Away (My Beautiful Balloon)|SATB|Deke Sharon
 Up, Up And Away (My Beautiful Balloon)|SATB|Joe Mannherz
 Up, Up And Away (My Beautiful Balloon)|SATB|Joey Minshall
@@ -19589,6 +23328,7 @@ Upside Down|SSAA|Deke Sharon
 Upside Down|SSAA|Liz Garnett
 Uptempo Folksong (Generic)|SSAA|Susan Kegley
 Uptown Country Woman|SSAA|Larry Wright
+Uptown Funk|TTBB|Steve Wolf
 Uptown Funk!|SATB|Deke Sharon
 Uptown Funk!|SATB|Nicholas Wright
 Uptown Funk!|SSAA|Kohl Kitzmiller
@@ -19597,6 +23337,7 @@ Uptown Funk!|TTBB|Nicholas Wright
 Uptown Girl|TTBB|Bryan W. Pulver
 Uptown Girl|TTBB|Deke Sharon
 Uptown Girl|TTBB|Nicholas Wright
+Use It For Good (Fallulah)|SSAA|Malene Rigtrup
 Use Somebody|SATB|Deke Sharon
 Use Somebody|SSAA|Nicholas Wright
 Use What You Got|TTBB|David Wright
@@ -19617,12 +23358,16 @@ Valerie|SSAA|Liz Garnett
 Valerie|TTBB|Greg Mallett
 Valse|TTBB|Jon Nicholas
 Vampire|SSAA|Kevin Koehl
+Various Themes of Fa-La-La|SSAA|Tedda Lippincott
 Varsity Drag|TTBB|Wesley Jackson
+Vaudeville|SSAA|Nancy Bergman
 Vaudeville (Two Shows A Day...)|SSAA|Nancy Bergman
 Vaya Con Dios|SATB|Kevin Keller
 Vaya Con Dios|SSAA|Kay Bromert
 Vaya Con Dios|SSAA|Kevin Keller
 Vaya Con Dios|TTBB|Kevin Keller
+Vaya Con Dios ( English)|SSAA|Kay Bromert
+Vaya Con Dios ( Spanish)|SSAA|Kay Bromert
 Vegas Medley|TTBB|Tom Gentry
 Vegemite|TTBB|Tom Gentry
 Velvet|SATB|Joe Mannherz
@@ -19632,7 +23377,10 @@ Verge|SATB|Nicholas Wright
 Very Last Day|TTBB|Jon Nicholas
 Very Weird Song|TTBB|Roger Payne
 Via Dolorosa|TTBB|David Wright
+Vic'try Road|TTBB|David Wright
 Vict'ry Polka|TTBB|Ron Middlestaedt
+Vict'ry Road|SSAA|David Wright
+Vict'ry Road|TTBB|David Wright
 Victorious|SATB|Nicholas Wright
 Victors March, The (U of M fight Song)|SATB|Kevin Keller
 Victors March, The (U of M fight Song)|SSAA|Kevin Keller
@@ -19656,6 +23404,7 @@ Vincent (Starry Starry Night)|TTBB|Jon Nicholas
 Vincent (Starry Starry Night)|TTBB|Mark Stevens
 Vincent (Starry Starry Night)|TTBB|Tom Gentry
 Violets Sweet|TTBB|Frank Thorne
+Virginmary Had A Baby Boy|SSAA|Bev Sellers
 Virtual Insanity|SSAA|Deke Sharon
 Viva La Vida|SATB|Aaron Dale
 Viva La Vida|SATB|Deke Sharon
@@ -19663,15 +23412,20 @@ Viva La Vida|SATB|Nicholas Wright
 Viva La Vida|SSAA|Emily Moriarty
 Viva La Vida|TTBB|Anders Lindqvist
 Viva Las Vegas|SSAA|Glenda Lloyd
+Viva Las Vegas|SSAA|Sylvia Alsbury
+Viva Las Vegas|TTBB|Jim Clancy
 VMbarrassment|TTBB|Tom Gentry
 Vo-De-O-Do|TTBB|Gregory Lyne
 Vocal Production|SSAA|Marie Johnson
+Vocal Warmup|TTBB|Barbershop Harmony Society
+Voice Dance|SATB|Greg Jasperse
 Voices|SSAA|Sheryl Neal
 Volare|SSAA|Jo Lund
 Volare|TTBB|Gene Cokeroft
 W.I.t.c.h|SSAA|Emily Moriarty
 Wagon Medley|TTBB|Phil Embury
 Wagon Wheel|TTBB|Aaron Dale
+Wagon Wheel|TTBB|Jonathan Sparks
 Wagon Wheels|TTBB|Aaron Dale
 Wagon Wheels|TTBB|Burt Szabo
 Wagon Wheels|TTBB|Jim Emery
@@ -19681,24 +23435,31 @@ Wahoo|TTBB|Denny Stiers
 Wahoo|TTBB|Earl Moon
 Wahoo|TTBB|Jack Payne
 Wahoo|TTBB|Warren 'Buzz' Haeger
+Waikiki|SSAA|Nancy Bergman
 Wait|TTBB|Nicholas Wright
+Wait 'Til the Sun Shines, Nellie|TTBB|Larry Triplett
 Wait A Bit|TTBB|Simon Arnott
 Wait and See|SATB|Joe Mannherz
 Wait Till The Sun Shines, Nellie|SATB|Larry Triplett
 Wait Till The Sun Shines, Nellie|SSAA|Jan Meyer
 Wait Till The Sun Shines, Nellie|SSAA|Larry Triplett
 Wait Till The Sun Shines, Nellie|SSAA|Walter Latzko
+Wait Till The Sun Shines, Nellie|TTBB|Buzz Haeger
 Wait Till The Sun Shines, Nellie|TTBB|Larry Triplett
 Wait Till The Sun Shines, Nellie|TTBB|Larry Wright
 Wait Till The Sun Shines, Nellie|TTBB|Toban Dvoretsky
 Wait Till The Sun Shines, Nellie|TTBB|Walter Latzko
 Wait Till The Sun Shines, Nellie|TTBB|Warren 'Buzz' Haeger
+Wait till You Get em' Up in the Air Boys|TTBB|John Hohl
 Wait Till You Get Them Up In The Air Boys|TTBB|Don Gray
 Wait Till You Get Them Up In The Air Boys|TTBB|John Hohl
 Wait Till You Get Them Up In The Air Boys|TTBB|Rob Hopkins
+Wait Till You Get Them Up In The Air, Boys|TTBB|Don Gray
 Wait'll You See My Girl|TTBB|Brian Beck
 Waitin' For The Evening Train|TTBB|Mac Huff
 Waitin' For The Light To Shine (from Big River)|TTBB|Joel Guyer
+Waitin' for the Robert E. Lee|TTBB|David Wright
+Waitin' For The Robert E. Lee|SSAA|Brian Beck
 Waitin' For The Train To Come In|SSAA|Barbara McNeill
 Waitin' For The Train To Come In|SSAA|Dorothy Herivel
 Waitin' For The Train To Come In|SSAA|Ig Jakovac
@@ -19706,14 +23467,17 @@ Waitin' For The Train To Come In|SSAA|Mary K. Coffman Music Fund
 Waitin' For The Train To Come In|TTBB|Joe Mannherz
 Waitin' On The Far Side Banks of Jordan|SSAA|Kay Bromert
 Waitin' On The Far Side Banks of Jordan|SSAA|Sheryl Neal
+Waiting At The End Of The Road|TTBB|Burt Szabo
 Waiting For A Star To Fall|TTBB|Mark Stevens
 Waiting For My Real Life To Begin|SSAA|Sam Hubbard
 Waiting For My Real Life To Begin|TTBB|Sam Hubbard
 Waiting For The End|SATB|Nicholas Wright
 Waiting For The End|TTBB|Nicholas Wright
 Waiting For The Guy To Die|SSAA|Margaret Cornell
+Waiting For The Robert E. Lee|TTBB|Jay Giallombardo
 Waiting For The Robert E. Lee|TTBB|Rob Campbell
 Waiting On The World To Change|SATB|Deke Sharon
+Wake Me Up Before You Go-Go|SSAA|Linda Edmondson
 Wake Me Up Before You Go-Go|TTBB|Nick Luna
 Wake Me Up!|SSAA|Deke Sharon
 Wake Me Up!|SSAA|Melody Hine
@@ -19748,12 +23512,15 @@ Walkin' After Midnight|TTBB|Manoj Padki
 Walkin' After Midnight|TTBB|Rick Spencer
 Walkin' My Baby Back Home|SATB|Deke Sharon
 Walkin' My Baby Back Home|SSAA|Larry Wright
+Walkin' My Baby Back Home|TTBB|Dave Briner, Buzz Haeger, Bob Shami
 Walkin' My Baby Back Home|TTBB|Don Reeves
 Walkin' My Baby Back Home|TTBB|Larry Wright
 Walkin' My Baby Back Home|TTBB|Louis Perry
 Walkin' My Baby Back Home|TTBB|M. Stollen
+Walkin' My Baby Back Home|TTBB|Val Hicks
 Walkin' My Baby Back Home / When My Sugar Walks Down the Street (Medley)|TTBB|David Briner
 Walkin' With My Sweetness|TTBB|Brian Beck
+Walkin' With My Sweetness (Down Among The Sugar Cane)|SSAA|Brian Beck
 Walking After Midnight|TTBB|Neil Cerutti
 Walking in Memphis|SATB|Deke Sharon
 Walking in Memphis|TTBB|Deke Sharon
@@ -19762,6 +23529,8 @@ Walking In The Air|SSAA|Carole Prietto
 Walking In The Air|SSAA|Emily Moriarty
 Walking In The Air|TTBB|Deke Sharon
 Walking In The Air|TTBB|Emily Moriarty
+Walking My Baby Back Home (Boston Common Version)|TTBB|Val Hicks
+Walking My Baby Back Home (Society Stock Version)|TTBB|Val Hicks
 Walking On Sunshine|SATB|Deke Sharon
 Walking On Sunshine|SSAA|Aaron Dale
 Walking On Sunshine|SSAA|Corinna Garriock
@@ -19769,6 +23538,8 @@ Walking On Sunshine|SSAA|Deke Sharon
 Walking On Sunshine|SSAA|Liz Garnett
 Walking On Sunshine|TTBB|Aaron Dale
 Walking On Sunshine|TTBB|Grant Goulding
+Waltz For Debbie|TTBB|Joe Johnson
+Waltz for Debby|TTBB|Joe Johnson
 Waltz Me Around Again, Willie|TTBB|Earl Moon
 Waltz Me Around Again, Willie|TTBB|Tom Gentry
 Waltz You Saved For Me|TTBB|Jim Stenson
@@ -19779,18 +23550,22 @@ Waltzing Matilda|TTBB|Linc Abbott
 Waltzing Matilda|TTBB|Tom Gentry
 Wand'rin' Star|TTBB|J Rae Jamieson
 Wandering Boy|TTBB|Adam Bock
+Wandrin' Star|TTBB|Unspecified
 Wang Wang Blues|TTBB|Tom Gentry
 Wannabe|SSAA|Erica Kelch-Slesnick
 Wannabe|TTBB|Deke Sharon
 Wanted Dead Or Alive|SATB|Jon Nicholas
 Wanted Dead Or Alive|SATB|Nicholas Wright
+Wanting Memories|SSAA|Ysaye M Barnwell
 War Eagle|SSAA|Joyce Glover
 Warm|SATB|Joe Mannherz
 Warm|SSAA|Joe Mannherz
 Warm|TTBB|Joe Mannherz
 Warm And Fuzzy|SSAA|Jay Giallombardo
+Warm And Fuzzy|SSAA|Pete Benson
 Warm And Fuzzy|SSAA|Peter Benson
 Warm And Fuzzy|TTBB|Jay Giallombardo
+Warm And Fuzzy|TTBB|Pete Benson
 Warm And Fuzzy|TTBB|Peter Benson
 Warm-Ups|SSAA|Jo Lund
 Warriors|TTBB|Nicholas Wright
@@ -19836,11 +23611,14 @@ Way You Look Tonight|SSAA|Tom Gentry
 Way You Look Tonight|TTBB|Deke Sharon
 Way You Look Tonight|TTBB|Joe Mannherz
 Way You Look Tonight|TTBB|Larry Wright
+Way You Look Tonight|TTBB|Mark Hale
 Way You Look Tonight|TTBB|Tom Gentry
 Wayfaring Stranger|SATB|Kevin Keller
 Wayfaring Stranger|SSAA|Kevin Keller
+Wayfaring Stranger|TTBB|Dan Tice
 Wayfaring Stranger|TTBB|Kevin Keller
 Wayfaring Stranger|TTBB|Paul Jorg
+We All Are Here|SSAA|C. Hayes
 We All Need Saving|TTBB|Deke Sharon
 We All Need Saving|TTBB|Jeremey Johnson
 We All Stand Together|SSAA|Fran Carter
@@ -19848,11 +23626,16 @@ We All Stand Together|TTBB|Rob Campbell
 We Are A Beauty Shoppe Quartette|SSAA|Marie Johnson
 We Are Climbing Jacob's Ladder|TTBB|Paul Jorg
 We Are Family|SSAA|Anna-Maria Nystrom
+We Are Family|SSAA|Anna-Marie Nystrom
 We Are Family|SSAA|Liz Garnett
+We Are Family|SSAA|Tedda Lippincott
+We Are Family (Nystrom)|SSAA|Anna-Marie Nystrom
 We Are In Love|TTBB|Adam Scott
 We Are In Love|TTBB|Dan Wessler
 We Are Never Ever Getting Back Together|SSAA|Nicholas Wright
 We Are Never Ever Getting Back Together|TTBB|Nicholas Wright
+We Are One|SSAA|Jim Arns
+We Are One|SSAA|Sharon Holmes
 We Are Santa's Elves|TTBB|Kevin Keller
 We Are The Champions|SSAA|Jay Giallombardo
 We Are The Champions|TTBB|Jay Giallombardo
@@ -19860,12 +23643,15 @@ We Are The Senior Moments|TTBB|Jim Shubert
 We Are The World|SATB|Kevin Keller
 We Are The World|SSAA|Kevin Keller
 We Are The World|TTBB|Mark Stevens
+We Are The World (6 part)|SSAA|Kevin Keller
+We Are Two|SSAA|Joe Liles
 We Are Young|SATB|Deke Sharon
 We Are Young|SATB|Nicholas Wright
 We Built This City|SATB|Mark Stevens
 We Built This City|SSAA|Melody Hine
 We Built This City|TTBB|Mark Stevens
 We Can Be Kind|SSAA|Michael Gellert
+We Can Do It|SSAA|Lynnell Diamond
 We Can Work It Out|SATB|Anders Lindqvist
 We Can Work It Out|SSAA|Carolyn Schmidt
 We Can Work It Out|SSAA|Jay Giallombardo
@@ -19878,6 +23664,8 @@ We Don't Talk About Bruno|TTBB|Nicholas Wright
 We Gather Together|TTBB|Jon Nicholas
 We Go Together|SSAA|Carolyn Schmidt
 We Go Together|SSAA|Jo Lund
+We Go Together|SSAA|Unspecified
+We Go Together (YWIH)|SSAA|Carolyn Schmidt
 We Got Love|SSAA|Lyndal Thorburn
 We Got The World/Timber/Wrecking Ball|SSAA|Deke Sharon
 We Got Us|SATB|Kevin Keller
@@ -19888,15 +23676,19 @@ We Gotta Get Out Of This Place|SSAA|Glenda Lloyd
 We Have This Moment|SSAA|Doris Twardosky
 We Just Couldn't Say Goodbye|SSAA|Carole Prietto
 We Just Couldn't Say Goodbye|TTBB|Howie Sponseller
+We Kinda Miss Those Good Old Songs|TTBB|Lou Perry
 We Kinda Miss Those Good Old Songs|TTBB|Louis Perry
 We Kiss In A Shadow|TTBB|David Wright
 We Live On Borrowed Time|SSAA|Tedda Lippincott
 We Make A Beautiful Pair|SSAA|Marge Bailey
 We Meet Again|TTBB|Mark Burnip
+We Need a Little Christmas|TTBB|Anita Kerr
+We Need a Little Christmas|TTBB|Clay Hine
 We Need a Little Christmas|TTBB|Dave Briner
 We Need A Little Christmas|SATB|Deke Sharon
 We Need A Little Christmas|SATB|Melody Hine
 We Need A Little Christmas|SSAA|Connie Nickel
+We Need A Little Christmas|SSAA|Dave Briner
 We Need A Little Christmas|SSAA|Jim Massey
 We Need A Little Christmas|SSAA|Jo Lund
 We Need A Little Christmas|SSAA|June Berg
@@ -19908,11 +23700,15 @@ We Need A Little Christmas|TTBB|Gabriel Lawson
 We Need A Little Christmas|TTBB|Jon Nicholas
 We Need A Little Christmas|TTBB|Kay Bromert
 We Need A Little Christmas|TTBB|Nancy Bergman
+We Need A Little Christmas (Bergman)|SSAA|Nancy Bergman
+We Need A Little Christmas (Massey)|SSAA|Jim Massey
 We Never Really Say Goodbye|TTBB|David Wright
 We Owned The Night|SATB|Nicholas Wright
 We Rise Again|SSAA|Tedda Lippincott
 We Rise Again|SSAA|Tom Gentry
+We Rise Again|TTBB|Tedda Lippincott
 We Rise Again|TTBB|Tom Gentry
+We Rise Again (alt. tag)|SSAA|Tedda Lippincott
 We Shall Overcome|SATB|Deke Sharon
 We Shall Overcome|SSAA|David Wright
 We Shall Overcome|TTBB|David Wright
@@ -19920,6 +23716,8 @@ We Sing That They Shall Speak|TTBB|Barbershop Harmony Society
 We Sing That They Shall Speak|TTBB|Clarence Burgess
 We The People|TTBB|Derric Johnson
 We The People (Parody)|TTBB|Clay Hine
+We Three|SSAA|Ig Jakovac
+We Three|TTBB|Walter Latzko
 We Three (My Echo, My Shadow and Me)|SSAA|Kay Bromert
 We Three Kings|SSAA|Carolyn Johnson
 We Three Kings|SSAA|Jay Giallombardo
@@ -19927,8 +23725,11 @@ We Three Kings|TTBB|Dan Wessler
 We Three Kings|TTBB|Deke Sharon
 We Three Kings|TTBB|Jay Giallombardo
 We Three Kings|TTBB|Jon Nicholas
+We Three Kings|TTBB|Patrick Rose
+We Three Kings (solo)|TTBB|Jon Nicholas
 We Three Kings / God Rest Ye Merry Medley|TTBB|Paul Jorg
 We Will Rock You|TTBB|Jay Giallombardo
+We Wish You a Merry Christmas|TTBB|Barbershop Harmony Society
 We Wish You A Merry Christmas|SATB|David Harrington
 We Wish You A Merry Christmas|SATB|Deke Sharon
 We Wish You A Merry Christmas|SATB|Joe Mannherz
@@ -19943,6 +23744,7 @@ We Wish You A Merry Christmas|SSAA|Liz Garnett
 We Wish You A Merry Christmas|SSAA|Marie Johnson
 We Wish You A Merry Christmas|SSAA|Marsha Zwicker
 We Wish You A Merry Christmas|SSAA|Nancy Bergman
+We Wish You A Merry Christmas|SSAA|Renee Craig
 We Wish You A Merry Christmas|TTBB|David Harrington
 We Wish You A Merry Christmas|TTBB|Derric Johnson
 We Wish You A Merry Christmas|TTBB|Jim West
@@ -19957,6 +23759,7 @@ We'd Make A Peach Of A Pair|TTBB|Jim Shubert
 We'd Rather Be With You|TTBB|Walter Latzko
 We'll Be A Dream|TTBB|Deke Sharon
 We'll Be Right Back|TTBB|Jim West
+We'll Be Seeing You|SSAA|Renee Craig
 We'll Be Seeing You/Come Back And See Us|SSAA|Larry Wright
 We'll Be Seeing You/Come Back And See Us|TTBB|Larry Wright
 We'll Be Seeing You/Goody Goodbye|SSAA|Larry Wright
@@ -19965,7 +23768,9 @@ We'll be together again|SATB|Robert Rund
 We'll be together again|SATB|Scott Kitzmiller
 We'll be together again|SSAA|Robert Rund
 We'll be together again|TTBB|Robert Rund
+We'll Be Together Again|TTBB|Richard Loebakka
 We'll Bring the World his Truth|TTBB|Aaron Dale
+We'll Gather Lilacs|SSAA|Lynnell Diamond
 We'll Have A Jubilee In My Old Kentucky Home|SATB|Larry Triplett
 We'll Have A Jubilee In My Old Kentucky Home|SSAA|Larry Triplett
 We'll Have A Jubilee In My Old Kentucky Home|TTBB|Burt Szabo
@@ -19975,6 +23780,7 @@ We'll Have A Jubilee In My Old Kentucky Home|TTBB|Rob Campbell
 We'll have to Pass the Apples/Little Bit of Bad Medley|TTBB|Jay Giallombardo
 We'll Meet Again|SATB|Hannah Briggs
 We'll Meet Again|SATB|Robert Rund
+We'll Meet Again|SSAA|Carolyn Healey
 We'll Meet Again|SSAA|Nancy Bergman
 We'll Meet Again|SSAA|Robert Rund
 We'll Meet Again|SSAA|Sam Hubbard
@@ -19982,6 +23788,7 @@ We'll Meet Again|SSAA|Tedda Lippincott
 We'll Meet Again|SSAA|Tom Gentry
 We'll Meet Again|TTBB|Earl Moon
 We'll Meet Again|TTBB|Kirk Roose
+We'll Meet Again|TTBB|Lou Perry
 We'll Meet Again|TTBB|Louis Perry
 We'll Meet Again|TTBB|Mark Burnip
 We'll Meet Again|TTBB|Nancy Bergman
@@ -19992,13 +23799,17 @@ We'll Sing Another Jolson Song|TTBB|Burt Szabo
 We're A Couple of Misfits|SATB|Kevin Keller
 We're A Couple of Misfits|TTBB|Kevin Keller
 We're All Alone|SSAA|Takako Fuke
+We're All In This Together|SSAA|Lynnell Diamond
 We're Behind You All the Way|TTBB|Burt Szabo
 We're Glad You're Here|TTBB|Jeremey Johnson
 We're Gonna Change the World|SSAA|Liz Garnett
+We're Harmony We're Strong|SSAA|Russ Foris
+We're Harmony, We're Strong|SSAA|Unspecified
 We're Here For a Good Time (Not a Long Time)|SSAA|Joey Minshall
 We're Here For a Good Time (Not a Long Time)|TTBB|Joey Minshall
 We're Number One|SSAA|Tom Gentry
 We're Number One|TTBB|Tom Gentry
+We're off to see the wizard|TTBB|Lloyd Steinkamp
 We're Off To See The Wizard|SSAA|Kevin Keller
 We're Off To See The Wizard|SSAA|Nancy Bergman
 We're Off To See The Wizard|TTBB|Kevin Keller
@@ -20008,6 +23819,7 @@ We're On Top|SSAA|Tedda Lippincott
 We're the Children/Harmonize the World|SSAA|David Wright
 We're the Children/Harmonize the World|SSAA|Nancy Bergman
 We're Through|SSAA|Gene Cokeroft
+We're Working Our Way Through College|TTBB|Walter Latzko
 We've Got A World That Swings|SSAA|Steve Tramack
 We've Got A World That Swings|TTBB|Melody Hine
 We've Only Just Begun|SSAA|Diana DeBruycker
@@ -20016,6 +23828,9 @@ We've Only Just Begun|TTBB|Mark Burnip
 We've Only Just Begun|TTBB|Mark Stevens
 We've Only Just Begun|TTBB|Walter Latzko
 Wear A Corset (Parody)|SSAA|Carolyn Johnson
+Wedding Bells|TTBB|Alan Siegal
+Wedding Bells|TTBB|David Wright
+Wedding Bells (Are Breaking Up That Old Gang Of Mine)|TTBB|David Wright
 Wedding Bells Are Breaking Up That Old Gang Of Mine|SSAA|David Wright
 Wedding Bells Are Breaking Up That Old Gang Of Mine|SSAA|Jo Lund
 Wedding Bells Are Breaking Up That Old Gang Of Mine|SSAA|Walter Latzko
@@ -20037,6 +23852,8 @@ Wedding Song|SSAA|Tom Gentry
 Wedding Song|TTBB|Rob Campbell
 Wedding Song|TTBB|Tom Gentry
 Wedding Song (There is Love)|TTBB|Jim West
+Weekend in New England|SSAA|Ann Minihane
+Weekend in New England|TTBB|Bob Mattes
 Weekend In New England|SATB|Kevin Koehl
 Weekend In New England|SSAA|Carolyn Schmidt
 Weekend In New England|SSAA|David Wright
@@ -20057,6 +23874,7 @@ Welcome Home|SSAA|Kristina Roper
 Welcome Home|TTBB|Kirk Young
 Welcome Home|TTBB|Rowena Harper
 Welcome Song|SSAA|Gene Cokeroft
+Welcome Song (Parody of the Irish Blessing)|TTBB|Barbershop Harmony Society
 Welcome To Duloc|TTBB|Ed Howard
 Welcome To Duloc|TTBB|Michael Webber
 Welcome To My Nightmare|SSAA|Melody Hine
@@ -20075,8 +23893,10 @@ Wells Fargo Wagon|TTBB|Kyle Snook
 Wells Fargo Wagon|TTBB|Walter Latzko
 Welsh National Anthem|TTBB|Diane Butler
 Were You There?|TTBB|Derric Johnson
+West Of The Great Divide|TTBB|Lou Perry
 West Of The Great Divide|TTBB|Louis Perry
 West Side Story Medley|SSAA|Jo Lund
+West Side Story Medley|TTBB|Walter Latzko
 West Texas Town|TTBB|Mason Eubank
 West Virginia University Alma Mater|TTBB|Tom Gentry
 West Virginia University March Medley|TTBB|Tom Gentry
@@ -20090,13 +23910,18 @@ What A Diff'rence a Day Makes|TTBB|Adam Reimnitz
 What A Difference A Day Made|SSAA|Becky Cartine
 What A Difference A Day Made|TTBB|Adam Reimnitz
 What A Difference A Day Made|TTBB|Eric Ruthenberg
+What A Difference A Day Makes|TTBB|Adam Reimnitz
+What a Dream Can Do|SSAA|Steve Delehanty
 What A Friend We Have In Jesus|TTBB|Paul Jorg
 What A Friend We Have In Jesus Medley|TTBB|Burt Szabo
 What A Glorious Night|TTBB|Gabriel Lawson
 What A Merry Christmas Tree|TTBB|Derric Johnson
+What A Wonderful Daddy You'd Be|SSAA|Lorraine Rochefort
 What A Wonderful Day|TTBB|Mervin Keedy
 What A Wonderful Pal You Are|TTBB|Kirk Roose
 What A Wonderful Wedding That Will Be|TTBB|Joe Liles
+What a Wonderful World|SSAA|Laura Edmondson
+What a Wonderful World|TTBB|Russ Foris
 What A Wonderful World|SATB|Bryan W. Pulver
 What A Wonderful World|SSAA|Bob Long
 What A Wonderful World|SSAA|Cheryl Suhr
@@ -20111,6 +23936,7 @@ What A Wonderful World|SSAA|Marge Bailey
 What A Wonderful World|SSAA|Michael Gellert
 What A Wonderful World|SSAA|Peg Millard
 What A Wonderful World|SSAA|Tedda Lippincott
+What A Wonderful World|TTBB|Bill Mitchell
 What A Wonderful World|TTBB|Bob Long
 What A Wonderful World|TTBB|Dan Naumann
 What A Wonderful World|TTBB|David Wright
@@ -20121,9 +23947,13 @@ What A Wonderful World|TTBB|Jim West
 What A Wonderful World|TTBB|Joe Liles
 What A Wonderful World|TTBB|Justin Miller
 What A Wonderful World|TTBB|Marilyn Penketh
+What A Wonderful World|TTBB|Stuart Sides
 What About Us|SSAA|Liz Garnett
 What About Us|SSAA|Nicholas Wright
+What Are You Doing New Year's Eve|SSAA|Bergman/Wheeler
+What Are You Doing New Year's Eve|SSAA|Ruby Rhea
 What Are You Doing New Year's Eve?|SATB|Ben Hawker
+What Are You Doing New Year's Eve?|SATB|Brian Beck
 What Are You Doing New Year's Eve?|SATB|Dan Naumann
 What Are You Doing New Year's Eve?|SATB|Patrick McAlexander
 What Are You Doing New Year's Eve?|SSAA|Brent Graham
@@ -20142,7 +23972,10 @@ What Are You Doing New Year's Eve?|TTBB|Joe Grimme
 What Are You Doing New Year's Eve?|TTBB|Joe Mannherz
 What Are You Doing New Year's Eve?|TTBB|Larry Wright
 What Are You Doing New Year's Eve?|TTBB|Mark Goodney
+What Are You Doing New Year's Eve?|TTBB|Ruby Rhea
 What Are You Doing New Year's Eve?|TTBB|Tom Gentry
+What Are You Doing New Years Eve|TTBB|Aaron Dale
+What Are You Doing New Years Eve?|SSAA|Janice Wheeler
 What Are You Doing The Rest Of Your Life|SATB|Joe Mannherz
 What Are You Doing The Rest Of Your Life|SATB|Kevin Keller
 What Are You Doing The Rest Of Your Life|SSAA|Jenny Mills
@@ -20160,8 +23993,10 @@ What Child Is This|SSAA|Carolyn Johnson
 What Child Is This|SSAA|Jay Giallombardo
 What Child Is This|TTBB|Aaron Dale
 What Child Is This|TTBB|Burt Szabo
+What Child Is This|TTBB|Gary Lewis
 What Child Is This|TTBB|Jay Giallombardo
 What Child Is This|TTBB|Rob Campbell
+What Child Is This Medley|TTBB|Joe Johnson
 What Child is This/A Child of the Poor|SSAA|Kevin Keller
 What Child is This/A Child of the Poor|TTBB|Kevin Keller
 What Christmas Means To Me|TTBB|Kohl Kitzmiller
@@ -20185,6 +24020,7 @@ What Do You Want To Make Those Eyes At Me For|TTBB|Dennis Driscoll
 What Do You Want To Make Those Eyes At Me For|TTBB|Kirk Roose
 What Do You Want To Make Those Eyes At Me For|TTBB|Rob Hopkins
 What Does The Fox Say?|SATB|Kevin Koehl
+What Doesn't Kill You (Stronger)|SSAA|Kevin Keller
 What Ever Happened To Mary?|SSAA|Marie Johnson
 What Ever Happened To Mary?|TTBB|DUPLICATE see 509971 Senter
 What Ever Happened To Mary?|TTBB|Mike Senter Music
@@ -20195,15 +24031,18 @@ What I Did For Love|SSAA|David Wright
 What I Did For Love|SSAA|Jo Lund
 What I Did For Love|SSAA|Joe Mannherz
 What I Did For Love|SSAA|Marsha Zwicker
+What I Did For Love|SSAA|Renee Craig
 What I Did For Love|SSAA|Sylvia Alsbury
 What I Did For Love|TTBB|Brent Graham
 What I Did For Love|TTBB|David Wright
 What I Did For Love|TTBB|Ed Waesche
 What I Did For Love|TTBB|Gabriel Lawson
 What I Did For Love|TTBB|Joe Mannherz
+What I Did For Love|TTBB|Scott Werner
 What I Did For Love|TTBB|Theodore Hicks
 What I Did For Love|TTBB|Walter Latzko
 What I Did For Love|TTBB|Wayne Grimmer
+What I Did For Love (Chorus Line)|SSAA|Ann Minihane Judy Vidal
 What I Did For Love (from Chorus Line)|TTBB|Brent Graham
 What I Did For Love (from Chorus Line)|TTBB|David Wright
 What I Like About You|TTBB|Deke Sharon
@@ -20227,14 +24066,27 @@ What Kind Of Fool Am I|TTBB|Joe Mannherz
 What Kind Of Fool Am I|TTBB|Kevin Keller
 What Kind Of Fool Am I|TTBB|Steve Tramack
 What Kind Of Fool Am I|TTBB|Walter Latzko
+What Kind Of Fool Am I?|TTBB|David Harrington
 What Kind Of Fool Am I?|TTBB|Don Gray
+What Kind Of Fool Am I?|TTBB|John Hohl
+What Kind Of Fool Am I?|TTBB|Kevin Keller
+What Kind Of Fool Am I?|TTBB|Steve Tramack
 What Kind Of King|SSAA|Charlotte Rubio
+What Kind Of King?|TTBB|Shaun Agnew
 What Makes You Beautiful|TTBB|Aaron Dale
 What Makes You Beautiful|TTBB|Dan Wessler
 What Makes You Beautiful|TTBB|Nicholas Wright
+What Makes You Beautiful (One Direction)|SSAA|Shelley Gray
 What More Can A Soldier Give|TTBB|Robert Rund
+What More Can a Soldier Give?|TTBB|Robert Rund
+What More Can a Woman Give|SSAA|Robert Rund
 What More Can a Woman Give?|SSAA|Robert Rund
+What No Women Parody|TTBB|Ed Waesche
+What Shall We Do With the Drunken|TTBB|Sailor Unknown
+What Shall We Do With The Drunken Sailor|SSAA|Robert Shaw
+What Shall We Do With The Drunken Sailor|TTBB|Robert Shaw
 What Strangers Are These|SSAA|Suzy Buerer
+What Sweeter Music|TTBB|Steven Armstrong
 What The Hell|SSAA|Deke Sharon
 What The World Needs Now Is Love|SSAA|Fran Carter
 What The World Needs Now Is Love|SSAA|Liz Garnett
@@ -20244,7 +24096,9 @@ What Was I Made For?|SSAA|Kirk Young
 What Was I Made For?|SSAA|Liz Garnett
 What Was I Made For?|SSAA|Melody Hine
 What Was I Made For?|TTBB|Gabriel Lawson
+What Will I Tell My Heart|SSAA|Linda Edmondson
 What Wondrous Love Is This|SSAA|Kay Bromert
+What Wondrous Love Is This|TTBB|J. Harold Moyer
 What Wondrous Love/O Sacred Head|TTBB|Jay Giallombardo
 What Word Is Sweeter Than Sweetheart|TTBB|William Fisher
 What Would Christmas Be Without A Song|TTBB|Dan Wilson
@@ -20255,6 +24109,12 @@ What Would I Do Without You|SATB|Cay Outerbridge
 What Would I Do Without You|SSAA|Takako Fuke
 What You'd Call A Dream|TTBB|Dan Wessler
 What! No Women?|TTBB|Ed Waesche
+What'll I Do|SSAA|Ed Waesche
+What'll I Do|SSAA|Ed Waesche and Renee Craig
+What'll I Do|SSAA|Renee Craig
+What'll I Do|TTBB|Ed Waesche
+What'll I Do|TTBB|Ed Waesche and Renee Craig
+What'll I Do|TTBB|Second Edition
 What'll I Do?|SATB|Deke Sharon
 What'll I Do?|SATB|Ed Waesche
 What'll I Do?|SATB|Ed Waesche & Renee Craig
@@ -20263,11 +24123,14 @@ What'll I Do?|SSAA|Ed Waesche
 What'll I Do?|SSAA|Renee Craig
 What'll I Do?|TTBB|Dennis Driscoll
 What'll I Do?|TTBB|Ed Waesche
+What'll I Do?|TTBB|Ed Waesche, Renee Craig
 What'll I Do?|TTBB|Renee Craig
+What'll I Do? Will|TTBB|Hamblett
 What's Going On|TTBB|Deke Sharon
 What's Going On|TTBB|Melody Hine
 What's Inside|TTBB|Fran Carter
 What's Left To Sing About Christmas|TTBB|Jim Shubert
+What's More American|TTBB|Fred Polnisch
 What's The Matter With Kids Today?|SSAA|Larry Wright
 What's The Matter With Kids Today?|TTBB|Larry Wright
 What's The Use Of Wond'rin'|TTBB|Michael Webber
@@ -20285,6 +24148,7 @@ Whatever Happened To The Old Songs|TTBB|Tom Gentry
 Whatever Happened To The Old Songs / Tootsie Medley|TTBB|Stewart Peterson
 Whatever Happened to the Old Songs?/Yes Sir, That's My Baby|SSAA|Jay Giallombardo
 Whatever Happened to the Old Songs?/Yes Sir, That's My Baby|TTBB|Jay Giallombardo
+Whatever Happened to the Old Songs/Tootsie|SSAA|June Dale
 Whatever It Takes|SATB|Nicholas Wright
 Whatever It Takes|TTBB|Nicholas Wright
 Whatever Lola Wants|SATB|Austin Shortes
@@ -20302,6 +24166,7 @@ When A Peach In Georgia Weds A Rose From Alabam|TTBB|Jason Ryner
 When A Rambling Rose Goes Rambling Home Again|SSAA|Avis Fellows
 When A Rambling Rose Goes Rambling Home Again|TTBB|Dennis Driscoll
 When Alexander Takes His Ragtime Band To France|TTBB|Steve Jamison
+When Angels Sing|SSAA|Joe Liles
 When Autumn Comes|SATB|Joe Mannherz
 When Autumn Comes|SSAA|Jay Giallombardo
 When Autumn Comes|SSAA|Joe Mannherz
@@ -20355,18 +24220,24 @@ When I Fall In Love|SSAA|Carolyn Schmidt
 When I Fall In Love|SSAA|David Wright
 When I Fall In Love|SSAA|Jay Giallombardo
 When I Fall In Love|SSAA|Jo Lund
+When I Fall In Love|SSAA|Kirby Shaw
 When I Fall In Love|SSAA|Liz Garnett
 When I Fall In Love|TTBB|David Wright
 When I Fall In Love|TTBB|Derric Johnson
 When I Fall In Love|TTBB|Frank Marzocco
 When I Fall In Love|TTBB|Jay Giallombardo
+When I Fall In Love|TTBB|Mac Huff
+When I Fall In Love|TTBB|Rich Hasty
 When I Get Low I Get High|SSAA|Dawn Haggerty
+When I Get My Name in Lights|SSAA|Carole Prietto/June Berg
+When I Get My Name in Lights|SSAA|Mary Ann Wydra
 When I Get My Name In Lights|SSAA|Carole Prietto
 When I Get My Name In Lights|TTBB|Carole Prietto
 When I Get You Alone Tonight|SSAA|Jay Giallombardo
 When I Get You Alone Tonight|SSAA|Tom Gentry
 When I Get You Alone Tonight|TTBB|Jay Giallombardo
 When I Get You Alone Tonight/All Alone Medley|TTBB|Rob Campbell
+When I Grow Too Old to Dream|SSAA|Ardeth Fullmer
 When I Grow Too Old To Dream|SSAA|Nancy Bergman
 When I Grow Too Old To Dream|TTBB|Brent Graham
 When I Grow Too Old To Dream|TTBB|Don Fraser
@@ -20381,12 +24252,14 @@ When I Grow Too Old To Dream|TTBB|Theodore Hicks
 When I Grow Too Old To Dream|TTBB|Tim Wheeler
 When I Grow Too Old To Dream|TTBB|Tom Gentry
 When I Grow too Old to Sing|TTBB|Don Gray
+When I Grow Up|SATB|Tim Minchin
 When I Grow Up|TTBB|Patrick McAlexander
 When I Have Sung My Songs|TTBB|David Zimmerman
 When I Just Wear My Smile|SSAA|Tom Gentry
 When I Just Wear My Smile|TTBB|Tom Gentry
 When I Leave The World Behind|SSAA|Joni Bescos
 When I Leave The World Behind|SSAA|Nancy Bergman
+When I Leave The World Behind|TTBB|Barbershop Harmony Society
 When I Leave The World Behind|TTBB|SPEBSQSA
 When I Leave The World Behind|TTBB|the Barbershop Harmony Society
 When I Lift Up My Head|SATB|David Wright
@@ -20397,6 +24270,7 @@ When I Look At You|SSAA|Theodore Hicks
 When I Look At You|TTBB|Joe Liles
 When I Look At You|TTBB|Rob Hopkins
 When I Look At You (from The Scarlet Pimpernel)|TTBB|Rob Hopkins
+When I Look At You (Scarlet Pimpernel)|SSAA|Judy Vidal
 When I Look In Your Eyes|SATB|Joe Mannherz
 When I Look In Your Eyes|SATB|Larry Triplett
 When I Look In Your Eyes|SSAA|David Wright
@@ -20408,6 +24282,7 @@ When I Look In Your Eyes|TTBB|Joe Mannherz
 When I Look In Your Eyes|TTBB|Jon Nicholas
 When I Look In Your Eyes|TTBB|Larry Triplett
 When I Look In Your Eyes|TTBB|Larry Wright
+When I Look Into Your Eyes|TTBB|Jon Nicholas
 When I Lost You|SSAA|Carolyn Schmidt
 When I Lost You|SSAA|Marie Johnson
 When I Lost You|SSAA|Nancy Bergman
@@ -20419,6 +24294,7 @@ When I Lost You|TTBB|Barbershop Harmony Society
 When I Lost You|TTBB|Burt Szabo
 When I Lost You|TTBB|David Harrington
 When I Lost You|TTBB|Dennis Driscoll
+When I Lost You|TTBB|Ed Waesche
 When I Lost You|TTBB|Inc. SPEBSQSA
 When I Lost You|TTBB|SPEBSQSA
 When I Lost You|TTBB|Steve Tramack
@@ -20426,12 +24302,15 @@ When I Lost You|TTBB|Tom Gentry
 When I Lost You|TTBB|Val Hicks
 When I Lost You|TTBB|Walter Latzko
 When I Lost You (Aging Superheroes Parody)|TTBB|Tom Gentry
+When I Lost You (Parody)|TTBB|Tom Gentry
 When I Rise|SATB|Deke Sharon
 When I Sang The Tenor In That Old Quartet|TTBB|Mel Knight
 When I Sang The Tenor In That Old Quartet|TTBB|Toban Dvoretsky
 When I Sang The Tenor In That Old Quartet|TTBB|Unknown
 When I See All The Lovin' They Waste On Babies|TTBB|Larry Wright
+When I See An Elephant Fly|SSAA|Aaron Dale
 When I See An Elephant Fly|SSAA|Adam Scott
+When I See An Elephant Fly|TTBB|Aaron Dale
 When I See An Elephant Fly|TTBB|Brent Graham
 When I See An Elephant Fly|TTBB|Michael Webber
 When I Sing|SSAA|Tom Gentry
@@ -20453,8 +24332,13 @@ When I Wore My Daddy's Brown Derby|TTBB|Floyd Connett
 When I Wore My Daddy's Brown Derby|TTBB|J Rae Jamieson
 When I Wore My Daddy's Brown Derby|TTBB|SPEBSQSA
 When I Wore My Daddy's Brown Derby (And You Wore Your Mother's Blue Gown)|TTBB|SPEBSQSA
+When I'm 64|SSAA|Carolyn Schmidt
+When I'm 64|SSAA|Charlene Yazurlo
+When I'm 64|SSAA|Tedda Lippincott
+When I'm 64|TTBB|Tom Gentry
 When I'm Cleaning Windows|SATB|Matthew Spinner
 When I'm Gone|TTBB|Michael Webber
+When I'm Gone Medley|SSAA|Jim Arns
 When I'm Not Near The Girl I Love|TTBB|Mark Goodney
 When I'm Sixty Four|SATB|Joe Mannherz
 When I'm Sixty Four|SATB|Tom Gentry
@@ -20470,6 +24354,7 @@ When I'm Sixty Four|SSAA|Tom Gentry
 When I'm Sixty Four|TTBB|Deke Sharon
 When I'm Sixty Four|TTBB|Jon Nicholas
 When I'm Sixty Four|TTBB|Tom Gentry
+When I'm Sixty-Four|SSAA|Tom Gentry
 When I'm With You|SATB|Mark Stevens
 When Irish Eyes Are Smiling|SSAA|Carolyn Johnson
 When Irish Eyes Are Smiling|SSAA|Nancy Bergman
@@ -20483,11 +24368,16 @@ When is Sometime|SATB|Robert Rund
 When is Sometime|SSAA|Robert Rund
 When is Sometime|TTBB|Robert Rund
 When It Comes To Lovin' The Girls / They're All Sweeties Medley|TTBB|Ed Waesche
+When It Comes To Lovin' the Girls/They're All Sweeties Medley|TTBB|Greg Lyne and Ed Wasche
+When It Comes To Lovin' The Girls/They're All Sweeties Medley(Ed Wae|TTBB|Ed Waesche
 When It's Circus Day Back Home|TTBB|Mel Knight
 When It's Night Time Down In Dixieland/Original Dixieland One-Step (Parody)|TTBB|Brent Graham
 When It's Night Time In Dixie Land|TTBB|Earl Moon
+When It's Night Time In Dixieland|TTBB|David Wright
+When It's Night Time In Dixieland|TTBB|Earl Moon
 When It's Night time in Italy, It's Wednesday Over Here|SSAA|Jo Lund
 When It's Sleepy Time Down South|SSAA|Larry Wright
+When It's Sleepy Time Down South|TTBB|Darin Drown
 When It's Sleepy Time Down South|TTBB|Jay Giallombardo
 When It's Sleepy Time Down South|TTBB|Larry Wright
 When It's Springtime In The Rockies|TTBB|Alden Parker
@@ -20498,6 +24388,7 @@ When Johnny Comes Marching Home|TTBB|Dave Stevens
 When Johnny Comes Marching Home|TTBB|David Wright
 When Johnny Comes Marching Home|TTBB|Derric Johnson
 When Johnny Comes Marching Home|TTBB|Jay Giallombardo
+When Johnny Comes Marching Home/Apple Tree Medley|TTBB|Adam Reimnitz
 When Lights Are Low|SSAA|Jan Meyer
 When Lindy Comes Home|TTBB|Jay Giallombardo
 When Lindy Flew The Ocean|TTBB|Joe Liles
@@ -20505,10 +24396,12 @@ When Love Is Gone|TTBB|Dan Wessler
 When Mother Played The Organ|TTBB|Robert Rund
 When Mother Played The Organ|TTBB|Wes Farmer
 When My Baby Smiles At Me|SSAA|Carole Prietto
+When My Baby Smiles At Me|SSAA|Mark Hale
 When My Baby Smiles At Me|TTBB|Burt Szabo
 When My Baby Smiles At Me|TTBB|Gerald Hooper
 When My Baby Smiles At Me|TTBB|Mark Hale
 When My Baby Smiles At Me|TTBB|Walter Latzko
+When My Baby Smiles At Me Medley|SSAA|June Berg
 When My Heart Finds Christmas|SATB|Joe Mannherz
 When My Heart Finds Christmas|TTBB|Steve Tramack
 When My Sugar Walks Down The Street|SSAA|David Harrington
@@ -20518,8 +24411,10 @@ When My Sugar Walks Down The Street|TTBB|Barbershop Harmony Society
 When My Sugar Walks Down The Street|TTBB|David Harrington
 When My Sugar Walks Down The Street|TTBB|Ed Waesche
 When My Sugar Walks Down The Street|TTBB|Walter Latzko
+When October Goes|SATB|Dave Briner
 When October Goes|SATB|Kevin Keller
 When October Goes|SSAA|Bev Sellers
+When October Goes|SSAA|Dave Briner
 When October Goes|SSAA|David Briner
 When October Goes|SSAA|Joe Mannherz
 When October Goes|SSAA|Kevin Keller
@@ -20536,14 +24431,18 @@ When She Loved Me|SATB|Deke Sharon
 When She Loved Me|SSAA|Joe Mannherz
 When She Loved Me|SSAA|June Dale
 When She Loved Me|SSAA|Kevin Keller
+When She Loved Me|SSAA|Randy Newman
 When She Loved Me|SSAA|Rob Campbell
 When She Loved Me|SSAA|Tom Campbell
 When She Loved Me|TTBB|Gabriel Lawson
+When She Loved Me|TTBB|Jim Kahlke
 When She Loved Me|TTBB|Joe Mannherz
 When She Loved Me|TTBB|Kevin Keller
 When She Loved Me|TTBB|Kirk Young
 When She Loved Me|TTBB|Kohl Kitzmiller
 When She Loved Me|TTBB|Luke Stevenson
+When She Loved Me|TTBB|Richard Lewellen
+When She Loved Me|TTBB|Unspecified
 When She Loved Me (from Toy Story 2)|TTBB|Rasmus Krigström
 When She Loved Me (from TOY STORY 2)|TTBB|Jimbob Kahlke
 When Sunny Gets Blue|SATB|Joe Mannherz
@@ -20553,21 +24452,27 @@ When Sunny Gets Blue|SSAA|Sharon Carlson
 When Sunshine Comes Along|TTBB|Dan Wilson
 When Sweet Susie Goes Steppin' By|TTBB|John Hohl
 When That Great Day Comes|TTBB|Val Hicks
+When That Midnight Choo Choo Leaves for Alabam|SSAA|Dot Calvin
+When That Midnight Choo Choo Leaves For Alabam(Jay Giallomb|TTBB|Jay Giallombardo
 When The Bell In The Lighthouse Rings|TTBB|Dennis Driscoll
+When The Blue Of The Night Meets The Gold Of The Day|TTBB|Oliver and Campbell
 When the Call is Rolled up Yonder|SSAA|Kevin Keller
 When the Call is Rolled up Yonder|TTBB|Kevin Keller
 When The Circus Came To Town|TTBB|Burt Szabo
 When The Circus Comes To Town|TTBB|Burt Szabo
 When The Circus Leaves Town|TTBB|Walter Latzko
+When The Girls Grow Up To Be Women|TTBB|Brian Beck
 When The Gold Turns To Gray|TTBB|J Rae Jamieson
 When The Gold Turns To Gray|TTBB|Jay Giallombardo
 When The Grown Up Ladies Act Like Babies|TTBB|Burt Szabo
 When The Grown Up Ladies Act Like Babies|TTBB|Ed Waesche
 When The Idle Poor Become The Idle Rich|TTBB|Mark Goodney
+When The Lights Go On Again (All Over The World)|TTBB|Percy Winedropper
 When The Lights Go On Again (All Over The World)|TTBB|Walter Latzko
 When The Lord Comes Knockin'|TTBB|Derric Johnson
 When the Maple Leaves Were Falling|TTBB|Jay Giallombardo
 When The Meadow Was Bloomin'|TTBB|Tom Gentry
+When the Midnight Choo Choo Leaves for Alabam'|TTBB|Paul Olguin
 When The Midnight Choo Choo Leaves For Alabam'|SSAA|Jay Giallombardo
 When The Midnight Choo Choo Leaves For Alabam'|TTBB|Aaron Dale
 When The Midnight Choo Choo Leaves For Alabam'|TTBB|Burt Szabo
@@ -20576,6 +24481,7 @@ When The Midnight Choo Choo Leaves For Alabam'|TTBB|David Wright
 When The Midnight Choo Choo Leaves For Alabam'|TTBB|Ed Waesche
 When The Midnight Choo Choo Leaves For Alabam'|TTBB|Jay Giallombardo
 When The Midnight Choo Choo Leaves For Alabam'|TTBB|Warren 'Buzz' Haeger
+When The Midnight Choo-Choo Leaves for Alabam'|TTBB|Paul Olguin, Clay Hine
 When The Midnight Choo-Choo Leaves For Alabam'|TTBB|Dave Briner
 When The Moon Comes Over The Mountain|TTBB|Al Burgess
 When The Morning Glories Wake Up In The Morning|TTBB|David Briner
@@ -20585,6 +24491,10 @@ When The Organ Played At Twilight|SSAA|Carole Prietto
 When The Organ Played At Twilight|TTBB|Ernie Johansen
 When The Parson Hands The Wedding Band From Me To Mandy Lee|TTBB|Joe Mannherz
 When The Party's Over|SATB|Alex Morris
+When The Red red Robin|SSAA|Greg Volk
+When The Red Red Robin|SSAA|Dave Briner
+When The Red Red Robin|SSAA|Dot Calvin
+When The Red Red Robin Comes Bob Bob Bobbin Along (Ed Wae|TTBB|Ed Waesche
 When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|David Briner
 When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Dot Calvin
 When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Tom Gentry
@@ -20592,12 +24502,20 @@ When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Blaine Mack
 When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Ed Waesche
 When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Harry Mays
 When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Tom Gentry
+When the Red Red Robin Goes Bob-Bob-Bobbin' Along|SSAA|Dot Calvin
+When The Red, Red Robin Comes Bob, Bob, Bobbin' Along|TTBB|Barbershop Harmony Society
+When The Red, Red Robin Goes Bob, Bob Bobbin'|SSAA|Greg Volk
 When The Rest Of The World Don't Want You|TTBB|Burt Szabo
 When The Right Little Girl Comes Along|TTBB|Burt Szabo
 When the River Meets the Sea|SSAA|Tom Gentry
 When the River Meets the Sea|TTBB|Tom Gentry
+When The Roll Is Called Up Yonder|SSAA|Joe Liles
 When The Roll Is Called Up Yonder|TTBB|Joe Liles
 When The Roses Kissed The Autumn Leaves Goodbye|TTBB|Jack Baird
+When the Saints Go Marchin' In|SSAA|Aileen Nightingale
+When The Saints Go Marchin' In|SSAA|Greg Volk
+When The Saints Go Marchin' In|TTBB|Greg Volk
+When The Saints Go Marchin' In|TTBB|Steven Armstrong
 When The Saints Go Marching In|SATB|Deke Sharon
 When The Saints Go Marching In|SSAA|Aileen Nightingale Music
 When The Saints Go Marching In|SSAA|Russ Foris
@@ -20620,17 +24538,20 @@ When The Whole World Has Gone Back On You|TTBB|Burt Szabo
 When The Wind Was Green|SSAA|Nancy Bergman
 When There Is Someone|SATB|Richard Curtis
 When There Is Someone|TTBB|Richard Curtis
+When There's Love at Home|SSAA|Mo Rector
 When There's Love At Home|SSAA|Tom Gentry
 When There's Love At Home|TTBB|Jim West
 When There's Love At Home|TTBB|Mel Knight
 When There's Love At Home|TTBB|Melvin Knight
 When There's Love At Home|TTBB|Tom Gentry
+When There's Love At Home (There Is Beauty All Around)|TTBB|Mel Knight
 When They Call My Name|SSAA|Diane Landry
 When They're Old Enough To Know Better|TTBB|Burt Szabo
 When They're Old Enough To Know Better|TTBB|Tom Gentry
 When Uncle Joe Plays A Rag On His Banjo|TTBB|Chuck Olsen
 When Uncle Joe Plays A Rag On His Banjo|TTBB|Jack Baird
 When We Dance|TTBB|Nicholas Wright
+When We Were Young|SSAA|Thomas J. West
 When We Were Young|TTBB|Nicholas Wright
 When We're Together|SSAA|Simon Arnott
 When Will I Be Loved|SATB|Deke Sharon
@@ -20657,6 +24578,7 @@ When You Come Back To Me Again|SSAA|Deke Sharon
 When You Come Home|TTBB|Kevin Keller
 When You Find Her Remind Her Of Me|TTBB|Burt Szabo
 When You Long For A Pal Who Would Care|TTBB|Burt Szabo
+When You Look in the Heart of a Rose|TTBB|Greg Lyne
 When You Look In The Heart Of A Rose|SSAA|Gregory Lyne
 When You Look In The Heart Of A Rose|SSAA|Jay Giallombardo
 When You Look In The Heart Of A Rose|TTBB|Dennis Burnett
@@ -20666,6 +24588,7 @@ When You Play With The Heart Of A Girl|TTBB|Burt Szabo
 When You Ring Some Chords With Your Newest Friends|SSAA|Paul Engel
 When You Sang Soprano|TTBB|Burt Szabo
 When You Sang Soprano|TTBB|Jay Giallombardo
+When You Say Nothing at All|TTBB|Peter Mumford
 When You Say Nothing At All|SSAA|Carole Prietto
 When You Say Nothing At All|TTBB|Alex Kaiserman
 When You Say Nothing At All|TTBB|Mark Stevens
@@ -20678,22 +24601,32 @@ When You Were Sweet Sixteen|TTBB|Jack Baird
 When You Were The Blossom Of Buttercup Lane And I Was You're Little Boy Blue|TTBB|Burt Szabo
 When You Whispered I Love You|TTBB|Burt Szabo
 When You Wish upon a Star|TTBB|the Barbershop Harmony Society
+When You Wish Upon a Star|TTBB|Jay Giallombardo
 When You Wish Upon A Star|SATB|Nancy Bergman
 When You Wish Upon A Star|SSAA|Carolyn Schmidt
 When You Wish Upon A Star|SSAA|Jo Lund
+When You Wish Upon A Star|SSAA|JoAnne Ingles
+When You Wish Upon A Star|SSAA|Joni Bescos
 When You Wish Upon A Star|SSAA|Nancy Bergman
 When You Wish Upon A Star|TTBB|Aaron Dale
+When You Wish Upon A Star|TTBB|Barbershop Harmony Society
 When You Wish Upon A Star|TTBB|Brent Graham
 When You Wish Upon A Star|TTBB|Jay Althof
 When You Wish Upon A Star|TTBB|Matthew Gallagher
+When You Wish Upon A Star|TTBB|Russ Young and Frasier Brown
 When You Wish Upon A Star|TTBB|SPEBSQSA
+When You Wish Upon A Star|TTBB|Steven Armstrong
+When You Wish Upon a Star - SSAA|SSAA|Pete King
 When You Wore A Tulip|SSAA|Emily Moriarty
 When You Wore A Tulip|SSAA|Jan Meyer
+When You Wore A Tulip|TTBB|Greg Lyne
+When You Wore A Tulip|TTBB|Greg Volk
 When You Wore A Tulip|TTBB|Harry Buerer
 When You Wore A Tulip|TTBB|Rob Campbell
 When You Wore A Tulip|TTBB|Warren 'Buzz' Haeger
 When You Wore A Tulip (And I Wore A Big Red Rose)|TTBB|Warren Haeger
 When You're A Long, Long Way From Home|TTBB|Burt Szabo
+When You're A Long, Long Way From Home|TTBB|Scott Werner
 When You're A Long, Long Way From Home|TTBB|Walter Latzko
 When You're Over Sixty & Feel Like Sweet Sixteen|SSAA|Tedda Lippincott
 When You're Smiling|SSAA|Brent Graham
@@ -20715,6 +24648,7 @@ When Your Feet Don't Touch The Ground|TTBB|Theodore Hicks
 When Your Hair Has Turned To Silver|TTBB|Ed Waesche
 When Your Hair Has Turned To Silver|TTBB|T. W. De Crow
 When Your Lover Has Gone|TTBB|Dennis Driscoll
+When Your Old Wedding Ring Was New|SSAA|Marge Bailey/Tom Williams
 When Your Old Wedding Ring Was New|TTBB|Archie Steen
 When Your Old Wedding Ring Was New|TTBB|Bob Graham
 When Your Old Wedding Ring Was New|TTBB|Dennis Driscoll
@@ -20722,17 +24656,22 @@ When Your Old Wedding Ring Was New|TTBB|Don Fraser
 When Your Old Wedding Ring Was New|TTBB|Jim Hickman
 When Your Old Wedding Ring Was New|TTBB|Milton Teitel
 When Your Old Wedding Ring Was New|TTBB|Tom Williams
+When Your Old Wedding Ring Was New|TTBB|Unspecified
 When Your Old Wedding Ring Was New|TTBB|Walter Latzko
 When Your Old Wedding Ring Was New/Dear Old Sue|TTBB|Tom Gentry
+Whenever I'm In Your Arms|TTBB|Joe Liles
 Where Are The Roses Of Yesterday|TTBB|Rob Campbell
+Where Are the Simple Joys of Maidenhood|SSAA|Lynnell Diamond
 Where Are The Smiles|TTBB|Mo Rector
 Where Are You|TTBB|Walter Latzko
+Where Are You Christmas|SSAA|Joan D'Agostino
 Where Are You Christmas?|SATB|Dan Naumann
 Where Are You Christmas?|SATB|Joe Mannherz
 Where Are You Christmas?|SSAA|Dan Naumann
 Where Are You Christmas?|SSAA|Joan D 'Agostino
 Where Are You Christmas?|SSAA|Nancy Bergman
 Where Are You Christmas?|TTBB|Dan Naumann
+Where Are You Christmas? (from The Polar Express)|TTBB|Dan Naumann
 Where Can I Go Without You|TTBB|Walter Latzko
 Where Did Robinson Crusoe Go With Friday On Saturday Night|SSAA|Jo Lund
 Where Did Robinson Crusoe Go With Friday On Saturday Night|SSAA|Kay Bromert
@@ -20740,6 +24679,7 @@ Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Gerald Hooper
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|J Rae Jamieson
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Tom Gentry
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Walter Latzko
+Where Did the Circus Go|SSAA|Dorothy Herivel
 Where Did The Circus Go?|SSAA|Dorothy Herivel
 Where Did The Good Times Go?|SSAA|Sonny Steffan
 Where Did You Get That Girl?|TTBB|Larry Wright
@@ -20755,11 +24695,13 @@ Where Do You Start?|SSAA|Michael Gellert
 Where Do You Start?|TTBB|Dan Wessler
 Where Do You Start?|TTBB|Dennis Driscoll
 Where Do You Start?|TTBB|Joe Mannherz
+Where Does the Time Go|SSAA|Nancy Bergman
 Where Does The Time Go?|SSAA|Nancy Bergman
 Where Does The Time Go?|TTBB|Mark Goodney
 Where Everybody Knows Your Name|SATB|Manoj Padki
 Where Everybody Knows Your Name|SSAA|Kevin Keller
 Where Everybody Knows Your Name|SSAA|Larry Wright
+Where Everybody Knows Your Name|SSAA|Lorraine Rochefort
 Where Everybody Knows Your Name|TTBB|Eric Ruthenberg
 Where Everybody Knows Your Name|TTBB|Kevin Keller
 Where Everybody Knows Your Name|TTBB|Larry Wright
@@ -20767,12 +24709,17 @@ Where Everybody Knows Your Name (Theme from "Cheers")|SATB|Eric Ruthenberg
 Where Everybody Knows Your Name (Theme from "Cheers")|SSAA|Eric Ruthenberg
 Where Everybody Knows Your Name (Theme from "Cheers")|TTBB|Eric Ruthenberg
 Where Everybody Knows Your Name (Theme from "Cheers")|TTBB|Kevin Keller
+Where Everybody Knows Your Name (Theme from Cheers)|SSAA|Lorraine Rochefort
 Where Have My Old Friends Gone?|SSAA|Joe Liles
 Where Have My Old Friends Gone?|TTBB|Joe Liles
 Where Have You Been Hiding All These Years|TTBB|Burt Szabo
 Where I Wanna Be|SATB|Melody Hine
+Where In The World|SSAA|Jean Flinn
 Where In The World Is Carmen Sandiego?|SSAA|Dianne Goldrick
 Where In The World Is Carmen Sandiego?|TTBB|Dianne Goldrick
+Where Is Love|SATB|Gene Puerling
+Where Is Love|SSAA|June Dale
+Where Is Love|TTBB|Tom Gentry
 Where Is Love?|SSAA|June Dale
 Where Is Love?|SSAA|Kay Bromert
 Where Is Love?|SSAA|Mary K. Coffman Music Fund
@@ -20791,6 +24738,7 @@ Where is the One?|SSAA|Diane Clark
 Where is the One?|TTBB|Walter Latzko
 Where Is Your Heart At|SSAA|June Dale
 Where Is Your Heart At|TTBB|Tom Gentry
+Where Love Is|TTBB|Joe Johnson
 Where Or When|SSAA|Diane Clark
 Where Or When|SSAA|Roger Tarpy
 Where Or When|TTBB|Walter Latzko
@@ -20806,6 +24754,7 @@ Where The Boys Are|SSAA|Brent Graham
 Where The Boys Are|SSAA|Elaine Gain
 Where The Boys Are|SSAA|Marsha Zwicker
 Where The Boys Are|SSAA|Tedda Lippincott
+Where The Heck Is Dixie?|SSAA|Joey Minshall
 Where The Morning Glories Grow|TTBB|Jack Baird
 Where The River Shannon Flows|TTBB|Dennis Driscoll
 Where The River Shannon Flows|TTBB|Kim Brittain
@@ -20836,7 +24785,9 @@ Whiffenpoof Song|TTBB|Louis Perry
 Whiffenpoof Song|TTBB|Renee Craig
 Whiffenpoof Song|TTBB|Ron Middlestaedt
 Whiffenpoof Song|TTBB|Steve Shannon
+While By My Sheep|TTBB|Barbershop Harmony Society
 While By My Sheep|TTBB|Jim West
+While Shephers Watched Medley|TTBB|Zac Booles
 While Strolling Through The Park One Day|SSAA|Nancy Bergman
 While Strolling Through The Park One Day|TTBB|Val Hicks
 While We're Young|SSAA|Nancy Bergman
@@ -20845,6 +24796,7 @@ Whispering|SSAA|Carolyn Johnson
 Whispering|SSAA|Suzy Lobaugh
 Whispering|SSAA|Tedda Lippincott
 Whispering|SSAA|Tom Gentry
+Whispering|TTBB|Jim Kahlke
 Whispering|TTBB|Louis Perry
 Whispering|TTBB|Robert Standley
 Whispering|TTBB|Tom Gentry
@@ -20862,6 +24814,7 @@ White Christmas|SSAA|Liz Garnett
 White Christmas|SSAA|Nancy Bergman
 White Christmas|SSAA|Sheryl Neal
 White Christmas|SSAA|Tedda Lippincott
+White Christmas|SSAA|Unspecified
 White Christmas|TTBB|Austin Shortes
 White Christmas|TTBB|Clay Hine
 White Christmas|TTBB|Deke Sharon
@@ -20872,8 +24825,10 @@ White Christmas|TTBB|Larry Wright
 White Christmas|TTBB|Mac Huff
 White Christmas|TTBB|Steve Tramack
 White Christmas|TTBB|Tom Gentry
+White Christmas|TTBB|Unspecified
 White Christmas (doo wop)|SSAA|Patricia Godfrey
 White Christmas (doo wop)|TTBB|Larry Wright
+White Cliffs of Dover|TTBB|Barbershop Harmony Society
 White Cliffs Of Dover|SATB|Larry Triplett
 White Cliffs Of Dover|SSAA|Jay Giallombardo
 White Cliffs Of Dover|SSAA|Larry Triplett
@@ -20896,6 +24851,8 @@ White Winter Hymnal|SSAA|Takako Fuke
 White Winter Hymnal|TTBB|Brian Mastrull
 Whiter Than Snow|TTBB|Jon Nicholas
 Who Am I|TTBB|Jim West
+Who Can I Turn To|TTBB|Roger Payne
+Who Can I Turn To?|SSAA|Kevin Keller
 Who Can I Turn To?|TTBB|Jay Giallombardo
 Who Can I Turn To?|TTBB|Robert Rund
 Who Can I Turn To? (When Nobody Needs Me)|SSAA|Kevin Keller
@@ -20906,17 +24863,22 @@ Who Can I Turn To? (When Nobody Needs Me)|TTBB|Kevin Keller
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Liz Garnett
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Robert Rund
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Simon Arnott
+Who Can Smile|TTBB|Simon Rylander
 Who Cares|SSAA|Avis Fellows
 Who Cares|TTBB|Burt Szabo
 Who Cares? (from Of Thee I Sing)|TTBB|Johnny Bugarin
 Who Do You Think You Are Kidding Mr. Hit|TTBB|Liz Garnett
+Who Do You Think You're Foolin/I'm Nobody's|SSAA|Lynnell Diamond
 Who I Am|SSAA|Elaine Gain
 Who I Am|SSAA|Jay Giallombardo
 Who I'd Be|TTBB|Dan Wessler
 Who I'd Be|TTBB|Soren Detlefsen
 Who Loves You|SSAA|Liz Garnett
 Who Loves You|TTBB|Deke Sharon
+Who Loves You?|SSAA|Liz Garnett
 Who Needs You|TTBB|Sam Hubbard
+Who Put the Bomp|SSAA|S. Turnbull
+Who Put the Bomp|TTBB|Scott Turnbull
 Who Put The Bomp|SSAA|Carolyn Healey
 Who Put The Bomp|SSAA|LaVeda Redfield
 Who Put The Bomp|SSAA|Tom Gentry
@@ -20929,6 +24891,7 @@ Who Threw The Overalls In Mrs. Murphy's Chowder|TTBB|Jack Baird
 Who Threw The Overalls In Mrs. Murphy's Chowder|TTBB|SPEBSQSA
 Who Threw The Overalls In Mrs. Murphy's Chowder?|TTBB|SPEBSQSA, Inc.
 Who Told You?|TTBB|Louis Perry
+Who Told You? / Side By Side|TTBB|David Harrington
 Who Wants To Live Forever|SSAA|David Wright
 Who Will Buy|SATB|Dave Briner
 Who Will Buy|SATB|David Briner
@@ -20937,22 +24900,35 @@ Who Will Buy|TTBB|Dave Briner
 Who Will Buy|TTBB|David Briner
 Who Will Buy|TTBB|Kirk Young
 Who Will Buy|TTBB|Mark Burnip
+Who Will Buy|TTBB|Phil Ordaz
 Who Will Buy|TTBB|Walter Latzko
+Who Will Buy?|SSAA|Ann Minihane
+Who Will Buy?|SSAA|Dave Briner
+Who Will Buy?|SSAA|Greg Volk
+Who Will Buy?|TTBB|Kirk Young
+Who Will Buy? / Where Is Love?|TTBB|Rod Sgrignoli
 Who Would Imagine A King|SSAA|Jen Squires
+Who Would Imagine A King|SSAA|K Andrews
 Who Would Imagine A King|SSAA|Kim Andrews
 Who You Are|TTBB|Nicholas Wright
 Who?|TTBB|Dennis Driscoll
 Who'll Be The Next One|SSAA|Nancy Bergman
 Who'll Be The Next One|TTBB|Thomas Gentry
 Who'll Be The Next One|TTBB|Tom Gentry
+Who'll Dry Your Tears|TTBB|Dennis Driscoll
+Who'll Dry Your Tears (When You Cry)|TTBB|Unspecified
+Who'll Dry Your Tears When You Cry|TTBB|Dennis Driscoll/Rob Hopkins
 Who'll Dry Your Tears When You Cry?|SSAA|Kay Bromert
 Who'll Dry Your Tears When You Cry?|TTBB|Burt Szabo
 Who'll Dry Your Tears When You Cry?|TTBB|Dennis Driscoll
 Who'll Dry Your Tears When You Cry?|TTBB|Rob Hopkins
 Who'll Dry Your Tears When You Cry?|TTBB|Steven Armstrong
 Who'll Dry Your Tears?|TTBB|Steve Armstrong/Dennis Driscoll
+Who'll Take My Place|SSAA|Barbara Bianchi
+Who'll Take My Place (When I'm Gone)|TTBB|Greg Lyne
 Who'll Take My Place When I'm Gone|SSAA|Barbara Bianchi
 Who'll Take My Place When I'm Gone|SSAA|Marie Johnson
+Who'll Take My Place When I'm Gone|TTBB|Brian Beck
 Who'll Take My Place When I'm Gone|TTBB|Gregory Lyne
 Who'll Take My Place When I'm Gone|TTBB|Jay Giallombardo
 Who'll Take The Place Of Mary|TTBB|Ed Waesche
@@ -20967,8 +24943,11 @@ Who's In The Strawberry Patch With Sally?|TTBB|Mark Goodney
 Who's In The Strawberry Patch With Sally?|TTBB|Tom Gentry
 Who's Lovin' You|TTBB|Aaron Dale
 Who's Sorry Now|SSAA|Carolyn Johnson
+Who's Sorry Now|SSAA|Dave Briner
 Who's Sorry Now|SSAA|David Briner
 Who's Sorry Now|SSAA|Earl Moon
+Who's Sorry Now|SSAA|Earl Moon/Dave Briner
+Who's Sorry Now|SSAA|Joni Bescos
 Who's Sorry Now|SSAA|Nancy Bergman
 Who's Sorry Now|SSAA|Rick Witte
 Who's Sorry Now|TTBB|David Briner
@@ -20985,8 +24964,10 @@ Whoevers On Your Mind|SSAA|Barbara Huffman
 Whole Again|TTBB|Kevin Koehl
 Whole Lot Of Heart|SATB|Nicholas Wright
 Whole Lotta Love|SATB|Deke Sharon
+Whose Honey Are You|SSAA|Jean Shook
 Whose Pretty Baby Are You Now|TTBB|Rob Hopkins
 Why Can't We Be Friends?|SATB|Deke Sharon
+Why Did I Choose You|SSAA|Greg Volk
 Why Did I Choose You?|SSAA|Dede Nibler
 Why Did I Choose You?|SSAA|Fred King
 Why Did It Have To Be Me?|SSAA|Larry Wright
@@ -21005,6 +24986,7 @@ Why Do They Always Say No / There's Yes Yes In Your Eyes Medley|TTBB|John Hohl
 Why Do They Always Say No / There's Yes Yes In Your Eyes Medley|TTBB|Renee Craig
 Why Doesn't Santa Claus Go Next Door|TTBB|Tom Gentry
 Why Don't My Dreams Come True|TTBB|Lou Perry
+Why Don't My Dreams Come True|TTBB|Ted Hanna
 Why Don't My Dreams Come True?|TTBB|Louis Perry
 Why Don't We Do This More Often|SSAA|Jim West
 Why Don't We Do This More Often|TTBB|Burt Szabo
@@ -21012,9 +24994,12 @@ Why Don't We Do This More Often|TTBB|Dennis Driscoll
 Why Don't We Do This More Often|TTBB|Walter Latzko
 Why Don't We Just Dance|SATB|Nicholas Wright
 Why Don't We Just Dance|TTBB|Aaron Dale
+Why Don't You Fall in Love With Me|SSAA|Nancy Bergman
 Why Don't You Fall In Love With Me?|SSAA|Larry Wright
 Why Don't You Fall In Love With Me?|TTBB|Larry Wright
 Why Don't You Fall In Love With Me?/Undecided (Medley)|TTBB|Clay Hine
+Why Don't You Fall In Love With Me?/Undecided Medley|TTBB|Clay Hine
+Why Don't You Fall In Love With Me/Undecided Medley(Clay|TTBB|Clay Hine
 Why Georgia|TTBB|Aaron Dale
 Why Haven't I Heard From You|SSAA|Kevin Keller
 Why Haven't I Heard From You|SSAA|Tedda Lippincott
@@ -21023,6 +25008,7 @@ Why Not Say Goodbye the Way We Said Hello|TTBB|Melvin Knight
 Why Not Say Goodbye The Way We Said Hello|SSAA|Mel Knight
 Why Not Say Goodbye The Way We Said Hello|SSAA|Melvin Knight
 Why Not Say Goodbye The Way We Said Hello|TTBB|Mel Knight
+Why Should I Cry Over You|TTBB|Ed Waesche
 Why Should I Cry Over You?|SSAA|Carolyn Schmidt
 Why Should I Cry Over You?|SSAA|Nancy Bergman
 Why Should I Cry Over You?|TTBB|Burt Szabo
@@ -21056,18 +25042,22 @@ Wide Open Spaces|TTBB|Steve Jamison
 Wide World of Sports|SATB|Joe Mannherz
 Wiegenlied|SSAA|Tom Gentry
 Wiegenlied|TTBB|Tom Gentry
+Wild and Wooly Son of the West|TTBB|Burt Szabo
 Wild In The Country|TTBB|Jim West
 Wild Mountain Thyme|TTBB|Anders Lindqvist
 Wild Ones|SATB|Nicholas Wright
 Wild Things|SSAA|Nicholas Wright
+Wild West Woman|SSAA|Sylvia Alsbury
 Wild Wild Women|TTBB|Jack Baird
 Wild World|TTBB|Mark Stevens
 Wildest Dreams|SSAA|Nicholas Wright
 Wildfire|SSAA|Jo Lund
 Wildflowers|SATB|Kari Francis
 Will I Ever Tell You|SSAA|Marie Johnson
+Will I Ever Tell You|SSAA|Nancy Bergman
 Will I Ever Tell You|TTBB|Howard Jones
 Will I Ever Tell You|TTBB|Mike Sotiriou
+Will It Be Me This Time|SSAA|Lynnell Diamond
 Will It Be Me This Time?|SSAA|Nancy Bergman
 Will The Angels Let Me Play|TTBB|Jim West
 Will The Circle Be Unbroken?|TTBB|Jon Nicholas
@@ -21075,6 +25065,7 @@ Will The Sun Ever Shine Again|SSAA|Fran Carter
 Will The Sun Ever Shine Again|SSAA|Kevin Keller
 Will The Sun Ever Shine Again|TTBB|Kevin Keller
 Will The Sun Ever Shine Again|TTBB|Mark Goodney
+Will The Sun Ever Shine Again?|TTBB|Kevin Keller
 Will Ye Go Lassie Go|TTBB|Ralph Urquhart
 Will You Love Me In December As You Do In May|TTBB|David Wright
 Will You Love Me In December As You Do In May|TTBB|Toban Dvoretsky
@@ -21084,6 +25075,9 @@ Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|SSAA|Robert Rund
 Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|TTBB|Marilyn Penketh
 Will You Love Me Tomorrow (Will You Still Love Me Tomorrow)|TTBB|Steve Tramack
 Will You Love Me Tomorrow-Doo Wop|TTBB|Dave Theile
+Will You Still Love Me Tomorrow|SSAA|Elaine Gain
+Will You Still Love Me Tomorrow|TTBB|Chris MacMartin, Steve Tramack
+Will You Still Love Me Tomorrow?|TTBB|Chris MacMartin
 William Tell Overture|SSAA|Jay Giallombardo
 William Tell Overture|TTBB|Jay Giallombardo
 Willie Wonka Medley I|TTBB|Kevin Keller
@@ -21092,6 +25086,10 @@ Willow Weep For Me|SSAA|David Briner
 Willow Weep For Me|SSAA|Ed Waesche
 Willow Weep For Me|TTBB|Ed Waesche
 Willow Weep For Me|TTBB|Walter Latzko
+Willy Wonka Medley|TTBB|Kevin Keller
+Willy Wonka Medley|TTBB|Rob Hopkins
+Wimoweh (The Lion Sleeps Tonight)|SSAA|Charlene Yazurlo
+Win The Game / That's Life|TTBB|Jay Giallombardo
 Winchester Cathedral|SSAA|Jo Lund
 Winchester Cathedral|SSAA|Tom Gentry
 Winchester Cathedral|TTBB|Tom Gentry
@@ -21103,6 +25101,7 @@ Wind Beneath My Wings|SSAA|Tom Gentry
 Wind Beneath My Wings|TTBB|Derric Johnson
 Wind Beneath My Wings|TTBB|Tom Gentry
 Wind Beneath My Wings/You Raise Me Up Medley|TTBB|Jay Giallombardo
+Windmill in old Amsterdam|TTBB|Tony Pelling
 Windy|SSAA|Larry Wright
 Windy|TTBB|Jon Nicholas
 Windy|TTBB|Larry Wright
@@ -21113,25 +25112,38 @@ Wings|SSAA|Hari Birtles
 Wings|SSAA|Lyndal Thorburn
 Wings|SSAA|Michael Gellert
 Wings|TTBB|Simon Arnott
+Wink and a Smile|TTBB|Kim Brittain
+Wink and A Smile|SSAA|Sharon Vitkovsky
+Wink And A Smile|SSAA|Jim Massey
+Winner's Song|SSAA|Mary Ann Wydra
 Winter in America is Cold|TTBB|Steve Jamison
 Winter Is The Loveliest Time|SSAA|Ruth Emley Craven
+Winter Is The Loveliest Time Of The Year|SSAA|Renee Craig Emley
 Winter Song|SATB|Jay Dougherty
 Winter Song|TTBB|Ray Buntaine
+Winter Weather/A Marshmallow World (medley)|SSAA|Dave Briner
 Winter Wonderland|SATB|Ed Waesche
+Winter Wonderland|SSAA|Adam Reimnitz
 Winter Wonderland|SSAA|Ed Waesche
+Winter Wonderland|SSAA|June Berg
 Winter Wonderland|SSAA|Matt Parks
 Winter Wonderland|SSAA|Nancy Bergman
+Winter Wonderland|SSAA|Tedda Lippincott
+Winter Wonderland|SSAA|Valerie Hoy
 Winter Wonderland|TTBB|Aaron Dale
+Winter Wonderland|TTBB|Adam Reimnitz
 Winter Wonderland|TTBB|Derric Johnson
 Winter Wonderland|TTBB|Ed Waesche
 Winter Wonderland|TTBB|Jon Nicholas
 Winter Wonderland|TTBB|Melody Hine
+Winter Wonderland|TTBB|Steve Delehanty
 Winter Wonderland|TTBB|Walter Latzko
 Wise Men Still Seek Him|TTBB|Derric Johnson
 Wish I Didn't|SATB|Mark Stevens
 Wish You Were Gay|TTBB|Greg Mallett
 Wishing|SSAA|Avis Fellows
 Wishing|TTBB|Dennis Driscoll
+Wishing (YWIH)|SSAA|Avis Fellows
 Wishing You Were Somehow Here Again|SSAA|Julie Starr
 Wishing You Were Somehow Here Again|TTBB|David Wright
 Wishing You Were Somehow Here Again|TTBB|Theo Hicks
@@ -21141,16 +25153,22 @@ Witchcraft|TTBB|Dave Briner
 Witchcraft|TTBB|David Briner
 Witchcraft|TTBB|Jim Shubert
 Witchy Woman|SSAA|Liz Garnett
+With a Little Help From My Friends|SSAA|Rich Hasty
 With A Little Help From My Friends|SATB|Deke Sharon
 With A Little Help From My Friends|SSAA|Joey Minshall
 With A Little Help From My Friends|SSAA|Richard Hasty
 With A Little Help From My Friends|SSAA|Suzy Lobaugh
+With A Little Help From My Friends|SSAA|Unspecified
 With A Little Help From My Friends|TTBB|Patrick McAlexander
+With A Little Help From My Friends|TTBB|Rich Hasty
 With A Little Help From My Friends|TTBB|Richard Hasty
 With A Little Help From My Friends|TTBB|Steve Jamison
 With A Little Help From My Friends|TTBB|Steve Tramack
+With A Little Help From My Friends (YWIH)|SSAA|Suzy Lobaugh
 With A Smile And A Song|TTBB|Russ Foris
+With A Smile And A Song|TTBB|Russ Foris, Dave Stevens
 With a Song and a Smile|TTBB|Russ Foris
+With A Song In My Heart|SATB|Jim Henry
 With A Song In My Heart|SATB|Renee Craig
 With A Song In My Heart|SSAA|Brent Graham
 With A Song In My Heart|SSAA|Carolyn Schmidt
@@ -21165,10 +25183,15 @@ With Bells On|SSAA|Tedda Lippincott
 With My Little Stick of Blackpool Rock|SATB|Matthew Spinner
 With My Shillelagh Under My Arm|SSAA|Bev Sellers
 With One Look|SSAA|Tedda Lippincott
+With Plenty O' Money and You|SSAA|Nancy Bergman
+With Plenty of Money and You|SSAA|Nancy Bergman
+With Plenty of Money and You|TTBB|Walter Latzko
 With Plenty Of Money And You/Were In The Money Medley|SSAA|Jo Lund
+With Plenty of Money/High Society Medley|SSAA|Brian Beck
 With Summer Coming On|SSAA|Paul Grimm
 With These Hands|SATB|Jay Giallombardo
 With Two Wings|TTBB|Tom Gentry
+With Two Wings (8-Part Mixed)|SATB|Tom Gentry
 With You|SATB|Kevin Keller
 With You|SSAA|Kevin Keller
 With You|TTBB|David Wright
@@ -21186,6 +25209,7 @@ Without Me|SATB|Nicholas Wright
 Without You|SATB|Alex Morris
 Without You|TTBB|Kohl Kitzmiller
 Without You|TTBB|Steve Jamison
+Without You / Lost Without Your Love Medley|SSAA|N Williams
 Wiz/Wizard Of Oz Medley|SSAA|Larry Wright
 Wiz/Wizard Of Oz Medley|TTBB|Larry Wright
 Wizard Of Oz Medley|SSAA|Jo Lund
@@ -21193,8 +25217,10 @@ Wizard Of Oz Medley|SSAA|Kevin Keller
 Wizard Of Oz Medley|SSAA|Liz Garnett
 Wizard Of Oz Medley|TTBB|Kevin Keller
 Wizard Of Oz Medley|TTBB|Lloyd Steinkamp
+Wizard Of Oz Medley|TTBB|Zac Booles
 Wo Ai Ni|TTBB|Deke Sharon
 Woman|TTBB|Mark Stevens
+Women Would Never Get Married|SSAA|John Hohl
 Won't You Charleston With Me/Charleston Medley|SSAA|Jo Lund
 Won't You Play a Simple Melody|TTBB|Mark Goodney
 Won't You Please Come Back To Me|TTBB|SPEBSQSA
@@ -21216,8 +25242,12 @@ Wonderful Day like Today|TTBB|Mike Wallen
 Wonderful Day like Today|TTBB|Mo Rector
 Wonderful Day like Today|TTBB|Rob Hopkins
 Wonderful Day like Today|TTBB|Walter Latzko
+Wonderful Day Medley|SSAA|David Wright and Marty Griebel
 Wonderful Day Medley|SSAA|David Wright and Mike Griebel
+Wonderful Day Medley|SSAA|David Wright/Mike Griebel
+Wonderful Day Medley|TTBB|David Wright
 Wonderful Day Medley|TTBB|David Wright and Mike Griebel
+Wonderful Day Medley|TTBB|David Wright, Mike Gabriel, Mo Rector, Brian Beck, Bob Dowmy, Jim Clancy
 Wonderful Grace Of Jesus|TTBB|Walter Latzko
 Wonderful One|TTBB|Bob Bohn
 Wonderful One|TTBB|David Wright
@@ -21238,6 +25268,7 @@ Wonderwall|TTBB|Deke Sharon
 Woot Woot Song|SATB|Robert Rund
 Words|SSAA|Tedda Lippincott
 Words|TTBB|Gary Thiel
+Words|TTBB|Pete Rupay
 Words Fail|TTBB|Greg Mallett
 Words Fail (from Dear Evan Hansen)|TTBB|Rasmus Krigström
 Work Song|SATB|Nicholas Wright
@@ -21247,22 +25278,29 @@ World War I Girls Medley|TTBB|Marie Johnson
 World War I Medley|SSAA|Jean Shook
 World War I Medley|TTBB|Dick Ott
 World War I Medley|TTBB|Don Gray
+World War I Medley|TTBB|Ed Waesche
 World War I Medley|TTBB|George Davidson
 World War I Medley|TTBB|John Hohl
+World War I Medley|TTBB|John Hohl, Val Hicks, Jack Baird
 World War I Medley|TTBB|Richard Gray
 World War Medley|SSAA|Nancy Bergman
 World War Medley|TTBB|Burt Szabo
+World, Here I Am|SSAA|Nancy Bergman
 World, Here I Am!|SSAA|Nancy Bergman
 Would It Still Be Christmas|SATB|Joe Mannherz
 Would Jesus Wear a Rolex|TTBB|Todd Troutman
 Would Jesus Wear a Rolex|TTBB|Tom Gentry
+Would You Go With Me|TTBB|Adam Reimnitz
 Would You Like To Take A Walk|TTBB|Walter Latzko
 Wouldja Be My Valentine|SSAA|Doris Twardosky
 Wouldn't It Be Loverly|SSAA|Jay Giallombardo
 Wouldn't It Be Loverly|TTBB|Paul Davies/Ed Waesche
 Wouldn't It Be Nice|TTBB|Jay Giallombardo
 Wouldn't It Be Nice|TTBB|Steve Delehanty
+Wrap Your Troubles in Dreams|SSAA|Joni Bescos
+Wrap Your Troubles in Dreams|TTBB|Ed Waesche
 Wrap Your Troubles In Dreams|SSAA|Jo Lund
+Wrap Your Troubles In Dreams|SSAA|Mark Hale
 Wrap Your Troubles In Dreams|TTBB|Jim Shubert
 Wrap Your Troubles In Dreams|TTBB|Mark Hale
 Wrap Your Troubles In Dreams|TTBB|Walter Latzko
@@ -21280,13 +25318,16 @@ Writing's On the Wall|TTBB|Kohl Kitzmiller
 Writing's On the Wall|TTBB|Matt Astle
 Writing's On the Wall|TTBB|Nicholas Wright
 Written In The Stars|TTBB|Mark Hale
+WW1 Medley|SSAA|Nancy Bergman
 WWI Medley|SSAA|Jay Giallombardo
 WWI Medley|TTBB|Jay Giallombardo
 WWI Smile Medley|SSAA|Tom Gentry
 WWI Smile Medley|TTBB|Tom Gentry
 Xanadu|SSAA|Jen Squires
 Xo|SATB|Nicholas Wright
+Y Viva Espana|SSAA|Mike Taylor
 Y-you Tell Her-I S-stutter|TTBB|Tom Gentry
+Y.M.C.A|TTBB|Tom Gentry
 Y.M.C.A.|SSAA|Joey Minshall
 Y.M.C.A.|SSAA|Tedda Lippincott
 Y.M.C.A.|SSAA|Tom Gentry
@@ -21298,11 +25339,18 @@ Y'all Come Back Saloon|TTBB|David Briner
 Y'all Come Back Saloon|TTBB|Jon Nicholas
 Ya Got Trouble|TTBB|David Briner
 Ya Got Trouble|TTBB|Gene Cokeroft
+Ya Got Trouble|TTBB|Jay Giallombardo
 Ya Got Trouble|TTBB|Walter Latzko
 Ya Gotta Be|SATB|Deke Sharon
+Ya Gotta Have Heart|SSAA|Larry Wright
 Ya Gotta Know / I Can't Give You Anything But Love|SSAA|Nancy Bergman
+Ya Gotta Know How To Dance|SSAA|Clay Hine
 Ya Gotta Know How To Love|SSAA|Nancy Bergman
 Ya Gotta Know How To Love|TTBB|Nancy Bergman
+Ya Gotta Know How To Love|TTBB|Nancy Bergman, Lloyd Steinkamp and Mike McGee
+Ya Gotta Know How To Love Em'/I Can't Give You Anything But Love Medley(Nancy Ber|SSAA|Nancy Bergman
+Ya Gotta Know/I Can't Give You Anything|SSAA|Nancy Bergman
+Ya' Got Trouble|TTBB|Bluegrass Student Union
 Yacht Rock TV Theme Medley|TTBB|Deke Sharon
 Yahoo!|SSAA|Mike Menefee
 Yakety Yak|SATB|Jay Dougherty
@@ -21310,6 +25358,7 @@ Yakko's Universe|SSAA|Lauren Kahn
 Yankee Doodle|SATB|Deke Sharon
 Yankee Doodle|TTBB|Derric Johnson
 Yankee Doodle|TTBB|Jay Giallombardo
+Yankee Doodle March|TTBB|Ed Hinkley
 Yawning|TTBB|William Hotin
 Yearning (Just for You)|TTBB|Kyle Snook
 Yellow|SATB|Deke Sharon
@@ -21321,19 +25370,28 @@ Yellow Rose Of Texas|TTBB|Paul Jorg
 Yellow Submarine|SATB|Manoj Padki
 Yellow Submarine|SSAA|Jan-Ake Westin
 Yellow Submarine|TTBB|Jan-Ake Westin
+Yellow Submarine|TTBB|Steve Delehanty
 Yes I Can|TTBB|Steve Tramack
 Yes Indeed|SATB|Earl Moon
 Yes Indeed|SSAA|Earl Moon
 Yes Indeed|SSAA|Karen McCarville
+Yes Indeed|SSAA|Renee Craig
 Yes Indeed|TTBB|David Wright
 Yes Indeed|TTBB|Earl Moon
+Yes Indeed!|TTBB|David Wright
+Yes Sir That's My Baby|SSAA|David Wright
+Yes Sir That's My Baby|TTBB|Val Hicks
 Yes Sir, That's My Baby|SSAA|David Wright
+Yes Sir, That's My Baby|SSAA|W. Donaldson
 Yes Sir, That's My Baby|TTBB|Dan Naumann
 Yes Sir, That's My Baby|TTBB|David Wright
 Yes Sir, That's My Baby|TTBB|Jack Baird
 Yes Sir, That's My Baby|TTBB|Val Hicks
 Yes Sir, That's My Baby/Ain't She Sweet|SSAA|Joe Mannherz
 Yes Sir, That's My Baby/Ain't She Sweet|TTBB|Joe Mannherz
+Yes Sir, That's My Baby/Ain't She Sweet (Medley)|TTBB|Larry Autenreith
+Yes, Indeed|SSAA|Earl Moon
+Yes, Indeed!|SSAA|Lorraine Rochefort
 Yes, Still the Starry Banner Waves|TTBB|Tom Gentry
 Yes, We Have No Bananas|SSAA|Carolyn Johnson
 Yes, We Have No Bananas|SSAA|Jo Lund
@@ -21341,12 +25399,16 @@ Yes, We Have No Bananas|TTBB|Bob Kelly
 Yes, We Have No Bananas|TTBB|Mort Burt
 Yes, We Have No Bananas|TTBB|Peter Briant
 Yes, We Have No Bananas|TTBB|Sigmund Spaeth
+Yes, We Have No Bananas|TTBB|Unspecified
 Yesterday|SATB|Tom Gentry
 Yesterday|SSAA|Carolyn Johnson
+Yesterday|SSAA|Delyth Knight
 Yesterday|SSAA|Diana DeBruycker
 Yesterday|SSAA|Mark Burnip
+Yesterday|SSAA|Nancy Bergman/Aileen Nightingale
 Yesterday|SSAA|Renee Craig
 Yesterday|SSAA|Tom Gentry
+Yesterday|TTBB|Brian Beck
 Yesterday|TTBB|David Harrington
 Yesterday|TTBB|Jay Giallombardo
 Yesterday|TTBB|Jim Shubert
@@ -21354,8 +25416,10 @@ Yesterday|TTBB|Mark Burnip
 Yesterday|TTBB|Thomas Gentry
 Yesterday|TTBB|Todd Troutman
 Yesterday|TTBB|Tom Gentry
+Yesterday (YWIH)|SSAA|Renee Craig
 Yesterday I Heard The Rain|SSAA|Brent Graham
 Yesterday I Heard The Rain|SSAA|Carolyn Johnson
+Yesterday I Heard The Rain|SSAA|G Avener
 Yesterday I Heard The Rain|SSAA|Sharon Carlson
 Yesterday I Heard The Rain|TTBB|Brent Graham
 Yesterday Once More|SSAA|Dan Naumann
@@ -21367,7 +25431,9 @@ Yesterday, When I Was Young|TTBB|Tom Gentry
 Yesterday's Roses Medley|TTBB|Tom Gentry
 Yesterday/A Day In The Life|TTBB|David Harrington
 Yesterdays|TTBB|Walter Latzko
+YMCA|SSAA|Sandie Zalewski
 Yo-Ho A Pirate's Life For Me|TTBB|Chris Hebert
+Yodel' Song ( Cowboy's Sweetheart)|SSAA|Jim Clancy
 Yona From Arizona|TTBB|Aaron Dale
 Yona From Arizona|TTBB|Barbershop Harmony Society
 Yona From Arizona|TTBB|SPEBSQSA
@@ -21375,6 +25441,8 @@ Yona From Arizona|TTBB|the Barbershop Harmony Society
 You|SATB|Joe Mannherz
 You|SSAA|Joe Mannherz
 You|TTBB|Joe Mannherz
+You Ain't Gettin' Diddly Squat|SSAA|Tom Gentry
+You Ain't Gettin' Diddly Squat|TTBB|Tom Gentry
 You Ain't Heard Nothin' Yet|TTBB|Tom Gentry
 You Ain't Heard Nothing Yet|TTBB|Paul Bowman
 You Ain't Heard Nothing Yet|TTBB|Renee Craig
@@ -21383,6 +25451,8 @@ You Ain't Much Fun (Since I Quit Drinkin')|TTBB|Jim West
 You Always Hurt the One You Love|SSAA|Jo Lund
 You Always Hurt the One You Love|TTBB|Andrew Wittenberg
 You Always Hurt the One You Love|TTBB|Mark Goodney
+You Always Hurt The One You Love|TTBB|Don Gray
+You and I|TTBB|Adam Reimnitz
 You and I|TTBB|Lou Perry
 You And I|SATB|Deke Sharon
 You And I|SATB|Kyle Kitzmiller
@@ -21397,6 +25467,7 @@ You And I|TTBB|Kyle Kitzmiller
 You And I|TTBB|Louis Perry
 You And I (We Can Conquer The World)|TTBB|David Harrington
 You And Me|SSAA|Tamra Perez
+You And Me|TTBB|Steve Tramack
 You and Me (But Mostly Me)|SSAA|Kohl Kitzmiller
 You and Me (But Mostly Me)|TTBB|Steve Tramack
 You and Me (We Wanted It All)|SSAA|Tom Gentry
@@ -21409,27 +25480,35 @@ You and the Night and the Music|TTBB|Aaron Dale
 You and the Night and the Music|TTBB|Joe Mannherz
 You Are Everything|SSAA|Dan Naumann
 You Are Love|TTBB|Walter Latzko
+You Are Mine, All Mine|TTBB|Tony Nasto
+You are My Sunshine|TTBB|Clay Hine
 You Are My Sunshine|SATB|Deke Sharon
 You Are My Sunshine|SATB|Vicki Uhr
 You Are My Sunshine|SATB|Viki Uhr
+You Are My Sunshine|SSAA|Brian Beck
 You Are My Sunshine|SSAA|Elaine Gain
 You Are My Sunshine|SSAA|Vicki Uhr
 You Are My Sunshine|SSAA|Viki Uhr
 You Are My Sunshine|SSAA|Walter Latzko
 You Are My Sunshine|TTBB|Barb Laukaitis
+You Are My Sunshine|TTBB|Dave Briner, Ed Waesche
 You Are My Sunshine|TTBB|Derric Johnson
 You Are My Sunshine|TTBB|Jon Nicholas
+You Are My Sunshine|TTBB|Unspecified
 You Are My Sunshine|TTBB|Vicki Uhr
 You Are My Sunshine|TTBB|Viki Uhr
 You Are Never Far Away From Me|SSAA|Marge Bailey
 You Are So Beautiful|SATB|Jeremey Johnson
 You Are So Beautiful|SSAA|Jeremey Johnson
+You Are So Beautiful|SSAA|Mo Field
 You Are So Beautiful|TTBB|Gabriel Lawson
 You Are So Beautiful|TTBB|Jeremey Johnson
 You Are So Much of Christmas To Me|TTBB|Larry Triplett
 You Are the New Day|SATB|Peter Knight
 You Are the New Day|SSAA|Kay Bromert
 You Are the New Day|TTBB|Gary Thiel
+You Are The New Day|TTBB|Peter Knight
+You are the One I Love|TTBB|Paul Olguin
 You Are The One I Love|TTBB|Paul C. Olguin
 You Are The Sunshine Of My Life|SATB|Clay Hine
 You Are The Sunshine Of My Life|SSAA|Bev Sellers
@@ -21469,6 +25548,7 @@ You Came A Long Way From St. Louis|SSAA|Patsee Parker
 You Can Build A Bridge|TTBB|Derric Johnson
 You Can Call Me Al|TTBB|Deke Sharon
 You Can Fly|SATB|Deke Sharon
+You Can Fly|SSAA|Clay Hine
 You Can Fly|SSAA|Tamra Perez
 You Can Fly|TTBB|Clay Hine
 You Can Have Every Light On Broadway|SSAA|Jean Shook
@@ -21506,17 +25586,22 @@ You Didn't Want Me When You Had Me|SSAA|Connie Kash
 You Didn't Want Me When You Had Me|TTBB|Melody Hine
 You Didn't Want Me When You Had Me|TTBB|Patrick McAlexander
 You Didn't Want Me When You Had Me|TTBB|Walter Latzko
+You Do Something to Me|SSAA|Marsha Zwicker
 You Do Something To Me|TTBB|Liz Garnett
 You Do Something To Me|TTBB|Rob Hopkins
 You Don't Bring Me Flowers|SSAA|Chris Arnold
 You Don't Bring Me Flowers|SSAA|David Wright
 You Don't Bring Me Flowers|TTBB|Adam Scott
 You Don't Have To Be A Baby To Cry|TTBB|Aaron Dale
+You Don't Know Me|SATB|Ben Folds
 You Don't Know Me|SSAA|David Harrington
 You Don't Know Me|SSAA|Jim Clancy
+You Don't Know Me|SSAA|Nancy Bergman
+You Don't Know Me|SSAA|Nancy Bergman (changes by Jim Arns)
 You Don't Know Me|TTBB|Curt Kimball
 You Don't Know Me|TTBB|David Harrington
 You Don't Know Me|TTBB|Jim Clancy
+You Don'T Know Me|SSAA|Tedda Lippincott
 You don't know what love is|SATB|Joe Mannherz
 You don't know what love is|SSAA|Joe Mannherz
 You don't know what love is|TTBB|Joe Mannherz
@@ -21550,19 +25635,24 @@ You Gotta Be A Football Hero|TTBB|Don Coldren
 You Gotta Be A Football Hero|TTBB|Jack Baird
 You Gotta Be A Football Hero|TTBB|Jay Giallombardo
 You Gotta Be A Football Hero / Betty Coed Medley|TTBB|Steve Jamison
+You Gotta Go South|TTBB|Lee Whitener
 You Gotta Have Charts|TTBB|Roger Payne
 You Gotta Have Love|TTBB|Louis Perry
 You Gotta Have Skin|TTBB|Dennis Driscoll
+You Gotta Have Skin|TTBB|Ed Waesche
+You Gotta Know How to Love Him|SSAA|Nancy Bergman
 You Gotta Start Off Each Day with a Song|SSAA|Sonny Steffan
 You Grow Sweeter As The Years Go By|TTBB|Dennis Driscoll
 You Haven't Done Nothin'|TTBB|Deke Sharon
 You Hit the Spot|SSAA|Larry Wright
 You Keep Coming Back Like A Song|SSAA|Brent Graham
+You Keep Coming Back Like A Song|SSAA|Brian Beck
 You Keep Coming Back Like A Song|SSAA|Jim Arns
 You Keep Coming Back Like A Song|SSAA|Nancy Bergman
 You Keep Coming Back Like A Song|TTBB|Brent Graham
 You Keep Coming Back Like A Song|TTBB|Douglas Smith
 You Keep Coming Back Like A Song|TTBB|Fraser Brown
+You Keep Coming Back Like A Song|TTBB|Terry Shannon
 You Know My Name|SATB|Deke Sharon
 You Know You Belong To Somebody Else|TTBB|Tom Gentry
 You Light Up My Life|SSAA|David Wright
@@ -21580,6 +25670,7 @@ You Made Me Love You|SSAA|Avis Fellows
 You Made Me Love You|SSAA|Jim Arns
 You Made Me Love You|SSAA|Joe Mannherz
 You Made Me Love You|SSAA|Liz Garnett
+You Made Me Love You|SSAA|Lorraine Rochefort
 You Made Me Love You|SSAA|Nancy Bergman
 You Made Me Love You|SSAA|Walter Latzko
 You Made Me Love You|TTBB|Ed Waesche
@@ -21593,12 +25684,16 @@ You Make It Feel Like Christmas|SSAA|Jay Dougherty
 You Make It Feel Like Christmas|TTBB|Jay Dougherty
 You Make Me Feel Like Dancing|SSAA|Anna Maria Parker
 You Make Me Feel So Young|SSAA|Adam Bock
+You Make Me Feel So Young|SSAA|Anita Barzilla
 You Make Me Feel So Young|SSAA|Jo Lund
 You Make Me Feel So Young|SSAA|Joe Mannherz
+You Make Me Feel So Young|SSAA|Mark Hale
 You Make Me Feel So Young|SSAA|Melody Hine
+You Make Me Feel So Young|SSAA|Ruth Emley
 You Make Me Feel So Young|SSAA|Walter Latzko
 You Make Me Feel So Young|TTBB|Jo Lund
 You Make Me Feel So Young|TTBB|Joe Mannherz
+You Make Me Feel So Young|TTBB|Mark Hale
 You Make Me Feel So Young|TTBB|Todd Troutman
 You Make Me Feel So Young|TTBB|Walter Latzko
 You Make My Dreams|SATB|Deke Sharon
@@ -21615,20 +25710,25 @@ You Meet the Nicest People|SSAA|Tom Gentry
 You Meet the Nicest People|TTBB|Tom Gentry
 You Must Come In at the Bottom|TTBB|Tom Gentry
 You Must Come In At The Door|TTBB|Derric Johnson
+You Must Have Been a Beautiful Baby|SSAA|Renee Craig
+You Must Have Been a Beautiful Baby|TTBB|Jay Giallombardo
 You Must Have Been A Beautiful Baby|TTBB|David Briner
 You Must Have Been A Beautiful Baby|TTBB|Ed Waesche
 You Must Have Been A Beautiful Baby|TTBB|Jim Shubert
 You Must Have Been A Beautiful Baby|TTBB|Renee Craig
+You Must Have Been A Beautiful Baby|TTBB|Renee Craig/Ed Waesche
 You Must Have Been A Beautiful Baby|TTBB|Rob Hopkins
 You Must Have Been A Beautiful Baby|TTBB|Walter Latzko
 You Must Have Been A Beautiful Baby / You're Some Pretty Doll Medley|TTBB|David Briner
 You Need Hands|SSAA|Tedda Lippincott
+You Needed Me|SSAA|Dennis Driscoll
 You Needed Me|SSAA|Joe Mannherz
 You Needed Me|TTBB|Andrew Carolan
 You Needed Me|TTBB|Dennis Driscoll
 You Needed Me|TTBB|James Halvorson
 You Needed Me|TTBB|Jim Halvorson
 You Needed Me|TTBB|Joe Mannherz
+You Never Had It So Good|SSAA|Jim Massey
 You Never Had It So Good|TTBB|Dan Wessler
 You Never Miss The Water Till The Well Runs Dry|TTBB|Walter Latzko
 You Only Want Me When You're Lonesome|TTBB|Louis Perry
@@ -21636,25 +25736,35 @@ You Only Want Me When You're Lonesome|TTBB|Toban Dvoretsky
 You Oughta Be In Pictures|SSAA|Carole Prietto
 You Planted A Rose In The Garden Of Love|TTBB|Jack Baird
 You Raise Me Up|SATB|Jake Bavarsky
+You Raise Me Up|SSAA|Anna Maria Parker
 You Raise Me Up|SSAA|Carole Prietto
+You Raise Me Up|SSAA|Jim Clancy
 You Raise Me Up|SSAA|Jim West
+You Raise Me Up|SSAA|Joe Liles
 You Raise Me Up|SSAA|Joey Minshall
+You Raise Me Up|SSAA|June Dale
 You Raise Me Up|SSAA|Larry Wright
 You Raise Me Up|SSAA|Takako Fuke
 You Raise Me Up|SSAA|Tedda Lippincott
+You Raise Me Up|TTBB|Ed Waesche
 You Raise Me Up|TTBB|Joe Liles
+You Raise Me Up|TTBB|Joe Liles, Pat Hannon
 You Raise Me Up|TTBB|Jon Nicholas
 You Raise Me Up|TTBB|Larry Wright
 You Raise Me Up|TTBB|Walter Latzko
+You Really Got A Hold On Me|TTBB|Adam Scott
 You Should Have Told Me|SSAA|Sonny Steffan
 You Should Read Your Gideon Bible|TTBB|Jim West
+You Started Me Dreaming|SSAA|Lorraine Rochefort
 You Stepped Out Of A Dream|SSAA|Dan Naumann
 You Stepped Out Of A Dream|TTBB|Dan Naumann
 You Stepped Out Of A Dream|TTBB|Walter Latzko
 You Take My Breath Away|SSAA|Simon Arnott
 You Take My Breath Away|TTBB|Mark Burnip
 You Taught Me to Care|SSAA|Joan D 'Agostino
+You Tell Me Your Dream|SSAA|Clay Hine
 You Tell Me Your Dream|SSAA|Walter Latzko
+You Tell Me Your Dream|TTBB|Barbershop Harmony Society
 You Tell Me Your Dream|TTBB|Clay Hine
 You Tell Me Your Dream|TTBB|Phil Embury
 You There In The Back Row|SSAA|David Wright
@@ -21662,6 +25772,7 @@ You Think (That You Love Me)|TTBB|Norma Andersen
 You Took Advantage Of Me|SATB|Joe Mannherz
 You Took Advantage Of Me|SSAA|Aaron Dale
 You Took Advantage Of Me|SSAA|Joe Mannherz
+You Took Advantage Of Me|SSAA|Unspecified
 You Took Advantage Of Me|TTBB|Aaron Dale
 You Took Advantage Of Me|TTBB|Jay Giallombardo
 You Took Advantage Of Me|TTBB|Joe Mannherz
@@ -21677,6 +25788,7 @@ You Were Meant For Me|TTBB|Jim Shubert
 You Were Meant For Me|TTBB|Walter Latzko
 You Were Meant For Me/You Are My Lucky Star Medley|SSAA|Jo Lund
 You Were Only Fooling|SSAA|Marie Johnson
+You Were Only Fooling|SSAA|Mo Rector
 You Were Only Fooling|TTBB|Joe Liles
 You Will Be Found|SATB|Deke Sharon
 You Will Be Found|SATB|Simon Arnott
@@ -21715,6 +25827,9 @@ You'll Have To Put A Nightie On Aphrodite|TTBB|Don Gray
 You'll Never Know|SSAA|Brent Graham
 You'll Never Know|SSAA|David Briner
 You'll Never Know|SSAA|Joni Bescos
+You'll Never Know|SSAA|Nancy Bergman
+You'll Never Know|SSAA|Tedda Lippincott
+You'll Never Know|TTBB|Dave Briner
 You'll Never Know|TTBB|David Briner
 You'll Never Know|TTBB|Don Gray
 You'll Never Know|TTBB|Einar Pedersen
@@ -21732,13 +25847,18 @@ You'll Never Walk Alone|SSAA|LaVeda Redfield
 You'll Never Walk Alone|SSAA|Molly Rowland
 You'll Never Walk Alone|SSAA|Nancy Bergman
 You'll Never Walk Alone|SSAA|Tedda Lippincott
+You'll Never Walk Alone|SSAA|Tony Searle
 You'll Never Walk Alone|TTBB|Adam Reimnitz
 You'll Never Walk Alone|TTBB|Adam Scott
 You'll Never Walk Alone|TTBB|Brent Graham
+You'll Never Walk Alone|TTBB|Chris Peterson
 You'll Never Walk Alone|TTBB|Derric Johnson
 You'll Never Walk Alone|TTBB|Don Gray
+You'll Never Walk Alone|TTBB|Jim Clancy
+You'll Never Walk Alone|TTBB|John Hohl
 You'll Never Walk Alone|TTBB|Jon Nicholas
 You'll Never Walk Alone|TTBB|Kohl Kitzmiller
+You'll Never Walk Alone|TTBB|Terry Phillips
 You're A Dangerous Girl|TTBB|Burt Szabo
 You're A Good Man, Charlie Brown|TTBB|Theodore Hicks
 You're A Grand Old Flag|SSAA|Carolyn Johnson
@@ -21753,17 +25873,24 @@ You're A Mean One, Mr. Grinch|SATB|Chris Arnold
 You're A Mean One, Mr. Grinch|SSAA|Joe Mannherz
 You're A Mean One, Mr. Grinch|SSAA|June Berg
 You're A Mean One, Mr. Grinch|SSAA|Michael Gellert
+You're A Mean One, Mr. Grinch|SSAA|Nancy Bergman
+You're A Mean One, Mr. Grinch|TTBB|Greg Volk
 You're A Mean One, Mr. Grinch|TTBB|Jon Nicholas
+You're A Mean One, Mr. Grinch|TTBB|Scott Turnbull, Shaun Agnew
 You're All I Need to Get By|TTBB|Deke Sharon
 You're All I Want For Christmas|SSAA|Donna Stewart
 You're All I Want For Christmas|TTBB|Richard Bain
 You're All The World To Me|TTBB|Larry Triplett
+You're an Education|TTBB|Bob Rund
 You're an Education (in Yourself)|TTBB|Robert Rund
 You're An Old Smoothie|SSAA|Walter Latzko
 You're An Old Smoothie|TTBB|Walter Latzko
+You're As Welcome as the Flowers In May|SSAA|Traditional
 You're As Welcome As the Flowers In May|TTBB|David Wright
 You're As Welcome As the Flowers In May|TTBB|Floyd Connett
 You're Breaking In A New Heart|SSAA|Dan Naumann
+You're Breaking In A New Heart|SSAA|Joni Bescos
+You're Breaking In A New Heart|SSAA|Rich Hasty
 You're Breaking My Heart|SSAA|Becky Cartine
 You're Cheatin Yourself When You're Cheatin On Me|TTBB|Matthew Gallagher
 You're Driving Me Crazy|SSAA|Anna Maria Parker
@@ -21777,18 +25904,26 @@ You're Getting To Be A Habit With Me|TTBB|Walter Latzko
 You're Gonna Live Forever In Me|TTBB|Ed Schubel
 You're Here|TTBB|Norma Andersen
 You're In Love With Everyone|TTBB|Earl Moon
+You're in Style When You're Wearing a Smile|SSAA|Ig Jakovac
 You're In Style When You're Wearing A Smile|SSAA|Tedda Lippincott
+You're In Style When You're Wearing A Smile|TTBB|Dave Briner
 You're In Style When You're Wearing A Smile|TTBB|David Briner
 You're In Style When You're Wearing A Smile|TTBB|Gene Cokeroft
 You're In Style When You're Wearing A Smile|TTBB|Kirk Roose
+You're In Style With A Smile Medley|TTBB|Adam Reimnitz
 You're in Wrong /How Come You Do Me|SSAA|Jay Giallombardo
 You're Just A Flower From An Old Bouquet|SSAA|Nancy Bergman
 You're Just A Flower From An Old Bouquet|TTBB|N. Bauman
 You're Just A Flower From An Old Bouquet|TTBB|Nancy Bergman
+You're Just in Love|SATB|Joni Bescos
 You're Just in Love|SATB|Tom Gentry
+You're Just in Love|SSAA|Tom Gentry
 You're Just in Love|TTBB|Steve Jamison
 You're Just in Love|TTBB|Walter Latzko
+You're Just In Love|SATB|Steve Jamison, Dan Falcone
+You're Just In Love (8-Part Mixed)|SATB|Tom Gentry
 You're My Baby|SSAA|Brian Beck
+You're My Baby|SSAA|Jim Arns
 You're My Best Friend|SATB|Adam Scott
 You're My Best Friend|SATB|Jay Dougherty
 You're My Best Friend|SSAA|Jay Dougherty
@@ -21819,14 +25954,19 @@ You're Nobody 'Til Somebody Loves You|TTBB|Jon Nicholas
 You're Nobody 'Til Somebody Loves You|TTBB|Lance Fisher
 You're Nobody 'Til Somebody Loves You|TTBB|Mark Goodney
 You're Nobody 'Til Somebody Loves You|TTBB|Walter Latzko
+You're Nobody 'Til Somebody Loves You / Ain't That A Kick In The Head|TTBB|Jay Giallombardo
 You're Nobody 'Til Somebody Loves You/Ain't That A Kick In The Head?|TTBB|Jay Giallombardo
+You're Nobody til Somebody Loves You|SSAA|Clay Hine
+You're Nobody til Somebody Loves You|SSAA|Greg Volk
 You're Nobody Til Somebody Loves You/Ain't That A Kick|SSAA|Jay Giallombardo
 You're Nobody Til Somebody Loves You/Ain't That A Kick|TTBB|Jay Giallombardo
+You're Nobody Til' Somebody Loves You|TTBB|Greg Volk
 You're Nobody's Sweetheart Medley|TTBB|Renee Craig
 You're Sixteen|TTBB|Dick Rode
 You're Sixteen You're Beautiful And You're Mine|SSAA|Aaron Dale
 You're Sixteen You're Beautiful And You're Mine|TTBB|Aaron Dale
 You're Sixteen You're Beautiful And You're Mine|TTBB|Jim Shubert
+You're Sixteen, You're Beautiful And You're Mine(Aaron|TTBB|Aaron Dale
 You're So Vain|SSAA|Mike Taylor
 You're Some Pretty Doll|TTBB|John Hohl
 You're Some Pretty Doll|TTBB|Louis Perry
@@ -21843,11 +25983,13 @@ You're The Cream In My Coffee|SSAA|Debbie Porter
 You're The Cream In My Coffee|SSAA|Jeanne Elmuccio
 You're The First, The Last, My Everything|TTBB|Kohl Kitzmiller
 You're The First, The Last, My Everything|TTBB|Nick Bryant
+You're the Flower of My Heart Sweet Adeline|TTBB|Barbershop Harmony Society
 You're The Flower Of My Heart, Sweet Adeline|SSAA|Jay Giallombardo
 You're The Flower Of My Heart, Sweet Adeline|SSAA|Joey Minshall
 You're The Flower Of My Heart, Sweet Adeline|TTBB|Jay Giallombardo
 You're The Flower Of My Heart, Sweet Adeline|TTBB|Louis Perry
 You're The Flower Of My Heart, Sweet Adeline|TTBB|Tom Gentry
+You're The Flower Of My Heart, Sweet Adeline(Barbershop Harmony Soc|TTBB|Barbershop Harmony Society
 You're the Girl I Love|TTBB|Jay Giallombardo
 You're The Inspiration|SSAA|Rowena Harper
 You're The Inspiration|TTBB|Adam Scott
@@ -21855,7 +25997,9 @@ You're The Inspiration|TTBB|Rowena Harper
 You're the Music in My Heart, Sweet Adeline|SSAA|Joey Minshall
 You're The One|SSAA|Michael Gellert
 You're The One That I Want|SSAA|Melody Hine
+You're The Only Girl For Me|TTBB|Renee Craig
 You're The Only Girl That Made Me Cry|TTBB|Barbershop Harmony Society
+You're The Spirit Of Sweet Adelines|SSAA|Lynnell Diamond
 You're The Voice|SSAA|Emily Moriarty
 You're Welcome|SATB|Deke Sharon
 You're Welcome|TTBB|Dan Wessler
@@ -21870,6 +26014,7 @@ You've Got A Friend|SSAA|Tedda Lippincott
 You've Got A Friend|SSAA|Tom Gentry
 You've Got A Friend|TTBB|Brian Mastrull
 You've Got A Friend|TTBB|Cay Outerbridge
+You've Got A Friend|TTBB|Jon Colbath
 You've Got A Friend|TTBB|Mark Stevens
 You've Got A Friend|TTBB|Tom Gentry
 You've Got A Friend In Me|SATB|Dan Wessler
@@ -21877,6 +26022,7 @@ You've Got A Friend In Me|SATB|Deke Sharon
 You've Got A Friend In Me|SSAA|Dan Wessler
 You've Got A Friend In Me|SSAA|David Harrington
 You've Got A Friend In Me|SSAA|Jay Giallombardo
+You've Got A Friend In Me|SSAA|Jo Lund
 You've Got A Friend In Me|SSAA|Larry Wright
 You've Got A Friend In Me|TTBB|Dan Wessler
 You've Got A Friend In Me|TTBB|David Harrington
@@ -21895,13 +26041,19 @@ You've Got Me Under Your Thumb|TTBB|Kyle Snook
 You've Got To Be Carefully Taught|TTBB|Eric Ruthenberg
 You've Got To Do It|TTBB|Melody Hine
 You've Got To Hide Your Love Away|SSAA|Carolyn Johnson
+You've Got to See Mama Ev'ry Night|SSAA|Tom Gentry
+You've Got To See Mama Ev'ry Night|SSAA|Janet Landstrom
+You've Got To See Mama Every Night|SSAA|Janet Landstrom
 You've Got To See Mamma Ev'ry Night|SSAA|Janet Landstrom
 You've Got To See Mamma Ev'ry Night|TTBB|Tom Gentry
 You've Had A Long, Long Day|TTBB|Bill Busby
 You've Lost That Lovin' Feelin|SSAA|Jeanette Perry
 You've Lost That Lovin' Feelin|TTBB|Larry Wright
+Young and Foolish|SSAA|Marge Bailey
+Young and Foolish|TTBB|Brent Graham
 Young And Foolish|SSAA|Brent Graham
 Young And Foolish|SSAA|Joe Mannherz
+Young And Foolish|SSAA|Joni Bescos
 Young And Foolish|SSAA|Tom Gentry
 Young And Foolish|TTBB|Earl Moon
 Young And Foolish|TTBB|Joe Mannherz
@@ -21909,6 +26061,7 @@ Young And Foolish|TTBB|Tom Gentry
 Young At Heart|SSAA|Cris Conerty
 Young At Heart|SSAA|Tedda Lippincott
 Young At Heart|TTBB|Dennis Driscoll
+Young At Heart|TTBB|Dennis Malone
 Young At Heart|TTBB|Tom Gentry
 Your Back Yard|TTBB|Mark Stevens
 Your Cheatin' Heart|SSAA|Kevin Keller
@@ -21918,6 +26071,7 @@ Your Eyes Have Told Me So|TTBB|Burt Szabo
 Your Eyes Have Told Me So|TTBB|Dennis Driscoll
 Your Eyes Have Told Me So|TTBB|Keith Hamilton
 Your Eyes Have Told Me So|TTBB|Walter Latzko
+Your Feet's Too Big|SSAA|Carolyn Schmidt
 Your Feets Too Big|SSAA|Carolyn Schmidt
 Your First Day In Heaven|SSAA|Aaron Dale
 Your First Day In Heaven|SSAA|Susan Wells
@@ -21947,6 +26101,12 @@ Yours is My Heart Alone|TTBB|Theodore Hicks
 Youth|SATB|Nicholas Wright
 Yuletide Medley|TTBB|Richard Curtis
 Zanzibar|TTBB|Deke Sharon
+Ziegfeld Medley|SSAA|Nancy Bergman
+Zing Went the Strings of My Heart|TTBB|Renee Craig
+Zing Went The Strings Of My Heart|SSAA|Renee Craig
+Zing Went The Strings Of My Heart|TTBB|Barbershop Harmony Society
+Zing! Went the String of My Heart|SSAA|Renee Craig
+Zing! Went the Strings of My Heart|TTBB|Greg Volk
 Zing! Went The Strings Of My Heart|SSAA|Carolyn Johnson
 Zing! Went The Strings Of My Heart|SSAA|Walter Latzko
 Zing! Went The Strings Of My Heart|TTBB|Bill Biffle
@@ -21959,10 +26119,15 @@ Zing! Went the Strings Of My Heart/Get Me To The Church On Time|TTBB|Kohl Kitzmi
 Zip A Dee Doo Dah|SATB|Deke Sharon
 Zip A Dee Doo Dah|SSAA|Joe Mannherz
 Zip A Dee Doo Dah|TTBB|Larry Wright
+Zip-a-dee Doo-dah|TTBB|Joe Liles
+Zip-A-Dee-Doo-Dah|SSAA|Lorraine Rochefort
 Zip-A-Dee-Doo-Dah|TTBB|Joe Liles
+Zip-A-Dee-Doo-Dah|TTBB|Jon Nicholas
+Zip-Ah-Dee-Doo-Dah|SSAA|Nancy Bergman
 Zombie|SATB|Emily Moriarty
 Zombie|SSAA|Emily Moriarty
 Zombie Jamboree|SSAA|Dan Naumann
+Zombie Jamboree|SSAA|Lorraine Rochefort
 Zombie Jamboree|TTBB|Dan Naumann
 Zombie Jamboree|TTBB|Deke Sharon
 Zoom|SSAA|Alex Kaiserman

--- a/data/sources/barbershoptracks_song_suggestions.psv
+++ b/data/sources/barbershoptracks_song_suggestions.psv
@@ -1,0 +1,6551 @@
+Song Title|Voicing|Arranger
+'Til I Hear You Sing|SSAA|Theo Hicks
+'Til the Season Comes 'Round Again|TTBB|Adam Reimnitz
+(Everybody's Waitin' For) The Man With The Bag|TTBB|Tom Gentry
+(Ghost) Riders In The Sky|TTBB|Dave Briner
+(Ghost) Riders In The Sky|TTBB|Jon Nicholas
+(I Found A) Million Dollar Baby|SSAA|Renee Craig
+(I'm Afraid) The Masquerade Is Over|TTBB|Ed Waesche
+(Them Was The) Good Old Days|SSAA|Brian Beck
+(You Are) My Special Angel|SSAA|Kevin Keller
+*On Eagles' Wings|SSAA|Jarmela Speta
+100 Years|SSAA|Carole Prietto
+1927 Kansas City|TTBB|Brian Beck
+2:57 Ed Sullivan Show|TTBB|Clay Hine
+23rd Psalm (Vicar Of Dibley Theme)|SSAA|Howard Goodall
+3 Little Fishies|SSAA|Saxie Dowell
+409|TTBB|Marty Israel
+50,60,70 Medley|SSAA|Brian Beck
+50's Rock and Roll Medley|TTBB|Kevin Keller
+50s Medley|TTBB|Jay Giallombardo
+59th Street Bridge Song|SSAA|Bev Sellers
+59th Street Bridge Song|SSAA|Marge Bailey
+59th Street Bridge Song (Feelin' Groovy)|TTBB|Don Gray
+59th Street Bridge Song (Feelin' Groovy) (Adult)|SSAA|Marge Bailey
+59th Street Bridge Song (Feelin' Groovy) (YWIH)|SSAA|Marge Bailey
+70's Medley|SSAA|Jim Arns
+76 Trombones|SSAA|Nancy Bergman
+789|TTBB|Steve Wolf
+A Band Of Brothers|TTBB|Larry Triplett
+A Barbershop Tango|TTBB|Sherwyn Heckt, Alden Parker
+A Beatles Celebration|TTBB|Greg Volk
+A Beautiful Lady In Blue|TTBB|Chris Arnold
+A Blossom Fell|TTBB|Earl Moon
+A Boy And A Girl|SATB|Eric Whitacre
+A Bundle of Old Love Letter|SSAA|Carolyn Schmidt
+A Bundle of Old Love Letter|SSAA|Nancy Bergman
+A Bundle Of Old Love Letters|SSAA|Carolyn Schmidt
+A Bundle Of Old Love Letters|SSAA|David Wright
+A Bushel And A Peck|SSAA|Marge Bailey
+A Carol Medley|SSAA|Floyd Connett
+A Chocolate Sundae On A Saturday Night|TTBB|Jeremey Johnson
+A Christmas To Remember|TTBB|Jim Clancy
+A Christmas Wish|TTBB|Richard Loebakka
+A Dream is a Wish Your Heart Makes|SSAA|Lorraine Rochefort
+A Dream Is A Wish Your Heart Makes|SSAA|Lorraine Rochefort Joey Minshall
+A Dream Is A Wish Your Heart Makes|TTBB|David Wright
+A Fool Such As I|TTBB|Aaron Dale
+A Gaelic Blessing|TTBB|Jon Nicholas
+A Garden in the Rain|SSAA|David Harrington
+A Good Man is Hard to Find|SSAA|Walter Latzko
+A Good Man Is Hard To Find|SSAA|Floyd Connett
+A Grinch Medley|SSAA|Nancy Bergman
+A Hard Day's Night|TTBB|Jon Nicholas
+A Hard Day's Night|TTBB|Liz Garnett
+A Hard Days Night|TTBB|Liz Garnet
+A Holly Jolly Christmas|TTBB|Kirby Shaw
+A Hundred and Sixty Acres|TTBB|Jordan Johnson
+A Hundred Years From Today|SSAA|Marsha Zwicker
+A Jingle Bell Travelogue|SSAA|Kay Bromert
+A Kid Named Joe|TTBB|David Wright
+A Little Bit O' Heaven|SSAA|Jay Giallombardo
+A Little Bit O' Heaven|TTBB|Jay Giallombardo
+A Little Bit Of Happiness|TTBB|Unspecified
+A Little Bit of Heaven|SSAA|Renee Craig/Joni Bescos
+A Little Bit of Heaven, Sure They Called It Ireland|TTBB|Steve Jamison
+A Little Less Conversation|SSAA|David Wright
+A Little Old Lady in Tennis Shoes|SSAA|Mary Coffman
+A Little Patch Of Heaven|SSAA|Aaron Dale
+A Little Patch Of Heaven|TTBB|Aaron Dale
+A Little Street Where Old Friends Meet|TTBB|Rob Hopkins
+A Little Street Where Old Friends Meet|TTBB|Sam Breedon
+A Long, Slow Train|TTBB|Jon Nicholas
+A Lot of Living to Do|SSAA|Joey Minshall
+A Love That Will Last|SSAA|Henrik Rosenberg
+A Lovely Way To Spend An Evening|TTBB|Earl Moon / Ed Waesche
+A Man Of Constant Sorrow|TTBB|Aaron Dale
+A Marshmallow World|SSAA|Joni Bescos
+A Mighty Fortress Is Our God|TTBB|Joe Johnson
+A New York Medley In Three Quarter Time|TTBB|Burt Szabo
+A Nightingale Sang In Berekely Square|SSAA|Joni Bescos
+A Nightingale Sang in Berkeley Square|SSAA|Ann Minihane
+A Nightingale Sang in Berkeley Square|SSAA|Joni Bescos
+A Nightingale Sang In Berkeley Square|SATB|Gene Puerling
+A Nightingale Sang In Berkeley Square|TTBB|Brian Beck
+A Nightingale Sang In Berkeley Square|TTBB|SK Grundy
+A Nightingale Sang In Berkeley Square|TTBB|Tom Gentry
+A Nightingale Sang in Berkely Square|SSAA|Tedda Lippincott
+A Nightingale Sang In Berkely Square|TTBB|Brian Beck
+A Nightingale Sang In Berkely Square|TTBB|Webb Comfort
+A Nightingale Sang In Berkley Square|SATB|Gene Puerling
+A Nightingale Sang In Berkley Square|SSAA|A Minihane
+A Nightingale Sang In Berkley Square|SSAA|Renee Craig
+A Place in the Choir|SSAA|Lorraine Rochefort
+A Place in the Choir|SSAA|Tom Gentry
+A Prayer For You|TTBB|Richard Loebakka
+A Pretty Girl Is Like A Melody/With A Song In My Heart Medley(Jay Giallomb|TTBB|Jay Giallombardo
+A Quiet Place|SATB|Jerry Rubino
+A Ride With Glen Miller (Medley)|TTBB|Paul Davies
+A Room With a View|SSAA|Liz Garnett
+A Shanty in Old Shanty Town|SSAA|Sylvia Alsbury
+A Shanty In Old Shanty Town|TTBB|Unspecified
+A Shine on Your Shoes|SSAA|Nancy Bergman
+A Shine On Your Shoes|TTBB|Aaron Dale
+A Son Of The Sea|TTBB|Ed Waesche
+A Song For Mary|TTBB|Jay Giallombardo
+A Song For The Little Guy|TTBB|David Wright
+A Song of Friendship|SSAA|Joanne Chambers
+A Spoonful Of Sugar|TTBB|Russ Foris
+A Straw Hat And A Cane|TTBB|Unspecified
+A Sunday Kind Of Love|TTBB|Adam Reimnitz
+A Thousand Things|TTBB|Adam Scott
+A Thousand Thoughts of You|TTBB|Larry Triplett
+A Thousand Thoughts Of You|TTBB|Tom Gentry
+A Thousand Years|SSAA|Henrik Rosenberg
+A Tisket A Tasket|SSAA|Greg Volk
+A Tree in the Meadow|SSAA|Ann Minihane
+A Tree In The Meadow|SSAA|Ruby Rhea
+A Whole New World|SSAA|David Wright
+A Whole New World|SSAA|Joey Minshall
+A Whole New World|TTBB|David Gillingham
+A Wink and a Smile|TTBB|Steve Jamison
+A Wink and A Smile|SSAA|Dave Briner
+A Wink And A Smile|TTBB|Kim Brittain
+A Wonderful Day Like Today|SSAA|Tedda Lippincott
+A Wonderful Day Like Today|TTBB|Dick Floersheimer
+A Wonderful Day Like Today|TTBB|Rob Hopkins
+A Wonderful Day Medley|SSAA|Joey Minshall
+A Wonderful Time Up There|TTBB|Kay Brooks
+A-Tisket A-Tasket|SSAA|David Harrington
+ABBA Medley|SSAA|Brian Beck
+ABBA Medley|SSAA|Dan Naumann
+ABBA Medley|SSAA|Debbie Hopkinson
+ABBA Medley|TTBB|Dan Naumann
+Abide with Me|TTBB|Ig Jakovac
+Abilene|TTBB|G.E. Howe
+Above My Head, I Hear Music In The Air|TTBB|David Wright
+Ac-cent-chu-ate the Positive|TTBB|Jim West
+Ac-cent-tch-uate the Positive|TTBB|Buzz Haeger
+Ac-cent-tchu-ate the Positive|TTBB|Tom Gentry
+Accentchuate The Positive|TTBB|Buzz Haeger
+Accentuate the Positive|TTBB|Adam Reimnitz
+Accentuate the Positive|TTBB|Clay Hine
+Achy Breaky Heart|SSAA|Nancy Bergman
+Adelaide's Lament|SATB|Steven Armstrong
+Adiemus|SSAA|Karl Jenkins
+Advance Australia Fair|SSAA|Renee Craig
+Africa|SSAA|Kevin Keller
+Africa|SSAA|Lorraine Rochefort
+Africa|SSAA|Sandra Kerr
+Africa|SSAA|Tom Gentry
+Africa|TTBB|Kevin Keller
+Africa|TTBB|Tony Searle
+After The Ball|TTBB|Ted Hanna
+After The Ball|TTBB|Tom Gentry
+After the Curtain Comes Down|SSAA|Mary Coffman
+After the Gold Rush|SSAA|Donna Stewart
+After the Lovin'|SSAA|Jean Flinn
+After You've Gone|SSAA|Anna Maria Parker
+After You've Gone|SSAA|Bergman/Wright
+After You've Gone|SSAA|Don Gray
+After You've Gone|SSAA|Joni Bescos
+After You've Gone|SSAA|Nancy Bergman/Leola Wright
+After You've Gone|SSAA|Renee Craig
+After You've Gone|SSAA|Steve Jamison
+After You've Gone|TTBB|Alan Siegal
+After You've Gone|TTBB|Don Gray
+Aging Superheroes Medley|TTBB|Tom Gentry
+Ain't Goin Down Till The Sun Comes Up|TTBB|Aaron Dale
+Ain't He Sweet|SSAA|Lorraine Rochefort
+Ain't He Sweet/Yes Sir, That's My Baby|SSAA|Clay Hine
+Ain't Misbehavin'|SSAA|Dot Calvin
+Ain't Misbehavin'|SSAA|Earl Moon, Ed Waesche
+Ain't Misbehavin'|SSAA|Lorraine Rochefort
+Ain't Misbehavin'|SSAA|Marge Bailey
+Ain't Misbehavin'|SSAA|Tedda Lippincott
+Ain't Misbehavin'|TTBB|Earl Moon / Ed Waesche
+Ain't Misbehavin'|TTBB|Earl Moon and Ed Waesche
+Ain't Misbehavin'|TTBB|Earl Moon, Ed Waesche
+Ain't Misbehavin'|TTBB|Mel Knight
+Ain't Misbehaving|SSAA|Greg Volk
+Ain't No Mountain High Enough|SSAA|Deke Sharon
+Ain't No Mountain High Enough|SSAA|Joey Minshall
+Ain't She (He) Sweet|SSAA|Lorraine Rochefort
+Ain't She Sweet|TTBB|Barbershop Harmony Society
+Ain't She Sweet / Yes Sir That's My Baby|TTBB|Unspecified
+Ain't That A Kick in the Head|SSAA|Rich Hasty
+Ain't That A Kick In The Head|TTBB|Rich Hasty
+Ain't We Got Fun|SSAA|JoAnne Ingels
+Ain't We Got Fun|TTBB|Robert Meyer
+Ain't We Got Fun/Sunny Side of the Street|SSAA|Nancy Bergman
+Ain't-A That Good News|TTBB|Bev Sellers
+Ain't-A That Good News (YWIH)|SSAA|Bev Sellers
+Ain'ta That Good News|SSAA|Bev Sellers
+Aint Misbehavin'|SSAA|Earl Moon/Ed Waesche
+Aint No Mountain High Enough|SSAA|Joey Minshall
+Air For Advent|TTBB|Tom Fetke
+Aka-tombo|TTBB|Jim Henry
+Alabama Jubilee|TTBB|Aaron Dale
+Alabama Jubilee|TTBB|Tom Gentry
+Alabama Medley|TTBB|Ed Waesche
+Alabama/Cottontown|SSAA|Nancy Bergman
+Alabamy Bound|SSAA|Unspecified
+Alabamy Bound|TTBB|David Wright
+Alabamy Bound/Alabama Jubilee Medley|SSAA|Tom Gentil
+Aladdin Medley|TTBB|Aaron Dale
+Aladdin Medley|TTBB|David Wright
+Aladdin Medley 1|TTBB|Jay Giallombardo
+Alaska Flag Song|SSAA|Mac Huff
+Alaska Medley|SSAA|Tom Gentry
+Alaska's Flag Song|TTBB|Unspecified
+Alexander's Band Medley|SSAA|Dave Briner
+Alexander's Band Medley|TTBB|Dave Briner
+Alexander's Ragtime Band|SSAA|Bergman/Beck
+Alexander's Ragtime Band|SSAA|Brian Beck
+Alexander's Ragtime Band|SSAA|Greg Volk
+Alexander's Ragtime Band|SSAA|Joni Bescos
+Alexander's Ragtime Band|SSAA|Nancy Bergman
+Alexander's Ragtime Band|TTBB|Barbershop Harmony Society
+Alexander's Ragtime Band|TTBB|Burt Szabo
+Alexander's Ragtime Band|TTBB|Ed Waesche
+Alexander's Ragtime Band|TTBB|Steven Armstrong
+Alexanders Ragtime Band|TTBB|Burt Szabo
+Alice Blue Gown|TTBB|Barbershop Harmony Society
+All Aboard for Dixie Land|TTBB|David Wright
+All Aboard For Dixieland|TTBB|David Wright
+All About That Bass|SATB|Henrik Rosenberg
+All About That Bass|SATB|Wayne Grimmer
+All About That Bass|SSAA|Elaine Gain
+All Alone|TTBB|Ed Waesche
+All Alone / What'll I Do?|TTBB|Walter Latzko
+All American Girl|TTBB|Ed Waesche
+All Creatures Of Our God And King|TTBB|Joe Johnson
+All Dressed Up With A Broken Heart|SSAA|Carolyn Schmidt
+All Dressed Up With A Broken Heart|TTBB|Rob Hopkins
+All Dressed Up With A Broken Heart|TTBB|Tom Gentry
+All God's Chillun Got Rhythm/Clap Yo' Hands|TTBB|Mark Hale
+All I Do Is Dream Of You|SSAA|Marsha Zwicker
+All I Do Is Dream Of You|TTBB|Aaron Dale
+All I Do Is Dream Of You|TTBB|David Wallace
+All I Do Is Dream Of You|TTBB|Kevin Keller
+All I Have to Do Is Dream|SSAA|LaVeda Redfield
+All I Have To Do Is Dream|SSAA|Tedda Lippincott
+All I Have To Do Is Dream|TTBB|Barbershop Harmony Society
+All I Have To Do Is Dream|TTBB|Jon Nicholas
+All I Have To Do Is Dream|TTBB|Tom Gentry
+All I Have To Do Is Dream (Adult)|SSAA|Tedda Lippincott
+All I Have To Do Is Dream (YWIH)|SSAA|Tedda Lippincott
+All I Want for Christmas is My Two Front Teeth|SSAA|Nancy Bergman
+All I Want for Christmas is You|SSAA|June Berg
+All I Want for Christmas Is You|SSAA|Kate Morrical
+All I Want For Christmas Is You|SSAA|Larry Triplett
+All I Want For Christmas Is You|TTBB|Larry Triplett
+All My Lovin'|SSAA|Carolyn Schmidt
+All My Lovin'|SSAA|June Berg
+All My Loving|SSAA|Carolyn Schmidt
+All Nation Rise|SATB|Jay Giallombardo
+All Nations Rise|SSAA|Jay Giallombardo
+All Nations Rise|TTBB|Jay Giallombardo
+All of Me|SSAA|Carole Prietto
+All of Me|SSAA|Joan D'Agostino
+All of Me|SSAA|Tedda Lippincott
+All Of Me|TTBB|Alan Levine
+All Of Me|TTBB|Dennis Driscoll
+All Of Me|TTBB|Dennis Malone
+All Of Me|TTBB|Scott Kitzmiller
+All of Me (Loves All of You)|SSAA|Elaine Gain
+All of My Life|SSAA|Mary Grace Lodico
+All of My Life|SSAA|Nancy Bergman
+All Of My Life|SSAA|Larry Wright
+All Over Nothing at All|SSAA|Ig Jakovac
+All Over Nothing at All|TTBB|Ig Jakovac
+All People That On Earth Do Dwell|TTBB|Jim Henry
+All Rise|SATB|Dave Williamson
+All That Jazz|SSAA|Ann Minihane
+All That Jazz|SSAA|Clay Hine
+All That Jazz|TTBB|Clay Hine
+All That Jazz / Razzle Dazzle Medley|SSAA|Ann Minihane/Renee Craig
+All That Jazz/Razzle Dazzle|SSAA|Ann Minihane/Renee Craig
+All the Things You Are|SSAA|Elaine Gain
+All The Things You Are|TTBB|Walter Latzko
+All the Way|SSAA|Brent Graham
+All the Way|SSAA|Clay Hine
+All The Way|SSAA|Dave Briner
+All The Way|SSAA|Joni Bescos
+All The Way|SSAA|Tom Gentry
+All The Way|SSAA|Unspecified
+All The Way|TTBB|Dave Briner
+All The Way|TTBB|Pete Rupay
+All The Way|TTBB|Tom Gentry
+All The World Will Be Jealous Of Me|TTBB|David Wright
+All The World Will Be Jealous Of Me Verse|TTBB|David Wright
+All Things Bright Medley|TTBB|Joe Johnson
+All You Need Is Love|SSAA|Carolyn Schmidt
+Alleluia|SSAA|G. Blackwell
+Alleluia|TTBB|David Wright
+Alleluia|TTBB|Jim Henry
+Alleluia|TTBB|Ralph Manuel
+Alleluia|TTBB|Randall Thompson
+Almost Like A Song|SSAA|Unspecified
+Almost Like Being in Love|SSAA|Sonny Steffan
+Almost Like Being In Love|SSAA|David Harrington
+Almost Like Being In Love|TTBB|David Harrington
+Almost Like Being In Love|TTBB|Eric King
+Almost Like Being In Love|TTBB|Jay Giallombardo
+Always|SSAA|Joni Bescos
+Always|SSAA|Mark Hale/Don Gray
+Always|TTBB|Mark Hale
+Always|TTBB|Mark Hale, Don Gray
+Always|TTBB|Mark Hale/Don Gray
+Always Leave 'Em Laughing|TTBB|Dick Floersheimer
+Always Live Down By The Firehouse|TTBB|Will Hamblet
+Always Look On The Bright Side Of Life|TTBB|Will Hamblet
+Always On My Mind|TTBB|David Gillingham
+Am I Ready?|TTBB|Jon Nicholas
+Am I Wasting My Time On You|SSAA|Jo Lund
+Amarillo (Is This The Way To)|TTBB|Linda Corcoran
+Amazing Grace|SSAA|Carolyn Butler
+Amazing Grace|SSAA|Margaret Little
+Amazing Grace|SSAA|Mo Rector/Kim Hulbert
+Amazing Grace|SSAA|Sylvia Alsbury
+Amazing Grace|TTBB|Dennis Malone
+Amazing Grace|TTBB|Joe Johnson
+Amazing Grace|TTBB|Mo Rector
+Amazing Grace|TTBB|Tom Gentry
+Amazing Grace/ My Chains Are Broken|SSAA|Jay Giallombardo
+Amazing Grace/Oldtime Religion|SSAA|Nancy Bergman
+Amazing-I Gotta Feeling-Firework|SSAA|Joey Minshall
+Amen|TTBB|Unspecified
+America|SSAA|Jo Lund
+America|SSAA|Joe Liles
+America|SSAA|Peg Millard
+America|TTBB|Jim Clancy
+America Medley|SSAA|Mary Coffman
+America Medley (Am The Beautiful God Bless Am)|SSAA|Judy Vidal
+America the Beautiful|SSAA|Joe Liles
+America the Beautiful|SSAA|Nancy Bergman, Joni Bescos
+America the Beautiful|SSAA|Suzy Buerer
+America the Beautiful|TTBB|John Hayden
+America the Beautiful|TTBB|Sean Milligan
+America The Beautiful|SATB|Nancy Bergman
+America The Beautiful|SSAA|Bergman/Bescos
+America The Beautiful|SSAA|Nancy Bergman
+America the Beautiful Medley|SSAA|Tedda Lippincott
+America The Beautiful Overlay|SSAA|Joe Liles
+America The Beautiful Overlay|TTBB|Joe Liles
+America, the Beautiful|SSAA|Bergman/Bescos
+America, The Beautiful|SATB|Darmon Meader
+America, The Beautiful|TTBB|Dennis Malone
+America, The Beautiful|TTBB|Mark Hayes
+America, The Beautiful / Liberty Anthem Medley|TTBB|Shaun Agnew
+America, the Dream Goes On|SSAA|Tedda Lippincott
+America/Give Me Your Tired|TTBB|Jim Clancy
+America/God Bless the USA Medley|TTBB|Unspecified
+American / Canadian Ode To Joy|TTBB|Jay Giallombardo
+American Anthem|SSAA|Joey Minshall
+American Armed Forces Medley|TTBB|Jim Clancy
+American Revolution Medley - with narration|TTBB|Barbershop Harmony Society
+American Tune|TTBB|David Wright
+American-Canadian Ode To Joy|TTBB|Jay Giallombardo
+Among My Souvenirs|TTBB|Barbershop Harmony Society
+Amy|TTBB|Alex Kaiserman
+An American Medley|TTBB|Mike Wallen
+An American Trilogy|TTBB|Jim Clancy
+An American Tune (Simon & Garfunkel)|TTBB|Steve Tramack
+An Irish Blessing|SSAA|Sylvia Alsbury
+An Uptune In Search Of A Song|TTBB|Larry Triplett
+Anchor's Aweigh|SSAA|June Dale
+Anchors Aweigh|TTBB|Unspecified
+And All That Jazz|SSAA|Ann Minihane
+And So it Goes|TTBB|Kirby Shaw
+And So It Goes|SATB|Bob Chilcott
+And So It Goes|SSAA|Tedda Lippincott
+And So It Goes|SSAA|Unspecified
+And So It Goes|TTBB|Kirk Young
+And So It Goes (Lippincott)|SSAA|Tedda Lippincott
+And So It Goes (Shaw)|SSAA|Kirby Shaw
+And So It Goes (SSAA)|SSAA|Kirby Shaw
+And So To Sleep Again|SATB|Buzz Haeger
+And This Is My Beloved|TTBB|David Wright
+Angbatsblues|TTBB|Niclas Lindgren
+Angel Eyes|TTBB|Hal Maples
+Angel Of Music/Phantom Of The Opera|SSAA|David Wright
+Angels (Robbie Williams)|TTBB|Brad Stephenson
+Angels Among Us|SSAA|Tedda Lippincott
+Angels On Your Pillow|TTBB|Cary Burns
+Angels We Have Heard on High|SSAA|Sylvia Alsbury
+Angels We Have Heard On High|SSAA|Renee Craig
+Angels We Have Heard On High|TTBB|Barbershop Harmony Society
+Angels We Have Heard On High|TTBB|Yuletide Favorites
+Angina in the Morning|TTBB|Unspecified
+Angry Bill Bailey Medley|SSAA|Nancy Bergman
+Angry Bill Bailey Medley (heavy interp)|SSAA|Nancy Bergman
+Angry/Bill Bailey Medley|SSAA|Nancy Bergman
+Animal Crackers|SSAA|Tom Gentry
+Annie|TTBB|Burt Szabo
+Annie's Song|TTBB|Pete Benson
+Anniversary Song|TTBB|Tom Gentry
+Another Op'nin, Another Show|SSAA|Ann Minihane
+Another Op'nin' Another Show|SSAA|Dot Calvin
+Another Op'nin' Another Show|SSAA|Tom Gentry
+Another Op'nin', Another Show|TTBB|Tom Gentry
+Another Openin' Another Show|SSAA|Dot Calvin
+Another Somebody Done Somebody Wrong Song|TTBB|Barbershop Harmony Society
+Anthem|SSAA|Growing Girls
+Anthem|SSAA|Olle Nyman
+Anthem|TTBB|Olle Nyman
+Anthem (Chess)|SSAA|Olle Nyman
+Any Dream Will Do|SSAA|Tedda Lippincott
+Any Man Of Mine|SSAA|Tedda Lippincott
+Any Time|SSAA|Greg Volk
+Any Time|TTBB|Greg Volk
+Any Time At All|TTBB|Unspecified
+Anything Goes|SSAA|George Avener
+Anything Goes|TTBB|Rob Hopkins
+Anything is Nice If It Comes From Dixieland|SSAA|Nancy Bergman
+Anything You Can Do|SATB|Don Gray
+Anything You Can Do|SATB|Tom Gentry
+Anything You Can Do|SSAA|Tom Gentry
+Anything You Can Do|TTBB|Don Gray
+Anything You Can Do|TTBB|Jay Giallombardo
+Anytime|TTBB|Greg Volk
+Anyway|SSAA|Joey Minshall
+Anyway|SSAA|Steve Jamison
+Anywhere I Wander|SSAA|Nancy Bergman
+Applause|SSAA|Marge Bailey
+Applause|TTBB|Don Gray
+Apple Blossom Time|SSAA|Nancy Bergman
+April Fool|SSAA|Sylvia Alsbury
+April Showers|SSAA|David Harrington
+April Showers|TTBB|Dennis Driscoll
+Aquarius|SSAA|Dot Calvin
+Aquarius|TTBB|Larry Wright
+Are You From Dixie?|TTBB|Barbershop Harmony Society
+Are You From Dixie? (Cause I'm From Dixie Too)|TTBB|Lloyd Steinkamp
+Are You Havin' Any Fun?|SSAA|Kevin Keller
+Are You Havin' Any Fun?|TTBB|Kevin Keller
+Are You Lonesome Tonight|SSAA|Brent Graham
+Are You Lonesome Tonight|SSAA|Nancy Bergman
+Are You Lonesome Tonight|SSAA|Tom Gentry
+Are You Lonesome Tonight|TTBB|Brent Graham
+Are You Lonesome Tonight|TTBB|Nancy Bergman
+Are You Lonesome Tonight?|SSAA|Nancy Bergman
+Are You Lonesome Tonight?|TTBB|Barbershop Harmony Society
+Are You Lonesone Tonight?|TTBB|Barbershop Harmony Society
+Are You The One|TTBB|Adam Reimnitz
+Armed Forces Medley|SATB|Barbara Lyle
+Armed Forces Medley|SSAA|Nancy Bergman
+Armed Forces Medley|SSAA|Tedda Lippincott
+Armed Forces Medley|TTBB|Darin Drown
+Armed Forces Medley|TTBB|Fred King
+Armed Forces Medley|TTBB|John Grant, Fred King, Tom Ewald
+Armed Forces Medley|TTBB|Terry Ludwig
+Armed Services Medley|SSAA|Dot Short
+Army Medley|TTBB|Jay Giallombardo
+Art Is Calling For Me|SSAA|Tom Gentry
+As Long As He Needs Me|SSAA|Aaron Dale
+As Long As I Have Music|SSAA|Marge Bailey
+As Long as I'm Singin'|SSAA|Brian Beck
+As Long As I'm Singin'|SSAA|Tom Gentry
+As Long As I'm Singin'|TTBB|David Wright
+As Long As I'm Singin'|TTBB|Tom Gentry
+As Long As I'm Singing|SSAA|Larry Wright
+As Long As I'm Singing|TTBB|Mike Menefee
+As Long As She Needs Me|TTBB|Jay Giallombardo
+As Long As We're Singin'|TTBB|Will Hamblet
+As Long as You're Not in Love With Anyone Else / Undecided Medley|SSAA|Clay Hine
+As Long As You're Not In Love/Undecided|SSAA|Clay Hine
+As Long As You're Not in Love/You Were Meant|SSAA|Clay Hine
+As Time Goes By|SSAA|Dot Calvin
+As Time Goes By|SSAA|Marge Bailey
+As Time Goes By|TTBB|Rob Hopkins
+As Time Goes By|TTBB|Walter Latzko
+As You Desire Me|SSAA|Ig Jakovac
+At Last|SSAA|Jean McFadyen
+At Last|SSAA|Nancy Bergman
+At Last|TTBB|Clay Hine
+At Last|TTBB|Nancy Bergman
+At the Beginning|SSAA|Carolyn Schmidt
+At the Beginning (from Anastasia)|SSAA|Carolyn Schmidt
+At the End of the Day With You|SSAA|Ed Waesche
+At the Hop|TTBB|Gary Thiel
+At The Hop|SSAA|Sonny Steffan
+At the Jazz Band Ball|SSAA|Joni Bescos
+Atchison, Topeka And the Santa Fe|TTBB|Jay Giallombardo
+Attitude Dance|SSAA|Rasmus Krigstrom
+Auction Cries|TTBB|John Biggs
+Auld Land Syne|SSAA|Sylvia Alsbury
+Auld Lang Syne|SSAA|Carolyn Schmidt
+Auld Lang Syne|SSAA|Clay Hine
+Auld Lang Syne|SSAA|Don Gray
+Auld Lang Syne|TTBB|Clay Hine
+Auld Lang Syne|TTBB|Dave Briner
+Auld Lang Syne|TTBB|Don Gray
+Auld Lang Syne|TTBB|Kris Olson
+Auld Lang Syne|TTBB|Steve Jamison
+Auntie Skinner's Chicken Dinner|TTBB|Unspecified
+Aura Lee|TTBB|Barbershop Harmony Society
+Aura Lee / Love Me Tender|TTBB|Tom Gentry
+Aura Lee/Love Me Tender|TTBB|Tom Gentry
+Autumn Leaves|SSAA|Kay Bromert
+Autumn Leaves|TTBB|Adam Reimnitz
+Ave Maria|TTBB|Franz Biebl
+Ave Maria (Angelus Domini)|TTBB|Unspecified
+Ave Maria (Schubert)|SSAA|Carolyn Healey
+Ave Maria Angelus Domini|TTBB|Franz Biebl
+Away In a Manger|TTBB|Barbershop Harmony Society
+Away In a Manger|TTBB|Bradley Ellingboe
+Away In A manger|TTBB|Jon Nicholas
+Away In A Manger|SSAA|Chris Arnold
+Away In A Manger|SSAA|Dave Briner
+Away In A Manger|SSAA|Joni Bescos
+Away In A Manger|SSAA|Judy Vidal
+Away In A Manger|TTBB|Adam Reimnitz
+Away In A Manger|TTBB|Chris Arnold
+B & O Line|TTBB|Bob Disney
+B&O Line|TTBB|Bob Disney
+Baby Driver|SATB|Rasmus Krigstrom
+Baby Face|SSAA|Joni Bescos
+Baby Face|TTBB|Dave Stevens
+Baby Face (May 5, 2008 Version)|SSAA|Clay Hine
+Baby Face Parody|TTBB|Rob Hopkins
+Baby I'm Sayin' Goodbye|SSAA|Lynnell Diamond
+Baby Medley|TTBB|Tom Gentry
+Baby Mine|SSAA|Adam Scott
+Baby Mine|SSAA|Clay Hine
+Baby Mine|SSAA|Nancy Bergman
+Baby Mine|TTBB|Nancy Bergman
+Baby On Board|TTBB|Kyle Kitzmiller
+Baby On Board|TTBB|The Be Sharps
+Baby On Board|TTBB|Tom Gentry
+Baby Please Come Home|SSAA|Lorraine Rochefort
+Baby Won't You Please Come Home|TTBB|Barbershop Harmony Society
+Baby, It's Cold Outside|SATB|Joni Bescos
+Baby, It's Cold Outside|TTBB|Jon Nicholas
+Baby, It's You|TTBB|Adam Reimnitz
+Baby, Won't You Please Come Home|SSAA|Jo Lund
+Baby's Request|SSAA|Ig Jakovac
+Baby's Request|TTBB|Jon Nicholas
+Babys Request|SSAA|Unspecified
+Bach Fugue in D Minor|SSAA|Larry Wright
+Back In Business|TTBB|David Wright
+Back in the Old Routine|SSAA|Nancy Bergman
+Back in the Old Routine|SSAA|Renee Craig
+Back in the Old Routine|TTBB|Renee Craig
+Back In The Old Routine|TTBB|Dallas Town North
+Back In The Old Routine|TTBB|Greg Backwell
+Back In The Saddle Again|TTBB|Jon Nicholas
+Back to the Fifties|SSAA|Lynnell Diamond
+Back When Dad And Mother's Mother And Dad Were Young|TTBB|Mark Goodney
+Bad Bad Leroy Brown|TTBB|Fran Wilson
+Bad Bad Leroy Brown|TTBB|Tony Nasto
+Bad Bobbie's Baritone Blues|SSAA|Dot Calvin
+Bad Buncha Boys|TTBB|Kirk Roose
+Bad Buncha Boys Singin' Barbershop|TTBB|Kirk Roose
+Bad Day (You Had A)|TTBB|Steven Armstrong
+Bald Headed Men|SSAA|Barbara McNeill
+Bald-Headed Men|SSAA|Barbara McNeill
+Ballin' the Jack|SSAA|Chris Smith
+Ballin' The Jack|TTBB|Jack Baird
+Banana Man|TTBB|Steve Wolf
+Bandstand Boogie|SSAA|Renee Craig
+Bandstand in Central Park|SSAA|Nancy Bergman
+Banjo Medley|TTBB|Tom Gentry
+Banjo's Back In Town|SSAA|Renee Craig
+Barbara Ann|TTBB|Lars Holmstrom
+BARBERPOLE CAT II Package|TTBB|Barbershop Harmony Society
+BARBERPOLE CAT Package|TTBB|Barbershop Harmony Society
+Barbershop All Year Round|TTBB|Barbershop Harmony Society
+Barbershop Harmony Time|TTBB|Dave Stevens
+Barbershop Joe|SSAA|Karen Penketh
+Barbershop Song|TTBB|Steve Hall
+Barbershoppin' Cowgirl|SSAA|Carolyn E. Johnson
+Barbershoppin' Cowgirl|SSAA|Johnson
+Bare Necessities|SSAA|Tom Gentry
+Bare Necessities|TTBB|Simon Rylander
+Bare Necessities|TTBB|Tom Gentry
+Barry Manilow Medley|SSAA|Ann Minihane
+Barry Manilow Medley|TTBB|Jay Giallombardo
+Basin Street Blues|SSAA|Ann Minihane
+Basin Street Blues|SSAA|Brian Beck
+Basin Street Blues|SSAA|David Wright
+Basin Street Blues|SSAA|Nancy Bergman
+Basin Street Blues|TTBB|Dave Briner
+Basin Street Blues|TTBB|David Wright
+Basin Street Blues|TTBB|Unspecified
+Basin Street/Bye Bye Blues|SSAA|Lorraine Rochefort
+Battle Hymn of the Republic|SSAA|Judy West
+Battle Hymn Of the Republic|TTBB|Barbershop Harmony Society
+Battle Hymn Of The Republic|TTBB|Clay Hine
+Battle Hymn Of The Republic|TTBB|Joe Liles
+Battle Hymn Of The Republic|TTBB|Jon Nicholas
+Be a Clown|TTBB|Ed Waesche
+Be A Clown/Make 'em Laugh|SSAA|Joni Bescos
+Be A Clown/Make Em' Laugh Medley|TTBB|Jay Giallombardo
+Be My Baby Tonight|SSAA|Aaron Dale
+Be My Baby Tonight|TTBB|Aaron Dale
+Be My Life's Companion|TTBB|Tom Gentry
+Be Our Guest|SSAA|Margaret Rochon and Nancy Bergman
+Be Our Guest|SSAA|Nancy Bergman/Margaret Rochon
+Be Our Guest|SSAA|Unspecified
+Be Our Guest|TTBB|Greg Volk
+Be Our Guest|TTBB|Greg Volk, Steven Armstrong
+Be Our Guest|TTBB|Jay Giallombardo
+Be Our Guest|TTBB|Russ Foris
+Be Our Guest|TTBB|Steve Delehanty
+Be Prepared To Play|TTBB|Steve Tramack
+Beach Boys Medley|SSAA|Alex Kaiserman
+Beach Boys Medley|SSAA|P. Mauritzen
+Beach Boys Medley|SSAA|Paula Mauritzen
+Beach Boys Medley|SSAA|Tedda Lippincott
+Beach Boys Medley|SSAA|Tom Colville
+Beach Boys Medley|TTBB|Steve Delehanty
+Beach Boys Medley|TTBB|Tom Gentry
+Beach Boys Medley|TTBB|Unspecified
+Beale Street Blues|TTBB|Steve Delehanty
+Beat Me Daddy Eight to the Bar|SSAA|Jarmela Speta
+Beatles Medley|SSAA|Paula Mauritzen
+Beatles Medley (First Half)|TTBB|Greg Volk
+Beatles Medley (Second Half)|TTBB|Greg Volk
+Beatles Salute|SSAA|Jim Massey
+Beatles Sunshine Medley|SSAA|Mark Hale
+Beatles Sunshine Medley|TTBB|Mark Hale
+Beautiful|SSAA|Lorraine Rochefort
+Beautiful Dreamer|TTBB|David Wright
+Beautiful Savior|TTBB|J. Spencer Cornwall
+Beautiful Savior|TTBB|Joe Liles
+Beautiful Savior|TTBB|Tom Gentry
+Beautiful/Just The Way You Are Medley|SSAA|Hari Birtles
+Beauty And the Beast|SSAA|Carolyn Schmidt
+Beauty And The Beast|TTBB|Fred Kingsbury
+Beauty School Dropout|SSAA|Joni Bescos
+Because|SSAA|Derek Hollis
+Because|TTBB|Jim Henry
+Because|TTBB|John Hohl
+Because|TTBB|Josh Ehrlich
+Because It's Christmas|SSAA|Tedda Lippincott
+Because of You|SSAA|Don Gray
+Because Of You|TTBB|Don Gray
+Because We Believe|SSAA|Joe Liles
+Beep Beep|SSAA|Tedda Lippincott
+Beep Beep|TTBB|Don Gray
+Beethoven's Fifth|SSAA|Tom Gentry
+Before the Parade Passes By|SSAA|Carolyn Schmidt
+Before the Parade Passes By|SSAA|Jay Giallombardo
+Before the Parade Passes By|SSAA|Lorraine Rochefort
+Before The Parade Passes By|TTBB|Don Gray
+Before The Parade Passes By|TTBB|Jay Giallombardo
+Bein' Green|TTBB|Kirk Young
+Being With You|TTBB|Steve Delehanty
+Believe|SSAA|Joey Minshall
+Believe|TTBB|Adam Reimnitz
+Believe|TTBB|Kevin Keller
+Believe It Or Not|SSAA|Mo Rector
+Believe It Or Not|SSAA|Sylvia Alsbury
+Benediction|TTBB|Gene Grier and Lowell Everson
+Besame Mucho|SSAA|Ruby Rhea
+Beside an Open Fireplace|SSAA|Michael Gellert
+Best Day Of My Life|SSAA|Deke Sharon
+Best of Doo-Wop|TTBB|Ed Lojeski
+Best of Times|SSAA|Tedda Lippincott
+Betelehemu (TTBB)|TTBB|Olatunji / Whalum
+Between the Devil and the Deep Blue Sea|SSAA|Nancy Bergman
+Between The Devil And The Deep Blue Sea|SSAA|Jon Nicholas
+Between The Devil And The Deep Blue Sea|TTBB|David Wright
+Between The Devil And The Deep Blue Sea|TTBB|Jon Nicholas
+Between The Devil And The Deep Blue Sea|TTBB|Pete Rupay
+Between You And The Birds And The Bees And Cupid|TTBB|Aaron Dale
+Beyond the Sea|SSAA|Dave Briner
+Beyond the Sea|SSAA|Elaine Gain
+Beyond the Sea|TTBB|D.Kynaston
+Beyond the Sea|TTBB|David Briner
+Beyond The Sea|TTBB|Adam Reimnitz
+Bidin' My Time|SSAA|Norma Andersen
+Big Bad Bill|SSAA|Jim Arns
+Big Girls Don't Cry|SSAA|Marsha Zwicker
+Big Hair|SSAA|Lorraine Rochefort
+Big Spender|SSAA|Bev Sellers
+Big Spender|SSAA|Jo Lund
+Big, Bad Bill Is Sweet William Now|SSAA|Jim Arns
+Bigger Isn't Better|TTBB|Dennis Driscoll
+Bill|SSAA|Nancy Bergman
+Bill Bailey, Won't You Please Come Home|TTBB|David Harrington
+Bill Grogan's Goat|TTBB|Jay Giallombardo
+Billy-A-Dick|SSAA|Jim Arns
+Billy-A-Dick|SSAA|June Dale
+Birdland|SSAA|Ann Minihane
+Birth of the Blues|SSAA|Carolyn Schmidt
+Birth of the Blues|SSAA|David Wright
+Birth Of the Blues|TTBB|J. Rae Jamieson
+Birth Of The Blues|TTBB|Roger Payne
+Birthday Of A King|SSAA|Matt Swann
+Birthday Of A King|TTBB|Matt Swann
+Black Horse and the Cherry Tree|SSAA|Lorraine Rochefort
+Black Water|SSAA|Jon Nicholas
+Black Water|TTBB|Jon Nicholas
+Blackbird|SSAA|Deke Sharon
+Blackbird Medley|TTBB|Gary Parker
+Blah Blah Blah|TTBB|Steven Armstrong
+Blame It On the Bossa Nova|SSAA|Cheryl Suhr
+Bless the Broken Road|SSAA|Carole Prietto
+Bless Us All|TTBB|Adam Bock
+Blew By You|TTBB|Tom Gentry
+Blow, Gabriel Blow|SSAA|Jo Lund
+Blow, Gabriel Blow|SSAA|Renee Craig
+Blowin' in the Wind|SSAA|Kay Bromert
+Blue & Sentimental/Solitude|TTBB|Wayne Grimmer
+Blue Bayou|SSAA|Tom Gentry
+Blue Christmas|SSAA|Tedda Lippincott
+Blue Christmas|TTBB|Don Gray
+Blue Christmas|TTBB|Jim Clancy
+Blue Christmas|TTBB|Joel T. Rutherford
+Blue Christmas|TTBB|Jon Nicholas
+Blue Christmas (I'll have a)|SSAA|Lynnell Diamond
+Blue Moon|SSAA|Carolyn Schmidt
+Blue Moon|TTBB|Andy Isbell
+Blue Moon|TTBB|Dave Briner
+Blue Moon|TTBB|Tom Gentry
+Blue Moon Of Kentucky|SSAA|Aaron Dale
+Blue Moon Of Kentucky|TTBB|Aaron Dale
+Blue Shadows|TTBB|Jon Nicholas
+Blue Shadows On The Trail|SSAA|Jay Giallombardo
+Blue Shadows On The Trail|TTBB|Jay Giallombardo
+Blue Skies|SSAA|Clay Hine
+Blue Skies|SSAA|Renee Craig
+Blue Skies|TTBB|Buzz Haeger
+Blue Skies|TTBB|Clay Hine
+Blue Skies|TTBB|Ed Waesche
+Blue Skies|TTBB|Grant Libramento (Palmetto Statesmen)
+Blue Skies|TTBB|Jon Nicholas
+Blue Skies (YWIH)|SSAA|Renee Craig
+Blue Suede Shoes|SSAA|Tom Gentry
+Blue Velvet|TTBB|Curt Kimbal
+Blue Velvet|TTBB|Curt Kimball
+Blue Velvet|TTBB|Ruby Rhea
+Blue, Turning Grey Over You|TTBB|David Wright
+Blues in the Night|SSAA|Dave Briner
+Blues in the Night|TTBB|Dave Briner
+Blues In The Night|SSAA|Ann Minihane
+Blues In The Night|SSAA|Mary Coffman
+Boar's Head Carol|TTBB|Jay Giallombardo
+Boar's Head Carol, The (TTBB)|TTBB|Grant Cochran
+Bohemian Rhapsody|SATB|Queen
+Bohemian Rhapsody|SSAA|Heather Lane
+Bohemian Rhapsody|SSAA|Lorraine Rochefort
+Bohemian Rhapsody|TTBB|Steven Armstrong
+Bon jour mon Coeur|TTBB|Orlando di Lasso
+Boogie Woogie Bugle Boy|SSAA|Connie Kash
+Boogie Woogie Bugle Boy|SSAA|David Wright
+Boogie Woogie Bugle Boy|SSAA|Joni Bescos
+Boogie Woogie Bugle Boy|SSAA|Nancy Bergman
+Boogie Woogie Bugle Boy|SSAA|Unspecified
+Boogie Woogie Bugle Boy|TTBB|Tom Gentry
+Boot Scootin' Boogie|SSAA|Brian Beck
+Boot Scootin' Boogie|SSAA|Tedda Lippincott
+Bop 'Til You Drop|SSAA|BTM
+Bop Til You Drop|SSAA|Barbara McNeill
+Born to Be Blue|TTBB|Theo Hicks
+Born to be Wild|SSAA|Joey Minshall
+Bottom of the River|SSAA|Joel Derksen
+Boyfriend Medley|SSAA|David Wright
+Boyfriend Medley|SSAA|Jan Meyer
+Brahms Lullabye|TTBB|Steven Armstrong
+Brand New Day|TTBB|Bob Disney
+Bread And Gravy|TTBB|David Wright
+Break It To Me Gently|SSAA|Brian Beck
+Breakaway|SSAA|Carole Prietto
+Breakin' Up is Hard to Do|SSAA|Nancy Bergman/Joan D'Agnostino
+Breakin' Up Is Hard to Do|SSAA|Bev Sellers
+Breakin' Up Is Hard To Do|SSAA|Anna Maria Parker
+Breakin' Up Is Hard To Do|TTBB|Tom Gentry
+Breakin' Up Is Hard To Do (YWIH)|SSAA|Anna Maria Parker
+Breakin' Up Is Hard To Do (YWIH)|SSAA|Tedda Lippincott
+Breaking Up is Hard to Do|SSAA|Tedda Lippincott
+Breaking Up Is Hard To Do|SSAA|Tom Gentry
+Breaking Up Is Hard To Do|TTBB|Adam Reimnitz
+Breaking Up Is Hard To Do|TTBB|Tom Campbell
+Breaking Up Is Hard To Do (contest)|SSAA|Tom Gentry
+Bricklayer Song|TTBB|Al Fisk
+Bridge of Light|SSAA|June Berg
+Bridge Over Troubled Water|SATB|Kirby Shaw
+Bridge Over Troubled Water|TTBB|A. Nightingale, T. Pearce
+Bridge Over Troubled Water|TTBB|Brent Graham
+Bridge Over Troubled Water|TTBB|Greg Volk ed. Gary Lewis
+Bridge Over Troubled Water|TTBB|Unspecified
+Brigadoon Medley|TTBB|Jay Giallombardo
+Bright Was The Night|TTBB|David Wright
+Brighter Than the Sun/We Are Young|SSAA|Carole Prietto
+Bring Back Those Good Old Days|TTBB|Barbershop Harmony Society
+Bring Him Home|SSAA|Dave Briner
+Bring Him Home|TTBB|Darin Drown
+Bring Him Home|TTBB|Jay Giallombardo
+Bring Him Home|TTBB|Pete Rupay
+Bring Him Home|TTBB|Rich Hasty
+Bring Him Home|TTBB|Rob Hopkins
+Bring Him Home (2000 version)|TTBB|Jay Giallombardo
+Bring Me Sunshine|TTBB|Steve Armstrong
+Britney Spears Medley|SSAA|Matthew Hodge
+Broadway Baby|SSAA|Bev Sellers and Sylvia Alsbury
+Broadway Baby|SSAA|Marge Bailey
+Broadway Baby|SSAA|Sellers Alsbury
+Broadway Baby (From 'Follies')|SSAA|Renee Craig
+Broadway Grandma's Medley|SSAA|Nancy Bergman
+Broadway Rose|TTBB|Dennis Burnett
+Broadway Show Opener|TTBB|J. Rae Jamieson
+Broadway Star|SSAA|Wydra Joni Bescos
+Broadway Star Medley|SSAA|Joni Bescos / Mary Ann Wydra
+Brother Can You Spare A Dime|TTBB|David Wright
+Brother Can You Spare A Dime|TTBB|Jim Clancy, Bob Shami
+Brother Can You Spare A Dime|TTBB|Steven Armstrong
+Brother, Can You Spare A Dime|TTBB|David Wright
+Brother, Can You Spare A Dime|TTBB|Nighthawks
+Brother, Can You Spare A Dime|TTBB|Steven Armstrong
+Brother, Can You Spare A Dime?|TTBB|Backwell/Turner
+Brother, My Brother|TTBB|Kevin Keller
+Brotherhood of Man|TTBB|Jay Giallombardo
+Brothers, Sing On!|TTBB|Edvard Grieg
+Bucket of Love|SSAA|Joey Minshall
+Buddy Holly Medley|SSAA|Becky Wilkins
+Buffalo Bills Uptune Medley|TTBB|Walter Latzko
+Bugler's Holiday|TTBB|Jay Giallombardo
+Bugs Bunny Overture|TTBB|Ed Waesche
+Buona Sera|TTBB|Janne Olsson
+Bury Me Not On The Lone Prairie|TTBB|Adam Reimnitz
+Bury Me Out On The Lone Prairie|TTBB|Jon Nicholas
+Butterfly Kisses|TTBB|Tom Gentry
+Button Up Your Overcoat|SSAA|Nancy Bergman
+Button Up Your Overcoat|TTBB|Tom Gentry
+Button Up Your Overcoat (Senior Men's Version)|TTBB|Tom Gentry
+Button Up Your Overcoat (Seniors' Version)|TTBB|Tom Gentry
+Buttons And Bows|TTBB|Steve Delehanty
+By the Beautiful Sea|SSAA|Dot Calvin
+By The Beautiful Sea (YWIH)|SSAA|Dot Calvin
+By the Sea Medley|SSAA|Nancy Bergman
+By the Time I Get to Phoenix|SSAA|Nancy Bergman
+Bye Bye Baby|SSAA|Dot Calvin
+Bye Bye Baby/Won't You Please Come Home|SSAA|Chari Pernert
+Bye Bye Blackbird|SSAA|Carolyn Schmidt
+Bye Bye Blackbird|SSAA|David Wright
+Bye Bye Blackbird|SSAA|Mike Senter
+Bye Bye Blackbird|TTBB|Jon Nicholas
+Bye Bye Blues|SSAA|Fred Hamm/Dave Bennett
+Bye Bye Blues|SSAA|The Barbertones
+Bye Bye Blues|TTBB|Greg Volk
+Bye Bye Love|SSAA|Anna Maria Parker
+Bye Bye Love|SSAA|Tom Gentry
+Bye Bye Love|TTBB|Tom Gentry
+Bye Bye, Love|TTBB|Barbershop Harmony Society
+Bye, Bye Blackbird|TTBB|Brian Beck
+Cabaret|SSAA|Jo Lund
+Cabaret|SSAA|Nancy Bergman
+Cabaret|TTBB|Barbershop Harmony Society
+Cabaret|TTBB|Buzz Haeger
+Cabaret|TTBB|Unspecified
+Caissons Medley|SSAA|June Dale
+Calendar Girl|SSAA|Marge Bailey
+Calendar Girl|TTBB|Jon Nicholas
+California Dreamin'|SSAA|Lynnell Diamond
+California Dreamin'|SSAA|Michael Gellert
+California Dreamin'|SSAA|Tedda Lippincott
+California Dreamin'|TTBB|Joe Johnson
+California Dreaming|SSAA|Lynnell Diamond
+California Dreaming|TTBB|Mike Taylor
+California Here I Come|TTBB|Dave Stevens
+California Medley|SSAA|Nancy Bergman
+California, Here I Come|SSAA|Nancy Bergman
+California, Here I Come|TTBB|Dave Stevens/Dealer?s Choice
+Call It Nostalgia|TTBB|Charles Stahl
+Call Me|SSAA|Deke Sharon
+Call Me Back, Pal O Mine|TTBB|Ed Gentry
+Call Me Irresponsible|TTBB|Adam Scott
+Calypso Clapping Carol|SSAA|Farris Collins
+Calypso Clapping Carol|TTBB|Farris Collins
+Camptown Races Medley|TTBB|Jay Giallombardo
+Camptown Racetrack|TTBB|Joe Liles
+Can You Feel the Love Tonight|SSAA|June Dale
+Can You Feel the Love Tonight|SSAA|Tedda Lippincott
+Can You Feel The Love Tonight|SSAA|Marge Bailey
+Can You Feel The Love Tonight|TTBB|June Dale
+Can You Feel The Love Tonight (YWIH)|SSAA|Marge Bailey
+Can You Feel the Love Tonight?|TTBB|June Dale
+Can You Tame Wild Wimmen?|TTBB|Bob Benson
+Can-Can|SSAA|Clay Hine
+Can't Buy Me Love|SSAA|Tom Gentry
+Can't Buy Me Love|TTBB|Aaron Dale
+Can't Buy Me Love|TTBB|Tom Gentry
+Can't Help Falling In Love|SATB|Henrik Rosenberg
+Can't Help Falling In Love|TTBB|David Wright
+Can't Help Falling In Love|TTBB|Jon Nicholas
+Can'T Help Falling In Love Love Me Tender|SSAA|Joanne Dockrell
+Can't Help Lovin' That Man of Mine|SSAA|Anna Maria Parker
+Can't Help Lovin' That Man Of Mine|SSAA|Brian Beck
+Can't Take My Eyes Off Of You|SATB|Mason Kaye
+Can't Take My Eyes Off Of You|SSAA|Elaine Gain
+Can't Take My Eyes Off Of You|TTBB|Alex Morris
+Can't Take My Eyes Off Of You|TTBB|Zac Booles
+Canadian Medley|SSAA|Joey Minshall
+Candle on the Water|SSAA|Anna Maria Parker
+Candle on the Water|SSAA|June Dale
+Candle on the Water (YWIH)|SSAA|Anna Maria Parker
+Candyman Medley|SSAA|Alex Kaiserman
+Captain Of The Toy Brigade|TTBB|Jay Giallombardo
+Car Wash|SSAA|Joey Minshall
+Careless|TTBB|Platinum
+Carol From An Irish Cabin|TTBB|Dale Wood
+Carol Medley|SSAA|Floyd Connett
+Carol of the Bells|SSAA|Avis Fellows
+Carol of the Bells|SSAA|Kirby Shaw
+Carol of the Bells|SSAA|Liz Garnett
+Carol of the Bells|TTBB|Peter Wilhousky/Greg Lyne
+Carol Of The Bells|TTBB|David Wright
+Carol Of The Bells|TTBB|Greg Lyne
+Carol of the Bells (SATB)|SATB|Unspecified
+Carol Of The Bells/What Child Is This Medley(Joe Spie|SSAA|Joe Spiecker
+Carolina Blues|TTBB|Robert Rund
+Carolina in the Morning|SSAA|Nancy Bergman
+Carolina In The Morning|TTBB|Ed Waesche
+Carolina Medley|TTBB|Jay Giallombardo
+Carolina Moon|TTBB|Gene Cokeroft
+Carolina Moon|TTBB|John Stefero
+Carolina Parody|TTBB|Ed Wasche - Lyrics John Werth
+Caroline|TTBB|Larry Cole/Wally Cluett
+Caroline|TTBB|Larry Cole/Wally Cluett/Boston Common
+Caroline|TTBB|Rudy Newman
+Caroline|TTBB|Wally Cluett
+Caroling Caroling|TTBB|David Wright
+Caroling, Caroling|SSAA|Brian Beck
+Caroling, Caroling|SSAA|David Wright
+Caroling, Caroling|SSAA|Norma Andersen
+Caroling, Caroling|TTBB|Dave Briner
+Caroling, Caroling|TTBB|David Wright
+Carrickfergus|SSAA|Chris MacMartin
+Cartoon Medley|TTBB|Kevin Keller
+Catch a Falling Star|TTBB|Steve Hall
+Cause I'm A Blond|SSAA|Debbie Connelly
+Cecilia|TTBB|Interstate Rivals
+Cecilia|TTBB|Unspecified
+Celebrate Harmony|TTBB|Joe Liles
+Celebration|SATB|Renee Craig
+Celebration|SSAA|Connie Kash
+Celebration|SSAA|Renee Craig
+Celebration Medley|SSAA|Nancy Faddegon
+Cell Block Tango|SSAA|Kevin Keller
+Chances Are|SSAA|Greg Volk
+Chances Are|TTBB|Don Gray
+Chances Are|TTBB|Greg Volk
+Chances Ares|TTBB|Greg Volk
+Change the World|SSAA|Mac Huff
+Changes Medley|SSAA|Bev Sellers
+Changes Medley|SSAA|Jim Arns
+Changes Medley|SSAA|Nancy Bergman
+Changes Medley|SSAA|Renee Craig
+Changes/I Used to Love You Medley|SSAA|Carolyn Schmidt
+Channel Surfin'|SSAA|Tedda Lippincott
+Chanson D'Amour|SSAA|Bob O'Connell
+Chanukah Is Here|TTBB|Alan Josephson
+Chapel of Love|SSAA|Anna Maria Parker
+Chapel of Love|SSAA|Charlene Yazurlo
+Chapel of Love|SSAA|Dotty Hougen
+Charleston|SSAA|Brian Beck
+Charleston|SSAA|Marsha Zwicker
+Charlie and the MTA|SSAA|Lorraine Rochefort
+Charmed Life|SSAA|Chris Moyer
+Chase the Rain Away|SSAA|Lynnell Diamond
+Chasing Cars|TTBB|Jon Nicholas
+Chattanooga Choo Choo|SSAA|Joni Bescos
+Chattanooga Choo Choo|SSAA|Renee Craig
+Chattanooga Choo Choo|TTBB|Kirk Young
+Chattanooga Choo Choo|TTBB|Renee Craig
+Chattanooga Choo Choo/Pennsylvania, Goodbye Medley|SSAA|Jon Nicholas
+Chattanooga Choo Choo/Pennsylvania, Goodbye Medley|TTBB|Jon Nicholas
+Cheek to Cheek|SSAA|Ruby Rhea
+Cheek To Cheek|SSAA|Brian Beck
+Cheek To Cheek|SSAA|Ed Waesche
+Cheek To Cheek|TTBB|Ed Waesche
+Cheek To Cheek-My Blue Heaven Medley|TTBB|John Brockman
+Cheer Up Charlie|SSAA|Sharon Holmes
+Cheer Up, Charlie|SSAA|Brent Graham
+Cheer Up, Charlie|SSAA|Jim Henry
+Cheer Up, Charlie|TTBB|Jim Henry
+Chemistry|TTBB|Patrick McAlexander
+Cherish|SSAA|Kevin Keller
+Cherry Pink and Apple Blossom White|SSAA|Ruby Rhea
+Chicago - My Kind of Town Medley|TTBB|Jack Baird
+Chicago Medley|SSAA|Jay Giallombardo
+Chicago Medley|SSAA|Jo Lund
+Children Go Where I Send Thee|TTBB|Jon Nicholas
+Children's Medley (Jolly Old St. Nicholas/Up on the Housetop)|TTBB|Barbershop Harmony Society
+Chili con Carne|SSAA|Anders Edenroth
+Chitty Chitty Bang Bang|SSAA|Joni Bescos
+Choc'late In My Stocking|SSAA|Aaron Dale
+Choc'late In My Stocking|SSAA|Lynnell Diamond
+Chocolate in My Stocking|SSAA|Aaron Dale
+Choo Choo Ch' Boogie|TTBB|Walter Latzko
+Choo Choo Ch'Boogie|SSAA|Cheryl Suhr
+Choo Choo Train|SSAA|Joan Adler
+Chordbuster March|SSAA|Joe Liles
+Chordbuster March|SSAA|WA Wyatt
+Chordbuster's March|SSAA|A. A. Wyatt
+Chordbuster's March|TTBB|WA Wyatt
+Chordbusters March|SSAA|WA Wyatt
+Christ-Mas|SSAA|Greta Somers
+CHRISTmas|SSAA|Greta Somers
+CHRISTMAS|SSAA|Tedda Lippincott
+Christmas Canon (with Children's Choir)|SATB|Shaun Agnew
+Christmas Carol Medley|SSAA|Marie Johnson
+Christmas Carol Medley|TTBB|Barbershop Harmony Society
+Christmas Chopstick|SSAA|Traditional
+Christmas Chopsticks|SSAA|Unspecified
+Christmas Chopstix|SSAA|Sweet Adelines International
+Christmas Chopstix|SSAA|Unspecified
+Christmas Eve In My Hometown|TTBB|Hal Maples
+Christmas Eve In My Hometown|TTBB|Mark Hale
+Christmas Eve in Washington|SSAA|Ann Minihane
+Christmas In Dixie|SSAA|Joe Liles
+Christmas in San Francisco|SSAA|Lynnell Diamond
+Christmas Is A Feeling|SSAA|Tedda Lippincott
+Christmas Is Meant For Children|SSAA|Renee Craig
+Christmas Is The Best Time Of The Year|SSAA|Judy Vidal
+Christmas Island|SSAA|Jean Shook
+Christmas Means|TTBB|Joe Johnson
+Christmas Medley|SSAA|Tedda Lippincott
+Christmas Medley|TTBB|Unspecified
+Christmas Medley for Kids|SSAA|Marsha Zwicker
+Christmas Overture|TTBB|Kenny Ray Hatton and Joe Johnson
+Christmas Stays the Same|SSAA|Joe Johnson
+Christmas Stays The Same|TTBB|Joe Johnson
+Christmas Through Your Eyes|TTBB|Larry Triplett
+Christmas Time Is Here|SSAA|Adam Bock
+Christmas Time Is Here|SSAA|Carole Prietto
+Christmas Time Is Here|SSAA|Sharon Holmes
+Christmas Time Is Here|TTBB|Adam Bock
+Christmas Time Is Here|TTBB|Brian Beck
+Christmas Time Is Here|TTBB|Jay Giallombardo
+Christmas Time Is Here|TTBB|Jon Nicholas
+Christmas Waltz/Silver Bells Medley|SSAA|Tedda Lippincott
+Christmas Was Meant For Children|SSAA|Brent Graham
+Christmas Was Meant For Children|SSAA|Renee Craig
+Church Bells|SSAA|Clay Hine
+Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
+Church Bells Parody|TTBB|Clay Hine
+Cinderella|TTBB|Gene Cokeroft
+Circle of Life|SSAA|Lorraine Rochefort
+Circle Of Life|TTBB|Jay Giallombardo
+Circle Of Life|TTBB|R. Soderlund
+Circle of Life (Chorus Parts Only)|TTBB|R. Soderlund
+Circle of Life (chorus with 4-part overlay)|SSAA|Lorraine Rochefort
+Circle Of Life All|SATB|R. Soderlund, Chris Arnold
+Circle Of Life Men|TTBB|R. Soderlund, Chris Arnold
+Circus Day In Dixie|TTBB|Ed Waesche
+Circus Medley|TTBB|Steve Tramack
+Civil War Medley|TTBB|Barbershop Harmony Society
+Clap Hands|TTBB|Will Hamblet
+Clap Yo Hands|TTBB|Steve Jamison
+Clear-Day|TTBB|Unspecified
+Climb Every Mountain|SSAA|Joe Liles
+Climb Every Mountain|SSAA|Nancy Bergman
+Climb Every Mountain|SSAA|Unspecified
+Climb Every Mountain|TTBB|Don Gray
+Climb Every Mountain|TTBB|Frank Bloebaum
+Climb Every Mountain|TTBB|Jay Giallombardo
+Climb Every Mountain|TTBB|Steve Delehanty
+Closest Thing To Crazy (Katie Melua)|SSAA|Linda Corcoran
+Clown (Emile Sande)|SSAA|Lisa Hannant
+Clown Medley|TTBB|Jay Giallombardo
+Clown Medley|TTBB|Tom Gentry
+Cocktails for Two|SSAA|Joni Bescos
+Coconut|SSAA|Joe Liles
+Cohan Medley|SSAA|Aileen Nightingale
+Cohan Medley|SSAA|Bergman/Nightingale
+Cold & Fugue|SSAA|Foncannon/Jones
+College Days Medley|TTBB|Tom Gentry
+Collegiate|TTBB|Chuck Brooks
+Colorado Christmas|TTBB|Jay Giallombardo
+Colorado My Home|TTBB|Darin Drown
+Colorado, My Home|SSAA|Sylvia Alsbury
+Colors of the Wind|SSAA|Tedda Lippincott
+Colors of the Wind|TTBB|Chris MacMartin
+Colours of the Wind|SSAA|Liz Garnett
+Come And See What's Hap'nin' In The Barn|TTBB|Jay Giallombardo
+Come Dance With Me/Come Fly With Me Medley|TTBB|Kevin Keller
+Come Fly With Me|SSAA|Carolyn Schmidt
+Come Fly With Me|SSAA|Kevin Keller
+Come Fly With Me|TTBB|Kevin Keller
+Come Fly With Me|TTBB|Unspecified
+Come Fly With Me/Fly Me To The Moon Medley(Joel T. Ruther|SATB|Joel T. Rutherford
+Come Follow The Band|SSAA|Ann Minihane
+Come Go With Me|TTBB|Daniel Goldschmidt
+Come Go With Me|TTBB|Tom Gentry
+Come In From the Rain|SSAA|Betty Oliver
+Come Josephine In My Flying Machine|TTBB|Burt Szabo
+Come On Get Happy|SSAA|Aaron Dale
+Come On Get Happy|TTBB|Aaron Dale
+Come Rain or Come Shine|SSAA|Ardeth Fullmer
+Come Rain or Come Shine|SSAA|Jo Lund
+Come Rain Or Come Shine|TTBB|Adam Reimnitz
+Come See What's Happening In The Barn|TTBB|Jeremey Johnson
+Come Share His Life With Me|TTBB|Richard Loebakka
+Come Take Your Place In My Heart|SSAA|Jim Clancy
+Come Take Your Place In My Heart|TTBB|Jim Clancy
+Come What May|SSAA|Alex Kaiserman
+Come What May|TTBB|Kevin Keller
+Comedy (Harmony) Tonight|SSAA|Sharon Holmes
+Comedy Tonight|SSAA|Betty Steele
+Comedy Tonight|TTBB|Hal Maples
+Comedy Tonight|TTBB|Roger Payne
+Comelet Us Sing Of Christmas Day|SSAA|Renee Craig
+Comes Love|SSAA|Adam Reimnitz
+Comes Love|TTBB|Adam Reimnitz
+Coney Island Baby|TTBB|Barbershop Harmony Society
+Coney Island Washboard|SSAA|Clay Hine
+Conga/Rhythm Medley|SSAA|Brian Beck
+Connie Francis Medley: Lipstick Collar, Who'S Sorry Now|SSAA|Unspecified
+Consider Yourself|SSAA|Dot Calvin
+Consider Yourself|TTBB|Don Gray
+Consider Yourself|TTBB|Ed Waesche
+Consider Yourself|TTBB|Tom Gentry
+Consider Yourself At Home (YWIH)|SSAA|Dot Calvin
+Convoy|TTBB|Bryan Ziegler
+Cool Water|TTBB|Don Gray
+Cool Water|TTBB|Jon Nicholas
+Cool Yule|TTBB|Aaron Dale
+Cop On The Beat|TTBB|Fred King
+Copacabana|SSAA|Greg Volk
+Copacabana|SSAA|Jean McFadyen
+Copacabana|TTBB|Tom Gentry
+Cotton Fields (Them Old...)|TTBB|Peter Mumford
+Could I Have This Dance|SSAA|Charlene Yazurlo
+Could I Have This Dance|SSAA|Joni Bescos
+Could I Have This Dance|SSAA|June Berg
+Could It Be Magic?|SSAA|Renee Craig
+Count On Me|SSAA|Elaine Gain
+Count On Me|SSAA|June Berg
+Count On Me|TTBB|Jeremey Johnson
+Count Your Blessings|SSAA|Sharon Holmes
+Count Your Blessings|TTBB|Jim Massey
+Country Boy|TTBB|Aaron Dale
+Country Dances|SATB|Ward Swingle
+Country Girl|SSAA|Aaron Dale
+Country Girl (Country Boy)|SSAA|Aaron Dale
+Country Roads|SSAA|Nancy Bergman
+Country Roads|TTBB|Steve Jamison
+Country Roads Take Me Home|TTBB|Steve Jamison
+Country Roads, Take Me Home|SSAA|Nancy Bergman
+Country Roads/Sunshine On My Shoulders Medley|TTBB|Steve Jamison
+County Fair|TTBB|Russ Foris
+Coventry Carol|SSAA|Renee Craig
+Coventry Carol|TTBB|Barbershop Harmony Society
+Coventry Carol|TTBB|Renee Craig
+Cow Patti|TTBB|Don Gray
+Crazy|SSAA|Carolyn Schmidt
+Crazy|SSAA|Clay Hine
+Crazy|SSAA|Lorraine Rochefort
+Crazy|SSAA|Nancy Bergman
+Crazy|SSAA|Tedda Lippincott
+Crazy|TTBB|Walter Latzko
+Crazy 'Bout Ya Baby|TTBB|Larry Wright
+Crazy 'Bout Ya, Baby|TTBB|Rob Campbell
+Crazy For You (Madonna)|SSAA|Liz Garnett
+Crazy Little Thing Called Love|SSAA|Aaron Dale
+Crazy Little Thing Called Love|TTBB|Aaron Dale
+Crazy Little Thing Called Love|TTBB|Chris Peterson
+Crazy Man Medley|TTBB|Greg Lapp, Rich Hasty
+Crazy Words, Crazy Tune|TTBB|139th Street Quartet
+Creole Cutie|TTBB|Unspecified
+Cross That Mason Dixon Line|TTBB|David Wright
+Cross That Mason-Dixon Line|TTBB|David Wright
+Crown Him with Many Crowns|TTBB|Heather Sorenson
+Cruella De Vil|SSAA|David Wright
+Cruella De Vil|SSAA|Lynnell Diamond
+Cruella De Vil|TTBB|David Wright
+Cruising Down The River|TTBB|Mo Rector
+Cry Baby|SSAA|Nancy Bergman
+Cry Baby/So Long Dearie|SSAA|Nancy Bergman
+Cry Me a River|SSAA|Carolyn Healey
+Cry Me A River|SSAA|Peter W Godfrey
+Cry Me A River|SSAA|Unspecified
+Cry Me A River|TTBB|Brent Graham
+Crying|TTBB|David Wright
+Crying|TTBB|Unspecified
+Crying In The Rain|TTBB|Tom Gentry
+Crying Myself to Sleep|SSAA|Nancy Bergman
+Cuddle Up|TTBB|Clay Hine
+Cuddle Up A Little Closer|SSAA|Ed Hinkley
+Cuddle Up A Little Closer|TTBB|Clay Hine
+Cup Song|SSAA|J. Mariano
+Cups (Pitch Perfect)|SSAA|Kirby Shaw
+Daddy Sang Bass|SSAA|Larry Wright
+Daddy Sang Bass|TTBB|Carl Perkins
+Daddy Sang Bass|TTBB|Chris Arnold
+Daddy Sang Bass Baseball Parody|TTBB|Unspecified
+Daddy You've Been a Mother to Me|TTBB|Jack Baird
+Daddy's Little Girl|SSAA|Don Gray
+Daddy's Little Girl|SSAA|Nancy Bergman
+Daddy's Little Girl|TTBB|David Wright
+Daddy's Little Girl|TTBB|Don Gray
+Daisy Bell (A Bicycle Built For Two)|TTBB|Jon Nicholas
+Daisy Bell (Bicycle Built For Two)|TTBB|Jon Nicholas
+Dance With Me Tonight|SSAA|Liz Garnett
+Dancin (Darktown Strutters Ball Adaptation)|SSAA|Judy Vidal
+Dancin' in the Streets|TTBB|Jay Giallombardo
+Dancin' in the Streets of New Orleans|SSAA|Bergman/Hill
+Dancin' in the Streets of New Orleans/Mardis Gras March|SSAA|Marsha Hill/Nancy Bergman
+Dancing in the Dark Medley|SSAA|Nancy Bergman
+Dancing Medley|SSAA|Joe Mannherz
+Dancing Queen|SSAA|Deke Sharon
+Dancing Queen|SSAA|Elaine Gain
+Dancing Queen|TTBB|Steven Armstrong
+Dancing Queen (Gain)|SSAA|Elaine Gain
+Dangerous Dan|TTBB|Sidewinders
+Dangerous Dan McGrew|TTBB|The Sidewinders
+Danny Boy|SATB|Steve Wolf
+Danny Boy|SSAA|Anna Maria Parker
+Danny Boy|SSAA|Lynnell Diamond
+Danny Boy|SSAA|Renee Craig
+Danny Boy|TTBB|Barbershop Harmony Society
+Danny Boy|TTBB|Ed Waesche
+Danny Boy|TTBB|Gene Cokeroft
+Danny Boy|TTBB|Jay Giallombardo
+Danny Boy|TTBB|Jim Clancy
+Danny Boy|TTBB|Jon Nicholas
+Danny Boy|TTBB|Mike Sotiriou
+Danny Boy|TTBB|Renee Craig
+Danny Boy|TTBB|Simon Arnott
+Danny Boy|TTBB|Steve Bishop / Patrick Rose
+Danny Boy (SSAA)|SSAA|Dede Duson
+Darkness on the Delta|TTBB|Bluegrass Student Union
+Darkness On The Delta|TTBB|Barbershop Harmony Society
+Darkness On The Delta|TTBB|Rob Hopkins
+Darkness On the Delta (Parody)|TTBB|Chordiac Arrest
+Darktown Strutter's Ball|TTBB|Don Gray
+Darktown Strutter's Ball|TTBB|Ed Waesche
+Day By Day|SSAA|Ruby Rhea
+Day In Day Out|TTBB|Jeremey Johnson
+Daybreak|SSAA|Norma Andersen
+Daydream|TTBB|Mel Knight
+Daydream Medley|TTBB|Joe Johnson
+Dayton Ohio|TTBB|King's Singers
+De King Is Born Today|TTBB|Morgan Ames
+Dean Martin Medley|TTBB|Jay Giallombardo
+Dear Hearts and Gentle People|TTBB|Rob Campbell
+Dear Little Boy / Soldier Medley|SSAA|Dave Briner
+Dear Little Boy Of Mine|SSAA|Joe Liles and Floyd Connett
+Dear Old Donegal|TTBB|Steve Jamison
+Dear Old Girl|TTBB|Fred King
+Dear Old Girl|TTBB|Rob Hopkins
+Deck the Hall|TTBB|Mark Patterson
+Deck the Halls|SATB|Burt Szabo
+Deck The Halls|SSAA|Renee Craig
+Deck The Halls|TTBB|Andreas Weiland
+Deck The Halls|TTBB|Burt Szabo
+Deck The Halls|TTBB|Robert Shaw
+Deed I Do|SSAA|Aaron Dale
+Deed I Do|SSAA|Joni Bescos
+Deed I Do|SSAA|Lynnell Diamond
+Deed I Do|TTBB|Aaron Dale
+Deed I Do Medley|SSAA|Joni Bescos
+Deed I Do/Yes Sir, That's My Baby|SSAA|Bev Sellers
+Deep Henderson|TTBB|Jon Nicholas
+Deep in a Dream|TTBB|Chris MacMartin
+Deep In The Heart Of Texas|TTBB|Jack Baird
+Deep Purple|SSAA|Jim Arns
+Deep River|SSAA|Anna Maria Parker
+Defying Gravity|SSAA|Joey Minshall
+Delta Dawn|SSAA|Joni Bescos
+Delta Dawn|TTBB|Jim Clancy
+Demons|SSAA|Jonathan Sparks
+Dentist!|TTBB|Roger Payne
+Desert Song|TTBB|Jon Nicholas
+Desperado|SSAA|Brian Hogan
+Desperado|SSAA|Jeremey Johnson
+Desperado|TTBB|Jeremey Johnson
+Desperado|TTBB|Tom Gentry
+Destination Moon|SSAA|Siegal-Seirup
+Destination Moon|TTBB|Adam Reimnitz
+Destination Moon|TTBB|Anthony Nasto
+Devoted to You|SSAA|Tom Gentry
+Diamonds Are A Girl's Best Friend|SSAA|Jarmela Speta
+Diamonds Are A Girl's Best Friends|SSAA|Tedda Lippincott
+Diamonds Medley|SSAA|Carolyn Schmidt
+Diddly Squat|TTBB|Tom Gentry
+Didn't My Lord Deliver Daniel|TTBB|Aaron Dale
+Didn't We|SSAA|George Avener
+Didn't We / MacArthur Park Medley|TTBB|Jim Clancy, Larry Wright, Rich Hasty
+Diet Riot|SSAA|Lynnell Diamond
+Dinah|TTBB|David Wright
+Ding Dong The Witch Is Dead|SSAA|Clay Hine
+Ding Dong The Witch Is Dead|TTBB|Clay Hine
+Disco Medley|SSAA|Brian Beck
+Disco Medley|SSAA|Janne Olsson
+Disney Song Medley|TTBB|Joe Liles
+Dixie|TTBB|Mo Rector
+Dixie Down Broadway|SSAA|Frank Marzocco
+Dixie Medley|TTBB|Ed Waesche
+Dixie Sunshine|SSAA|Nancy Bergman
+Dixie/Battle Hymn Medley|SSAA|Sharon Holmes
+Dixieland Delight|SSAA|Brian Beck
+Do Lord|SSAA|Dot Short
+Do You Believe in Magic|SSAA|Joan D'Agostino
+Do You Ever Think Of Me?|SSAA|June Dale
+Do You Hear The People Sing|TTBB|Tom Gentry
+Do You Hear The People Sing?|TTBB|Jay Giallombardo
+Do You Hear The People Sing?|TTBB|Tom Gentry
+Do You Hear What I Hear|SSAA|Gas House Gang
+Do You Hear What I Hear|TTBB|Jay Giallombardo
+Do You Hear What I Hear|TTBB|Joe Liles
+Do You Hear What I Hear|TTBB|Phil Ordaz
+Do You Hear What I Hear|TTBB|Unspecified
+Do You Hear What I Hear?|SSAA|Joe Liles
+Do You Hear What I Hear?|SSAA|Judy Vidal
+Do You Hear What I Hear?|SSAA|Tedda Lippincott
+Do You Hear What I Hear?|TTBB|Gas House Gang, Jay Giallombardo
+Do You Hear What I Hear?|TTBB|Joe Liles
+Do You Hear What I Hear?|TTBB|Jon Nicholas
+Do You Hear What I Hear?|TTBB|Unspecified
+Do You Know What It Means|SSAA|Sylvia Alsbury
+Do You Know What It Means to Miss New Orleans|SSAA|Tom Campbell
+Do You Know What It Means To Miss New Orleans?|TTBB|Don Gray
+Do You Know What It Means To Miss New Orleans?|TTBB|Val Hicks
+Do You Know What It Means To Miss New Orleans(Barbershop Harmony Soc|TTBB|Barbershop Harmony Society
+Do You Really Love Me?|SSAA|Ruby Rhea
+Do You See What I See?|SSAA|Nancy Bergman/Aileen Nightingale
+Doctor Jazz Medley|SSAA|Mary Coffman
+Dominion / Chesapeake Medley|TTBB|Don Gray
+Don Juan|SSAA|Carolyn Schmidt
+Don't Be a Baby, Baby|TTBB|Boston Common
+Don't Be A Baby, Baby|TTBB|Aaron Dale
+Don't Be A Baby, Baby|TTBB|Barbershop Harmony Society
+Don't Be Cruel (To A Heart That's True)|TTBB|Greg Gilpin
+Don't Be So Mean to Baby|SSAA|Ig Jakovac
+Don't Blame Me|TTBB|Lou Perry
+Don't Break the Heart that Loves You|TTBB|Greg Volk
+Don't Break the Heart That Loves You|SSAA|Greg Volk
+Don't Break the Heart That Loves You|SSAA|Unspecified
+Don't Break The Rules|TTBB|Aaron Dale
+Don't Bring Lulu|TTBB|Fraser Brown
+Don't Cry Out Loud|SSAA|Joni Bescos
+Don't Cry, Little Girl|SSAA|Nancy Bergman
+Don't Ever Make Fun of an Egg|TTBB|Unspecified
+Don't Fence Me In|TTBB|Burt Szabo
+Don't Fence Me In|TTBB|Darin Drown
+Don't Fence Me In|TTBB|Jon Nicholas
+Don't Get Around Much Anymore|TTBB|Al Downey
+Don't Get Around Much Anymore|TTBB|Walter Latzko
+Don't Laugh at Me|TTBB|Jake Kynaston
+Don't Let The Rain Come Down|SSAA|Don Rose
+Don't Put a Tax On My Barbershop Chords|TTBB|Tom Gentry
+Don't Put a Tax on the Beautiful Girls|TTBB|Burt Szabo
+Don't Put a Tax On the Beautiful Girls|TTBB|Tom Gentry
+Don't Rain On My Parade|SSAA|David Harrington
+Don't Rain On My Parade|TTBB|David Harrington
+Don't Sit Under the Apple Tree|SSAA|Dot Short
+Don't Sit Under the Apple Tree|SSAA|Marie Johnson
+Don't Sit Under the Apple Tree|SSAA|Nancy Bergman
+Don't Sit Under the Apple Tree|TTBB|Dick Rode
+Don't Sit Under the Apple Tree|TTBB|Unspecified
+Don't Sit Under The Apple Tree|SSAA|David Harrington
+Don't Stop Believin'|SSAA|Lorraine Rochefort
+Don't Stop Believing|SSAA|Lorraine Rochefort
+Don't Take Your Love From Me|SSAA|Sharon Holmes
+Don'T Tell Me The Same Things Lies Medley|SSAA|Joni Bescos Judy Vidal intro
+Don't Tell Me the Same Things/I Used to Love You|SSAA|Bescos/Alsbury
+Don't Tell Me the Same Things/It's the Last Time|SSAA|Jim Arns
+Don't Tell Me the Same Things/Lies Medley|SSAA|Joni Bescos
+Dont Break The Heart That Loves You|SSAA|Unspecified
+Doo Wop Medley|SSAA|Anna Maria Parker
+Down At the Barbecue|SSAA|Marie Johnson
+Down At The Long Branch Saloon|SSAA|Nancy Bergman
+Down At The Twist & Shout|SSAA|Barbara McNeill
+Down at the Twist and Shout|SSAA|Barbara McNeill
+Down By the Old Mill Stream|TTBB|Tell Taylor
+Down By The Old Mill Stream|TTBB|Barbershop Harmony Society
+Down By The Riverside|TTBB|Tom Gentry
+Down In The Valley|TTBB|George Mead
+Down On The Farm|TTBB|Joe Colon
+Down Our Way|TTBB|Floyd Connett
+Down The River To Pray|SSAA|Sharon Holmes
+Down to the River to Pray|SSAA|Sharon Holmes
+Down To The River To Pray|TTBB|Joe Johnson
+Down Under Medley|SSAA|Brian Beck
+Down Where The South Begins|TTBB|Bill Busby
+Down Where The South Begins|TTBB|Renee Craig
+Down Where the Swanee River Flows|TTBB|Clay Hine
+Down With Love|TTBB|Aaron Dale
+Dr Jazz Jazz Holiday Medley|SSAA|Sellers Alsbury
+Dr Jazz Medley|SSAA|Mary Coffman
+Dr. Jazz/Holiday Medley|SSAA|Mary Coffman
+Dream|SSAA|Carolyn Schmidt
+Dream a Little Dream of Me|SSAA|Gentry/Ramsson
+Dream a Little Dream of Me|SSAA|Tom Gentry
+Dream a Little Dream of Me|SSAA|Tom Gentry/Beth Ramsson
+Dream a Little Dream of Me|TTBB|Clay Hine
+Dream A Little Dream of Me|SSAA|Don Gray
+Dream A Little Dream of Me|SSAA|Norma Andersen
+Dream A Little Dream Of Me|TTBB|Joe Johnson
+Dream A Little Dream Of Me|TTBB|Jon Nicholas
+Dream A Little Dream Of Me|TTBB|Tom Gentry
+Dream a Little Dream of Me/Penthouse Serenade|TTBB|Webb Comfort
+Dream Is A Wish, A (YWIH)|SSAA|Lorraine Rochefort
+Drinking Song|TTBB|Don Gray
+Drive|TTBB|Jon Nicholas
+Drive By|TTBB|The Blenders
+Drive My Car|TTBB|Jim Henry
+Drivin Me Crazy|SSAA|Bob Disney
+Drivin' Me Crazy|SSAA|Bob Diz Disney
+Drivin' Me Crazy|TTBB|Bob Disney
+Drivin' My Life Away|TTBB|Jon Nicholas
+Drunken Sailor|SSAA|June Dale
+Drunken Sailor|TTBB|Alice Parker, Robert Shaw, Pippa Goodall
+Dry Bones|SSAA|Nancy Bergman
+Dry Bones|TTBB|David Harrington
+Duetto Buffo di Quatro Gatti|SSAA|Dede Nibler
+Duke Ellington's Swingtime|SSAA|Renee Craig
+Dumas Walker|TTBB|Jon Nicholas
+Dust Off That Old Pianna|TTBB|David Wright
+Each Time I Fall in Love|SSAA|SK Grundy
+Each Time I Fall In Love|SSAA|Suzy Lobaugh
+Each Time I Fall In Love|TTBB|SK Grundy
+Each Time I Fall In Love|TTBB|Unspecified
+Early American 'Uptempo' Medley|TTBB|Jay Giallombardo
+Early American Medley|TTBB|Barbershop Harmony Society
+Ease on Down the Road|SSAA|Dede Nibler
+East Bound And Down|TTBB|Jon Nicholas
+Easter Parade|SSAA|Nancy Bergman
+Easter Parade|TTBB|Ed Waesche
+Easy Goin?|TTBB|David Wallace
+Easy Goin'|TTBB|Walter Latzko
+Ebb Tide|SSAA|Fred King
+Ebb Tide|TTBB|Fred King
+Ebb Tide|TTBB|Freddie King
+Edelweiss|SSAA|Jean Shook
+Edelweiss|TTBB|Johan Wikstrom
+Edelweiss|TTBB|Mac Huff
+Eight Days A Week|SSAA|David Harrington
+Eight Days A Week|TTBB|David Harrington
+Eight Days A Week mini|SSAA|David Harrington
+Eight Days A Week mini|TTBB|David Harrington
+Eine Kleine NOT Musik|TTBB|Jim Henry
+El Yivneh Hagalil|TTBB|Peter Sozio
+Eleanor Rigby|TTBB|Jay Giallombardo
+Eleanor Rigby|TTBB|Jon Nicholas
+Elegance (From Hello, Dolly !)|SSAA|J Speta
+Eli's Comin'|SSAA|Brian Beck
+Elijah Rock|SATB|Moses Hogan
+Elmer Fudd Medley|TTBB|Scott Turnbull
+Elmer's Tune|SSAA|Joni Bescos
+Elvis Medley|TTBB|John Hohl
+Elvis Medley; Can'T Help Fall Love Love Me Tender|SSAA|Joanne Dockrell
+Emaline|TTBB|Earl Moon
+Emaline|TTBB|Walter Latzko
+Embraceable You|SATB|Steven Armstrong
+Embraceable You|SSAA|Dave Briner
+Embraceable You|SSAA|Ed Waesche
+Embraceable You|TTBB|Ed Waesche
+Embraceable You|TTBB|Jay Giallombardo
+Embraceable You|TTBB|John Hohl
+Embraceable You/You Do Something to Me|SSAA|Ed Hinkley
+Emily|TTBB|Bob Pyper
+Empire State Of Mind (Alicia Keys)|SSAA|H Zimmerman
+Empty Chairs At Empty Tables|TTBB|Steve Tramack
+Encore|SSAA|Steve Delehanty / Roger Payne
+Enjoy The Ride|TTBB|Steve Tramack
+Entrance of the Gladiators - March of Triumph|SSAA|Joey Minshall
+Erie Canal|TTBB|Walter Latzko
+Eternal Father|TTBB|Dan Tice
+Eternal Father, Strong To Save|TTBB|Joe Johnson
+Ev'ry Street's a Boulevard|SSAA|Jarmela Speta
+Ev'ry Time We Say Goodbye|SATB|Henrik Rosenberg
+Eve Wasn't Modest Till She Ate That Apple|TTBB|Ig Jakovac
+Every Breath You Take|SSAA|Aaron Dale
+Every Breath You Take|TTBB|Aaron Dale
+Every Day of My Life|SSAA|Lynnell Diamond
+Every Day of My Life|TTBB|Bob Mattes
+Every Day Of My Life|SSAA|Unspecified
+Every Day Of My Life|TTBB|Unspecified
+Every Street's a Boulevard|SSAA|Jarmela Speta
+Every Time We Say Goodbye|TTBB|Dave Briner
+Everybody Loves a Hero|TTBB|Drayton Justus
+Everybody Loves a Lover|SSAA|Anna Maria Parker
+Everybody Loves a Lover|TTBB|Unspecified
+Everybody Loves A Lover|TTBB|Drayton Justus
+Everybody Loves Somebody|TTBB|John Hohl
+Everybody Loves Somebody|TTBB|Kevin Keller
+Everybody Loves Somebody|TTBB|Larry Triplett
+Everybody Loves Somebody Sometime|SSAA|Tedda Lippincott
+Everybody Step|SSAA|Linda Edmondson
+Everybody Step/Alexander's Ragtime Band Medley|TTBB|Greg Volk
+Everybody's Buddy|TTBB|Jay Giallombardo
+Everybody's Changing|TTBB|Henrik Rosenberg
+Everybody's Crazy Over Dixie|TTBB|Steve Taylor
+Everyone's Wrong But Me|TTBB|Kevin Keller
+Everything|SSAA|Aaron Dale
+Everything|SSAA|Lynnell Diamond
+Everything|TTBB|Aaron Dale
+Everything (Michael Buble)|SSAA|Aaron Dale
+Everything I Do, I Do It For You|SSAA|Tedda Lippincott
+Everything Is Beautiful|TTBB|Jim Stenson
+Everything Old Is New Again|SSAA|Ann Minihane
+Everything Old Is New Again|SSAA|Bev Sellers
+Everything Old Is New Again|TTBB|Ed Waesche
+Everything Old Is New Again|TTBB|Hank Shuster
+Everything's Comin' Up Roses|SSAA|Carolyn Schmidt
+Everything's Comin' Up Roses|TTBB|Greg Volk
+Everything's Coming Up Roses|SSAA|Carolyn Schmidt
+Everything's Coming Up Roses|SSAA|Joey Minshall
+Everything's Coming Up Roses|TTBB|David Wright
+Everything's Coming Up Roses|TTBB|Unspecified
+Everything's Coming Up Roses/There's No Business Like Show Business Medley(Brian|TTBB|Brian Beck
+Everything's Up To Date In Kansas City|TTBB|Jay Giallombardo
+Everywhere You Go|SSAA|Nancy Bergman
+Exactly Like You|SSAA|Elaine Gain
+Exactly Like You|TTBB|Scott Kitzmiller
+Exodus|SATB|Nancy Bergman
+Eyes Medley|SSAA|Brent Graham
+Eyes Medley|SSAA|Clay Hine
+Ezekiel Saw da Wheel|SSAA|Breath of Life Quartet
+Ezekiel Saw The Wheel|TTBB|David Wright
+Fa La La|TTBB|Tom Gentry
+Fa-La-La|TTBB|Tom Gentry
+Fallen for Somebody New|TTBB|Larry Wright
+Fame|SSAA|Debbie Keretz/Jo Kraut
+Fame|SSAA|Jarmela Speta
+Fame|SSAA|Mike Taylor
+Fame|SSAA|Paula Mauritzen
+Fame!|SSAA|Mike Taylor
+Fare The Well Love|TTBB|Jay Giallombardo
+Fare Thee Well|SSAA|Joey Minshall
+Fare Thee Well Love|TTBB|David Wright
+Fare Thee Well, Love|SSAA|Joey Minshall
+Fare Thee Well, Love|TTBB|David Wright
+Fare Thee Well, Love|TTBB|David Wright, Chris Arnold
+Farmer Tan|TTBB|Dan Wessler
+Farmer Tan|TTBB|Jayson Ryner
+Fascinatin' Rhythm|TTBB|Jay Giallombardo
+Fascinating Rhythm|TTBB|Walter Latzko
+Fat Bottomed Girls|TTBB|Mason Kaye
+Fat Bottomed Girls|TTBB|Simon Hunt
+Fat Bottomed Girls (Queen)|TTBB|Simon Hunt
+Fattig Bonddrang|TTBB|Johan Wikstrom
+Feast Of Lights|SSAA|Greg Lyne
+Feast of Lights Medley|TTBB|Barbershop Harmony Society
+Feed The Birds|SSAA|Joe Spiecker
+Feed The Birds|TTBB|Kevin Keller
+Feelin' Groovy|SSAA|YWIH
+Feelin' Groovy|TTBB|Aidan Brand
+Feelin' Groovy (The 59th Street Bridge Song) (YWIH)|SSAA|Marge Bailey
+Feeling Good|SSAA|Liz Garnett
+Feeling Good 4-part|SSAA|David Harrington
+Feeling Good 5-part|SSAA|David Harrington
+Feels Like Home|SSAA|Nancy Bergman
+Feliz Navidad|SATB|Mel Knight
+Feliz Navidad|SSAA|Julie Starr
+Feliz Navidad|SSAA|Marge Bailey
+Feliz Navidad|SSAA|Marge Bailey/Kathy Ramos
+Feliz Navidad|SSAA|Nancy Bergman
+Feliz Navidad|TTBB|Brian Beck
+Feliz Navidad|TTBB|Dave Briner/ Tom Gentry
+Feliz Navidad|TTBB|Roger Payne
+Feliz Navidad|TTBB|Tom Gentry
+Feliz Navidad|TTBB|Will Hamblet
+Festival Of Lights|TTBB|Alan Josephson
+Fever|SSAA|Greg Volk
+Fever|SSAA|Jim Arns
+Fever|SSAA|Tedda Lippincott
+Fiddle in the Band|SSAA|Tedda Lippincott
+Fiddler on the Roof Medley|TTBB|Walter Latzko
+Fields of Gold|SSAA|Anna-Marie Nystrom
+Fields of Gold|SSAA|June Dale
+Fields Of Gold|SSAA|Deke Sharon
+Fifties Medley|SSAA|Sonny Steffan
+Fine Fine Line|TTBB|Ben Brown
+Finian's Rainbow Medley|TTBB|Gene Cokeroft
+Fireflies|SATB|E.C. Schirmer Publishing
+Firefly|SSAA|Nancy Bergman
+Firefly|TTBB|Barbershop Harmony Society
+Firefly|TTBB|Jon Nicholas
+Firefly|TTBB|Unspecified
+Firefly / Glow Worm Medley|TTBB|Don Gray
+Firework|SSAA|Carole Prietto
+Firework|SSAA|Hari Birtles
+Fit As A Fiddle|SSAA|Arline Cardoso
+Fit As A Fiddle|SSAA|Brian Beck
+Fit As A Fiddle|SSAA|Clay Hine
+Fit As A Fiddle|SSAA|David Wright
+Fit As A Fiddle|TTBB|Clay Hine
+Fit As A Fiddle|TTBB|David Wright
+Fit As A Fiddle/The Bells Are Ringing (Medley)|SSAA|Clay Hine
+Five Foot Two|SATB|Clay Hine
+Five Foot Two|TTBB|Clay Hine
+Five Foot Two (Parody)|TTBB|Joe Liles
+Five Minutes More|SSAA|Doris Twardosky
+Five Minutes More|SSAA|Tom Gentry
+Five Minutes More|TTBB|Jon Nicholas
+Five Minutes More|TTBB|Tom Gentry
+Five Minutes More / It All Depends on You|SSAA|Doris Twardosky / D.Dolan
+Five Pennies Medley|TTBB|Jeremey Johnson
+Fixing A Hole|TTBB|Jon Nicholas
+Flag Waver Medley|SSAA|Nancy Bergman
+Flamin' Agnes|TTBB|Bryan Ziegler
+Flashdance (What A Feeling)|SSAA|D Keretz
+Flim Flam Man|SSAA|Frank Marzocco
+Flirty Eyes|SSAA|Marcia Hill/Nancy Bergman
+Flirty Eyes|SSAA|Nancy Bergman
+Flirty Eyes|SSAA|Nancy Bergman/Marcia Hill
+Flirty Eyes|TTBB|Tony Nasto
+Floatin' Down The River Medley|TTBB|Ed Waesche
+Floatin' Down to Cotton Town|SSAA|David Wright
+Floatin' Down to Cotton Town|SSAA|Renee Craig
+Floatin' Down to Cotton Town|TTBB|Rob Campbell
+Flowers On The Wall|TTBB|Tom Gentry
+Fly Me to the Moon|SSAA|Mo Field
+Fly Me to the Moon|SSAA|Zona Snyder
+Fly Me To The Moon|SSAA|Aaron Dale
+Fly Me To The Moon|TTBB|Aaron Dale
+Fly To Heaven Medley: I'll Fly Away, I Surrender All, Down In The River To Pray, When We All Get to Heaven|TTBB|David Harrington
+Flyin' High Medley|SSAA|June Dale
+Flying High Medley|SSAA|June Dale
+Flying Sinatra Medley|SSAA|Roger Payne
+Flying Sinatra Medley|TTBB|Roger Payne
+Flying Sinatra Medley|TTBB|Roger Payne, Ed Waesche
+Follow Me|TTBB|Johan Wikstrom
+Follow Me|TTBB|Kohl Kitzmiller
+Follow The Drinking Gourd|SSAA|Bob Jones
+Follow The Flag|TTBB|Doug Nichol
+Follow The Fold|SATB|Don Gray
+Follow Your Star|TTBB|Douglas E. Wagner
+Fools Rush In|TTBB|Joe Johnson
+Football Medley|SSAA|Tom Gentry
+Footloose|SSAA|Brian Beck
+Footloose|TTBB|Aaron Dale
+For All We Know|SSAA|Avis Fellows
+For All We Know|SSAA|Clay Hine
+For All We Know|SSAA|Dave Briner
+For All We Know|SSAA|June Dale
+For All We Know|SSAA|Renee Craig
+For All We Know|TTBB|Lou Perry
+For Good|SSAA|Carole Prietto
+For Good|SSAA|Carolyn Healey
+For Good|SSAA|June Berg
+For Good|SSAA|Lynnell Diamond
+For Good|SSAA|Tom Gentry
+For Good|TTBB|Aaron Dale
+For Good|TTBB|Steven Armstrong
+For Lovin' Me|TTBB|Roy Keys
+For Once in My Life|SSAA|Joni Bescos
+For Once In My Life|TTBB|John Hohl
+For Once In My Life|TTBB|Tom Gentry
+For Sale, One Broken Heart|TTBB|Val Hicks
+For Sentimental Reasons|SSAA|Jim Arns
+For the Longest Time|SSAA|Lorraine Rochefort
+For the Longest Time|SSAA|Tom Gentry
+For the Longest Time|TTBB|Roger Emerson
+For the Sake of Auld Lang Syne|SSAA|Joni Bescos
+For the Sake of Auld Lang Syne|SSAA|Renee Craig
+For The Sake of Auld Lang Syne|TTBB|Ed Waesche
+For The Sake Of Auld Lang Syne|TTBB|Jim Clancy
+For The Sake Of Auld Lang Syne|TTBB|John Hohl, Ed Waesche
+Forest Lawn|SSAA|Bev Sellers
+Forever and a Day|TTBB|Tom Gentry
+Forever and Ever, Amen|TTBB|Kevin Keller
+Forever Young|SSAA|Tedda Lippincott
+Forgive Me|SSAA|Tom Gentil
+Forgive Me|TTBB|Earl Moon
+Forgive Me (Parody)|TTBB|Unspecified
+Forties Tune|SSAA|Joe Liles
+Fortune In Dreams|TTBB|Earl Moon
+Fortuosity|TTBB|Russ Foris
+Forty Second Street|SSAA|Dot Calvin
+Forty Second Street|TTBB|Greg Volk
+Four Leaf Clover|TTBB|Barbershop Harmony Society
+Four Leaf Clover/Yes Sir Medley|SSAA|Joe Spiecker
+Four Seasons Medley|TTBB|Tom Gentry
+Freddie Feelgood|SSAA|Jay Giallombardo
+Freddie Feelgood [And His Funky Little Four Piece Band](Dave Br|TTBB|Dave Briner
+Free Fallin'|TTBB|Aaron Dale
+Friend Like Me|SSAA|Carolyn Schmidt
+Friend Like Me|TTBB|David Wright
+Friends|SSAA|David Wright
+Friends|SSAA|Tedda Lippincott
+Friends|TTBB|David Wright
+Friends Medley|SSAA|David Wright
+Friendship|SSAA|Jean Shook
+Frim Fram Sauce|SSAA|Betty Grant
+Frog Kissin'|SSAA|Marie Johnson
+Frog Kissin'|SSAA|Nancy Bergman
+Frog Kissin'|TTBB|Bob Jones
+Frog Kissin'|TTBB|Bob Jones, John Hohl
+Frog Kissin' (YWIH)|SSAA|Marie Johnson
+From A Distance|SSAA|Lorraine Rochefort
+From A Distance|SSAA|Tedda Lippincott
+From A Distance (SSAA)|SSAA|Mac Huff
+From the First Hello|TTBB|Lou Perry
+From The First Hello|TTBB|Ed Waesche
+From the First Hello to the Last Goodbye|SSAA|Jim Arns
+From The First Hello To The Last Goodbye|TTBB|Lou Perry
+From the Sniff Hello|SSAA|Lou Perry
+From This Moment On|TTBB|John Hohl
+Frosty / Santa Medley|TTBB|Roger Payne
+Frosty the Snowman|SSAA|Carolyn Schmidt
+Frosty the Snowman|SSAA|Donna Shorkey
+Frosty the Snowman|SSAA|Sandy Sharpe
+Frosty the Snowman|TTBB|Rob Campbell
+Frosty The Snowman|TTBB|Aaron Dale
+Fun Fun Fun|TTBB|Aaron Dale
+Fun In Just One Lifetime|SATB|Joe Liles
+Fun In Just One Lifetime|SSAA|Joe Liles
+Fun In Just One Lifetime|TTBB|Joe Liles
+Funky Rudolph|SSAA|Ann Minihane
+Gaither Vocal Band Medley|SSAA|Steve Tramack
+Gary, Indiana|TTBB|Walter Latzko
+Gee I'm Glad It's Raining|TTBB|Jeremey Johnson
+Gee, But It's Good To Be Here|SSAA|Joey Minshall
+Gee, I Wish I Was Back In The Army|SSAA|Tom Gentry
+Gee, I Wish I Was Back In The Army|TTBB|Tom Gentry
+George M. Cohan Medley|SSAA|Nancy Bergman
+George M. Cohan Medley|TTBB|Paul Engel
+George M. Cohan Medley|TTBB|Val Hicks
+George M. Cohan Medley|TTBB|Val Hicks/Greg Lyne
+Georgia Camp Meeting|SSAA|Larry Wright
+Georgia Lullaby|SSAA|Joey Minshall
+Georgia May|SSAA|Aaron Dale
+Georgia May|TTBB|Aaron Dale
+Georgia on my Mind|SSAA|Brian Beck
+Georgia on My Mind|SSAA|Steve Jamison
+Georgia on My Mind|TTBB|Steve Jamison
+Georgia On My Mind|SSAA|Jim Massey
+Georgia On My Mind|SSAA|Joni Bescos
+Georgia On My Mind|SSAA|Mary Coffman
+Georgia On My Mind|SSAA|Susan Lamb
+Georgia On My Mind|TTBB|David Harrington
+Georgia On My Mind|TTBB|Jim Clancy
+Geronimo|SSAA|Thomas J. West
+Gershwin Love Song Medley|TTBB|Jay Giallombardo
+Gershwin Montage|TTBB|Jay Giallombardo
+Gesu Bambino|SATB|Joe Liles
+Gesu Bambino|SSAA|Jarmela Speta
+Gesu Bambino|SSAA|Joe Liles
+Get Happy|SSAA|Ann Minihane
+Get Happy|SSAA|Nancy Bergman
+Get Happy|TTBB|Ann Minihane
+Get Happy|TTBB|Kevin Keller
+Get Me to the Church on Time|SSAA|Nancy Bergman
+Get Me to the Church on Time|SSAA|Tom Gentry
+Get Me To the Church on Time|SSAA|Carolyn Schmidt
+Get Me To The Church On Time|SSAA|Aaron Dale
+Get Me To The Church On Time|TTBB|Don Gray
+Get Me To The Church On Time|TTBB|Jay Giallombardo
+Get Me To The Church On Time|TTBB|Tom Gentry
+Get Me To The Church On Time Medley|TTBB|David Wright
+Get Out And Get Under The Moon|TTBB|Ed Waesche
+Get Out And Shop|SSAA|Nancy Bergman
+Get Out Those Old Records|SSAA|Walter Latzko
+Get Out Those Old Records|TTBB|HEP
+Get Ready|SSAA|Kevin McMahon
+Get Your Happy Days On! Medley|TTBB|Aaron Dale
+Getting to Know You|SSAA|Brent Graham
+Getting to Know You|SSAA|Tedda Lippincott
+Ghost Riders|TTBB|Unspecified
+Ghost Riders in the Sky|TTBB|Unspecified
+Ghost Riders In the Sky|TTBB|Larry Wright
+Gimme A Man After Midnite|SSAA|Ase Hagerman
+Gimme Gimme Gimme (Abba)|SSAA|Alison Jack
+Gimme! Gimme! Gimme! (A Man After Midnight)|SSAA|Ase Hagerman
+Girl of My Dreams|TTBB|Jay Giallombardo
+Girl Of My Dreams|TTBB|Barbershop Harmony Society
+Girl Of My Dreams|TTBB|Roy Keys
+Girls Just Wanna Have Fun|SSAA|Carolyn Schmidt
+Girls Medley|TTBB|Ed Waesche
+Girls Night Out|SSAA|Brian Beck
+Girls Night Out|SSAA|Moses Hogan
+Give 'Em A Show They'll Never Forget|SSAA|Lynnell Diamond
+Give A Little Whistle|TTBB|Joe Liles
+Give Em A Show They'll Never Forget|SSAA|Lynnell Diamond
+Give Me a Barbershop Song|SSAA|Roy Dawson and Steve Hall
+Give Me A Barbershop Song|TTBB|Roy Dawson
+Give Me A Barbershop Song|TTBB|Steve Hall
+Give Me a Night in June|TTBB|Mark Hale
+Give Me That Barbershop Style|TTBB|Dave Stevens
+Give Me That Smile|TTBB|Adam Scott
+Give Me the Simple Life|TTBB|Liz Garnett
+Give Me the Simple Life|TTBB|Walter Latzko
+Give Me The Simple Life|TTBB|Aaron Dale
+Give Me Your Tired, Your Poor|TTBB|Barbershop Harmony Society
+Give My Regards To Broadway|SSAA|Betty Owens
+Give My Regards To Broadway|TTBB|Al Baker, Steve Tramack
+Give My Regards To Broadway|TTBB|Jay Giallombardo
+Give My Regards to Broadway Medley|SSAA|Nancy Bergman
+Glad Rag Doll|TTBB|Dennis Driscoll
+Glenn Miller Medley|TTBB|Dick Rode
+Glenn Miller Medley|TTBB|Unspecified
+Glitter in the Air|SSAA|Joey Minshall
+Gloria|TTBB|David Wright
+Glow Worm / Cab Driver Medley|TTBB|Waesche/Martinez
+Go Away Little Girl|TTBB|Unspecified
+Go Down Moses|TTBB|David Wright
+Go Down, Mose|TTBB|Moses Hogan
+Go Home, Little Girl, Go Home|SSAA|Marie Johnson
+Go Tell It On the Mountain|SSAA|Joe Liles
+Go Tell It On The Mountain|SSAA|Judy Vidal
+Go Tell It On The Mountain|SSAA|June Berg
+Go Tell It On The Mountain|TTBB|David Wright
+Go Tell It On The Mountain|TTBB|Joe Johnson
+Go Tell It On The Mountain|TTBB|Joe Liles
+Go Tell It On The Mountain|TTBB|Jon Nicholas
+Go Tell It On The Mountain|TTBB|Roger Payne
+Go the Distance|SSAA|Aaron Dale
+Go the Distance|SSAA|Joey Minshall
+Go The Distance|TTBB|Aaron Dale
+Go The Distance (Disney)|SSAA|Aaron Dale
+God Be In My Head|TTBB|John Rutter
+God Be With You Till We Meet Again|TTBB|Joe Johnson
+God Bless America|SATB|Derric Johnson
+God Bless America|SSAA|Jarmela Speta
+God Bless America|SSAA|Nancy Bergman
+God Bless America|SSAA|Renee Craig/Nancy Bergman
+God Bless America|TTBB|Greg Lyne
+God Bless America|TTBB|Jon Nicholas
+God Bless America Greg Lyne|TTBB|Unspecified
+God Bless The Child|TTBB|Tom Gentry
+God Bless the U.S.A. Medley|SSAA|Jarmela Speta
+God Bless the USA|SSAA|Brian Beck
+God Bless the USA|SSAA|Charlene Yazurlo
+God Bless the USA|SSAA|Tedda Lippincott
+God Bless The USA|SSAA|Carolyn Healey
+God Bless The USA|TTBB|Brian Beck
+God Only Knows|SATB|A Mighty Wind
+God Only Knows|SSAA|Deke Sharon
+God Only Knows|TTBB|Clive Chase
+God Only Knows|TTBB|David Wright
+God Rest Ye Merry Gentlemen|SSAA|Renee Craig
+God Rest Ye Merry Gentlemen|TTBB|Barbershop Harmony Society
+God Rest Ye Merry Gentlemen|TTBB|Greg Volk
+God Rest Ye Merry, Gentlemen|SSAA|Renee Craig
+God Rest Ye Merry, Gentlemen|TTBB|Barbershop Harmony Society
+God Rest Ye Merry, Gentlemen|TTBB|Greg Volk
+God's Healing Love|SSAA|Diane Clark
+Goin' Home|TTBB|Joe Liles
+Going Away|SSAA|Russ Foris
+Going, Going, Gone Medley|SSAA|Sylvia Alsbury
+Gold|SSAA|Joe Liles
+Gold|TTBB|Jay Giallombardo
+Golden Dreams|TTBB|Phil Ordaz
+Gone|SSAA|Nancy Bergman
+Gone|TTBB|Ed Waesche
+Gonna Build A Mountain|SSAA|A. Nightingale
+Gonna Build A Mountain|SSAA|Aileen Nightingale
+Gonna Build A Mountain|TTBB|Ed Waesche
+Gonna Get Along Without You Now|SSAA|Nancy Bergman
+Gonna Rise Up Singin'|TTBB|Ray Danley
+Good Day Sunshine|TTBB|Tony Nasto
+Good Day-Wonderful Day Medley|TTBB|Jay Giallombardo
+Good Enough for Now|SSAA|Tom Gentry
+Good Enough For Now|SSAA|Hasty-Lapp
+Good Enough For Now|TTBB|Tom Gentry
+Good Luck Charm|SSAA|Aaron Dale
+Good Luck Charm|TTBB|Aaron Dale
+Good Morning Starshine|SSAA|Lorraine Rochefort
+Good News!|TTBB|Jay Althouse
+Good Night Ladies|TTBB|Barbershop Harmony Society
+Good Night My Someone|TTBB|Walter Latzko
+Good Ol' A Cappella|TTBB|Linda Reed
+Good Old A Capella|SSAA|Chris Moyer
+Good Old A Capella|SSAA|David Wright
+Good Old A Cappella|SSAA|David Wright
+Good Old A Cappella|TTBB|David Wright
+Good Old Acapella|SSAA|Tedda Lippincott
+Good Old Acappella|SSAA|Chris Moyer
+Good Ole Barbershop Style|SSAA|Jo Lund
+Good Vibrations|SSAA|Elaine Gain
+Good Vibrations|TTBB|David Wright
+Good-bye My Lady Love|TTBB|Renee Craig, Joe Liles
+Goodbye Cruel World|SSAA|June Berg
+Goodbye Dixie Goodbye/Going Back To Caroline Medley|TTBB|Chris Slacke
+Goodbye Dixie, Goodbye|TTBB|Aaron Dale
+Goodbye Dixie, Goodbye|TTBB|Gary Parker
+Goodbye Means the End of My World|SSAA|Joe Liles
+Goodbye Means The End Of My World|TTBB|Joe Liles
+Goodbye Medley|SSAA|Mary Coffman
+Goodbye Medley|SSAA|Tom Gentry
+Goodbye My Goodtime Friend|SSAA|Sylvia Alsbury
+Goodbye World Goodbye|SSAA|Dave Briner
+Goodbye World Goodbye|SSAA|David Wright
+Goodbye World Goodbye|TTBB|David Wright
+Goodbye World Goodbye|TTBB|Jay Giallombardo
+Goodbye World, Goodbye|SSAA|David Wright
+Goodbye Yellow Brick Road|TTBB|Joe Johnson
+Goodbye, You Phony Lyin' Baby|SSAA|Nancy Bergman
+Goodnight Little Soldier|SSAA|Shook, Breidert and Twaredosky
+Goodnight My Angel|TTBB|David Wright
+Goodnight My Someone|TTBB|SK Grundy
+Goodnight Sweetheart|SSAA|June Berg
+Goodnight Sweetheart Goodnight|SSAA|Becky Wilkins
+Goodnight Sweetheart, Goodnight|TTBB|Mel Knight
+Goodnight, Saigon|TTBB|Tom Gentry
+Goodnight, Sweetheart, Goodnight|SSAA|Tom Gentry
+Goodtime Barbershop and Variety Show|SSAA|Nancy Bergman
+Goodtime Strutter's Ball|SSAA|Nancy Bergman
+Goody Goodbye|SSAA|George Avener
+Goody Goody|SSAA|Joni Bescos
+Goody Goody|SSAA|Nancy Bergman
+Goody Goody|TTBB|Rob Hopkins
+Goody Goody (version 2)|TTBB|Rob Hopkins
+Gospel Medley|SSAA|Ed Waesche
+Gospel Medley|SSAA|Jay Giallombardo
+Gospel Medley|TTBB|Bluegrass Student Union
+Gospel Medley|TTBB|Ed Waesche
+Got My Thumb Out|TTBB|Joe Liles
+Gotta Be On My Way|SSAA|Mike Senter
+Gotta Lot Of Rhythm In My Soul|SSAA|Kevin Keller
+Gotta Lot Of Rhythm In My Soul|TTBB|Kevin Keller
+Graduation Day|SATB|EdLojeski
+Grand Old Flag This Is My Country Medley|SSAA|Judy Vidal
+Grandma Got Run Over By A Reindeer|TTBB|Jon Nicholas
+Grandma's Feather Bed|SSAA|Joni Bescos
+Grandma's Feather Bed|TTBB|Tom Gentry
+Grandma's Feather Bed (YWIH)|SSAA|Joni Bescos
+Grandmother's Love Letters|SSAA|Lois Whitney
+Grapefruit Diet|SSAA|Dave Briner
+Grease Medley|SSAA|Linda Masterson
+Great Balls of Fire|SSAA|Larry Wright
+Great Day|SSAA|David Harrington
+Great Day|SSAA|David Wright
+Great Day|SSAA|Larry Wright
+Great Day|SSAA|Nancy Bergman
+Great Day|TTBB|David Harrington
+Great Day Medley|SSAA|Larry Wright
+Great Race|SSAA|Joni Bescos
+Greatest Day|SSAA|Rosalind Johnson
+Greatest Love of All|SSAA|Jo Lund
+Grim Grinning Ghosts|TTBB|Kyle Williamson
+Grow Old With Me|TTBB|Aaron Dale
+Grow Old With You|TTBB|Aaron Dale
+Growin' Old|TTBB|Unspecified
+Grown Up Christmas List|SSAA|Brian Beck
+Grown-Up Christmas List|SATB|Tom Gentry
+Grown-Up Christmas List|SSAA|Jean Crockett Kane
+GTO|TTBB|Jon Nicholas
+Guess Who I Saw Today|SSAA|Joey Minshall
+Guys and Dolls|TTBB|Theo Hicks
+Guys And Dolls|SATB|Don Gray
+Gypsy Love Song|TTBB|Jay Giallombardo
+Gypsy Medley|SSAA|Lorraine Rochefort
+Hakuna Matata|TTBB|David Wright
+Hakunah Matata|SSAA|Lorraine Rochefort
+Hakunah Matatah|SSAA|Lorraine Rochefort
+Hallelujah|SSAA|Deke Sharon
+Hallelujah|SSAA|Elaine Gain
+Hallelujah|SSAA|Jordan Travis
+Hallelujah|SSAA|Linda Corcoran
+Hallelujah|SSAA|Tedda Lippincott
+Hallelujah|TTBB|Brent Graham
+Hallelujah|TTBB|Jay Giallombardo
+Hallelujah|TTBB|Jim Clancy
+Hallelujah|TTBB|Jordan Travis
+Hallelujah|TTBB|Mark Hale
+Hallelujah (Gain)|SSAA|Elaine Gain
+Hallelujah (Sharon)|SSAA|Deke Sharon
+Hallelujah Chorus|SATB|George Frideric Handel
+Hallelujah Chorus|TTBB|David Wright
+Hallelujah Chorus (Parody)|SSAA|Jim Arns
+Halloween Medley|SSAA|M. Penketh
+Halls of Ivy|TTBB|Jay Giallombardo
+Handful Of Keys|SSAA|David Wright
+Handful Of Keys|TTBB|Walter Latzko
+Hang On The Bell, Nellie|TTBB|Barbershop Harmony Society
+Hang With Me|SSAA|Henrik Rosenberg
+Hannuka Medley|TTBB|James Shubert
+Hanukah Medley|SSAA|Lorraine Rochefort
+Hanukkah In Santa Monica|TTBB|John Hohl
+Hanukkah Medley|SSAA|Jim Arns
+Hanukkah Medley|TTBB|Jim Arns
+Hanukkah, Songs For|SSAA|Anna Maria Parker
+Happy|SSAA|Adam Scott
+Happy|SSAA|Elaine Gain
+Happy|SSAA|Larry Wright
+Happy|SSAA|Mo Field
+Happy|TTBB|Adam Scott
+Happy (Pharrell Williams)|SSAA|Elaine Gain
+Happy (Wright)|SSAA|Nick Wright
+Happy Birthday|SSAA|David Harrington
+Happy Birthday|SSAA|Larry Wright
+Happy Birthday|SSAA|Nancy Bergman/Renee Craig
+Happy Birthday|SSAA|Traditional
+Happy Birthday|TTBB|David Harrington
+Happy Birthday|TTBB|Not Specified
+Happy Birthday Baby|TTBB|Aaron Dale
+Happy Birthday Doo Wop|SSAA|Joey Minshall
+Happy Birthday To You|SATB|Peter Nugent
+Happy Birthday To You|TTBB|Jon Nicholas
+Happy Days and Lonely Nights|SSAA|Carolyn Healey
+Happy Days And Lonely Nights|TTBB|Earl Moon
+Happy Days are Here Again|SSAA|Jim Arns
+Happy Days are Here Again|TTBB|Bob Robson
+Happy Days Are Here Again|TTBB|John Hohl
+Happy Days Are Here Again|TTBB|Walter Latzko
+Happy Days Lonely Nights|SSAA|Pam Basinski
+Happy Days Theme|TTBB|J. Matisoft and J. Redgate
+Happy Feet Medley|TTBB|Ed Waesche
+Happy Hanukkah My Friend|SSAA|Nancy Bergman
+Happy Holiday|SSAA|Cheryl Suhr
+Happy Holiday/It's The Holiday Season Medley|SSAA|Mark Hale
+Happy Holidays/It's The Holiday Season|SSAA|Mark Hale
+Happy Holidays/It's The Holiday Season|TTBB|Mark Hale
+Happy Together|SSAA|Carolyn Schmidt
+Happy Together|SSAA|David Wright
+Happy Together|SSAA|Krista Carlson/David Wright
+Happy Together|SSAA|Liz Garnett
+Happy Together|SSAA|Marie Hampton
+Happy Together|TTBB|Chris Arnold
+Happy Together|TTBB|David Wright
+Happy Together|TTBB|Krista Carlson, David Wright
+Happy Together|TTBB|Liz Garnett
+Happy Together|TTBB|Nylons
+Happy Trails|TTBB|Jon Nicholas
+Happy Trails|TTBB|Ron Bergenstock
+Happy Trails|TTBB|Tom Gentry
+Happy Trails (4 Part Mens, 2 Part Womens)|SATB|Steve Delehanty
+Happy Trails To You/Route 66 Medley|TTBB|Brent Graham
+Happy Xmas War Is Over (Give Peace A Chance)|SSAA|Lynnell Diamond
+Harbor Lights|SSAA|Mary Coffman
+Harbour Lights|TTBB|Chris MacMartin
+Hard Hearted Hanna|TTBB|Clay Hine
+Hard Hearted Hannah|SSAA|Betty Oliver
+Hard Hearted Hannah|TTBB|Jeff Taylor
+Hard Hearted Hannah|TTBB|Val Hicks
+Hard Times Come Again No More|TTBB|Patrick Rose
+Hard Times, Come Again No More|TTBB|David Wright
+Hard-Hearted Hannah|SSAA|Lorraine Rochefort
+Hard-Hearted Hannah|SSAA|Marge Bailey
+Hard-Hearted Hannah|SSAA|Michael Gellert
+Hark The Angels Sing Gloria|SSAA|Judy Vidal Renee Craig
+Hark the Herald Angels Sing|TTBB|Barbershop Harmony Society
+Hark The Herald Angels Sing|SSAA|Renee Craig
+Hark The Herald Angels Sing|TTBB|David Harrington
+Hark! The Herald Angels Sing|TTBB|Barbershop Harmony Society
+Harley Davidson Medley|SSAA|Gene Cokeroft
+Harmonize the World|SSAA|Nancy Bergman
+Harmony|SATB|Doug Miller
+Harmony|SSAA|David Wright
+Harmony|SSAA|Susan Lamb
+Harmony|TTBB|David Wright
+Harmony Joe|TTBB|Joe Johnson
+Harmony Leads the Way|SSAA|Joe Liles
+Harmony Leads The Way|TTBB|Joe Liles
+Harmony Rag|TTBB|Mel Knight
+Have a Holly Jolly Christmas|SSAA|Sandy Sharpe
+Have A Little Talk With Myself|SSAA|Aileen Nightingale
+Have A Little Talk With Myself|TTBB|Gary Parker
+Have a Nice Day|SSAA|Beth Rothwell
+Have A Nice Day|TTBB|Tom Gentry
+Have I Stayed Too Long At The Fair|SSAA|Renee Craig
+Have I Told You Lately That I Love You?|SSAA|Henrik Rosenberg
+Have you Ever Been Lonely|SSAA|Aileen Nightingale
+Have You Ever Been Lonely|TTBB|Unspecified
+Have you Ever Heard the Swanee River Cry|SSAA|Dot Calvin
+Have You Met Miss Jones?|SSAA|Jo Lund
+Have You See the Child?|TTBB|Jay Giallombardo
+Have Yourself a Merry Little Christmas|TTBB|Brent Graham
+Have Yourself a Merry Little Christmas|TTBB|David Harrington
+Have Yourself A Merry Little Christmas|SSAA|Anna Maria Parker
+Have Yourself A Merry Little Christmas|SSAA|Avis Fellows
+Have Yourself A Merry Little Christmas|SSAA|Barb Watson
+Have Yourself A Merry Little Christmas|TTBB|Jim Clancy
+Have Yourself A Merry Little Christmas|TTBB|Unspecified
+Haven't Met You Yet|SSAA|Aaron Dale
+Haven't Met You Yet|TTBB|Aaron Dale
+He Ain't Heavy, He's My Brother|TTBB|Jim Clancy
+He Never Failed Me Yet|TTBB|Robert Ray
+He Was Really Saying Something/Needle In A Haystack Medley|SSAA|Zac Booles
+He Was There|SSAA|Nancy Bergman
+He'll Be Coming Down the Chimney|SSAA|Nancy Bergman
+He's Got The Whole World In His Hand|TTBB|Jon Nicholas
+He's Got The Whole World In His Hands|TTBB|Fred King
+He's the Good Man That Was so Hard to Find|SSAA|Burt Szabo
+Headless Horseman|TTBB|Aaron Dale
+Hear That Swanee River Cry|SSAA|Mary Coffman
+Hear Them Bells|TTBB|Jon Nicholas
+Heard It Through The Grapevine|TTBB|Alex Kaiserman
+Heart|SSAA|Jim Massey
+Heart|SSAA|Massey
+Heart|TTBB|Ed Waesche
+Heart (You've Gotta Have)|SSAA|Barbara McNeill
+Heart (You've Gotta Have)|SSAA|Larry Wright
+Heart And Soul|SSAA|Marsha Zwicker
+Heart Of a Clown|SSAA|Joni Bescos
+Heart Of A Clown|TTBB|Lloyd Steinkamp
+Heart of My Heart|SSAA|Barbershop Harmony Society
+Heart of My Heart|SSAA|Nancy Bergman
+Heart of My Heart|SSAA|Unspecified
+Heart of My Heart|TTBB|Traditional
+Heart Of My Heart|TTBB|Barbershop Harmony Society
+Heart of My Heart (The Story of the Rose)|TTBB|Barbershop Harmony Society
+Heart Of My Heart [Story Of The Rose]|TTBB|Barbershop Harmony Society
+Heartache Tonight|SSAA|Jim Arns
+Heartache Tonight|TTBB|Aaron Dale
+Heartaches|SSAA|Brian Beck
+Heartaches/Lies Medley|SSAA|Joni Bescos
+Heat Wave (Love is Like a Heat Wave)|SSAA|Joey Minshall
+Heatwave|SSAA|Kevin Keller
+Heaven on My Mind|TTBB|Unspecified
+Heigh-Ho|TTBB|Don Gray
+Hello Dolly|SSAA|Carolyn Schmidt
+Hello Dolly|TTBB|Don Gray
+Hello Hollywood Hello|SSAA|Nancy Bergman
+Hello Mary Lou|TTBB|David Wright
+Hello Muddah, Hello Faddah|SSAA|Tedda Lippincott
+Hello Muddah, Hello Faddah|TTBB|Tom Gentry
+Hello My Baby|SSAA|Kevin Keller
+Hello My Baby|TTBB|David Harrington
+Hello My Baby|TTBB|Kevin Keller
+Hello My Baby Through the Years|SSAA|Clay Hine
+Hello My Baby, Won't You Please Come Home|TTBB|Steven Armstrong, Jan-Ake Westin
+Hello, Mary Lou|TTBB|David Wright
+Hello, My Baby|TTBB|David Harrington
+Hello, Young Lovers|SSAA|Anna Maria Parker
+Hello! My Baby|TTBB|Burt Szabo
+Help Is On The Way|SSAA|Michael Gellert
+Help Me, Rhonda|TTBB|Jon Nicholas
+Help! I'm Turning Into My Parents!|SSAA|Nancy Shumard
+Her Eyes Don't Shine Like Diamonds|TTBB|Burt Szabo
+Here Am I, Brokenhearted|SSAA|Brent Graham
+Here and Now|SSAA|Joey Minshall
+Here Comes Santa Claus|SSAA|Marshall Webb
+Here Comes Santa Claus|TTBB|Jon Nicholas
+Here Comes Santa Claus|TTBB|Marshall Webb
+Here Comes The Show Boat|TTBB|Barbershop Harmony Society
+Here Comes the Showboat|TTBB|David Wright
+Here Comes the Sun|SSAA|Deke Sharon
+Here Comes The Sun|TTBB|Bob Shami
+Here Comes The Sun|TTBB|Jon Nicholas
+Here, There, and Everywhere|SSAA|June Berg
+Here's that Rainy Day|TTBB|Tony Pelling
+Here's That Rainy Day|SSAA|Joni Bescos
+Here's To Love|TTBB|Kevin Keller
+Here's To The Winners|TTBB|Renee Craig
+Hernando's Hideaway|SSAA|Bev Sellers
+Hernando's Hideaway|SSAA|Marge Bailey
+Hero|SSAA|Joey Minshall
+Hero (And Then A Hero Comes Along)|SSAA|Tedda Lippincott
+Hey Daddy|SSAA|Nancy Bergman
+Hey Daddy !|SSAA|Nancy Bergman
+Hey Daddy (You Oughta Get the Best For Me)|SSAA|Nancy Bergman
+Hey Good Lookin'|TTBB|David Wright
+Hey Little Baby O' Mine|TTBB|Joe Liles
+Hey Little Baby of Mine|SSAA|Joe Liles
+Hey Look Me Over|TTBB|Barbershop Harmony Society
+Hey Look me Over / If They Could See Me Now (Medley)|TTBB|Tom Gentry
+Hey Mister! Stay!|SSAA|Joey Minshall
+Hey Soul Sister|SSAA|Elaine Gain
+Hey There|SSAA|David Wright
+Hey, Good Lookin'|SSAA|David Wright
+Hey, Good Lookin'|SSAA|Nancy Bergman
+Hey, Good Lookin'|SSAA|Tom Gentry
+Hey, Good Lookin'|TTBB|David Wright
+Hey, Good Lookin'|TTBB|Jon Nicholas
+Hey, Good Lookin'|TTBB|Tom Gentry
+Hey, Look Me Over|TTBB|David Wright
+Hey, Look Me Over|TTBB|Ells Morey
+Hey, Look Me Over|TTBB|Tom Gentry
+Hey, Look Me Over|TTBB|Willis Diekema, John Hohl
+Hey, Look Me Over / If My Friends Could See Me Now|TTBB|Tom Gentry
+Hey, Soul Sister|SSAA|Elaine Gain
+Hey, Soul Sister|TTBB|Jon Nicholas
+Hey, Won't You Play Another Somebody|SSAA|Tedda Lippincott
+Hey! Look Me Over|SSAA|Nancy Bergman
+Hi Neighbor|TTBB|Rob Ozman
+Hi Neighbor|TTBB|Walter Latzko
+Hi Neighbor / One Of Those Songs|TTBB|Walter Latzko
+Hi Neighbor/Consider Yourself Medley|TTBB|Joe Simone
+Hi, Neighbor|TTBB|Walter Latzko
+Hickey|SSAA|Tom Gentry
+Hide And Seek|SATB|Joseph Bates
+High Hopes|SATB|Mel Knight
+High Hopes|SSAA|Ann Minihane
+High Hopes|TTBB|Dennis Driscoll
+High Time|TTBB|Roy Dawson
+Higher And Higher|SSAA|David Wright
+Higher And Higher|TTBB|David Wright
+Hit Me With A Hot Note|SSAA|June Berg
+Hit That Jive Jack|SSAA|Greg Volk
+Hit That Jive Jack|TTBB|Greg Volk
+Hit That Jive, Jack|TTBB|Aaron Dale
+Hit the Road Jack|SATB|Tom Gentry
+Hockey Song, The (aka The Good Old Hockey Game)|TTBB|Steven Armstrong
+Hocus Pocus Medley|SSAA|Liz Garnett
+Hold On|TTBB|David Wright
+Hold On|TTBB|Joe Pickin
+Holdin On For A Hero|SSAA|Jim Arns
+Holdin' Out for a Hero|SSAA|Jim Arns
+Holding Out for a Hero|SSAA|Paul Ayres
+Holding Out For A Hero|SSAA|Joey Minshall
+Holland Road|TTBB|Nathan Peplinski
+Holly Jolly Christmas|SSAA|Betty Oliver
+Holly, Jolly Christmas|SSAA|Betty Oliver
+Holy, Holy, Holy|TTBB|Joe Johnson
+Home Christmas Medley|SSAA|Carmen Youra
+Home For the Holidays|SSAA|Carolyn Schmidt
+Home For The Holidays|SSAA|Carolyn Schmidt Tedda Lippincott
+Home on the Range|SSAA|Brian Beck
+Home on the Range|TTBB|Don Gray
+Home on the Range|TTBB|Jack Baird
+Home On The Range|TTBB|Jim Clancy
+Home On The Range|TTBB|Jon Nicholas
+Home to Stay|SSAA|Joey Minshall
+Hometown in Dixieland|TTBB|Jay Giallombardo
+Homeward Bound|SSAA|Janice Wheeler
+Homeward Bound|TTBB|Jon Nicholas
+Honey (Open That Door)/Hey Good Lookin'|TTBB|Aaron Dale
+Honey I'm Home|SSAA|Corinna Garriock
+Honey Medley|SSAA|David Harrington
+Honey Medley|TTBB|David Harrington
+Honey Pie (Beatles)|SATB|Paul Hart
+Honey/Little 'Lize Medley|TTBB|Barbershop Harmony Society
+Honey/Little 'Lize Medley|TTBB|Floyd Connett
+Honeysuckle Rose|TTBB|Aaron Dale
+Honky Tonk Moon|SSAA|Anna Maria Parker
+Honolulu City Lights|SSAA|Brian Beck
+Hooked on a Feeling|TTBB|Deke Sharon
+Hooked On A Feeling|SSAA|Corinna Garriock
+Hooked On A Feeling|SSAA|Jim Arns
+Hooked On A Feeling|SSAA|Tedda Lippincott
+Hooked On A Feeling|TTBB|Jon Nicholas
+Hooray for Hollywood|SSAA|Joni Bescos
+Hooray For Hollywood|TTBB|Dennis Driscoll
+Hooray For Hollywood/That's Entertainment Medley(Jay Giallomb|TTBB|Jay Giallombardo
+Hooray for Love|TTBB|Alan Gordon
+Hopelessly Devoted to You|SSAA|Carolyn Healey
+Hospitality|TTBB|Gene Cokeroft
+Hot Diggity (YWIH)|SSAA|Muriel Berg
+Hot Diggity Dog (Dog Ziggity Boom)|SSAA|Muriel Berg
+Hot Stuff|SSAA|Sylvia Alsbury
+House At Pooh Corner|TTBB|Anthony Nasto
+House of Blue Lights|SSAA|Jo Lund
+House Of The Rising Sun|TTBB|Deke Sharon
+How 'Ya Gonna Keep 'Em Down On The Farm?|TTBB|Barbershop Harmony Society
+How Are Things in Glocca Morra?|TTBB|Don Gray
+How Are Ya Fixed For Love|SATB|Shawn York
+How Can I Keep From Singing|SSAA|Joe Liles
+How Can I Miss You If You Won't Go Away|SSAA|Unspecified
+How Can I Miss You If You Won'T Go Away|SSAA|Tedda Lippincott
+How Can I Miss You If You Won't Go Away?|TTBB|Lou Perry
+How Can You Mend A Broken Heart|TTBB|Henrik Rosenberg
+How Could You Believe Me|SSAA|Brian Beck
+How Could You Believe Me?|SSAA|Renee Craig
+How Deep is the Ocean|SSAA|Ed Waesche
+How Deep is the Ocean|TTBB|Rob Hopkins
+How Deep Is the Ocean|SSAA|Lynn McCord
+How Deep Is the Ocean|SSAA|Rob Hopkins
+How Deep Is The Ocean|TTBB|Ed Waesche
+How Deep Is The Ocean (How High Is The Sky)|TTBB|Ed Waesche
+How Deep is the Ocean?|TTBB|Jim Clancy
+How Deep is the Ocean?|TTBB|Rob Hopkins
+How Deep Is the Ocean?|TTBB|Ed Waesche
+How Deep Is Your Love|SSAA|Ruby Rhea
+How Deep Is Your Love|TTBB|Henrik Rosenberg
+How Deep Is Your Love|TTBB|John Palmer
+How Do I Love Thee|SSAA|Nathan Christensen
+How Do You Like Your Eggs in the Morning|SSAA|Tom Gentry
+How Far Is It to Betlehem|TTBB|Larry Triplett
+How Great Thou Art|SATB|Joe Johnson
+How Great Thou Art|TTBB|Clay Hine
+How Great Thou Art|TTBB|Fred King
+How High the Moon|SSAA|Cheryl Suhr
+How High The Moon|SSAA|Mark Hale
+How High The Moon|TTBB|Mark Hale
+How Lucky Can You Get/Luck Be a Lady|SSAA|Brian Beck
+How Many Hearts Have You Broken|SSAA|Jim Arns
+How Many Hearts Have you Broken?|SSAA|Jim Arns
+How Many Hearts Have You Broken?|SSAA|Steve Jamison
+How Many Hearts Have You Broken?|TTBB|Unspecified
+How Many Hearts/ Them There Eyes|SSAA|Brent Graham
+How To Build A Chorus|TTBB|Val Hicks
+How We Sang Today|SSAA|Unspecified
+How We Sang Today|SSAA|Vicki Uhr
+How Ya Gonna Keep 'Em Down On The Farm Medley|SSAA|Nancy Bergman
+How Ya Gonna Keep 'Em Down On the Farm?|TTBB|Mike Senter
+How Ya Gonna Keep Em' Down on the Farm?|TTBB|Barbershop Harmony Society
+How's Every Little Thing In Dixie|TTBB|Al Rekhop
+How's Every Little Thing in Dixie?|TTBB|David Wright
+Huron Carol|SSAA|Corinna Garriock
+Huron Carol|TTBB|Steven Armstrong
+Hush|TTBB|Dick Kneeland
+Hushabye Mountain|TTBB|Bill Mitchell
+Hushabye Mountain|TTBB|William Mitchell
+Hymns of Christmas Medley|TTBB|Shaun Agnew
+I Ain't Down Yet|SSAA|JoAnne Ingels
+I am Australian|TTBB|Unspecified
+I Am Not American|TTBB|Steven Armstrong
+I Am Sailing|SSAA|Unspecified
+I Am What I Am|SSAA|Michael Gellert
+I Am What I Am/My Way (Medley)|TTBB|Steve Tramack
+I Am Woman|SSAA|Judy Dixon
+I Asked The Lord|SSAA|Kay Bromert
+I Asked The Lord|TTBB|Buzz Haeger
+I Been Workin' On The Railroad|TTBB|Roger Payne
+I Believe|SSAA|Tom Gentry
+I Believe|TTBB|Barbershop Harmony Society
+I Believe|TTBB|David Harrington
+I Believe I Can Fly|SSAA|Joey Minshall
+I Believe in Father Christmas|TTBB|Shaun Agnew
+I Believe In Music|SSAA|Jo Lund
+I Believe In Music|SSAA|Joe Liles
+I Believe In Music|TTBB|Joe Liles
+I Believe/You'll Never Walk Alone|SSAA|Fred King
+I Can Cook Too|SSAA|Lorraine Rochefort
+I Can Dream, Can't I?|SSAA|Brad Rees
+I Can Dream, Can't I?|TTBB|Brent Graham
+I Can See Clearly Now|SSAA|Charlene Yazurlo
+I Can't Begin to Tell You|SSAA|Carolyn Schmidt
+I Can't Believe I'm Losing You|SSAA|Joni Bescos
+I Can't Believe I'm Not A Millionaire|SSAA|Julia Cope
+I Can't Give Anything But Love/I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I Can't Give You Anything But Love|SATB|Mason Kaye
+I Can't Give You Anything But Love|SSAA|Nancy Bergman
+I Can't Give You Anything But Love|TTBB|Clay Hine
+I Can't Give You Anything But Love|TTBB|David Harrington
+I Can't Give You Anything But Love|TTBB|Ed Waesche
+I Can't Give You Anything But Love|TTBB|Walter Latzko
+I Can't Give You Anything But Love & Steppin' Out With My Baby Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love-L.O.V.E.|SSAA|Nancy Bergman
+I Can't Give You Anything But Love-LOVE|SSAA|Nancy Bergman
+I Can't Give You Anything But Love, Baby|TTBB|David Harrington
+I Can't Give You Anything But Love/L-O-V-E Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/LOVE Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/Steppin' Out Medley|SSAA|Nancy Bergman
+I Can't Give You Anything But Love/Steppin' Out With My Baby (Medley)|SSAA|Nancy Bergman
+I Can't Give You Anything/I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I Can't Give You/Steppin' Out With My Baby|SSAA|Nancy Bergman
+I Can't Help Falling In Love|TTBB|Will Hamblet
+I Can't Help Falling In Love With You|TTBB|Johan Wikstrom
+I Can't Help Falling In Love With You|TTBB|Jon Nicholas
+I Can't Help Falling In Love With You|TTBB|Kevin Keller
+I Can't Recall Her Name|TTBB|Joe Liles
+I Can't Recall His Name|SSAA|Joe Liles
+I Could Have Danced All Night|TTBB|Brent Graham
+I Could Have Told You|TTBB|Henrik Rosenberg
+I Cover the Waterfront|TTBB|Webb Comfort
+I Didn't Wanna Fall|SSAA|Joe Liles
+I Didn't Want To Fall|SSAA|Joe Liles
+I Didn't Want To Fall|TTBB|Joe Liles
+I Didn't Want to Fall - modified words|SSAA|Joe Liles
+I Dig Rock and Roll Music|SSAA|Kevin Keller
+I Don't Care if the Sun Don't Shine|SSAA|Nancy Bergman
+I Don't Care/Steppin Out|SSAA|Nancy Bergman
+I Don't Know Enough About You|SSAA|Nancy Bergman
+I Don't Know Enough About You/ I Don't Know Why Medley(Tom Ge|SSAA|Tom Gentry
+I Don't Know Enough About You/ I Don't Know Why Medley(Tom Ge|TTBB|Tom Gentry
+I Don't Know If I Should Call Her|TTBB|Jon Nicholas
+I Don't Know Medley|TTBB|Tom Gentry
+I Don't Know Medley (I Know a Little Bit/I Don't Know Why I Love You Like I Do)|SSAA|Unspecified
+I Don't Know Why|SSAA|Buzz Haeger
+I Don't Know Why|TTBB|Mel Knight
+I Don't Know Why|TTBB|Webb Comfort
+I Don't Know Why (I Just Do)|SSAA|Haeger
+I Don't Know Why (I Love You Like I Do)|SSAA|Buzz Haeger
+I Don't Know Why Medley|SSAA|Mary Coffman
+I Don't Know Why, I Just Do|SSAA|Buzz Haeger
+I Don't Know Why/You Made Me Love You|SSAA|Mary Coffman
+I Don't Mind Being All Alone|TTBB|Barbershop Harmony Society
+I Don't Stand A Ghost of a Chance|SSAA|Cheryl Suhr
+I Don't Wanna Get Married/When You're Married|SSAA|Avis Fellows/Marie Johnson
+I Don't Wanna Walk Without You|SSAA|Nancy Bergman
+I Don't Wanna Walk Without You|SSAA|Renee Craig
+I Don't Want To Get Well|TTBB|Rob Hopkins
+I Don't Want To Set The World On Fire|TTBB|Joe Johnson
+I Don't Want To Set The World On Fire|TTBB|Lloyd McClur
+I Don't Want to Walk Without You|SSAA|Renee Craig
+I Don't Want to Walk Without You|TTBB|Joe Johnson
+I Don't Want to Walk Without You|TTBB|Tom Gentry
+I Dreamed A Dream|SSAA|June Dale
+I Dreamed A Dream (Les Miserable)|SATB|Philip Lawson
+I Enjoy Being A Girl (YWIH)|SSAA|Jean Kane
+I Feel A Song / Hallelujah!|TTBB|Ed Waesche
+I Feel A Song Comin On|SSAA|Nancy Bergman
+I Feel a Song Comin' On|SSAA|Nancy Bergman
+I Feel A Song Comin' On|SSAA|Jarmela Speta
+I Feel A Song Comin' On|TTBB|Larry Triplett
+I Feel A Song Comin' On|TTBB|Pete Rupay
+I Feel A Song Comin' On|TTBB|Rob Hopkins
+I Feel A Song Comin' On|TTBB|Unspecified
+I Feel A Song Coming On|SSAA|Jarmela Speta
+I Feel Pretty|SSAA|Carolyn Schmidt
+I Feel the Earth Move|SSAA|Ase Hagerman
+I Feel the Earth Move|SSAA|Deke Sharon
+I Found a Million Dollar Baby|TTBB|Bill Mitchell, Ed Wasche and Rob Hopkins
+I Found A Million Dollar Baby|TTBB|Ed Waesche, Rob Hopkins, Bill Mitchell
+I Found the End of the Rainbow|TTBB|Ed Waesche
+I Get A Kick Out Of You|SSAA|Joni Bescos
+I Get Along Without You Very Well|TTBB|Adam Reimnitz
+I Get Along Without You Very Well|TTBB|Janne Olsson
+I Get Along Without You Very Well|TTBB|Ruby Rhea
+I Get Around|TTBB|Larry Wright, Doug Anderson
+I Get By With a Little Help From My Friends|SSAA|Rich Hasty
+I Get the Blues When It Rains|SSAA|Anna Maria Parker
+I Get The Blues When It Rains|TTBB|Douglas Beck
+I Go to the Rock|SSAA|Don Gray
+I Got a Crush On You|SSAA|Marge Bailey
+I Got a Feelin' I'm Fallin'|SSAA|Nancy Bergman
+I Got Lost in His Arms|SSAA|Jo Lund
+I Got Plenty of Nothin'|TTBB|Jay Giallombardo
+I Got Rhythm|SSAA|Ann Minihane
+I Got Rhythm|SSAA|David Wright
+I Got Rhythm|TTBB|Bill Biffle
+I Got Rhythm|TTBB|Clay Hine
+I Got Rhythm|TTBB|Ed Waesche
+I Got Rhythm|TTBB|Walter Latzko
+I Got Rhythm Medley|SSAA|Nancy Bergman
+I Got Rhythm-Farewell To Love|TTBB|Steven Armstrong
+I Got You, Babe|SSAA|Brian Beck
+I Gotta Dance|SSAA|Brian Beck
+I Gotta Right To Sing The Blues|TTBB|Ed Waesche
+I Had Someone Before I Had You|SSAA|Avis Fellows
+I Had Someone Else Before I had You|SSAA|Avis Fellows
+I Hate to Lose You|TTBB|Unspecified
+I Have Dreamed|SSAA|David Briner
+I Have Dreamed|SSAA|David Wright
+I Have Dreamed|TTBB|David Wright
+I Have Had Singing|TTBB|Ron Jeffers
+I Have Seen The Light (chorus parts only)|TTBB|Jay Giallombardo
+I Heard It Through the Grapevine|SSAA|Dede Nibler
+I Heard It Through The Grapevine|TTBB|Aaron Dale
+I Heard The Bells On Christmas Day|TTBB|Jon Nicholas
+I Heard You Singing|TTBB|Jay Giallombardo
+I Hope You Dance|SSAA|Jean McFadyen
+I Hope You Dance|SSAA|Tedda Lippincott
+I Just Can't Wait To Be King|TTBB|Aaron Dale
+I Know Why (And So Do You)|TTBB|Kevin Keller
+I Left My Heart In San Francisco|TTBB|Jay Wright
+I Left My Heart In San Francisco|TTBB|Ted Byrne
+I Love A Barbershop Song|TTBB|Duane Enders
+I Love a Piano|SSAA|Jim Massey
+I Love A Piano|SSAA|Greg Volk
+I Love A Piano|TTBB|Jay Giallombardo
+I Love Being Here With You|SSAA|Aaron Dale
+I Love Being Here With You|SSAA|Kevin Keller
+I Love Being Here With You|TTBB|Aaron Dale
+I Love Jazz Medley|SSAA|David Wright
+I Love Jazz Medley|TTBB|David Wright
+I Love My Baby|SSAA|Tom Gentry
+I Love That Old Barbershop Style|TTBB|Val Hicks
+I Love That We're Old Fashioned|TTBB|Kevin Keller
+I Love the Whole United States|TTBB|Burt Szabo
+I Love to Hear That Good Old Barbershop Style|SSAA|Jo Lund
+I Love to Hear That Old Barbershop Style|SSAA|Jo Lund/Val Hicks
+I Love to Laugh|SSAA|Jim Massey
+I Love To Laugh|TTBB|Val Hicks
+I Love You for Sentimental Reasons|SSAA|Joan Adler
+I Love You Truly|TTBB|Barbershop Harmony Society
+I May Be Gone for a Long, Long Time|TTBB|Unspecified
+I May Wander|SSAA|Joey Minshall
+I Miss Mother Most of All|SSAA|Joe Liles
+I Miss Mother Most Of All|TTBB|Joe Liles
+I Never Can Say Goodbye|TTBB|Jeremey Johnson
+I Never Knew I Could Love Anybody (Like I'm Loving You)|SSAA|David Wright
+I Never Knew Medley|TTBB|Renee Craig
+I Never Knew You Were Meant for Me|SSAA|Rob Hopkins
+I Never Knew/Get Me To The Church On Time Medley(Clay|TTBB|Clay Hine
+I Never Knew/You Were Meant for Me|SSAA|Renee Craig
+I Never Meant to Fall in Love|SSAA|Joe Liles
+I Only Have Eyes For You|SSAA|Greg Volk
+I Only Have Eyes For You|SSAA|Tedda Lippincott
+I Only Have Eyes For You|SSAA|Tom Gentry
+I Only Have Eyes For You|SSAA|Unspecified
+I Only Have Eyes For You|TTBB|Bobby Gray
+I Only Have Eyes For You|TTBB|Greg Volk, Bobby Gray
+I Only Have Eyes For You|TTBB|R. Weiss
+I Remember You|SSAA|Jim Arns
+I Saw Her Standing There|TTBB|Brian Wollman
+I Saw Her Standing There|TTBB|Jon Nicholas
+I Saw Mommy Kissing Santa Claus|TTBB|Burt Szabo
+I Saw Mommy Kissing Santa Claus|TTBB|Steve Tramack
+I Saw Three Ships|SSAA|Diane Clark
+I Saw Three Ships|TTBB|Kevin Keller
+I Shot the Sheriff|TTBB|Steve Wolf
+I Sing the Mighty Power of God|TTBB|Andrew Ball
+I Still Call Australia Home|SSAA|Unspecified
+I Talk To The Trees|SSAA|D.C. DeBruycker
+I Thought About You|TTBB|Ruby Rhea
+I Thought About You|TTBB|Webb Comfort
+I Told 'em All About You/You Dear|SSAA|Four Harmonizers
+I Told Them All About You|SSAA|Jim Arns
+I Told Them All About You/You Dear Medley|SSAA|Joe Liles
+I Told Them All About You/You Dear Medley(Four Harmoni|TTBB|Four Harmonizers
+I Tried Your Love|TTBB|Jon Nicholas
+I Used To Be Color Blind|TTBB|Adam Reimnitz
+I Used To Call Her Baby|TTBB|Tom Gentry, Don Gray
+I Used to Call Him Baby asb Showtime|SSAA|Jay Giallombardo
+I Used to Call Him Baby Medley|SSAA|Jay Giallombardo
+I Wanna Be A Producer|TTBB|Nick Schurmann
+I Wanna Be Around|SSAA|Nancy Bergman
+I Wanna Be Around|TTBB|Jay Giallombardo
+I Wanna Be Around|TTBB|Mo Rector
+I Wanna Be Like You|SATB|Philip Lawson
+I Wanna Be Like You|SSAA|Unspecified
+I Wanna Be Like You|TTBB|David Wright
+I Wanna Be Loved By You|SSAA|Jarmela Speta
+I Wanna Come Back As A Man|SSAA|Jim Arns
+I Wanna Hippopotamus for Christmas|SSAA|Tedda Lippincott
+I Wanna Hold Your Hand|SSAA|David Harrington
+I Wanna Hold Your Hand|TTBB|David Harrington
+I Want a Girl|TTBB|Barbershop Harmony Society
+I Want a Hippopotamus for Christmas|SSAA|Kay Bromert
+I Want a Hippopotamus for Christmas|TTBB|Tony Searle
+I Want a Hippopotamus For Christmas|TTBB|Tom Gentry
+I Want A Hippopotamus For Christmas|TTBB|Jon Nicholas
+I Want To Hold Your Hand|TTBB|Adam Bock
+I Want To Hold Your Hand|TTBB|Steve Jamison
+I Want You Back|SSAA|Elaine Gain
+I Want You to be My Sweetheart|TTBB|Lou Perry
+I Want You, I Need You, I Love You|SSAA|Aaron Dale
+I Want You, I Need You, I Love You|TTBB|Aaron Dale
+I Will|SSAA|David Harrington
+I Will|TTBB|David Harrington
+I Will|TTBB|David Wright
+I Will Be There|TTBB|Steve Delehanty
+I Will Follow Him|SSAA|Tedda Lippincott
+I Will Go Sailing No More|TTBB|Rich Hasty
+I Will Love Again|SSAA|Vicki Uhr
+I Will Love You 'Til the End of Time|SSAA|Alan Baker
+I Will Love You Til The End of Time|SSAA|Al Baker
+I Will Never Pass This Way Again|TTBB|Don Gray
+I Will Survive|SSAA|Larry Wright
+I Wish I Could Be Santa Claus|SSAA|Larry Triplett
+I Wish I Could Be Santa Claus|TTBB|Larry Triplett
+I Wish I Could Shimmy Like My Sister Kate|SSAA|Jo Lund
+I Wish I Could Shimmy Like My Sister Kate|SSAA|Nancy Bergman
+I Wish You Love|SSAA|Dave Briner
+I Wish You Love|TTBB|Larry Triplett
+I Won't Dance|TTBB|Liz Garnett
+I Won't Send Roses|TTBB|Theo Hicks
+I Wonder as I Wander|SSAA|Joey Minshall
+I Wonder As I Wander|TTBB|Darin Drown
+I Wonder As I Wander|TTBB|Jon Nicholas
+I Wonder as I Wander (Bass feature)|SSAA|Joey Minshall
+I Wonder Who's Kissing Her Now?|TTBB|Lou Perry
+I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Ed Waesche
+I Write The Songs|TTBB|Buzz Haeger
+I'd Give A Million Tomorrows|SSAA|Nancy Bergman
+I'd Give A Million Tomorrows|SSAA|Tom Gentry
+I'd Give The World To Be In My Hometown|TTBB|Einar Pedersen
+I'd Give The World To Hear Alexanders Band Again|TTBB|Unspecified
+I'd Like to Teach the World to Sing|SSAA|Joey Minshall
+I'd Like to Teach the World to Sing|SSAA|Joni Bescos
+I'd Like to Teach the World to Sing|SSAA|Nancy Bergman
+I'd Like To Teach The World To Sing (In Perfect Harmony)|TTBB|Dave Stevens
+I'd Like To Teach The World To Sing (In Perfect Harmony)|TTBB|Rob Hopkins
+I'd Love To Live In Loveland|TTBB|Barbershop Harmony Society
+I'd Love To Live In Loveland|TTBB|Heritage of Harmony
+I'd Love To Live In Loveland|TTBB|Val Hicks
+I'd Love To Live In Loveland With A Girl Like You|TTBB|Aaron Dale
+I'll Always Love You (Smiling Face)|TTBB|Ruby Rhea
+I'll Be Easy To Find|SSAA|Joey Minshall
+I'll Be Home for Christmas|SSAA|Barbershop Harmony Society
+I'll Be Home For Christmas|SSAA|Renee Craig
+I'll Be Home For Christmas|SSAA|Sylvia Alsbury
+I'll Be Home For Christmas|TTBB|Barbershop Harmony Society
+I'll Be Home For Christmas|TTBB|Jon Nicholas
+I'Ll Be Home For Christmas|SSAA|Renee Craig Judy Vidal
+I'll Be Seeing You|SSAA|Renee Craig
+I'll Be Seeing You|SSAA|Tedda Lippincott
+I'll Be Seeing You|TTBB|Chris Slacke
+I'll Be Seeing You|TTBB|Chuck Brooks
+I'll Be Seeing You|TTBB|Don Gray
+I'll Be Seeing You|TTBB|Jim Clancy
+I'll Be Seeing You|TTBB|Rob Hopkins
+I'll Be There (SATB)|SATB|Dave King
+I'll Be There For You|SSAA|Jon Nicholas
+I'll Be There For You|TTBB|Jon Nicholas
+I'll Be With You in Apple Blossom Time|SSAA|Nancy Bergman
+I'll Be Your Friend Until Forever|SSAA|Tedda Lippincott
+I'll Fly Away|SSAA|Burt Szabo
+I'll Fly Away|SSAA|Don Gray
+I'll Fly Away|TTBB|Burt Szabo
+I'll Fly Away|TTBB|Don Gray
+I'll Fly Away (Keepsake Version)|TTBB|Don Gray
+I'll Fly Away (Society Stock Version)|TTBB|Don Gray
+I'll Follow the Sun|TTBB|Jay Giallombardo
+I'll Forget You|SSAA|Jay Giallombardo
+I'll Forget You|TTBB|Lou Perry
+I'll Get By|TTBB|Steven Armstrong
+I'll Know|SATB|Steven Armstrong
+I'll Never Fall in Love Again|SSAA|Tom Gentry
+I'll Never Say 'Never Again' Again|TTBB|Tom Gentry
+I'll Never Say Never Again|SSAA|Tom Gentry
+I'll Never Say Never Again Again|SSAA|Tom Gentry
+I'll Never Smile Again|TTBB|Roy Keys
+I'll Never Write A Love Song Anymore|SSAA|Joe Liles
+I'll String Along With You|TTBB|Tom Gentry
+I'll Take Romance|TTBB|Marshall Webb
+I'll Take You Dreaming|TTBB|Larry Triplett
+I'll Take You Home Again Kathleen|TTBB|Peter Nugent
+I'll Tell My Ma When I Go Home|SSAA|Joey Minshall
+I'll Walk With God|TTBB|Burt Szabo, Hank Vomacka
+I'll Walk With God|TTBB|Jeremey Johnson
+I'll Walk With God|TTBB|Pete Rupay
+I'm A Believer|TTBB|Greg Volk
+I'm a Fool to Want You|TTBB|Larry Triplett
+I'm A Great Big Baby|SSAA|Lynnell Diamond
+I'm a Woman|SSAA|Lorraine Rochefort
+I'm A Woman|SSAA|Nancy Bergman
+I'm Afraid the Masquerade is Over|SSAA|Renee Craig
+I'm All Alone|SSAA|Floyd Connett
+I'm All Alone|TTBB|David Wallace
+I'm Alone Because I Love You|SSAA|Brian Beck
+I'm Alone Because I Love You|SSAA|Mary Coffman
+I'm Alone Because I Love You|TTBB|Brian Beck
+I'm Alone Because I Love You|TTBB|Lou Perry, Ed Waesche
+I'm Alone Because I Love You|TTBB|Unspecified
+I'm Alright Now|TTBB|Theo Hicks
+I'm Always Chasing Rainbows|SSAA|Anna Maria Parker
+I'm Always Chasing Rainbows|SSAA|Nancy Bergman
+I'm Always Chasing Rainbows|SSAA|Ruby Rhea
+I'm Always Chasing Rainbows|TTBB|Earl Moon
+I'm Back In Love/I'm In Love Again|SSAA|Betty Oliver/Marie Johnson
+I'm Beginning to Like It|SSAA|Tom Gentry
+I'm Beginning To Like It|TTBB|Tom Gentry
+I'm Beginning to See the Light|SSAA|June Dale
+I'm Beginning to See the Light|SSAA|Linda Masterson
+I'm Beginning to See the Light|SSAA|Nancy Bergman
+I'm Beginning to See the Light|SSAA|Tedda Lippincott
+I'm Beginning to See the Light|SSAA|Walter Latzko
+I'm Beginning to See the Light|TTBB|Marshall Webb
+I'm Beginning To See The Light|SSAA|Rob Hopkins
+I'm Beginning To See The Light|TTBB|Rob Hopkins
+I'm Confessin'|SSAA|Don Gray
+I'm Confessin'|TTBB|Don Gray
+I'm Dancing This Dance in the Wrong Romance|SSAA|Frank Marzocco
+I'm Feelin' Fine|TTBB|Darin Drown
+I'm Feelin' Fine|TTBB|Joe Liles
+I'm Feeling Fine|SSAA|Tedda Lippincott
+I'm Gonna Live 'Til I Die|SSAA|Unspecified
+I'm Gonna Live 'Til I Die|TTBB|Greg Volk
+I'm Gonna Live 'Til I Die|TTBB|Robert Rund
+I'm Gonna Live Till I Die|TTBB|Greg Volk
+I'm Gonna Live Till I Die|TTBB|Greg Volk, Keepsake
+I'm Gonna Live TillI Die|SSAA|Greg Volk
+I'm Gonna Lock My Heart|SSAA|Jean Shook
+I'm Gonna Love That Guy|SSAA|Norma Andersen
+I'm Gonna Make It, Joe|TTBB|Phil Ordaz
+I'm Gonna Sing|TTBB|Gloria Gaither
+I'm Gonna Sing Til The Spirit Moves In My Heart(Darin D|TTBB|Darin Drown
+I'm Gonna Sit Right Down and Write Myself a Letter|SSAA|Tom Gentry
+I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Mo Rector (w/slight changes)
+I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Tom Gentry
+I'm Gonna Sit Right Down And Write Myself A Letter(Jim Ka|TTBB|Jim Kahlke
+I'm Gonna Wash That Man Right Outta My Hair|SSAA|Ruby Rhea
+I'm Happy|TTBB|Alan Siegal
+I'm In Love With A Big Blue Frog|SSAA|Carolyn Healey
+I'm In Love With the Mother of My Best Girl|TTBB|Dave Briner and Lloyd Steinkamp
+I'm In the Mood For Love|TTBB|Webb Comfort
+I'm Into Something Good|SSAA|John Fortino (Intro by Norbert Hammes)
+I'm Into Something Good|TTBB|Christopher Peterson
+I'm Into Something Good|TTBB|John Fortino
+I'm Into Something Good / Happy Together Medley|SSAA|Aaron Dale
+I'm Lonesome For You, Dear Old Pal|TTBB|Lou Perry
+I'm Looking Over a 4-Leaf Clover Medley|SSAA|Jim Arns
+I'm Looking Over A Four Leaf Clover|SSAA|Lorraine Rochefort
+I'm Looking Over A Four Leaf Clover|TTBB|Ed Waesche
+I'M Making Believe I Don'T Care|SSAA|Joni Bescos
+I'm My Own Grandpa|TTBB|Brian Beck
+I'm My Own Grandpaw|TTBB|Brian Beck
+I'm Nobody's Baby|SSAA|Nancy Bergman
+I'm Off to See my Sweetness|TTBB|Dan Wilson
+I'm Off To See My Sweetness|TTBB|Patrick McAlexander
+I'm Old Fashioned|SSAA|Renee Craig
+I'm Old Fashioned|TTBB|Roy Dawson
+I'm Old-Fashioned|SSAA|Diane Clark
+I'm Old-Fashioned|SSAA|Jo Lund
+I'm On My Way|TTBB|Jon Nicholas
+I'M Proud To Be An American|SSAA|Brian Beck
+I'm Sending A Letter to Santa Claus|SSAA|Carolyn Schmidt
+I'm Singing Your Love Songs to Somebody Else|SSAA|Renee Craig
+I'm Sittin' On Top of the World|TTBB|Bonston Consort and Rob Hopkins
+I'm Sittin' On Top Of The World|TTBB|Boston Consort
+I'm Sitting on Top of the World|SSAA|John Hohl/Dave Stevens
+I'm Sitting On Top of the World|SSAA|Lorraine Rochefort
+I'm Sitting On Top of the World|SSAA|Nancy Bergman
+I'm Sitting On Top of the World|SSAA|Renee Craig
+I'm Sitting On Top Of The World|TTBB|Boston Consort
+I'm So Excited|SSAA|Jim Massey
+I'm So Excited|SSAA|Liz Garnett
+I'm So Glad We Had This Time Together|SSAA|Nancy Bergman
+I'm So Glad We Had This Time Together|TTBB|Roger Olsen
+I'm Sorry I Made You Cry|TTBB|John Hohl
+I'm Still Holding You|SSAA|Jon Nicholas
+I'm Still Holding You|TTBB|Jon Nicholas
+I'm Stone In Love With You|TTBB|Kevin Keller
+I'm The Music Man|TTBB|David Wright
+I'm the One You're Looking For|SSAA|Marie Johnson
+I'm Walkin'|TTBB|Aaron Dale
+I'm Yours|SSAA|Rice/Florence
+I've Been Everywhere|TTBB|Earl Moon
+I've Been Waiting For Your Phone Call|SSAA|Nancy Bergman
+I've Been Waiting For Your Phone Call for 18 Years|SSAA|Nancy Bergman
+I've Been Workin' On The Railroad|TTBB|Roger Payne
+I've Got a Crush on You|SSAA|Joe Liles
+I've Got A Crush On You|SSAA|Steve Jamison
+I've Got A Crush/As Time Boes By|SSAA|Tedda Lippincott
+I've Got A Feeling I'm Fallin'|SSAA|Nancy Bergman
+I've Got A Feeling I'm Falling|SSAA|David Wright
+I've Got A Feeling I'm Falling|SSAA|Nancy Bergman
+I've Got My Love To Keep Me Warm|SSAA|Anastasio Rossi
+I've Got My Love To Keep Me Warm|TTBB|Adam Reimnitz
+I've Got My Love To Keep Me Warm|TTBB|Anastasio Rossi
+I've Got No Strings|TTBB|Jeremey Johnson
+I've Got the Music In Me|SSAA|Mary Ann Wydra
+I've Got the Time|SSAA|Joe Liles
+I've Got The Time - I've Got The Place|TTBB|Joe Liles
+I've Got the World on a String|SSAA|Larry Wright
+I've Got the World on a String|SSAA|Mac Huff
+I've Got the World on a String|TTBB|Unspecified
+I've Got The World On A String|TTBB|Adam Reimnitz
+I've Got The World On A String|TTBB|Rob Hopkins
+I've Got You Under My Skin|SSAA|Brian Beck
+I've Never Been In Love Before|SATB|Don Gray
+Icarus|TTBB|Ralph Towner and Gary Rosen
+If|SSAA|Nancy Bergman
+If|TTBB|John Hohl
+If|TTBB|Larry Triplett
+If All My Dreams Were Made Of Gold|TTBB|Aaron Dale
+If All My Dreams Were Made Of Gold, I'd Buy The World For You|TTBB|Lou Perry
+If Ever I Would Leave You|SSAA|Clay Hine
+If Ever I Would Leave You|TTBB|Clay Hine
+If Ever I Would Leave You|TTBB|Kris Olson
+If He Can Fight Like He Can Love|SSAA|Russ Foris
+If He Can Fight Like He Can Love, Good Night Germany|TTBB|Lloyd Steinkamp
+If He Walked Into My Life|SSAA|Mark Jennings
+If I Can Dream|SSAA|Tom Gentry
+If I Can Dream|TTBB|Tom Gentry
+If I Could Be With You|SSAA|Anna Maria Parker
+If I Could Write A Song|SSAA|Marie Johnson
+If I Could Write A Song|TTBB|Russ Foris
+If I Didn't Have You|SSAA|Tom Gentry
+If I Fell|TTBB|Brian A. Harding
+If I Fell In Love With You|SSAA|Nova Evans
+If I Give My Heart to You|SSAA|Jim Clancy
+If I Give My Heart To You|TTBB|Jim Clancy
+If I Had A Voice|SSAA|Dede Nibler
+If I Had My Life to Live Over|SSAA|Joni Bescos
+If I Had My Life to Live Over|SSAA|Nancy Bergman
+If I Had My Life To Live Over|SSAA|Tedda Lippincott
+If I Had My Way|SSAA|Clay Hine
+If I Had My Way|SSAA|David Harrington
+If I Had My Way|SSAA|Joni Bescos
+If I Had My Way|SSAA|Lorraine Rochefort
+If I Had My Way|SSAA|Nancy Bergman
+If I Had My Way|TTBB|David Harrington
+If I Had My Way Parody|TTBB|Adam Reimnitz
+If I Had The Last Dream Left In The World|SSAA|Joe Liles
+If I Had You|SSAA|Nancy Bergman
+If I Had You|TTBB|Joe Johnson
+If I Hear Another Song About Christmas|SSAA|Lynnell Diamond
+If I Love Again|SSAA|Ed Waesche
+If I Love Again|SSAA|Nancy Bergman
+If I Love Again|TTBB|Ed Waesche
+If I Love Again|TTBB|Katie Farrell
+If I Loved You|SSAA|Renee Craig
+If I Loved You|TTBB|Don Gray
+If I Loved You|TTBB|Jay Giallombardo
+If I Loved You|TTBB|Steve Tramack
+If I Loved You|TTBB|Walter Latzko
+If I Loved You ('Carousel')|SSAA|Renee Craig
+If I Only Had a Brain|SSAA|Nancy Bergman
+If I Only Had a Brain|SSAA|Paula Mauritzen
+If I Only Had A Brain|SSAA|Clay Hine
+If I Only Had A Brain|TTBB|Clay Hine
+If I Ruled the World|SSAA|Nancy Bergman
+If I Ruled the World|SSAA|Renee Craig
+If I Ruled the World|TTBB|Fred King
+If I Ruled The World|SSAA|Don Gray
+If I Ruled The World|SSAA|Ed Waesche
+If I Ruled The World|SSAA|June Dale
+If I Ruled The World|SSAA|Renee Craig/Nancy Bergman
+If I Ruled The World|TTBB|Ed Waesche
+If I Were A Bell|SATB|Don Gray, Steven Armstrong
+If I Were A Rich Man|TTBB|Walter Latzko
+If I Were the Only Girl|SSAA|Renee Craig
+If I Were the Only Girl in the World|SSAA|Nancy Bergman
+If My Friends Could See Me Now|SSAA|Renee Craig
+If My Friends Could See Me Now|TTBB|Ray Danley
+If My Nose Was Running Money|SSAA|Sharon Holmes
+If The Lord Be Willin' (And The Creek Don't Rise)|TTBB|Barbershop Harmony Society
+If the Lord Be Willing|TTBB|Dave Briner
+If The Rest Of The Worlds Don't Want You|TTBB|Lou Perry
+If There Never Was An Ireland|SSAA|Nancy Bergman
+If There's Anybody Here|SATB|Dave Briner
+If There's Anybody Here (From Out of Town)|TTBB|Ardeth Fullmer
+If There's Anybody Here From My Hometown|SATB|Dave Briner
+If There's Anybody Here From Out Of Town|SATB|Dave Briner
+If There's Anybody Here From Out Of Town (8-Part Mixed)|SATB|Dave Briner
+If We All Said A Prayer|SSAA|Renee Craig
+If We Can't Be the Same Old Sweethearts|TTBB|Carl Dahlke
+If We Can't Be The Same Old Sweethearts|SSAA|Jay Giallombardo
+If We Ever Needed the Lord Before|SSAA|Tom Gentry
+If We Hold On Together|SSAA|Greg Volk
+If You Had All the World and It's Gold|SSAA|Joni Bescos
+If You Love Me|SSAA|Nancy Bergman
+If You Love Me (Really Love Me)|TTBB|Renee Craig
+If You Love Me Really Love Me|SSAA|Nancy Bergman
+If You Love Me, Really Love Me|SSAA|Nancy Bergman
+If You Love Me, Really Love Me|SSAA|Renee Craig
+If You Love Me, Really Love Me|TTBB|David Wright
+If You Were Only Mine|TTBB|Tony Nasto
+If You Were The Only Girl In The World|TTBB|Ed Waesche
+If You've Only Got A Moustache|TTBB|Tom Gentry
+Imagination|TTBB|Herman Zimmerman
+Imagination|TTBB|Lou Perry
+Imagine|SSAA|Chris Arnold
+Imagine|SSAA|Lynnell Diamond
+Imagine|SSAA|Marge Bailey
+Imagine|TTBB|Steve Delehanty
+Imagine (YWIH)|SSAA|Marge Bailey
+Impossible Dream|SSAA|Jay Giallombardo
+Impossible Medley|TTBB|Rob Hopkins, Steven Armstrong
+In A Boat For Two|TTBB|Paul Santino
+In a Box on a Shelf|SSAA|Kay Bromert
+In an Old Barbershop Chair|TTBB|Joe Liles
+In Apple Blossom Time|TTBB|Dick Johnson
+In Heaven's Eyes|SSAA|Carolyn Schmidt
+In My Daughter's Eyes|SSAA|Carole Prietto
+In My Daughter's Eyes|SSAA|Lynnell Diamond
+In My Daughter's Eyes|SSAA|Tedda Lippincott
+In My Daughter'S Eyes (W Solo)|SSAA|Lynnell Diamond
+In My Life|SSAA|Carolyn Schmidt
+In My Life|SSAA|Jim Arns
+In My Life|SSAA|Tom Gentry
+In My Life|TTBB|Tom Gentry
+In My Life (YWIH)|SSAA|Carolyn Schmidt
+In My Merry Oldsmobile|SSAA|Unspecified
+In My Room|SSAA|Jonathan Wikeley
+In My Room|TTBB|Aaron Dale
+In My Room|TTBB|Tom Gentry
+In The Bleak Mid-Winter|TTBB|Joseph Jennings
+In the Bleak Midwinter|SSAA|Joe Liles
+In the City of God-Knows-Where|SSAA|Burt Szabo
+In the Cool, Cool, Cool of the Evening|TTBB|Jim Dodge
+In The Cool, Cool, Cool Of The Evening|TTBB|Don Gray
+In The Evening By The Moonlight|TTBB|Tom Gentry
+In the First Light|TTBB|Bob Kauflin
+In the Garden|SSAA|Vicki Uhr
+In the Garden|TTBB|Joe Johnson
+In The Garden|TTBB|Jason Graham
+In the Good Old Summer Time|TTBB|Barbershop Harmony Society
+In the Good Old Summertime|SSAA|Joe Liles
+In The Good Old Summertime|SSAA|Nancy Bergman
+In the Little Red Schoolhouse|SSAA|Fred King/Ronaleen Gapetz
+In the Mood|SSAA|Steve Jamison
+In The Mood|SSAA|Renee Craig
+In The Mood|TTBB|Dallas Town North
+In the Still of the Night|SSAA|Tom Gentry
+In the Still of the Night|TTBB|Tom Gentry
+In The Still Of The Night|TTBB|Unspecified
+In The Wee Small Hours / Always|TTBB|Walter Latzko
+In the Wee Small Hours of the Morning|SSAA|Clay Hine
+In the Wee Small Hours of the Morning|SSAA|Tedda Lippincott
+In the Wee Small Hours of the Morning|TTBB|Adam Reimnitz
+In the Wee Small Hours of the Morning|TTBB|Walter Latzko, Frank Salter, Paul Davies, Bob Walker, John Grant
+In The Wee Small Hours Of The Morning|SSAA|Jim Arns
+In The Wee Small Hours Of The Morning|TTBB|Walter Latzko
+In This Life|SSAA|Dave Briner
+In This Very Room|SSAA|Kay Bromert
+In This Very Room|TTBB|Greg Volk
+Indiana|SSAA|Dot Calvin
+Indiana|TTBB|Ed Waesche
+Indiana [Back Home Again]|TTBB|Sherry Brown
+Indiana Christmas|SSAA|Joyce Stanbery
+International Medley|TTBB|Roger Payne
+Invocation|TTBB|Claudia Bigler
+Iowa|TTBB|Unspecified
+Iowa Stubborn|TTBB|Walter Latzko
+Irish Blessing|SSAA|Don Gray
+Irish Blessing|SSAA|Greg Backwell
+Irish Blessing|SSAA|Jean McFadyen
+Irish Blessing|SSAA|Sylvia Alsbury
+Irish Blessing|TTBB|Don Gray
+Irish Medley|SSAA|Jay Giallombardo
+Irish Medley|SSAA|Nancy Bergman
+Irish Montage|SSAA|Jay Giallombardo
+Irish Montage|TTBB|Jay Giallombardo
+Is It Nothing To You?|TTBB|James Koerts
+Is It True What They Say About Dixie?|SSAA|Nancy Bergman
+Is Somebody Singing|TTBB|Chris Arnold
+Is You Is Or Is You Ain't My Baby|SSAA|Clay Hine
+Is You Is Or Is You Ain't My Baby|TTBB|Louis Jordan
+Isle of Innisfree|TTBB|Jeremey Johnson
+Isn't It A Pity|TTBB|Ed Waesche
+Isn't She Lovely|TTBB|John Brockman
+It All Depends On You|TTBB|John Hohl
+It Came Upon A Midnight Clear|SSAA|Jim Clancy
+It Came Upon A Midnight Clear|TTBB|Jim Clancy
+It Came Upon A Midnight Clear/Silent Night Medley(Jim Cl|TTBB|Jim Clancy
+It Could Happen To You|TTBB|Joe Johnson
+It Don't Mean a Thing|SSAA|Bev Sellers
+It Don't Mean A Thing|SSAA|Lorraine Rochefort
+It Don't Mean A Thing|TTBB|Steve Delehanty
+It Don't Mean A Thing / Sing, Sing, Sing|TTBB|Walter Latzko
+It Don't Mean A Thing/Sing Sing Sing|SSAA|Bev Sellers
+It Don't Mean a Thing/Sing, Sing, Sing|SSAA|Bev Sellers
+It Feels Like Home|SSAA|Nancy Shumard
+It Gets You Right Here!|SSAA|Nancy Bergman
+It Had to Be You|SSAA|Nancy Bergman
+It Had to Be You|TTBB|Steve Armstrong
+It Had To Be You|SSAA|Carolyn Schmidt
+It Had To Be You|SSAA|Fred King
+It Had To Be You|SSAA|Joni Bescos
+It Had To Be You|SSAA|Kevin Keller
+It Had To Be You|SSAA|Suzy Lobaugh, Greg Williams
+It Had To Be You|TTBB|Don Gray
+It Had To Be You|TTBB|Earl Moon
+It Had To Be You|TTBB|Earl Moon / Ed Waesche
+It Had To Be You|TTBB|Earl Moon, Ed Waesche
+It Had To Be You|TTBB|Greg Volk
+It Had To Be You|TTBB|Kevin Keller
+It Had To Be You|TTBB|Steven Armstrong
+It Had to Be You/Nevertheless|SSAA|Nancy Bergman
+It Happened In Monterrey|TTBB|John Brockman
+It is Well with My Soul|TTBB|Jim Clancy
+It Is Well With My Soul|SSAA|David Harrington
+It Is Well With My Soul|SSAA|Joe Liles
+It Is Well With My Soul|SSAA|Larry Wright
+It Is Well With My Soul|TTBB|Bradford Taylor
+It Is Well With My Soul|TTBB|Dan Tice
+It Is Well With My Soul|TTBB|David Harrington
+It Is Well With My Soul|TTBB|R. Vaughan
+It Only Takes A Moment|TTBB|David Wright
+It Was Almost Like a Song|SSAA|June Berg
+It Was Just One of Those Things|TTBB|Joni Bescos
+It Was Love At First Sight|SSAA|Jon Nicholas
+It Was Love At First Sight|TTBB|Jon Nicholas
+It Was Magic|TTBB|Jon Nicholas
+It'll Be Lonely This Christmas|SSAA|Zac Booles
+It's a Beautiful Day For a Ball Game|TTBB|Dennis Driscoll
+It's a Brand New Day|TTBB|Bob Disney
+It's A Brand New Day|SSAA|Bob Disney
+It's A Good Day|SSAA|Lloyd Steinkamp
+It's A Good Day|TTBB|Bob Dowma
+It's A Good Day|TTBB|Val Hicks
+It's A Grand Night for Singing|SSAA|Joni Bescos
+It's A Grand Night For Singing|TTBB|Jay Giallombardo
+It's A Grand Night For Singing|TTBB|Pete Rupay
+It's A Grand Night For Singing|TTBB|Rob Hopkins
+It's A Grand Night For Singing|TTBB|Steve Delehanty
+It's a Great Day for the Irish/MacNamara's Band|SSAA|Nancy Bergman
+It's A Lovely Day Today|TTBB|Joe Johnson
+It's a Million to One You're in Love|SSAA|Anna Maria Parker
+It's A Most Unusual Day|TTBB|Adam Reimnitz
+It's A Most Unusual Day|TTBB|Walter Latzko
+It's a Pity to Say Goodnight|SSAA|Nancy Bergman
+It's a Sin to Tell a Lie|SATB|Dave Briner
+It's A Sin to Tell A Lie|SSAA|David Wright
+It's A Sin to Tell A Lie|SSAA|Lorraine Rochefort
+It's A Sin To Tell A Lie|TTBB|David Wright
+It's A Sin To Tell A Lie|TTBB|Don Bazely
+It's A Small World|SSAA|Mary Coffman
+It's Alright|TTBB|Adam Scott
+It's Beginning to Look a Lot Like Christmas|SSAA|Louise Hamilton
+It's Beginning to Look A Lot Like Christmas|SSAA|Nancy Bergman
+It's Beginning To Look a Lot Like Christmas|TTBB|Willis Diekema
+It'S Beginning To Look A Lot Like Christmas|SSAA|Unspecified
+It's Beginning to Look a Lot Like Xmas/Pine Cones|SSAA|Jean Flinn
+It's Beginning to Look a Lot Like Xmas/Pine Cones|SSAA|Joni Bescos
+It's Beginning To Look Like Christmas|TTBB|Willis Diekema
+It's Beginning to Look/I'll Be Home For Christmas|SSAA|Kay Bromert
+It's Foxy|TTBB|David Harrington
+It's Good To Know I'm Welcome|TTBB|1967 HEP
+It's Impossible|TTBB|Ed Waesche
+It's Impossible|TTBB|Rob Hopkins
+It's Magic|SSAA|Michael Gellert
+It's My Party|SSAA|Marsha Zwicker
+It's My Song|SSAA|Jim Arns
+It's Never Too Late|SSAA|Lorraine Rochefort
+It's Never Too Late to Fall in Love|SSAA|Lorraine Rochefort
+It's Not Easy|TTBB|Johan Wikstrom
+It's Not Unusual|TTBB|Shaun Agnew
+It's Only A Paper Moon|SSAA|Clay Hine
+It's Only A Paper Moon|SSAA|Tedda Lippincott
+It's Only A Paper Moon|TTBB|Clay Hine
+It's Only A Paper Moon|TTBB|Steve Jamison
+It's Only the End of a Romance to You|SSAA|Burt Szabo
+It's Rainin' Men|SSAA|Ase Hagerman
+It's Rainin' Men|SSAA|Brian Beck
+It's Raining Men|SSAA|Ase Hagerman
+It's So Hard To Say Goodbye (To Yesterday)|SATB|Henrik Rosenberg
+It's the Most Wonderful Time of the Year|TTBB|Clay Hine
+It's the Most Wonderful Time of the Year|TTBB|Jay Giallombardo
+It's The Most Wonderful Time of the Year|SSAA|Gwen Schweitzer
+It's The Most Wonderful Time of the Year|SSAA|Nancy Bergman
+It's The Most Wonderful Time Of The Year|SSAA|Matt Swann
+It's The Most Wonderful Time Of The Year|TTBB|Matt Swann
+It's The Same Old Shillelagh|TTBB|Barbershop Harmony Society
+It's Time|SSAA|Kelly Brennan
+It's Today|SSAA|Tom Gentry
+It's Today|TTBB|Tom Gentry
+It's You|SSAA|Robert Rund
+It's You|TTBB|Bob Rund
+It's You|TTBB|Meredith Willson
+It's You|TTBB|Robert Rund
+It's Your Song|SSAA|Jim Arns
+It's Your Song|SSAA|Joe Liles
+Its A Lovely Day Today|SSAA|Unspecified
+Its A Sin To Tell A Lie|SSAA|Unspecified
+Ja Da|SSAA|Marie Johnson
+Ja-Da|TTBB|Dave Briner
+Ja-Da/Everybody's Doin It|SSAA|Nancy Bergman
+Jabberwocky|SATB|Sam Pottle
+Jailhouse Rock|TTBB|Larry Wright
+Jalousie|SSAA|Nancy Bergman
+Jamaica Farewell|TTBB|John Hohl
+Jamaica Farewell|TTBB|John Hohl, Fred Catto
+Java Jive|SSAA|Ann Minihane
+Java Jive|SSAA|Carolyn E. Johnson
+Java Jive|SSAA|Don Gray
+Java Jive|SSAA|Joe Liles
+Java Jive|SSAA|June Dale
+Java Jive|TTBB|Bluegrass Student Union
+Java Jive|TTBB|Ed Waesche, Tim Hauser
+Java Jive|TTBB|Steve Jamison
+Java Jive (YWIH)|SSAA|June Dale
+Jazz Baby|SSAA|Jay Giallombardo
+Jazz Came Up the River|SSAA|David Wright
+Jazz Came Up the River|SSAA|Nancy Bergman
+Jazz Me Blues|SSAA|Ann Minihane
+Jazz Me Blues|SSAA|Joe Johnson
+Jazz Me Blues|TTBB|Joe Johnson
+Jazz Medley|SSAA|Ann Minihane
+Jazzin' The Blues Away|TTBB|Jon Nicholas
+Jeannie With The Light Brown Hair|TTBB|Ed Waesche
+Jeepers Creepers|SSAA|Greg Volk
+Jeepers Creepers|SSAA|Joni Bescos
+Jeepers Creepers|SSAA|Marsha Zwicker
+Jeepers Creepers|SSAA|Sylvia Alsbury
+Jeepers Creepers/Them There Eyes Medley|TTBB|David Harrington
+Jersey Boys Medley|TTBB|Steve Delehanty
+Jesis Jesus Rest Your Head|SSAA|Judy Vidal
+Jesus, Hold My Hand|TTBB|David Briner
+Jesus, Jesus Rest Your Head|TTBB|Greg Lyne
+Jezebel|TTBB|Walter Latzko
+Jimmy Webb Medley|SSAA|Jim Clancy
+Jingle All The Way|SSAA|Unspecified
+Jingle Bell Jazz|SSAA|June Berg/Ed Wells
+Jingle Bell Rock|SSAA|Pat LeVezu
+Jingle Bell Rock|SSAA|Renee Craig
+Jingle Bells|SSAA|Joni Bescos
+Jingle Bells|TTBB|Barbershop Harmony Society
+Jingle Bells|TTBB|David Harrington
+Jingle Bells|TTBB|Traditional
+Jingle Bells Parody|TTBB|Jon Nicholas
+Jingle Bells/Sleigh Ride|TTBB|Pete Rupay
+Jingle Jangle Jingle|TTBB|Unspecified
+Jingle the Bells|SSAA|Bea Howell
+John Denver Medley|TTBB|Steve Jamison
+Johnny Angel|SSAA|Anita Barzilla
+Johnny Angel|SSAA|Debbie Porter
+Johnny Angel|SSAA|Harmony Inc., Music Judges
+Johnny Angel|SSAA|Ken Hatton
+Johnny Angel|SSAA|Lorraine Rochefort
+Johnny Doughboy Found A Rose In Ireland|TTBB|Ed Williamson
+Johnny Medley|SSAA|Betty Oliver
+Johnny Medley|SSAA|Nancy Bergman
+Johnny One Note|TTBB|Adam Reimnitz
+Johnny Schmoker|TTBB|James Rodde
+Johnny's Off To War Medley|TTBB|Rob Hopkins
+Jolly Holiday|TTBB|Val Hicks
+Joshua Fit The Battle Of Jericho|SSAA|David Wright
+Joshua Fit The Battle Of Jericho|TTBB|David Wright
+Joy to the World|SSAA|David Harrington
+Joy To The World|SATB|John Rutter
+Joy To The World|SSAA|Brian Beck
+Joy To The World|TTBB|Brian Beck
+Joy To The World|TTBB|Joe Johnson
+Joy To The World - Deck The Halls Medley|TTBB|Adam Scott
+Joy to the World (Jeremiah was a Bullfrog)|SSAA|Deke Sharon
+Joy To the World/Adeste Fidelis|TTBB|Greg Lyne
+Joy to the World/O Come All Ye Faithful Medley|SSAA|Jay Giallombardo
+Juke Box Saturday Night|SSAA|Joni Bescos
+Jukebox Saturday Night Medley|TTBB|Walter Latzko
+Jump in the Line|SSAA|Sylvia Alsbury
+Jump Shout Boogie|TTBB|Roger Payne
+Jump, Jive & Wail|SSAA|Lynnell Diamond
+Jump, Jive and Wail|SSAA|Lynnell Diamond
+Jump, Shout, Boogie|TTBB|Roger Payne
+Jungle Rhythm|SSAA|Alex Kaiserman
+Junglingswonne|TTBB|Franz Schubert
+Just a Baby's Prayer at Twilight|SSAA|Tom Gentry
+Just A Closer Walk With Thee|SSAA|Nancy Bergman
+Just A Closer Walk With Thee|SSAA|Tedda Lippincott
+Just A Closer Walk With Thee|TTBB|Clay Hine
+Just A Closer Walk With Thee/When The Saints (Medley)|TTBB|Jack Baird
+Just A Cottage Small|TTBB|Al Rekhop
+Just A Cottage Small (By A Waterfall)|TTBB|Chris Arnold
+Just a Gigolo|TTBB|Will Hamblet
+Just A Gigolo / I Ain't Got Nobody|TTBB|Roger Payne
+Just a Kid Named Joe|TTBB|Ed Waesche
+Just A Little Talk With Jesus|TTBB|David Harrington
+Just a Wearyin' for You|TTBB|Phil Embury
+Just Because / Shine|TTBB|Earl Moon
+Just Because/Shine (Medley)|TTBB|Earl Moon
+Just Between Old Friends|TTBB|Joe Johnson
+Just Friends|TTBB|Scott Kitzmiller
+Just In Case You Change Your Mind|TTBB|Jon Nicholas
+Just In Time|TTBB|Dave Briner
+Just One More Chance|TTBB|Jerry Bockus
+Just One of Those Things|SSAA|Joni Bescos
+Just One Of Those Things|TTBB|Aaron Dale
+Just One Of Those Things|TTBB|Joni Bescos
+Just the Way You Are/Just a Dream|SSAA|Deke Sharon
+Just Want To Dance The Night Away|TTBB|Liz Garnett
+K.P.|TTBB|Jim Henry
+Kalamazoo|TTBB|Greg Volk
+Kansas City Star|TTBB|Jay Giallombardo
+Kansas City, Here I Come|TTBB|Jay Giallombardo
+Katrina|TTBB|Jon Nicholas
+Kazoo Koncerto|SSAA|Tom Gentry
+Keep On The Firing Line|TTBB|John Peterson
+Keep On The Sunny Side|SSAA|Sharon Holmes
+Keep the Music Ringing|SSAA|Lynnell Diamond
+Keep The Whole World Singing|TTBB|Willis Diekema
+Keep Your Eye On The Girlie You Love / Somebody Stole My Gal|TTBB|Jack Baird, Dick Johnson
+Keep Your Sunny Side Up|SSAA|Nancy Bergman
+Keep Your Sunnyside Up|SSAA|Nancy Bergman
+Keeper Of the Stars|SSAA|Tedda Lippincott
+Keepin' Out of Mischief|SSAA|June Berg
+Keeping Out of Mischief|SSAA|David Wright
+Kentucky Babe|SSAA|Anna Maria Parker
+Kentucky Babe|SSAA|Kirk Roose
+Kentucky Babe|TTBB|Kirk Roose
+Kerry Dance|SSAA|Renee Craig
+Kickin' It Up a Notch|SSAA|Nancy Faddegon
+Kids/Coney Island Washboard|TTBB|139th Street Quartet
+King Of Spain|TTBB|Moxy Fruvous
+King of the Road|TTBB|Gene Cokeroft
+King Of The Road|TTBB|Dennis Driscoll
+King Of The Road|TTBB|Jay Giallombardo
+Kiss|TTBB|Unspecified
+Kiss Him Goodbye|TTBB|Don Gillespie
+Kiss Me Goodnight|SSAA|Brent Graham
+Kiss Me One More Time|SSAA|Norma Andersen
+Kiss Me One More Time|SSAA|Unspecified
+Kiss The Girl|TTBB|Kirby Shaw
+Kissing a Fool|TTBB|Kyle Kitzmiller
+Kissing A Fool|TTBB|Chris Arnold
+Knight Quest Medley|TTBB|Tom Gentry
+Knight Rhythm Medley|TTBB|Tom Gentry
+Knight School Medley|TTBB|Tom Gentry
+Knock Knock Song|SSAA|Tom Gentry
+Knock On My Door|SSAA|Donya Metzger
+Knowing Me, Knowing You|SSAA|Chris MacMartin
+Ko-Ko-Mo|TTBB|Don Reckenbeil
+Kodachrome|TTBB|David Gillingham
+Kokomo|SSAA|B. Sellars/C. Schmidt (YWIH)
+Kokomo|SSAA|Bev Sellers
+Kokomo|SSAA|Bev Sellers/Carolyn Schmidt
+Kokomo|SSAA|Jo Lund
+Kokomo|SSAA|Lorraine Rochefort
+Kokomo|TTBB|Don Reckenbeil
+Kokomo (YWIH)|SSAA|Bev Sellers
+Kuimba|TTBB|Victor Johnson
+Kwmbayah|TTBB|K.J. Dinham
+Kyrie|TTBB|Mark Stevens, Will Makra
+L-O-V-E|SSAA|Nancy Bergman
+L-O-V-E|TTBB|Chris Arnold
+L-O-V-E|TTBB|Ed Waesche
+L-O-V-E|TTBB|Larry Triplett
+L-O-V-E and Marriage Medley|TTBB|Matt Gallagher
+L.O.V.E.|SSAA|Larry Triplett
+La Cucaracha|SSAA|Kay Bromert
+Lady Takes the Cowboy Every Time|SSAA|Nancy Bergman
+Langtan Till Landet|TTBB|Traditional
+Last Christmas|SATB|Henrik Rosenberg
+Last Night On the Back Porch|SSAA|Nancy Bergman
+Last Night Was the End of the World|SSAA|Jim Clancy
+Last Night Was the End of the World|SSAA|Tedda Lippincott
+Last Night Was The End Of The World|TTBB|Barbershop Harmony Society
+Last Night Was The End Of The World|TTBB|Buzz Haeger
+Laugh Clown Laugh|SSAA|Lyle Pilcher
+Laughing On the Outside|SSAA|Nancy Bergman
+Laughing On The Outside (Crying On The Inside)|SSAA|Nancy Bergman
+Laura|TTBB|Webb Comfort
+LaWanda Darlene the Rodeo Queen|SSAA|Marcia Hill/Nancy Bergman
+Lawanda Darlene, Rodeo Queen|SSAA|Hill Nancy Bergman
+LaWanda Darlene, the Rodeo Queen|SSAA|Marcia Hill/Nancy Bergman
+Lazy|TTBB|Alan Siegal
+Lazy Bones|TTBB|Webb Comfort
+Lazy Day|SSAA|David Wright
+Lazy Day|TTBB|David Wright
+Lazy River|SSAA|Barbara McNeill
+Lazy River|SSAA|Tom Gentry
+Lazy River|TTBB|Ed Waesche
+Lazy River|TTBB|Tom Gentry
+Lazybones|TTBB|David Wright
+Le Canon|SSAA|Dianne Harding
+Le Jazz Hot!|SSAA|Ann Minihane
+Lean on Me|SSAA|Tedda Lippincott
+Lean On Me|SSAA|Joey Minshall
+Lean On Me|SSAA|Joey Minshall YWIH
+Lean On Me|SSAA|Nancy Shumard
+Lean On Me|TTBB|Adam Anders and Tim Davis
+Lean On Me|TTBB|Alex Kaiserman
+Lean On Me|TTBB|Craig Gibbins
+Lean On Me (YWIH)|SSAA|Joey Minshall
+Let A Smile Be Your Umbrella|TTBB|Bob Benson
+Let A Smile Be Your Umbrella / Rain|TTBB|Ed Waesche
+Let a Songbird Fly|TTBB|Paul Davies - Used for National Learn to Sing Day
+Let A Songbird Fly|TTBB|Paul Davies
+Let All Mortal Flesh Keep Silence|TTBB|J Taylor
+Let All Mortal Flesh Keep Silence|TTBB|Jeff Taylor
+Let Freedom Ring|SSAA|Larry Wright
+Let Freedom Ring (8-Part Arrangement)|TTBB|Mel Knight
+Let Freedon Ring|SSAA|Larry Wright
+Let It Be|SSAA|Norma Andersen
+Let It Be Me|SSAA|Dotty Hougen
+Let It Go|SSAA|Lorraine Rochefort
+Let It Go/Let Her Go Mashup|SSAA|Brittany E. Griffith
+Let It Snow|SSAA|Ann Minihane
+Let It Snow|SSAA|Becky Wilkins
+Let It Snow|TTBB|Joe Liles
+Let It Snow|TTBB|Mando Fonseca
+Let It Snow|TTBB|Unspecified
+Let It Snow!|SSAA|Ann Minihane
+Let It Snow! Let It Snow! Let It Snow!|SSAA|Ann Minihane
+Let It Snow! Let It Snow! Let It Snow!|TTBB|Joe Liles
+Let Me Be There|SSAA|Carolyn Healey
+Let Me Be There|SSAA|LABBS Polecat
+Let Me Be Your Teddy Bear|SSAA|Jon Nicholas
+Let Me Call You Sweetheart|SSAA|Jean Shook
+Let Me Call You Sweetheart|SSAA|Sylvia Alsbury
+Let Me Call You Sweetheart|SSAA|Unspecified
+Let Me Call You Sweetheart|TTBB|Barbershop Harmony Society
+Let Me Call You Sweetheart|TTBB|Beth Slater Whitson and Leo Friedman
+Let Me Call You Sweetheart|TTBB|Greg Lyne
+Let Me Sing and I'm Happy|TTBB|Ed Waesche
+Let Me Sing and I'm Happy|TTBB|Katie Farrell
+Let Me Sing And I'm Happy|SSAA|Renee Craig
+Let the Rest of the World Go By|TTBB|Kirk Roose
+Let the River Run|SSAA|Sylvia Alsbury
+Let Them Be Little|TTBB|Tom Gentry
+Let There Be Peace On Earth|SSAA|Alsbury
+Let There Be Peace On Earth|SSAA|S Alsbury
+Let There Be Peace On Earth|SSAA|Sylvia Alsbury
+Let There Be Peace On Earth|TTBB|Ralph Aldridge
+Let There Be Peace On Earth|TTBB|Tom Gentry
+Let There Be Peace On Earth (8-Part Mixed)|SATB|David Harrington
+Let There Be Peace On Earth (SATB)|SATB|Tom Gentry
+Let Us Break Bread Together|TTBB|Lloyd Erickson
+Let Yourself Go|SSAA|David Wright
+Let Yourself Go / Crazy Rhythm Medley|TTBB|Dave Ebersole
+Let Yourself Go/Doin' the New Low Down|SSAA|Dave Briner
+Let's Burn Up the Town|SSAA|Anthony Nasto
+Let's Burn Up The Town|TTBB|Tony Nasto
+Let's Call the Whole Thing Off|SSAA|Carolyn Schmidt
+Let's Call The Whole Thing Off|TTBB|Hal Maples
+Let's Do It (Let's Fall In Love)|TTBB|John Brockman
+Let's Do It, Let's Fall in Love|SSAA|Lynnell Diamond
+Let's Do It, Let's Fall In Love|SSAA|John Brockman
+Let's Do It/Let's Misbehave (Medley)|TTBB|Matt Gallagher
+Let's Face The Music And Dance-Cheek To Cheek Medley(Andrew Ho|TTBB|Andrew Howson
+Let's Get Away From It All|SSAA|Barbara Bianchi
+Let's Get Away From It All|SSAA|Larry Wright
+Let's Get Away From It All|TTBB|Rob Hopkins
+Let's Get Away From It All (Canadian)|TTBB|Rob Hopkins
+Let's Get Together Again / Keep the Whole World Singing|SSAA|Unspecified
+Let's Get Together Again/Keep The Whole World Singing|TTBB|Joseph Stern/Bill Diekema/SPEBSQSA
+Let's Live It Up|SSAA|Aaron Dale
+Let's Live It Up|TTBB|Aaron Dale
+Let's Love|TTBB|Kevin Keller
+Let's Sing Again|SSAA|David Wright
+Let's Sing Again|TTBB|David Wright
+Let's Start The New Year Right/Auld Lang Syne (Medley)|TTBB|Bryan Ziegler
+Let's Talk About My Sweetie|SSAA|Nancy Bergman
+Let's Talk About My Sweetie/Yes Sir That's My Sweetie|SSAA|Nancy Bergman
+Lets Burn Up the Town|SSAA|Tony Nasto
+Liar Medley|SATB|Nancy Bergman
+Liar Medley|SSAA|Renee Craig
+Liar Medley|TTBB|Renee Craig
+Liar Medley|TTBB|Unspecified
+Liar Medley Parody|TTBB|Unspecified
+Liar/Angry Medley|SSAA|Marge Bailey/Bea Howley
+Lida Rose|TTBB|Floyd Connett
+Lida Rose|TTBB|Meredith Willson
+Lida Rose|TTBB|Nancy Bergman
+Lida Rose Will I Ever Tell You?|SATB|Meredith Willson
+Lida Rose/Will I Ever Tell You|TTBB|Meredith Willson
+Lida Rose/Will I Never Tell You|SATB|Nancy Bergman
+Life Is A Highway|SSAA|Brent Graham
+Life Is A Highway|SSAA|Joey Minshall
+Lift Every Voice And Sing|TTBB|Dan Tice
+Light One Candle|TTBB|Carole Prietto
+Light the Candles|SSAA|Tedda Lippincott
+Like An Eagle|SSAA|Jim Arns
+Like Someone In Love|TTBB|Adam Reimnitz
+Lili Marlene|TTBB|Knights of Harmony
+Lion Sleeps Tonight|SSAA|Lorraine Rochefort
+Lion Sleeps Tonight|SSAA|Tedda Lippincott
+Lion Sleeps Tonight (The) SATB|SATB|Anne Raugh and Seke Sharon
+Lion Sleeps Tonight, The (Wimoweh)|TTBB|Ron Smail
+Listen To My Heart|SSAA|Michael Gellert
+Listen To That Dixie Band|SSAA|Greg Volk
+Listen to the Music|SSAA|Sharon Holmes
+Listen To The Music|TTBB|Aaron Dale
+Listen To The Music (Doobie Brothers)|SSAA|Liz Garnett
+Little Black Me (Lead Melody Tag)|TTBB|Tom Gentry
+Little Darlin'|TTBB|J. McCready
+Little Drummer Boy|SSAA|Tedda Lippincott
+Little Drummer Boy / Peace On Earth|TTBB|Jay Giallombardo
+Little Drummer Boy & Silent Night Medley|SSAA|Rosey Frerking
+Little Drummer Boy/Peace on Earth|SSAA|Joey Minshall
+Little Girl|TTBB|Lou Perry
+Little Gray Donkey|SSAA|Avis Fellows
+Little Man You've Had A Busy Day|TTBB|Fred King
+Little Pal|TTBB|Clay Hine
+Little Patch Of Heaven|SSAA|Aaron Dale
+Little Patch Of Heaven|TTBB|Aaron Dale
+Little Rascals Medley|TTBB|Greg Volk
+Little Saint Nick|SSAA|Ann Minihane
+Little Saint Nick|SSAA|Barbara McNeill
+Little Saint Nick|SSAA|Jon Nicholas
+Little Saint Nick|SSAA|June Berg
+Little Saint Nick|TTBB|Jon Nicholas
+Little Snow Girl|TTBB|Jim Clancy
+Little St Nick|TTBB|Steve Jamison
+Little Things Mean a Lot|SSAA|June Dale
+Little Tin Box|TTBB|Gene Cokeroft
+Little Toy Trains|SSAA|Tedda Lippincott
+Live And Let Die|TTBB|Stefan Pugliese
+Liza|TTBB|Ed Waesche
+Lo, How a Rose E'er Blooming|TTBB|Alice Parker and Robert Shaw
+Lo, How a Rose E'er Blooming|TTBB|Barbershop Harmony Society
+Loch Lomond|SATB|Jonathan Quick
+Loch Lomond|TTBB|David Overton
+Loch Lomond|TTBB|Jonathan Quick
+Loch Lomond|TTBB|Peter Bryant
+Loch Lomond|TTBB|Ralph Vaughan Williams
+Loch Lomond|TTBB|Unspecified
+Locked Out Of Heaven|SATB|Henrik Rosenberg
+Lollipop|SSAA|Tedda Lippincott
+Lonely Nights Medley|TTBB|David Wright
+Lonely Town|TTBB|Jay Giallombardo
+Lonesome Road|TTBB|Mike Menefee
+Lonesomest Girl in Town (You're the)|SSAA|Clay Hine
+Lonesomest Girl in Town (You're the)|SSAA|Joni Bescos
+Longest Time (The)|SATB|Tom Gentry
+Look Me Up When You're In Dixie|TTBB|Renee Craig
+Lookin At the World Thru Rose Colored Glasses|SSAA|Renee Craig
+Lookin' At The World Through Rose Colored Glasses(Greg|TTBB|Greg Lyne
+Lookin' At The World Thru Rose Colored Glasses|TTBB|David Wright
+Looking At The World Through Rose Colored Glasses(David Wr|TTBB|David Wright
+Looking at the World through Rose Coloured Glasses|TTBB|Ed Waesche
+Looking at the World thru Rose Colored Glasses|TTBB|Ed Waesche
+Looking For A Boy|SSAA|David Harrington
+Looking Through the Eyes of Love|SATB|John Hohl
+Lora-Belle Lee|TTBB|Dave Briner
+Lose that Long Face|TTBB|Kevin Keller
+Lost|TTBB|Soren Wohlers
+Lost in My Dreams|SSAA|Linda Edmondson
+Lost In the Fifties Tonight|SSAA|Joe Liles
+Lost In The Stars|TTBB|Buzz Haeger
+Louise|TTBB|David Wright
+Louisville Lou|SSAA|Jay Giallombardo
+Love and Marriage|SSAA|June Dale
+Love Can Build a Bridge|SSAA|Tedda Lippincott
+Love Can Build A Bridge|SSAA|Yvonne Connolly
+Love Eyes Medley|SSAA|David Wright
+Love Eyes Medley|SSAA|Unspecified
+Love In A Home|SSAA|Jay Giallombardo
+Love In Any Language|SSAA|Avis Fellows
+Love In Any Language|SSAA|Dave Briner
+Love In Any Language|SSAA|Dave Briner Tom Gentry
+Love in Any Language (solo and chorus)|SSAA|Dave Briner
+Love is a Many Splendored Thing|SSAA|Dave Briner
+Love Is a Many Splendored Thing|TTBB|Brent Graham
+Love Is A Many Splendored Thing|TTBB|John Hohl
+Love Is Here To Stay|TTBB|Ed Waesche
+Love Is In The Air|SSAA|Jo Lund
+Love Is Just Around The Corner|SSAA|Doris Twardosky
+Love Is On The Air Tonight|TTBB|Jon Nicholas
+Love Letters|SSAA|Carolyn Healey
+Love Letters|SSAA|Jim Arns
+Love Letters|TTBB|John Piercy
+Love Letters|TTBB|Steve Delehanty
+Love Letters Straight From Your Heart|SSAA|Jim Arns
+Love Letters Straight From Your Heart|TTBB|Steve Delehanty
+Love Me|SSAA|Aaron Dale
+Love Me|TTBB|Aaron Dale
+Love Me And The World Is Mine|TTBB|David Wright
+Love Me And The World Is Mine|TTBB|Jack Baird
+Love Me as Though There Were No Tomorrow|SSAA|Lorraine Rochefort
+Love Me Or Leave Me|TTBB|Janne Olsson
+Love Me Tender|SSAA|David Wright
+Love Me Tender|SSAA|Lorraine Rochefort
+Love Me Tender|SSAA|Norma Andersen
+Love Me Tender|TTBB|David Wright
+Love Me With All Your Heart|SSAA|Carolyn Schmidt
+Love Me, And The World Is Mine|SSAA|David Wright
+Love Me, And The World Is Mine|TTBB|David Wright
+Love Medley|SSAA|Marsha Zwicker
+Love of my Life|SSAA|David Wright
+Love of My Life|TTBB|Dale Kynaston
+Love Of My Life|SSAA|Alex Kaiserman
+Love Of My Life (Queen)|SSAA|Unspecified
+Love of My Live|SSAA|David Wright
+Love Potion #9|SSAA|June Dale
+Love That Ragtime|TTBB|Jay Giallombardo
+Love the World Away|SSAA|Avis Fellows
+Love Walked In|SSAA|Anastasio Rossi
+Love Walked In|SSAA|Nancy Bergman
+Love Walked In|TTBB|David Wright
+Love Walked In|TTBB|Stash Rossi
+Love Will Be Our Home|SSAA|Bob Rund
+Love Will Keep Us Together|SSAA|Renee Craig
+Love's Old Sweet Song|SSAA|Anna Maria Parker
+Love's Old Sweet Song|SSAA|Clay Hine
+Love's Old Sweet Song|SSAA|Joe Liles
+Love's Old Sweet Song|TTBB|Clay Hine
+Love's Old Sweet Song|TTBB|Val Hicks
+Lover Come Back|SSAA|Ed Waesche
+Lover Come Back|TTBB|Ed Waesche
+Lover Come Back to Me|SSAA|Nancy Bergman
+Lover, Come Back to Me|SSAA|Ed Waesche
+Lover, Come Back To Me|TTBB|Ed Waesche
+Loving You|SSAA|Lorraine Rochefort
+Low Gravy|SSAA|Walter Latzko
+Lu Lu's Back In Town|TTBB|Ed Waesche
+Luck Be a Lady|TTBB|David Harrington
+Luck Be a Lady|TTBB|Walter Latzko ed. Mark Hale
+Luck Be A Lady|SSAA|Carolyn Schmidt
+Luck Be A Lady|TTBB|Chris Arnold
+Luck Be a Lady *|TTBB|David Harrington
+Lucky Day|SSAA|Joni Bescos
+Lucky Day (This is Some)|TTBB|Greg Volk
+Lucky Day / Lucky In Love Medley|TTBB|Ed Waesche
+Lucky Day/Sitting On Top of the World|SSAA|Nancy Bergman
+Lucky Old Sun|TTBB|David Wright
+Lullaby|SSAA|Kirk Young
+Lullaby (Goodnight, My Angel)|TTBB|Kirk Young
+Lullaby In Ragtime|SSAA|Nancy Bergman
+Lullaby In Ragtime|SSAA|Unspecified
+Lullaby In Ragtime|TTBB|Bill Mitchell
+Lullaby In Ragtime|TTBB|Tom Gentry, Bill Mitchell
+Lullaby In Ragtime|TTBB|William Mitchell
+Lullaby of Broadway|SSAA|Joni Bescos
+Lullabye|SSAA|Kirby Shaw
+Lullabye|SSAA|Kirk Young
+Lullabye|TTBB|Kirk Young
+Lullabye (Goodnight My Angel) (Lower Lead Voicing Version)|SSAA|Kirk Young
+Lullabye (Goodnight, My Angel)|SSAA|Cheryl Suhr
+Lullabye in Ragtime|TTBB|Unspecified
+Lullabye Of Birdland|TTBB|Mark Hale
+Lulu's Back in Town|SSAA|Nancy Bergman
+Lulu's Back In Town|SSAA|Bergman/Nightingale
+Lulu's Back In Town|SSAA|Jim Arns
+Lulu's Back In Town|TTBB|Ed Waesche
+Lux Aurumque|SATB|Eric Whitacre
+Lux Aurumque|TTBB|Eric Whitacre
+Lydia the Tattooed Lady|TTBB|Lloyd Steinkamp
+Ma, She's Makin' Eyes At Me|TTBB|David Wallace
+Ma, She's Making Eyes At Me|TTBB|Chuck Morris
+Ma, They're Makin' Eyes At Me|TTBB|David Wallace
+Ma! She's Makin' Eyes At Me|TTBB|Mo Rector
+Mack the Knife|SSAA|Jim Arns
+MacNamara's Band|SSAA|Nancy Bergman
+MacNamara's Band/Great Day For The Irish Medley|SSAA|Nancy Bergman
+Madonna Medley|SSAA|Liz Garnett
+Magic To Do|SSAA|David Wright
+Magical Mystery Tour|SSAA|Kay Bromert
+Majsang|TTBB|Traditional
+Make 'Em Laugh|SSAA|Clay Hine
+Make 'Em Laugh|TTBB|Clay Hine
+Make Em' Laugh|TTBB|Clay Hine
+Make Love to Me|SSAA|Barbara McNeill
+Make Our Garden Grow|TTBB|Jay Giallombardo
+Make Someone Happy|SSAA|Joey Minshall
+Make Someone Happy|TTBB|Ed Waesche
+Make Them Hear You|TTBB|Kevin Keller
+Make Them Hear You|TTBB|Kevin Keller, Steven Armstrong
+Make You Feel My Love|TTBB|Alex Kaiserman
+Make You Feel My Love|TTBB|Dale Kynaston
+Make You Feel My Love (SATB)|SATB|Dale Kynaston
+Makin' Love Ukulele Style|SSAA|Nancy Bergman
+Makin' Whoopie|TTBB|Unspecified
+Making Our Dreams Come True|SSAA|Sheila Cope
+Mam'selle|TTBB|Adam Reimnitz
+Mam'selle|TTBB|Tom Sando
+Mama Goes Where Papa Goes|SSAA|Nancy Bergman
+Mama, I Wanna Make Rhythm|SSAA|Walter Latzko
+Mamas and Papas Medley|SSAA|Sharon Holmes
+Mame|TTBB|Renee Craig
+Mamma Mia|SSAA|Elaine Gain
+Mammas & Papas Medley|TTBB|Peter Mumford
+Mammy O' Mine|TTBB|Tom Gentry
+Man In The Mirror|TTBB|Kirby Shaw
+Man Of La Mancha|SSAA|David Wright
+Man Of La Mancha|TTBB|David Wright
+Man Of La Mancha|TTBB|Roger Payne
+Man With the Bag|SSAA|Lorraine Rochefort
+Man! I Feel Like A Woman|SSAA|Lorraine Rochefort
+Mandy Lee|TTBB|David Wright
+Manhattan|SSAA|Liz Garnet
+Manhattan Transfer|SSAA|Renee Craig
+Mansions Of The Lord|TTBB|Bob Shami
+Marching Along/Stout Hearted Men Medley|TTBB|Unspecified
+Mardi Gras March|SSAA|Nancy Bergman
+Mardi Gras March|SSAA|Renee Craig
+Margaritaville|SSAA|Lorraine Rochefort
+Margie|TTBB|Renee Craig
+Margie|TTBB|Walter Latzko
+Maria|TTBB|Jay Giallombardo
+Maria-Somewhere Medley|TTBB|Jay Giallombardo
+Marian The Librarian|TTBB|Walter Latzko
+Maritime Medley (Haul on the Bowline, The Squid Jiggin' Ground, Farewell to Nova Scotia)|TTBB|Bob Pyper
+Marry Me|TTBB|Aaron Dale
+Marry You|TTBB|Alex Kaiserman
+Marshmallow World|SSAA|Joni Bescos
+Marvelous Toy|SSAA|Doris Twardosky
+Mary Did You Know|SSAA|Joan Melling
+Mary Did You Know|SSAA|Joe Liles
+Mary Did You Know|SSAA|Julie Starr
+Mary Did You Know|SSAA|June Berg
+Mary Did You Know|SSAA|Mac Huff
+Mary Did You Know|SSAA|Tedda Lippincott
+Mary Did You Know|SSAA|Tom Gentry
+Mary Did You Know|TTBB|David Wright
+Mary Did You Know?|SSAA|David Wright
+Mary Did You Know?|SSAA|Jan Meyer
+Mary Did You Know?|SSAA|Joe Liles
+Mary Did You Know?|SSAA|Julie Starr
+Mary Did You Know?|SSAA|Tedda Lippincott
+Mary Did You Know?|TTBB|David Wright
+Mary Did You Know?|TTBB|Joe Liles
+Mary Did You Know?|TTBB|Tom Gentry
+Mary Had a Baby|SSAA|David Wright
+Mary Had A Baby|TTBB|David Wright
+Mary Poppins Medley|TTBB|Tom Gentry
+Mary, Did You Know?|TTBB|Joe Liles
+Mary, Did You Know?|TTBB|Jon Nicholas
+Mary, Mary|SSAA|Charlene Yazurlo
+Mary, You're A Little Bit Old Fashiond|SSAA|Mike Senter
+Mary's Boy Child|SSAA|Jean Flemming
+Mary's Boy Child|TTBB|Larry Triplett
+Mary's Little Boy Child|SSAA|Joey Minshall
+Mary's Little Boy Child|SSAA|Marie Johnson
+Mary's Little Boy Child|SSAA|Tedda Lippincott
+Mary'S Little Boy Chile|SSAA|Jarmela Speta
+Masochism Tango|TTBB|Marie Johnson
+Master Of The House|TTBB|Joe Pickin
+Material Girl|SSAA|Jon Nicholas
+Maxwell's Silver Hammer|TTBB|Jon Nicholas
+May I Never Love Again|SSAA|Jean Sutton
+May I Never Love Again|SSAA|Renee Craig
+May I Never Love Again|TTBB|Renee Craig
+May the Peace of God Be Within You|TTBB|Russell Wilson
+May You Always|SSAA|Ann Minihane
+May You Always|TTBB|Greg Lyne
+Maybe|SSAA|Lorraine Rochefort
+Maybe|TTBB|Walter Latzko
+Maybe I'm Amazed|SSAA|Robert Rund
+McGuire Sisters Medley|SSAA|Jean Shook
+Me And Julio Down By The Schoolyard|TTBB|Anthony Nasto
+Me And My Shadow|SSAA|Joni Bescos
+Me And My Shadow|SSAA|Nancy Bergman
+Me And My Shadow|TTBB|Dennis Driscoll
+Me and the Man in the Moon|SSAA|Anna Maria Parker
+Mean to Me|SSAA|Sylvia Alsbury
+Mean To Me|SSAA|David Wright
+Mean To Me|TTBB|David Wright
+Meatballs|TTBB|Clay Hine
+Medley from Mary Poppins|SSAA|Lorretta Martin
+Meet Me In Rosetime Rosie|TTBB|Greg Lyne, Ed Waesche
+Meet Me Tonight in Dreamland|SSAA|Nancy Bergman
+Meet Me Tonight In Dreamland|TTBB|Barbershop Harmony Society
+Meet Me Tonight In Dreamland|TTBB|Tom Gentry
+Meet the Flintsones|TTBB|Drew Tepe
+Melancholy Baby|SSAA|Brian Beck
+Mele Kalikimaka|TTBB|Dave Briner
+Memory|TTBB|Jay Giallombardo
+Memphis Blues|SSAA|Dave Briner
+Memphis Blues|TTBB|Dave Briner
+Men Of God, Behold He Calls Us|TTBB|Joe Johnson
+Mention My Name in Sheboygan|TTBB|Lou Perry
+Merry Christmas Darling|SSAA|June Berg
+Merry Christmas Darling|TTBB|Brian Beck
+Merry Christmas Darling|TTBB|Tom Gentry
+Merry Christmas, Darling|TTBB|Brian Beck
+Merry Christmas, Darling|TTBB|Tom Gentry
+Mexicali Rose|TTBB|Tom Gentry
+Michael Jackson Medley|SSAA|Rasmus Krigstrom
+Michelle|TTBB|Don Gray
+Michelle|TTBB|Steve Delehanty
+Midnight Choo Choo|SSAA|Jay Giallombardo
+Midnight Rose|SSAA|Nancy Bergman
+Midnight Rose|TTBB|Ed Waesche
+Midnight Serenade|SSAA|David Wright
+Midnight Serenade|TTBB|David Wright
+Miles And Miles Of Texas|TTBB|Joe Johnson
+Mills Brothers Medley|TTBB|Ed Waesche
+Minnie the Mermaid Medley|SSAA|Carolyn Schmidt
+Minnie the Moocher|TTBB|Walter Latzko
+Minstrel Montage|TTBB|Barbershop Harmony Society
+Minstrel Montage|TTBB|Unspecified
+Minute Waltz|SSAA|David Wright
+Miracle|TTBB|Kevin Keller
+Miss Celie's Blues|SSAA|Lorraine Rochefort
+Miss Celie's Blues (Sister)|SSAA|Lorraine Rochefort
+Miss Otis Regrets|SSAA|Marge Bailey
+Miss Otis Regrets (a la City Voices)|SSAA|Marge Bailey
+Mission Impossible Theme|SSAA|Steve Tramack
+Mission Impossible Theme|TTBB|Steve Tramack
+Mississippi Medley|SSAA|Jay Giallombardo
+Mississippi Mud|SSAA|Aileen Nightingale
+Mississippi Mud|SSAA|David Wright
+Mississippi Mud|SSAA|Nancy Bergman
+Mississippi Mud|TTBB|C. Morris
+Mississippi Mud|TTBB|David Wright
+Mississippi Mud|TTBB|Ed Waesche
+Mistakes|TTBB|Roy Keys
+Mistakes Parody|TTBB|Unspecified
+Mister Cellophane|SSAA|Ed Waesche
+Mister Cellophane|TTBB|Chris Slacke
+Mister Cellophane|TTBB|Ed Waesche
+Mister Mom|SSAA|Michael Gellert
+Mister Postman|TTBB|Unspecified
+Mister Sandman|SSAA|Bertha Bradley
+Mister Sandman|SSAA|Bradley
+Mister Sandman|TTBB|George Hulst
+Misty|SSAA|Russ Robinson
+Misty|TTBB|Webb Comfort
+MLK|TTBB|David Wright
+Mobile|TTBB|David Wright
+Mobile|TTBB|Jon Nicholas
+Mobile/Down Mobile Medley|TTBB|David Wright
+Molly Malone|SSAA|Paul Davies
+Molly Malone|TTBB|Paul Davies
+Moment I Saw Your Eyes The|TTBB|Joe Liles
+Moments to Remember|SSAA|Lyle Pilcher
+Moments to Remember|SSAA|Marge Bailey
+Mona Lisa|TTBB|Greg Volk
+Monday, Monday|SSAA|Tedda Lippincott
+Monday, Monday|TTBB|Jay Giallombardo
+Monday, Monday Medley|SSAA|Sharon Holmes
+Money, Money, Money|SSAA|Connie Nickel
+Montana Melody|TTBB|Jack Payne and Randy Rogers
+Monty Pythin Medley|TTBB|Mikael Erlandsson
+Mood Indigo|SSAA|Bev Sellers
+Mood Indigo|SSAA|Charlene Yazurlo
+Mood Indigo|SSAA|Joe Liles
+Mood Indigo|SSAA|Joni Bescos
+Mood Indigo|TTBB|Frank Thorne
+Mood Indigo|TTBB|J. Rae Jamieson
+Moon Medley|TTBB|Steve Delehanty
+Moon Medley|TTBB|Tom Gentry
+Moon Over Miami|SSAA|Dot Short
+Moon River|SSAA|Debi Cox
+Moon River|SSAA|Nigel Williams
+Moon River|SSAA|Renee Craig
+Moon River|TTBB|Walter Latzko
+Moondance|SSAA|Greg Volk
+Moondance|SSAA|Marshall Webb
+Moondance|TTBB|Marshall Webb
+Moonglow|SSAA|Joanne Dockrell
+Moonlight and Roses|SSAA|Walter Latzko
+Moonlight Bay|TTBB|Barbershop Harmony Society
+Moonlight Becomes You|TTBB|Ed Waesche
+Moonlight Becomes You|TTBB|Scott Kitzmiller
+Moonlight Brings Memories|TTBB|Jay Giallombardo
+Moonlight in Vermont|TTBB|Stephen Griffith
+Moonlight In Vermont|SSAA|Tedda Lippincott
+Moonlight In Vermont|TTBB|Webb Comfort
+Moonlight Serenade|SSAA|Carolyn Healey
+Moonlight Serenade|SSAA|Frank Marzocco
+Moonlight Serenade|SSAA|Sheila Cope
+Moonlight Sonata|TTBB|David Wright/Steve Wolf
+Moonshine Lullabye|TTBB|Phil Ordaz
+More I Cannot Wish You|TTBB|Mark Hale
+More I Cannot Wish You|TTBB|Steven Armstrong
+More Than Words|SSAA|Tedda Lippincott
+More Than You Know|TTBB|David Wallace
+Moscow Nights|TTBB|Chris Arnold
+Mosquitoes|SSAA|Unspecified
+Most Wonderful Time/We Need A Little Christmas (Medley)|TTBB|Don Gray
+Mother Machree|TTBB|Steve Jamison
+Moves Like Jagger|SSAA|Joey Minshall
+Movie Medley|TTBB|Steve Delehanty
+Moving Right Along/Ease on Down the Road|TTBB|Ben Brown
+Mr Bassman/Mahnah Mahnah Medley|SSAA|Liz Garnett
+Mr Blue Sky|TTBB|Liz Garnett
+Mr Morton|TTBB|Lynn Ahrens
+Mr Piano Man/I Love A Piano Medley|SSAA|Brian Beck
+Mr Sandman|SATB|George Hulst
+Mr Sandman|TTBB|George Hulst
+Mr Sandman / Dream Medley|SSAA|Unspecified
+Mr Success|TTBB|Clay Hine
+Mr Touchdown USA|SSAA|Nancy Bergman
+Mr. Touchdown USA|TTBB|Unspecified
+Much To My Surprise|TTBB|Jon Nicholas
+Mummy Parody|TTBB|Steven Armstrong
+Muppet Show|SSAA|Kirk Young
+Muppet Show|TTBB|Kirk Young
+Murder, He Says|SSAA|Carolyn Schmidt
+Music & The Mirror ('A Chorus Line')|SSAA|Mary Ann Wydra
+Music And The Mirror|SSAA|Maryanne Wydra
+Music Maestro Please|TTBB|Larry Wright
+Music Man II|TTBB|Steve Delehanty
+Music Man Medley|SSAA|Joni Bescos
+Music Man Medley|TTBB|Ed Waesche
+Music Man Medley|TTBB|Rob Hopkins
+Music Man Medley #1|TTBB|Ed Waesche
+Music Man Medley #2|TTBB|Ed Waesche
+Music Man Medley I|TTBB|Steve Delehanty
+Music Man Mini-Show|TTBB|Jay Giallombardo
+Music of the Night|SSAA|Lorraine Rochefort
+Music Of The Night|TTBB|David Wright
+Music Of The Night|TTBB|Gordon Haines
+Music Of The Night|TTBB|Jay Giallombardo
+Music, Music, Music|TTBB|Mo Rector
+Music! Music! Music!|SSAA|Jarmela Speta
+Music! Music! Music!|SSAA|Nancy Bergman
+Muskrat Ramble|SSAA|Dot Short
+Muskrat Ramble|TTBB|Rex Reeve, Bob Wachter
+My 'Wild' Irish Rose|TTBB|Burt Szabo
+My Baby Just Cares for Me|SSAA|Anna Maria Parker
+My Baby Just Cares for Me|SSAA|Elaine Gain
+My Baby Just Cares For Me|SSAA|Nancy Bergman
+My Baby Just Cares For Me|TTBB|Walter Latzko
+My Best Girl|TTBB|Theo Hicks
+My Blushin' Rosie|TTBB|Aaron Dale
+My Buddy|SSAA|Joe Liles
+My Buddy|SSAA|Norma Andersen
+My Buddy|SSAA|Walter Latzko
+My Buddy|TTBB|Joe Liles
+My Colouring Book|TTBB|Jay Wright
+My Country|SSAA|Dot Short
+My Cup Runneth Over|SSAA|Jean Crockett Kane
+My Cup Runneth Over With Love|TTBB|Ardeth Fullmer
+My Fair Lady Medley|SSAA|Renee Craig Anne Minihane
+My Fair Lady Medley|TTBB|Renee Craig
+My Fair Lady Medley|TTBB|Tom Gentry
+My Faithful Heart|TTBB|Walter Latzko
+My Father, My Friend, My Dad|TTBB|Bill Rashleigh
+My Father, My Friend, My Dad|TTBB|Earl Moon
+My Favorite Things|TTBB|Dave Briner
+My Favorite Things Parody|TTBB|Dave Briner
+My Foolish Heart|SSAA|Joni Bescos
+My Foolish Heart|TTBB|Brian Beck
+My Foolish Heart|TTBB|Dick Floersheimer
+My Foolish Heart|TTBB|Rob Hopkins
+My Foolish Heart - Reprise|TTBB|Brian Beck, Jay Giallombardo
+My Friend|TTBB|Fred King
+My Funny Valentine|SSAA|Renee Craig
+My Funny Valentine|TTBB|Jim Clancy
+My Funny Valentine|TTBB|Scott Kitzmiller
+My Gal Sal|TTBB|Clay Hine
+My Girl|TTBB|John Palmer
+My Girl|TTBB|Rob Campbell
+My Girl|TTBB|Steve Wolf
+My Grown Up Christmas List|SSAA|June Berg
+My Guy|SSAA|Tedda Lippincott
+My Guy (YWIH)|SSAA|Tedda Lippincott
+My Heart Stood Still|SSAA|Anna Maria Parker
+My Heart Stood Still|TTBB|John Hohl
+My Heart Will Go On|SSAA|Tedda Lippincott
+My Heart Will Go On (From Titanic) (SSAA)|SSAA|Kirby Shaw
+My Honey's Lovin' Arms|SSAA|Anna Maria Parker
+My Honey's Lovin' Arms|SSAA|David Wright
+My Honey's Lovin' Arms|TTBB|David Wright
+My Honey's Lovin' Arms|TTBB|Don Gray
+My Honey's Lovin' Arms|TTBB|Joseph Meyer, Don Gray, Scott Kitzmiller, Mark Betczynski
+My Ideal|TTBB|Leo Robin
+My Ideal|TTBB|Mark Hale
+My Kind of Town|TTBB|Dan Wessler
+My Kind of Town Chicago Is|SSAA|Nancy Bergman
+My Lady Loves To Dance|TTBB|Bob Dowma
+My Life Flows On|SSAA|Tom Gentry
+My Little Girl|TTBB|Todd Troutman
+My Little Girl|TTBB|Tom Gentry
+My Love Is Like A Red, Red Rose|SSAA|Mike Taylor
+My Man|SSAA|Mark Jennings
+My Melancholy Baby|SSAA|Joni Bescos
+My Melancholy Baby|TTBB|Lou Perry
+My Melancholy Baby|TTBB|Mark Hale
+My Most Beautiful Rose|TTBB|Henrik Rosenberg
+My Mother's Eyes|SSAA|Dave Briner
+My Mother's Eyes|SSAA|Nancy Bergman
+My Mother's Eyes|SSAA|Renee Craig
+My Mother's Eyes|TTBB|Unspecified
+My Mother's Pearls|TTBB|Burt Szabo
+My Name Is America!|TTBB|John Hohl
+My Old Dutch|TTBB|Tony Searle
+My Old Kentucky Home|SSAA|June Dale
+My Old Kentucky Home|TTBB|David Harrington
+My Old Kentucky Home|TTBB|Jon Nicholas
+My Old Kentucky Home, Goodnight|TTBB|Aaron Dale
+My Old Man|TTBB|Jim Henry
+My Old Man's A Sailor|TTBB|Jim Henry
+My Old Pal|SSAA|Jay Giallombardo
+My One And Only Love|TTBB|Rob Hopkins
+My Pretty Little Jesus|TTBB|Burt Szabo
+My Romance|SSAA|Joey Minshall
+My Romance|SSAA|Renee Craig
+My Romance|TTBB|Adam Reimnitz
+My Romance|TTBB|Jay Giallombardo
+My Romance|TTBB|Renee Craig, adapted by Rich Hasty
+My Romance|TTBB|Rob Campbell
+My Romance|TTBB|Walter Latzko
+My Special Angel|TTBB|Kevin Keller
+My Way|TTBB|Dave Briner
+My Way|TTBB|Eric Ruthenberg
+My Way|TTBB|John Hohl
+My Way|TTBB|Webb Comfort
+My Wife Is On A Diet|TTBB|Tom Gentry
+My Wife The Dancer|TTBB|Buzz Haeger
+My Wild Irish Rose|TTBB|Don Gray
+My Wild Irish Rose|TTBB|Floyd Connett
+My World is Beginning Today|SSAA|Kirk Young
+Nashville Cats|TTBB|Jay Giallombardo
+Naughty Angeline|TTBB|Mark Hale
+Naughty Baby|SSAA|Marge Bailey
+Naughty Lady of Shady Lane|SSAA|Tedda Lippincott
+Nearer My God Medley|TTBB|Joe Johnson
+Nearer My God To Thee|TTBB|James Stevens
+Nearer, My God, to Thee|SSAA|Leola Wright
+Nearer, My God, To Thee|TTBB|Joe Johnson
+Neil Sedaka Medley (Next Door to an Angel, Happy Birthday Sweet Sixteen, Oh Carol, Breaking Up is Hard to Do, Calendar Girl)|TTBB|Jan-Ake Westin
+Never Hit Your Grandma With A Shovel|TTBB|Rob Hopkins
+Never My Love|TTBB|Jon Nicholas
+Never Never Land|TTBB|Jay Giallombardo
+Never Neverland|TTBB|Bill Mitchell
+Never Pass This Way Again|TTBB|Clay Hine
+Never Say 'Never Again' Again|SSAA|Tom Gentry
+Never Say Never / Taking a Chance on Love|TTBB|Tony Searle
+Never Throw A Lighted Lamp At Mother|TTBB|David Wright
+Nevertheless|SSAA|Joe Liles
+Nevertheless|SSAA|Nancy Bergman
+Nevertheless|SSAA|Tom Campbell
+Nevertheless|TTBB|Tom Campbell
+Nevertheless (I'm In Love With You)|TTBB|Webb Comfort
+New Ashmolean Marching Society and Student's Conservatory Band(Dave Br|TTBB|Dave Briner
+New Ashmolean, Marching Society|TTBB|Dave Briner
+New Gospel Medley|SSAA|Ed Waesche
+New Orleans Post Parade|SSAA|Ardeth Fullmer
+New Orleans/Sweet Georgia Brown|SSAA|Kay Bromert
+New Words|SSAA|Michael Gellert
+New World Symphony - 2nd Movement|TTBB|Jonathan Rathbone
+New York Medley|TTBB|Burt Szabo
+New York New York|SSAA|Renee Craig
+New York, New York|TTBB|Alan Hale
+New York, New York|TTBB|Dan Wessler
+New York, New York|TTBB|David Wright
+New York, New York|TTBB|Don Gray
+New York, New York|TTBB|Don Gray, Ed Waesche
+New York, New York|TTBB|Ed Waesche
+New York, New York|TTBB|Steve Jamison
+New York, New York Opener|TTBB|Roger Payne
+New York, NY|TTBB|Jay Giallombardo
+New York(A Hell Of A Town) On Broadway Medley|SSAA|Judy Vidal
+New Zealand Song|SSAA|June Berg
+Nice N' Easy|TTBB|Ig Jakovac
+Nice Work If You Can Get It|SSAA|Marsha Zwicker
+Nice Work If You Can Get It|TTBB|Ed Waesche
+Nice Work If You Can Get It|TTBB|Rob Campbell
+Nine to Five|SSAA|Ann Minihane
+Nine to Five|SSAA|Steve Jamison
+Ning Wendete|TTBB|Steven Armstrong
+No Matter What|SSAA|Nova Evans
+No More Sorrow|TTBB|Shelton Kilby
+No More Sorrow|TTBB|Unspecified
+No No Nora|TTBB|Clay Hine
+No No Norman|SSAA|Clay Hine
+No One Knows|TTBB|Brad Coon
+No One Loves You Any Better Than Your M-A Double M-Y|TTBB|Tom Gentry
+No Other Love|TTBB|David Wright
+No Regrets|SSAA|Mark Jennings
+Nobody Does It Better|TTBB|Josh Ehrlich
+Nobody Knows What A Red-Head Mama Can Do|SSAA|Dennis Driscoll
+Nobody Knows What A Red-Head Mama Can Do|TTBB|Dennis Driscoll
+Nobody Knows What A Red-Head Mamma Can Do|TTBB|Dennis Driscoll
+Nobody Knows You|TTBB|Dennis Driscoll
+Nobody Knows You When You're Down And Out|TTBB|Steven Armstrong
+Nobody Knows You When You're Down And Out/That's Life (Medley)|SSAA|Joe Liles
+Nobody Knows You/That's Life Medley|SSAA|Joe Liles
+Nobody Loves Me Like You Do|SSAA|Mary Ann Wydra
+Nobody's Sweatheart Medley|SSAA|Renee Craig
+Nobody's Sweetheart|SSAA|Gene Cokeroft
+Nobody's Sweetheart|TTBB|Scott Kitzmiller
+Nobody's Sweetheart Now|SSAA|Bev Sellers
+Nobody's Sweetheart Now/Nobody's Baby Medley|SSAA|Larry Wright
+Noel Canon|TTBB|Steven Sametz
+Nonsense Medley|SSAA|Jo Lund
+Noone in the World|SSAA|David Sangster
+North to Alaska|TTBB|John Hohl
+Northwoods Woman|SSAA|Joe Liles
+Not While I'm Around|SSAA|Jeremiah Pope
+Not While I'm Around|TTBB|Jeremiah Pope
+Nothin' Rhymes|SSAA|Sharon Holmes
+Nothing Can Stop Me Now|SSAA|Aaron Dale
+Nothing's Gonna Stop Us Now|SSAA|Carole Prietto
+Now Is The Hour|TTBB|Adam Reimnitz
+Nowadays/Razzle Dazzle|SSAA|Jean McFadyen
+Nox Aurumque|SATB|Eric Whitacre
+Nutcracker Jingles|SSAA|Joan D'Agostino
+Nuttin' For Christmas|SSAA|Meyer
+Nuttin' For Christmas|SSAA|Sheila Cope
+Nuttin' For Christmas|TTBB|Burt Szabo
+Nuttin' For Christmas|TTBB|Jon Nicholas
+O Canada|SSAA|Joe Liles
+O Canada!|SSAA|Joe Liles
+O Canada!|TTBB|Barbershop Harmony Society
+O Canada!|TTBB|Chris Arnold
+O Canada!|TTBB|Joe Liles
+O Canada! (Bilingual)|TTBB|Chris Arnold
+O Christmas Tree|SSAA|Joe Liles
+O Come All Ye Faithful|SSAA|Dan Deisroth
+O Come All Ye Faithful|SSAA|Joni Bescos
+O Come All Ye Faithful|TTBB|Unspecified
+O Come All Ye Faithful / Joy To The World Medley|TTBB|Earl Moon
+O Come Emanuel|TTBB|Kevin Keller
+O Come O Come Emmanuel (Veni, Veni)|SSAA|Kevin Keller
+O Come O Come Emmanuel (Veni, Veni)|TTBB|Kevin Keller
+O Come, O Come Emmanuel|SSAA|Kevin Keller
+O Come, O Come Emmanuel|TTBB|Kevin Keller
+O Holy Night|SSAA|Greg Volk
+O Holy Night|SSAA|Joni Bescos
+O Holy Night|SSAA|Suzy Buerer
+O Holy Night|TTBB|Barbershop Harmony Society
+O Holy Night|TTBB|Chris Arnold
+O Holy Night|TTBB|Ed Lojeski
+O Holy Night|TTBB|Jay Giallombardo
+O Little Town of Bethlehem|TTBB|Kris Olson
+O Little Town Of Bethlehem|SSAA|Nancy Bergman
+O Little Town Of Bethlehem|TTBB|Kevin Keller
+O Love That Will Not Let Me Go|TTBB|David Phelps
+O Thou That Tellest Good Tidings To Zion|SATB|Handel's Messiah
+O, Canada|SSAA|Norma Andersen
+O, Holy Night|TTBB|Jon Nicholas
+Ob La Di, Ob La Da|TTBB|Mark Hale
+Ob La Di, Ob La Da, Life Goes On|TTBB|Mark Hale
+Ob-La-Di|SSAA|Mark Hale
+Ob-la-di, Ob-la-da|SSAA|Carolyn Schmidt
+Octopus' Garden|SSAA|Carolyn Schmidt
+Ode to Joy (Joyful, Joyful)|SSAA|Barbara McNeill
+Ode to Joy Medley|TTBB|Jay Giallombardo
+Oh Bury Me Out on the Lone Prairie|TTBB|The Thoroughbreds Chorus
+Oh Come All Ye Faithful|TTBB|Barbershop Harmony Society
+Oh Daddy Blues|SSAA|Mark Jennings
+Oh Darling|SSAA|David Harrington
+Oh Happy Day|SSAA|David Wright
+Oh Holy Night|SSAA|Joni Bescos
+Oh Holy Night|TTBB|Barbershop Harmony Society
+Oh How I Miss You Tonight|SSAA|Renee Craig
+Oh How I Miss You Tonight/When I Lost You Medley|TTBB|Jay Giallombardo
+Oh How We Roared In The Twenties|TTBB|Toban Dvoretzky
+Oh Little Town Of Bethlehem|SSAA|Nancy Bergman
+Oh Look at Me Now|TTBB|Aaron Dale
+Oh Look At Me Now|SSAA|Aaron Dale
+Oh Susanna (YWIH)|SSAA|Carolyn Schmidt
+Oh Susanna, Dust Off That Old Pianna|SSAA|David Wright
+Oh Susanna, Dust Off That Old Pianna|SSAA|David Wright/Carolyn Schmidt
+Oh Susannah|TTBB|Aaron Dale
+Oh Susannah, Dust Off That Old Pianna|SSAA|Avis Fellows and Randine Hartlestad
+Oh What a Beautiful Morning|SSAA|Anna Maria Parker
+Oh You Beautiful Doll|SSAA|Jay Giallombardo
+Oh, How I Hate To Get Up In The Morning|TTBB|Hal Maples
+Oh, How I Miss You Tonight|SSAA|Craig, Wyatt, Briner
+Oh, How I Miss You Tonight|SSAA|Jim Arns
+Oh, How I Miss You Tonight|SSAA|Renee Craig
+Oh, How I Miss You Tonight|SSAA|Renee Craig/Steve Jamison
+Oh, How I Miss You Tonight/When I Lost You|SSAA|Jay Giallombardo
+Oh, Lonesome Me|SSAA|David Wright
+Oh, Pretty Woman|TTBB|Steve Delehanty
+Oh, What A Beautiful Morning|SSAA|Nancy Bergman
+Oh, You Beautiful Doll|SSAA|Jay Giallombardo
+Oh! Darling|SSAA|David Harrington
+Oh! Darling|TTBB|David Harrington
+Oh! How I Hate to Get Up in the Morning|SSAA|Nancy Bergman
+Oh! Look At Me Now|SSAA|Aaron Dale
+Oh! Look At Me Now|TTBB|Aaron Dale
+Oh! Look At Me Now!|SSAA|Aaron Dale
+Oh! You Beautiful Doll|TTBB|Kirk Roose
+Oh! You Beautiful Doll|TTBB|Rob Campbell
+Oh! You Beautiful Doll!|SSAA|Jay Giallombardo
+Oklahoma|TTBB|Jay Giallombardo
+Oklahoma|TTBB|John Coffin
+Oklahoma|TTBB|Mo Rector
+Ol' Saint Nicholas|SSAA|Tedda Lippincott
+Old Black Joe|TTBB|Tom Gentry
+Old Black Magic|SSAA|Jim Massey
+Old Bones|TTBB|Earl Moon
+Old Bones|TTBB|Ig Jakovac
+Old Cape Cod|SSAA|Marge Bailey
+Old Cape Cod|SSAA|Tom Gentry
+Old Cape Cod|TTBB|Bradford Taylor
+Old Cape Cod|TTBB|Russ Foris
+Old Cape Cod|TTBB|Tom Gentry
+Old Cape Cod|TTBB|Unspecified
+Old Devil Moon|TTBB|Adam Reimnitz
+Old Fashioned Girl/Sweet And Lovely Medley(Rich H|TTBB|Rich Hasty
+Old Folks At Home|TTBB|Clay Hine
+Old Friends|TTBB|Kirk Young
+Old Hymns Medley|TTBB|David Wright
+Old Kentucky Home Medley|TTBB|Jay Giallombardo
+Old Man River|TTBB|Bryan Ziegler
+Old Man River|TTBB|Ed Boehm
+Old Man River|TTBB|Fred King
+Old Man River|TTBB|Melvin Knight
+Old Man River|TTBB|Ty Gwyn
+Old Man Time|TTBB|Dennis Malone, John Hohl
+Old Saint Louis|TTBB|David Wright
+Old Songs are Just Like Old Friends|SSAA|Lou Perry
+Old Songs Medley|TTBB|Ed Waesche
+Old Songs, Old Friends|SSAA|Vicki Uhr
+Old Songs, Old Friends|TTBB|Vicki Uhr
+Old St. Louie|TTBB|David Wright
+Old St. Louis|SSAA|David Wright
+Old Teddy Bear|SSAA|Lynnell Diamond
+Old Time Hymn Medley|SSAA|Kay Bromert
+Old Time Religion Medley|SSAA|Betty Oliver
+Old Time Religion Medley|TTBB|Steven Armstrong
+Old World Christmas Medley|TTBB|Larry Triplett
+Oliver Medley|SSAA|Tom Gentry
+Oliver Medley|TTBB|Kevin Keller
+Oliver Medley|TTBB|Pete Rupay
+Oliver Medley|TTBB|Tom Gentry
+On A Bicycle Built for Two|SSAA|Marie Johnson
+On a Clear Day|TTBB|Adam Reimnitz
+On A Clear Day|SSAA|Sylvia Alsbury
+On A Cruise|SSAA|Nancy Bergman
+On A Slow Boat to China|SSAA|Jo Lund
+On A Slow Boat To China|TTBB|Greg Hollander
+On A Slow Boat To China|TTBB|Jack McCabe
+On A Slow Boat To China|TTBB|Jon Nicholas
+On A Wonderful Day Like Today|SSAA|George Avener
+On A Wonderful Day Like Today|TTBB|Mo Rector
+On and On|TTBB|Marshall Webb
+On Angel's Wings|SSAA|Michael Gellert
+On Broadway|SSAA|Nancy Bergman
+On Eagle's Wings|SSAA|Nancy Bergman
+On My Own|SSAA|Barabara McNeill
+On My Own|SSAA|Barbara McNeill
+On My Own|SSAA|Jo Lund/Lorraine Rochefort
+On My Own|SSAA|June Dale
+On My Own|SSAA|Sylvia Alsbury
+On My Own|TTBB|Kevin Keller, Steven Armstrong, Chris Arnold
+On The Atchison, Topeka, And The Santa Fe|TTBB|Dick Rode
+On The Banks Of The Wabash|TTBB|David Wright
+On the Mississippi|SSAA|Bev Sellers
+On The Road Again|SSAA|Dot Calvin
+On The Road Again|TTBB|Jon Nicholas
+On the Street Where You Live|SSAA|Brent Graham
+On the Street Where You Live|SSAA|June Berg
+On The Street Where You Live|TTBB|David Wright
+On The Street Where You Live|TTBB|Ron Middlestadt
+On the Sunny Side of the Street|SSAA|Ann Minihane
+On The Sunny Side Of The Street|TTBB|Mel Knight
+On Top of Old Smokey|TTBB|Unspecified
+On! On! U Of K|TTBB|Jon Nicholas
+Once In A Lifetime|SSAA|Mark Hale
+Once in a Lifetime-I'll be Seeing You|SSAA|Rob Hopkins
+Once In Love With Amy|TTBB|Lou Perry
+Once In My Life|TTBB|Joni Bescos
+Once In Royal David's City|TTBB|Paul Selby
+Once Upon a December|SSAA|Judy Hendrickson
+Once Upon A December|TTBB|Chris Arnold
+Once Upon a Time|SSAA|Tom Gentry
+Once Upon A Time|SSAA|June Dale
+Once Upon A Time|SSAA|Rob Campbell
+Once Upon A Time|TTBB|Rob Campbell
+Once Upon A Time|TTBB|Tom Gentry
+One|SSAA|Renee Craig
+One|TTBB|Dot Calvin
+One (12 parts)|SSAA|Renee Craig
+One (Chorus Line)|SSAA|Dot Calvin
+One & Only Genuine Original Family Band|SSAA|Cheryl Suhr
+One Alone|TTBB|Don Gray
+One Boy|SSAA|Marge Bailey
+One Day Like This|SSAA|Liz Garnett
+One Day More|TTBB|Brian Beck
+One Fine Day|SSAA|David Wright
+One Fine Day|SSAA|M. Zwicker (YWIH)
+One Fine Day|SSAA|Marsha Zwicker
+One Fine Day|SSAA|Tedda Lippincott
+One Fine Day|TTBB|Chris Arnold
+One For My Baby|TTBB|Nathan Peplinski
+One For My Baby|TTBB|Roger Payne
+One God|SSAA|Anita Barzilla
+One God|SSAA|Anna Maria Parker
+One God|TTBB|John Hohl
+One Hand, One Heart/Tonight Medley|SSAA|Sylvia Alsbury
+One Heart, One Voice|SSAA|Joe Liles
+One Moment In Time|SSAA|Bev Sellers
+One Moment In Time|SSAA|David Wright
+One Moment In Time|TTBB|Greg Volk
+One More Last Chance|TTBB|Aaron Dale
+One More Song|SSAA|Joe Liles
+One Note Samba|TTBB|Brian Beck
+One Note Samba|TTBB|Larry Wright
+One of Those Songs|SSAA|Dan Gray
+One Of Those Songs|TTBB|Unspecified
+One Size Fits All|SSAA|Charlene Yazurlo
+One Song at a Time|SSAA|Joe Liles
+One Song At A Time|TTBB|Joe Liles
+One Tin Soldier|SSAA|June Dale
+One Voice|SSAA|Ann Minihane
+One Voice|SSAA|Jim Arns
+One Voice|SSAA|Joni Bescos
+One Voice|SSAA|M. Wert
+One Voice|SSAA|Tony Searle
+One Voice|TTBB|Jim Clancy
+One Voice|TTBB|Michael Gill
+One Voice (YWIH)|SSAA|Ann Minihane
+Only In My Dreams|SSAA|Sylvia Alsbury
+Only Remembered|TTBB|Paul Selby
+Only Time|SSAA|Brian Beck
+Only You|TTBB|David Harrington
+Only You|TTBB|Lorenz Maierhofer
+Only You (And You Alone)|SSAA|David Harrington
+Only You (And You Alone)|TTBB|Jim Kahlke
+Only You / The Great Pretender|TTBB|Unspecified
+Only You, as sung by the Flying Pickets (SATB)|SATB|Dale Kynaston
+Open Arms|TTBB|Bryan Ziegler
+Open Your Arms, My Alabamy|TTBB|Norma Andersen
+Opener Medley|TTBB|Mark Hale
+Opening Night on Broadway|SSAA|Nancy Bergman
+Operator|SSAA|Bev Sellers
+Operator|SSAA|C. Yazurlo
+Operator|SSAA|Charlene Yazurlo
+Operator|TTBB|Ed Waesche
+Operator|TTBB|Tom Gentry
+Optimistic Voices|SSAA|Joey Minshall
+Opus One|SSAA|Jo Lund
+Orange Colored Sky|SSAA|B. McNeill
+Orange Colored Sky|SSAA|Barbara McNeill
+Orange Colored Sky|SSAA|Carolyn Schmidt
+Orange Colored Sky|SSAA|David Harrington
+Orange Colored Sky|SSAA|Diana Franceschi
+Orange Colored Sky|SSAA|June Dale
+Orange Colored Sky|SSAA|Nick Papageorge
+Orange Colored Sky|SSAA|Tom Gentry
+Orange Colored Sky|TTBB|David Harrington
+Orange Colored Sky|TTBB|Greg Volk
+Orange Colored Sky|TTBB|Nick Papageorge
+Orange Colored Sky|TTBB|Tom Gentry
+Orange Colored Sky (Contest)|TTBB|Tom Gentry
+Orange Colored Sky (YWIH)|SSAA|Barbara McNeill
+Orange Coloured Sky|SSAA|Unspecified
+Orange Coloured Sky|TTBB|David Harrington
+Orange Coloured Sky|TTBB|Tom Gentry
+Orange-Colored Sky|SSAA|Carolyn Schmidt
+Orange-Colored Sky|SSAA|Diane Franchesci/Jim Arns
+Orange-Colored Sky|SSAA|Nick Papageorge
+Original Dixieland One Step|SSAA|Bev Sellers
+Original Dixieland One Step|SSAA|Unspecified
+Original Dixieland One Step|TTBB|David Wright
+Original Dixieland One Step|TTBB|Greg Volk
+Original Dixieland One Step|TTBB|Renee Craig, David Harrington
+Original Dixieland One-Step|SSAA|Bev Sellers
+Original Dixieland One-Step|SSAA|Greg Volk
+Original Dixieland One-Step|SSAA|Renee Craig
+Original Dixieland One-Step|TTBB|David Wright
+Our Love Is Here to Stay|TTBB|Ed Waesche
+Our Love Is Here to Stay|TTBB|Steve Delehanty
+Our Love Is Here To Stay|SSAA|Renee Craig
+Out Of Breath|TTBB|Jon Nicholas
+Over the Rainbow|SSAA|Anna Maria Parker
+Over the Rainbow|SSAA|Clay Hine
+Over the Rainbow|SSAA|Jay Giallombardo
+Over the Rainbow|SSAA|Joni Bescos
+Over the Rainbow|SSAA|Nancy Bergman
+Over The Rainbow|TTBB|Don Reckenbeil
+Over The Rainbow|TTBB|Ed Waesche
+Over The Rainbow|TTBB|Ed Waesche, Lloyd Steinkamp, Joe Caulkins
+Over The Rainbow|TTBB|Jay Giallombardo
+Over The Rainbow|TTBB|Lloyd Steinkamp
+Over The Rainbow|TTBB|Rob Hopkins
+Over The Rainbow|TTBB|Steven Armstrong
+Over The Rainbow|TTBB|Unspecified
+Over the Rainbow (SATB)|SATB|Dale Kynaston
+Over The Rainbow (YWIH)|SSAA|Joni Bescos
+Over The Rainbow [Interpolating 'I'm Always Chasing Rainbows'](Darin D|TTBB|Darin Drown
+Over The Rainbow 2006|TTBB|Jon Nicholas
+Over The Rainbow 2009|TTBB|Jon Nicholas
+Over There|TTBB|Robert Curt
+Overs (by Paul Simon)|SATB|Peter Eldridge (NY Voices)
+Overture (This Is It)|TTBB|Unspecified
+P.S. I Love You|TTBB|Robert Rund
+P.S. I Love You|TTBB|Rod Alexander
+Pack Up Your Troubles in Your Old Kit Bag|TTBB|Clay Hine
+Pack Up Your Troubles/Long Way To Tipperary Medley|TTBB|Jack Baird
+Paddlin' Madeline/Row, Row Row|SSAA|Nancy Bergman
+Paint Your Wagon Medley|SSAA|June Dale
+Paint Your Wagon Medley|TTBB|Dick Kneeland
+Painting This Old Town Blue|SSAA|Unspecified
+Pal of My Cradle Days|SSAA|Joni Bescos/Brian Beck
+Pal Of My Cradle Days|SSAA|Lyle Pilcher
+Paper Doll|TTBB|Lou Perry
+Paper Moon|SSAA|Clay Hine
+Paper Moon|TTBB|Clay Hine
+Parade of the Wooden Soldiers|SSAA|Teresa Reed
+Parade of the Wooden Soldiers|TTBB|Marty Israel
+Pass the Apples Medley|TTBB|Jay Giallombardo
+Pass the Apples Medley|TTBB|Unspecified
+Pat-a-pan|TTBB|Katherine Davis
+Patapan|SSAA|Kevin Keller
+Patriotic Medley|SSAA|Jay Giallombardo
+Peace I Leave with You|TTBB|Chris MacMartin
+Peace on Earth/Little Drummer Boy|SSAA|Joe Liles
+Peace On Earth/Little Drummer Boy|TTBB|Gil Dubray
+Peace on Earth/Little Drummer Boy Medley|SSAA|Joe Liles
+Peace on Earth/The Little Drummer Boy|SSAA|Joe Liles
+Peel Me A Grape|SSAA|Lynnell Diamond
+Peg O' My Heart|TTBB|Ed Waesche
+Peggy Sue|TTBB|Dale Hanson
+Pennies From Heaven|SSAA|Steve Shannon
+Perfidia|TTBB|Greg Volk
+Perhaps Love|SSAA|Tedda Lippincott
+Peter Pan Medley|TTBB|Steve Tramack
+Peter Pan Medley|TTBB|Tom Gentry
+Phantom / Music Of The Night|TTBB|Joe Spiecker
+Phantom Medley|SSAA|David Wright
+Pick A Little-Talk A Little/Goodnight Ladies(Walter La|SATB|Walter Latzko
+Pick A Little, Talk A Little / Good Night Ladies|TTBB|Walter Latzko
+Pick Yourself Up|SSAA|David Harrington
+Pick Yourself Up|TTBB|David Harrington
+Picture In A Frame|TTBB|Jordan Johnson
+Pirate Medley|TTBB|Greg Volk
+Pirate Medley|TTBB|Roger Payne
+Pity Party|SSAA|Sharon Holmes
+Play A Simple Melody|SATB|Joe Liles
+Play A Simple Melody|TTBB|Joe Liles
+Play A Simple Melody|TTBB|Russ Foris
+Playing the Clown|SSAA|Joey Minshall
+Please Come Home For Christmas|TTBB|Jon Nicholas
+Please Come Home For Christmas|TTBB|Steve Tramack
+Please Don't Talk About Me|SSAA|Floyd Connett
+Please Don't Talk About Me|SSAA|Joni Bescos
+Please Don't Talk About Me|SSAA|Nancy Bergman
+Please Don't Talk About Me When I'm Gone|SSAA|Ozzie Westley
+Please Don't Talk About Me When I'm Gone|TTBB|Ed Waesche
+Please Don'T Talk About Me When I'M Gone|SSAA|Nancy Bergman
+Please, Mr. Columbus|TTBB|David Wallace
+Please, Mr. Columbus|TTBB|Don Gray, Jack Baird and Dave Wallace
+Pokemon|TTBB|Steve Wolf
+Polka Dots And Moonbeams|TTBB|John Bober
+Polka Medley|TTBB|Russ Foris
+Polkadots And Moonbeams|TTBB|Steven Armstrong
+Polkadots And Moonbeams (version 2)|TTBB|Steven Armstrong
+Poor Papa|SSAA|Dot Calvin
+Pop, Pop, Poppin' Popcorn|SSAA|Avis Fellows
+Popular|SSAA|Steve Tramack
+Porgy And Bess Medley|TTBB|Walter Latzko
+Portrait Of My Love|SSAA|Larry Wright
+Powder Your Face With Sunshine|TTBB|Roy Keys
+Powder Your Face With Sunshine Medley|SSAA|Nancy Bergman
+Powder Your Face With Sunshine/Smile Medley|SSAA|Nancy Bergman
+Praise The Lord And Pass The Ammunition|TTBB|Merle Savage
+Prayer of the Children|SSAA|Joe Liles
+Prayer of the Children|TTBB|Andrea Klouse
+Prayer Of The Children|SATB|Andrea S. Klouse
+Prayer Of The Children (TTBB)|TTBB|Kurt Bestor / Andrea Klouse
+Precious Lord, Take My Hand|TTBB|Buzz Haeger
+Precious Lord, Take My Hand|TTBB|Dan Tice
+Precious Lord, Take My Hand|TTBB|Jon Nicholas
+Precious Lord, Take My Hand|TTBB|Roy Ringwald
+Presents|TTBB|Phil Ordaz
+Pretty Baby|TTBB|Paul Engel, Paul Eastman
+Pretty Baby|TTBB|Tom Gentry
+Pretty Baby|TTBB|Verse Bernie Cureton, song unknown
+Price Tag|SATB|Alex Kaiserman
+Price Tag|SSAA|Hari Birtles
+Prism Song|TTBB|Kris Olson
+Prisoner Of Love|TTBB|Brent Graham
+Professional Pirate|TTBB|Tom Gentry
+Proud Mary|SSAA|Tedda Lippincott
+Proud Mary|TTBB|David Wright
+Psalm 23|TTBB|Paul Basler
+Pure Imagination|SSAA|Dave Briner
+Pure Imagination|TTBB|Aaron Dale
+Pure Imagination|TTBB|Jim Clancy
+Pussywillows Cattails|SSAA|June Dale
+Put 'Em In A Box|SSAA|Sharon Holmes
+Put 'em In A Box, Tie 'em With A Ribbon (And Throw 'em In The Deep Blue Sea)|SSAA|Marsha Zwicker
+Put A Little Love In Your Heart|SSAA|Lorraine Rochefort
+Put Me To Sleep With An Old Fashioned Melody|TTBB|Clay Hine
+Put on a Happy Face|TTBB|Kevin Keller
+Put On A Happy Face/Let A Smile Be Your Umbrella Medley(Adam Reim|TTBB|Adam Reimnitz
+Put On An Old Pair Of Shoes|SSAA|Norma Andersen
+Put On Your Sunday Clothes|TTBB|Adam Reimnitz
+Put Your Arms Around Me Honey|SSAA|Nancy Bergman
+Put Your Arms Around Me Honey|TTBB|Rob Hopkins
+Put Your Arms Around Me, Honey|SSAA|Aaron Dale
+Put Your Arms Around Me, Honey|TTBB|Aaron Dale
+Put Your Arms Around Me, Honey|TTBB|Rob Hopkins
+Put Your Hands Together|SSAA|Renee Craig
+Put Your Head On My Shoulder|TTBB|Aaron Dale
+Put Your Head On My Shoulder|TTBB|Jim Clancy
+Puttin' on the Ritz|SSAA|Bev Sellers/Kay Bromert
+Puttin' On the Ritz|SSAA|Bev Sellers
+Puttin' On The Ritz|SSAA|David Wright
+Puttin' On The Ritz|SSAA|Kay Bromert
+Puttin' On The Ritz|SSAA|Larry Wright
+Puttin' On The Ritz|TTBB|Larry Wright
+Putting It Together|TTBB|David Wright
+Que Reste-t-il De Nos Amours ?|TTBB|John Hohl
+Queen Medley|SSAA|Steve Wolf
+Quicksilver|TTBB|Jon Nicholas
+R-E-S-P-E-C-T|SSAA|Anne Raugh
+Rag Mop|SSAA|Nancy Bergman
+Ragtime Cowboy Joe|TTBB|Barbershop Harmony Society
+Ragtime Cowgirl Jo|SSAA|Nancy Bergman
+Railroad Medley|TTBB|Walter Latzko
+Rain Medley|TTBB|Ed Waesche
+Raindrops Keep Falling On My Head|TTBB|Walter Latzko
+Raining in My Heart|SSAA|Paul Davies / Bob Croft
+Raining In My Heart|TTBB|Paul Davies
+Rainsong|TTBB|Houston Bright
+Raise Your Baton, Mister Leaderman|TTBB|Pete Rupay
+Rawhide|TTBB|Jon Nicholas
+Ray's Rockhouse|SSAA|Clay Hine
+Razzapple Medley|TTBB|Tom Gentry
+Razzle Dazzle|SSAA|Bev Sellers
+Razzle Dazzle|SSAA|Clay Hine
+Razzle Dazzle|SSAA|Renee Craig
+Razzle Dazzle|SSAA|Tom Gentry
+Razzle Dazzle|TTBB|Phil Ordaz
+Razzle Dazzle|TTBB|Tom Gentry
+Razzle Dazzle|TTBB|Unspecified
+Reach|SSAA|Pat LeVezu
+Reach|SSAA|Sharon Carlson
+Reach for the Light|SSAA|June Dale
+Real Emotional Girl|TTBB|Rich Hasty
+Recipe For Love|TTBB|Barbershop Harmony Society
+Red Hot|SSAA|Nancy Bergman
+Red Hot Mama Medley|SSAA|Larry Wright
+Red Hot Mama Medley (cut)|SSAA|Greg Volk
+Red Hot!|SSAA|Nancy Bergman
+Red Roses For a Blue Lady|TTBB|Chuck Brooks
+Red, Red Robin|SSAA|Greg Volk
+Redhead|SSAA|Marge Bailey
+Redhead|TTBB|Jim Clancy
+Remember|SSAA|Linda Edmondson
+Renaissance Woman|SSAA|Dave Briner
+Return To Sender|TTBB|Duane Enders
+Reunion|TTBB|Todd Troutman
+Rhapsody in Blue|SSAA|David Wright
+Rhythm Conga|SSAA|Brian Beck
+Rhythm In My Nursery Rhymes|SSAA|Kay Griffin
+Rhythm Is Gonna Get You|SSAA|Brian Beck
+Rhythm Medley|SSAA|Ann Minihane
+Rhythm Medley|TTBB|A.C Steen/Jay Dearling
+Rhythm Medley|TTBB|Aaron Dale
+Rhythm Medley|TTBB|Webb Comfort
+Rhythm Of Life|SSAA|David Wallace
+Rhythm Of Life|SSAA|Jim Massey
+Rhythm Of Life|SSAA|Jo Kraut
+Rhythm of Love|TTBB|Deke Sharon and David Wright
+Rhythm Of Love|SSAA|Brent Graham
+Rhythm Of Love|SSAA|David Wright
+Rhythm Of Love|TTBB|Alex Kaiserman
+Rhythm Of Love|TTBB|Brent Graham
+Rhythm Of Love|TTBB|David Wright
+Rhythm of the Night|SSAA|Cindy Becker
+Rhythm Of The Rain|SSAA|Kathy Hannesen
+Rhythm Of The Rain|TTBB|Bob Shami
+Rhythm Of The Rain|TTBB|Jon Nicholas
+Richest Man In The World|TTBB|Earl Moon
+Ride in That Chariot|SSAA|Unspecified
+Ride Red Ride|TTBB|Emi Mills
+Ride The Chariot|TTBB|Barbershop Harmony Society
+Ride The Chariot|TTBB|David Wright
+Ride The Chariot|TTBB|Jon Nicholas
+Riders In The Sky|TTBB|Don Gray
+Riders In The Sky|TTBB|Pete Rupay
+Ridin' Down the Canyon|TTBB|Unspecified
+Right From The Start|TTBB|David Wright
+Ring a Ding Ding|TTBB|Anthony Bartholemew
+Ring de Christmas Bells|TTBB|Dave Briner
+Ring Of Fire|TTBB|David Wright
+Rise Again|SSAA|Russ Foris
+Rise Up Shepherd|TTBB|Steve Armstrong
+Rise Up, Shepherd, and Follow|TTBB|Jon Nicholas
+Rise Up, Shepherd, And Follow|TTBB|David Maddux
+Rise, Shine, For the Light is A-Comin|SSAA|Unspecified
+Rise, Shine, For The Light Is A-Comin'|TTBB|Burt Szabo
+Riu Riu Chiu|TTBB|Michael McGlynn
+River of Dreams|SSAA|Becky Wilkins
+River Stay 'Way from My Door *|TTBB|Ed Waesche
+Ro-Ro-Rollin' Along|TTBB|Russ Foris
+Roar (Gain)|SSAA|Elaine Gain
+Roar (Katy Perry)|SATB|Jonathan Sparks
+Roar and Brave|SSAA|Whitney Fontoura
+Robot Parody|TTBB|Steven Armstrong
+Rock And Roll Christmas|SSAA|Jon Nicholas
+Rock And Roll Christmas|TTBB|Jon Nicholas
+Rock Around the Clock|SSAA|Bev Sellers
+Rock Around The Clock|SSAA|Norma Andersen
+Rock Around The Clock|TTBB|James Shubert
+Rock Around The Clock|TTBB|Jon Nicholas
+Rock Around The Clock (YWIH)|SSAA|Norma Andersen
+Rock It For Me|TTBB|Aaron Dale
+Rock Of Ages, Let Our Song|TTBB|Tom Gentry
+Rock This Town|TTBB|Aaron Dale
+Rock-A-Bye Your Baby With A Dixie Melody|TTBB|Don Gray, Mel Knight
+Rockin Around the Christmas Tree|SSAA|Sandy Sharpe
+Rockin Around The Christmas Tree|TTBB|Aaron Dale
+Rockin' Around the Christmas Tree|SSAA|Tedda Lippincott
+Rockin' Around The Christmas Tree|SSAA|Marsha Zwicker
+Rockin' Around The Christmas Tree|TTBB|Jon Nicholas
+Rockin' Around The Christmas Tree|TTBB|Ruby Rhea
+Rockin' Around the Christmas Tree (SATB)|SATB|Kirby Shaw and Dale Kynaston
+Rockin' Christmas Medley|TTBB|Adam Reimnitz
+Rockin' Robin|SSAA|Tedda Lippincott
+Rockin' Robin (YWIH)|SSAA|Tedda Lippincott
+Rockin' Round The Christmas Tree|TTBB|Kirby Shaw
+Rocky Top|SSAA|Jim Arns
+Rocky Top|TTBB|Aaron Dale
+Roll Jordan, Roll|TTBB|Jim Henry/Crossroads
+Roll On Mississippi Roll On|TTBB|Aaron Dale
+Roll On Mississippi, Roll On|TTBB|Barbershop Harmony Society
+Roll On Mississippi, Roll On|TTBB|Floyd Connett
+Roll Out of Bed With a Smile|TTBB|Dennis Driscoll
+Rolling in the Deep|SSAA|Don Henken
+Rolling in the Deep|SSAA|Michael Gellert
+Rolling in the Deep (Beck)|SSAA|Brian Beck
+Rolling in the Deep (Gain)|SSAA|Elaine Gain
+Room Full Of Roses|TTBB|Joe Liles
+Rose Of Bethelem|SSAA|Joe Liles
+Roses Of Picardy|SSAA|Nancy Bergman
+Roses Of Picardy|TTBB|Lou Perry
+Roses of Yesterday|SSAA|Nancy Bergman
+Rosetta|TTBB|Jon Nicholas
+Rosie the Riveter|SSAA|Bryan Ziegler
+Route 66|SSAA|Chris Droegmuller
+Route 66|SSAA|Marge Bailey
+Route 66|TTBB|Dan Wessler
+Route 66|TTBB|Mason Kaye
+Route 66|TTBB|Ruby Rhea
+Route 66 (YWIH)|SSAA|Marge Bailey
+Route Sixty-Six|SSAA|Jim Arns
+Route Sixty-Six|SSAA|Lorraine Rochefort
+Route Sixty-Six|SSAA|Marge Bailey
+Row, Row, Row|TTBB|Paul Olguin
+Row, Row, Row|TTBB|Val Hicks, Marv Klingerman
+Row, Row, Row / Paddlin' Madeline|TTBB|Renee Craig
+Roxie|SSAA|David Wright
+Royal Garden Blues|TTBB|David Wright
+Royal Garden Blues|TTBB|Renee Craig
+Royals|SSAA|Alex Kaiserman
+Royals|SSAA|Deke Sharon
+Rubber Duckie|TTBB|Kirk Roose
+Rude|SATB|Henrik Rosenberg
+Rudolf The Red-Nosed Reindeer|TTBB|The Blenders
+Rudolph The Red Nosed Reindeer|SSAA|LaVeda Redfield
+Rudolph the Red-Nosed Reindeer|SSAA|Burt Szabo
+Rudolph the Red-Nosed Reindeer|SSAA|Nancy Bergman
+Rudolph the Red-Nosed Reindeer|TTBB|Burt Szabo
+Rule The World|SATB|Unspecified
+Run, Run, Run|SSAA|Bob Dowma
+Run, Run, Run|TTBB|Bob Dowma
+Runnin' Wild|SSAA|Nancy Bergman
+Runnin' Wild!|TTBB|David Wright
+Russian Roulette|SSAA|Liz Garnett
+S Wonderful|TTBB|Chris Arnold
+S.O.S.|SSAA|Lynnell Diamond
+Sag Mir, Wo Di Blumen|SSAA|Jo Lund
+Sailin' Away On The Henry Clay|TTBB|Rob Campbell
+Sailing|TTBB|Mark Jennings
+Sailor Medley|TTBB|Steve Delehanty
+Salvation Is Created (Spasineye Sodelal) (Pavel Chesn|TTBB|Pavel Chesnokov
+Sam the Old Accordian Man|TTBB|Earl Moon
+Sam You Made the Pants Too Long|SSAA|Tedda Lippincott
+Sam, You Made The Pants Too Long|TTBB|Walter Latzko
+Same Old Saturday Night|TTBB|Jay Krumbholz
+San Antonio Rose|SSAA|Tedda Lippincott
+San Antonio Rose|TTBB|Dick Carr
+San Fernando Valley|TTBB|Phil Ordaz
+San Francisco Bay Blues|SSAA|Dave Stevens
+San Francisco Bay Blues|SSAA|Jean Sutton
+San Francisco Bay Blues|TTBB|C.J. Sams Jr.
+San Francisco Bay Blues|TTBB|Jon Nicholas
+Santa Baby|SATB|Aaron Dale
+Santa Baby|SATB|Tom Gentry
+Santa Baby|SSAA|Larry Wright
+Santa Baby|SSAA|Lorraine Rochefort
+Santa Baby|TTBB|Aaron Dale
+Santa Baby|TTBB|Clay Hine
+Santa Bring My Baby Back|TTBB|Jon Nicholas
+Santa Bring My Baby Back (To Me)|TTBB|Jon Nicholas
+Santa Claus Has Moved to Indiana|SSAA|Tedda Lippincott
+Santa Claus is Back Town|SSAA|Lynnell Diamond
+Santa Claus is Coming to Town|SSAA|Roger Pyne and Jean Sutton
+Santa Claus Is Coming to Town|SSAA|Nancy Bergman
+Santa Claus Is Coming To Town|SSAA|LaVeda Redfield
+Santa Claus Is Coming To Town|TTBB|Hal Maples
+Santa Claus Is Coming To Town - Here Comes Santa Claus Medley|TTBB|Rick Spencer
+Santa Medley|SSAA|Aaron Dale
+Santa Medley|TTBB|Aaron Dale
+Satin Doll|TTBB|Peter Beers
+Satisfied|SSAA|Mary Coffman
+Saturday In The Park|SSAA|Jim Arns
+Saturday In The Park|TTBB|David Wise
+Save The Last Dance/Sway Medley|SSAA|Aaron Dale
+Save The Last Dance/Sway Medley|TTBB|Aaron Dale
+Saved|TTBB|Tom Gentry
+Saxophone Man|SSAA|Bev Sellers
+Say It with Music|SSAA|Linda Edmondson
+Say Mister, Have You Met Rosie's Sister|TTBB|Adam Scott
+Scarborough Fair|SATB|Yumiko Matsuoka
+Scarborough Fair|TTBB|Greg Lyne/Paul Davies
+Scarborough Fair|TTBB|Stan Engebretson
+Scarlet Ribbons|SSAA|Nigel Williams
+Scarlet Ribbons|SSAA|Renee Craig
+Scarlett Ribbons|TTBB|Roger Payne
+School Days|TTBB|Burt Szabo
+Scotch and Soda|SSAA|Jo Lund
+Scotch And Soda|TTBB|Steve Iannacchione
+Seaside Rendezvous|TTBB|Paul Hart
+Seasons of Love|SSAA|Gene Bender
+Seasons of Love|SSAA|Joey Minshall
+Seasons of Love|TTBB|Walter Latzko
+Seasons Of Love (from Rent)|SATB|Sylvia Posso
+Second Hand Rose|SSAA|Nancy Bergman
+Second Hand Rose|SSAA|Norma Andersen
+Second Hand Rose|SSAA|Unspecified
+Second Hand Rose/More to Be Pitied|SSAA|Nancy Bergman
+Second Hand Rose/She Is More to Be Pitied|SSAA|Nancy Bergman
+Secret Love|SATB|Jay Giallombardo
+Secret Love|SSAA|Jay Giallombardo
+Secret Love|TTBB|Rosling
+Secrets|SSAA|Sylvia Alsbury
+Seems Like Old Times|SSAA|Lou Perry
+Seize The Day|SSAA|June Dale
+Seize The Day|SSAA|Kirby Shaw
+Seize The Day|TTBB|Aaron Dale
+Seize The Day (From Newsies)|SSAA|Carole Prietto
+Send In the Clowns|SSAA|Kay Bromert
+Send In the Clowns|TTBB|Randy Rogers
+Send In The Clowns|TTBB|Jim Dillett
+Send Your Love|SSAA|Renee Craig
+Sentimental Gentleman from Georgia|SSAA|Ed Waesche
+Sentimental Gentleman From Georgia|TTBB|Ed Waesche
+Sentimental Journey|SSAA|Carolyn Healey
+Sentimental Journey|SSAA|Joanne Dockrell
+Sentimental Journey|SSAA|Joni Bescos
+Sentimental Journey|TTBB|Jason Ryner
+Sentimental Journey|TTBB|John Hohl
+Sentimental Journey|TTBB|Steve Jamison
+Sentimental Journey|TTBB|Unspecified
+Sentimental Journey|TTBB|Webb Comfort
+September Song|SSAA|Ruth Emley
+September Song|TTBB|Don Gray
+September Song|TTBB|Jon Nicholas
+September Song|TTBB|Renee Craig
+Service Five Medley (Armed Forces Medley)|TTBB|Fred King
+Sesame Street Medley|TTBB|Steve Tramack
+Sesame Street Theme|TTBB|Aaron Dale
+Seven Bridges Road|TTBB|The Eagles
+Seventy Six Trombones|SSAA|Nancy Bergman
+Seventy Six Trombones|TTBB|David Wright
+Seventy Six Trombones|TTBB|George Hulst
+Seventy Six Trombones|TTBB|John Peterson
+Seventy Six Trombones|TTBB|Kenosha
+Seventy Six Trombones|TTBB|Kevin Keller
+Seventy-Six Trombones|SSAA|Nancy Bergman
+Seventy-Six Trombones|TTBB|David Wright
+Seventy-Six Trombones|TTBB|Jay Giallombardo
+Seventy-Six Trombones|TTBB|Walter Latzko
+Sh Boom (Life Could be A Dream)|SSAA|Unspecified
+Sh-Boom|SSAA|Marsha Zwicker
+Sh-Boom|SSAA|Tedda Lippincott
+Sh-Boom|TTBB|Tedda Lippincott
+Sh-Boom (Life Could Be A Dream)|TTBB|Dave Briner
+Sh-Boom (Life Could Be A Dream)|TTBB|Webb Comfort
+Sh-Boom (Life Could Be A Dream) (YWIH)|SSAA|Tedda Lippincott
+Sh-Boom/Splish Splash|SSAA|Joni Bescos
+Shackles|SSAA|Lynnell Diamond
+Shakin' the Blues Away|TTBB|Clay Hine
+Shakin' The Blues Away|SSAA|Renee Craig
+Shakin' The Blues Away|TTBB|Steve Delehanty
+Shaking The Blues Away|SSAA|Steve Delehanty
+Shambala|SATB|Kirby Shaw
+Shambala|SSAA|Kirby Shaw
+Shanghai|SSAA|Nancy Bergman
+She Belongs To Me|TTBB|Jeremey Johnson
+She Didn't Say No|TTBB|Val Hicks
+She's Always A Woman To Me|TTBB|Zac Booles
+She's Called Nova Scotia|TTBB|Joe Liles
+She's Gonna Fly|SSAA|Michael Gellert
+She's Like The Swallow|TTBB|Steven Armstrong
+She's Out Of My Life|TTBB|David Harrington
+Shelter|SSAA|Glenda Lloyd
+Shenandoah|SATB|James Erb
+Shenandoah|SSAA|Burt Szabo
+Shenandoah|SSAA|Carolyn Johnson
+Shenandoah|SSAA|Michael Gellert
+Shenandoah|TTBB|Burt Szabo
+Shenandoah|TTBB|Don Gray
+Shenandoah|TTBB|Joe DeRosa
+Shenandoah|TTBB|Mike Taylor
+Shenandoah|TTBB|Rick Spencer
+Shenendoah|SSAA|Burt Szabo
+Shenendoah|TTBB|Burt Szabo
+Shenendoah|TTBB|Jay Giallombardo
+Shenendoah|TTBB|Joe DeRosa
+Shenendoah|TTBB|Unspecified
+Shepherds Farewell|SSAA|Unspecified
+Shepherds, Come Quick|TTBB|Mark Hale
+Shine|SSAA|Heather Lane
+Shine|SSAA|James Porter
+Shine|SSAA|Liz Garnett
+Shine|SSAA|Lorraine Rochefort
+Shine|TTBB|David Wright
+Shine Medley|TTBB|David Wright
+Shine On Harvest Moon|SSAA|Dot Short
+Shine On Me|TTBB|Floyd Connett
+Shine On Me|TTBB|Unspecified
+Shine On Your Shoes / Steppin' Out Medley|TTBB|Greg Volk
+Shine On, Harvest Moon|TTBB|Val Hicks and Earl Moon
+Shine On, Harvest Moon|TTBB|Val Hicks, Earl Moon
+Shine Your Light|SSAA|Nancy Faddegon
+Shipoopi|TTBB|Walter Latzko
+Shoo-Fly Pie and Apple Pan Dowdy|SSAA|Ruby Rhea
+Shoop Shoop Song ('It's In His Kiss')|SSAA|Lorraine Rochefort
+Short People|TTBB|Jim Henry
+Short People|TTBB|King's Singers
+Short People|TTBB|Unspecified
+Show Me Where the Good Times Are|TTBB|Dot Short and Gene Cokeroft
+Showbiz Medley|TTBB|Jay Giallombardo
+Shure They Called It Ireland|TTBB|Unspecified
+Side by Side|SSAA|Brent Graham
+Side by Side|SSAA|Lorraine Rochefort
+Side by Side|SSAA|Nancy Bergman
+Side By Side|SSAA|Bill Stauffer
+Side By Side|SSAA|David Harrington
+Side By Side|SSAA|Ruth Emley
+Side By Side|SSAA|Tom Gentry
+Side By Side|TTBB|Brent Graham
+Side By Side|TTBB|Buzz Haeger
+Side By Side|TTBB|Tom Gentry
+Side By Side Parody|TTBB|Unspecified
+Signed, Sealed, Delivered|SATB|Henrik Rosenberg
+Silent Night|SATB|Steve Plumb
+Silent Night|SSAA|Floyd Connett
+Silent Night|SSAA|Renee Craig
+Silent Night|TTBB|Aaron Dale
+Silent Night|TTBB|Barbershop Harmony Society
+Silent Night|TTBB|Jim Clancy
+Silent Night|TTBB|Steven Armstrong
+Silent Night|TTBB|Unspecified
+Silent Night, Holy Night|TTBB|Jon Nicholas
+Silent Night/It Came Upon a Midnight Clear|TTBB|Jim Clancy
+Silent Night/Night of Silence|SSAA|Brian Beck
+Silhouettes|SSAA|Tom Gentry
+Silhouettes|TTBB|Tom Gentry
+Silver Bells|SATB|Barbershop Harmony Society
+Silver Bells|SSAA|Louise Hamilton
+Silver Bells|TTBB|Barbershop Harmony Society
+Silver Bells|TTBB|Greg Lyne
+Silver Bells|TTBB|Unspecified
+Silver Threads Among The Gold|TTBB|Joe Liles
+Silvia|TTBB|David Zimmerman
+Simon & Garfunkel Montage|TTBB|Greg Volk
+Sinatra Medley|TTBB|Ed Waesche
+Since I Don't Have You|TTBB|Aaron Dale
+Since You've Been Gone|SSAA|Jen Miller Lee
+Since You've Been Gone|SSAA|Joey Minshall
+Sincere|TTBB|Jay Giallombardo
+Sincere|TTBB|Meredith Willson
+Sincere|TTBB|Phil Embury
+Sincere (The Music Man)|TTBB|Meredith Willson
+Sincere-It's You|TTBB|Walter Latzko
+Sing & Celebrate|SSAA|Sylvia Alsbury and Bev Sellers
+Sing A Christmas Carol|TTBB|Charlie Kinnison
+Sing Me A Baby Song|TTBB|Renee Craig
+Sing Me A Song About Ireland|SSAA|Joni Bescos
+Sing Me That Song Again|SSAA|Ed Waesche
+Sing Me That Song Again|TTBB|Ed Waesche
+Sing Me To Heaven|SATB|Daniel Gawthrop
+Sing Sing|SSAA|Joey Minshall
+Sing Sing Sing/It Don't Mean a Thing|TTBB|Tony Nasto
+Sing We Noel|SSAA|Brian Beck
+Sing We Noel|SSAA|Judy Vidal
+Sing We Noel|TTBB|Judy Vidal
+Sing You Sinners|SSAA|Sharon Holmes
+Sing Your Way Home|SSAA|Joseph M. Martin
+Singin' in the Bathtub|SSAA|Roger Payne
+Singin' In the Rain|SSAA|Marie Johnson
+Singin' In The Rain|SSAA|Jo Lund
+Singin' In The Rain|TTBB|David Wright
+Singin' In The Rain|TTBB|Jay Giallombardo
+Singin' In The Rain Medley Overture|TTBB|Mark Hale
+Singin's Great In The Sunshine State|TTBB|Burt Szabo
+Singing For You In That Barbershop Style|TTBB|Jon Nicholas
+Singing In The Bathtub|TTBB|Rog
+Singing My Troubles Away|TTBB|Jon Nicholas
+Singing The Blues|TTBB|Dennis Malone
+SINGING VALENTINE Package|TTBB|Barbershop Harmony Society
+Single Ladies (Beyonce)|SSAA|H Zimmerman
+Sir Duke|SSAA|Karen Proctor
+Sir Duke|TTBB|Rob Hopkins
+Sisters|SSAA|Tedda Lippincott
+Sisters Are Doing It For Themselves|SSAA|Ase Hagerman
+Sisters/Together Wherever We Go|SSAA|Dede Nibler
+Sit Down You're Rockin' the Boat|SSAA|David Wright
+Sit Down You're Rockin' The Boat|TTBB|David Wright
+Sit Down You're Rockin' The Boat|TTBB|David Wright, Steven Armstrong
+Sit Down You're Rocking The Boat|SSAA|Bev Sellers
+Sit Down, You're Rockin' The Boat|TTBB|David Wright
+Sittin' On Top Of The World|TTBB|Roger Payne
+Sixteen Tons|SSAA|Tedda Lippincott
+Sixteen Tons|TTBB|David Wright
+Sixteen Tons|TTBB|Don Fraser
+Sixteen Tons|TTBB|Jim Clancy
+Sixteen Tons|TTBB|John Hohl
+Skyfall|SSAA|Nick Wright
+Skyfall (Adele)|SSAA|Jonathan Sparks
+Skyfall 4-part|SSAA|Nick Wright
+Skylark|TTBB|Jon Nicholas
+Skylark|TTBB|Webb Comfort
+Slap That Bass|SSAA|Walter Latzko
+Slap That Bass|TTBB|Walter Latzko
+Sleeps Judea Fair|SSAA|Diane Clark
+Sleepy Time Gal|SSAA|Sylvia Alsbury
+Sleepy Time Gal|TTBB|Walter Latzko
+Sleigh Ride|SSAA|Joni Bescos
+Sleigh Ride|SSAA|Norma Andersen
+Sleigh Ride|SSAA|Tom Gentry
+Sleigh Ride|TTBB|Jay Giallombardo
+Sleigh Ride|TTBB|Tom Gentry
+Sleigh Ride|TTBB|Walter Latzko
+Sloop John B|TTBB|Aaron Dale
+Sloop John B|TTBB|Alan T Rowe
+Slow Boat to China|SSAA|Greg Backwell
+Slow Boat to China|SSAA|Sue Kegley
+Slow Rockin' Christmas|TTBB|Jon Nicholas
+Smile|SSAA|Carolyn Schmidt
+Smile|SSAA|Dot Calvin
+Smile|SSAA|Tom Gentry
+Smile|TTBB|Kevin Keller
+Smile|TTBB|Tom Gentry
+Smile Medley|SSAA|Clay Hine
+Smile Medley|TTBB|Clay Hine
+Smile Medley|TTBB|Ron Black
+Smile Medley|TTBB|Steve Delehanty, Ed Waesche
+Smile Medley|TTBB|Unspecified
+Smile Medley|TTBB|Vic Brimmacombe
+Smile Medley (A Smile will go a Long Long Way, Smile Darn ya Smile)|TTBB|Ed Waesche
+Smile Medley (Let A Smile/Smile, Darn Ya)|SSAA|Nancy Bergman
+Smile Medley (Powder Your Face/Smile Darn Ya)|SSAA|Clay Hine
+Smiles|TTBB|Dennis Driscoll
+Smilin' Medley|TTBB|Will Hamblet
+Smilin' Through|TTBB|Lou Perry
+Smoke Gets in Your Eyes|SATB|Brian Beck
+Smoke Gets in Your Eyes|TTBB|David Gillingham
+Smoke Gets in Your Eyes|TTBB|Rob Hopkins
+Smoke Gets In Your Eyes|TTBB|Brian Beck
+Smoke Gets In Your Eyes|TTBB|Joel T. Rutherford
+Snow Miser/Heat Miser|TTBB|Mark Jennings
+Snowfall|TTBB|Jason Smith
+So High, So Low|TTBB|Walter Latzko
+So In Love|TTBB|David Wright
+So Long Dearie|SSAA|Nancy Bergman
+So Long Dearie|SSAA|Renee Craig
+So Long Mother, Kiss Your Boy Goodbye|SSAA|Senter/Kraut
+So Long, Dearie|TTBB|Barbershop Harmony Society
+So Many Voices (Sing America's Song)|TTBB|Tom Gentry
+So Much In Love|SATB|David Harrington
+So Much In Love|TTBB|Unspecified
+So Much In Love mini|SSAA|David Harrington
+So Much In Love mini|TTBB|David Harrington
+Soft Shoe Song|SSAA|Leola Wright
+Softly (I Will Leave You)|SSAA|Nigel Williams
+Softly As I Leave You|TTBB|Terry Phillips
+Sold (At the Grundy County Auction)|TTBB|Aaron Dale
+Sold (The Grundy County Auction Incident)|SSAA|Aaron Dale
+Sold (The Grundy County Auction Incident)|TTBB|Aaron Dale
+Soliloquy|TTBB|David Wright
+Solitaire|SSAA|Tom Gentry
+Solitaire|TTBB|Tom Gentry
+Some Children See Him|TTBB|Brian Beck
+Some Enchanted Evening|SSAA|David Wright
+Some Enchanted Evening|TTBB|Steve Jamison
+Some Nights|SSAA|Kevin Keller
+Some Nights|TTBB|Tom Anderson
+Some Sunny Day|SSAA|Lynnell Diamond
+Somebody Done Somebody Wrong Song/Cheatin On Me|SSAA|Bev Sellers
+Somebody Else Is Taking My Place|TTBB|Roger Craig
+Somebody Knows|TTBB|David Wright
+Somebody Loves Me|SSAA|Clay Hine
+Somebody Loves Me|TTBB|Clay Hine
+Somebody Loves You|SSAA|Dot Short
+Somebody Stole My Gal|TTBB|Ed Waesche
+Somebody Stole My Gal / Five Foot Two (Medley)|TTBB|Ed Waesche
+Somebody Stole My Gal Medley|TTBB|Rae Jamieson
+Somebody That I Used To Know|SATB|H Zimmerman
+Somebody That I Used To Know|SSAA|H Zimmerman
+Somebody to Love|SSAA|Aaron Dale
+Somebody to Love|SSAA|June Dale
+Somebody to Love|SSAA|Liz Garnett
+Somebody To Love|SATB|Adam Anders, Tim Davis, Roger Emerson
+Somebody To Love|SATB|Queen
+Somebody To Love|SSAA|Joe Spiecker
+Somebody To Love|SSAA|Kevin Keller
+Somebody To Love|TTBB|Jay Giallombardo
+Somebody To Love|TTBB|Kevin Keller
+Somebody's Talkin' 'Bout Jesus|TTBB|Jon Nicholas
+Someday My Prince Will Come|SSAA|Renee Craig
+Someday You'll Want Me to Want You|SSAA|Vicki Uhr
+Someone Like You|SSAA|Alex Kaiserman
+Someone Like You|SSAA|Michael Gellert
+Someone Like You|SSAA|Nancy Bergman
+Someone Sorry Medley (I Had Someone Else/Who's Sorry Now)|SSAA|Tom Gentry
+Someone to Watch Over Me|SSAA|Carolyn Schmidt
+Someone to Watch Over Me|SSAA|Muriel Berg
+Someone to Watch Over Me|SSAA|Tedda Lippincott
+Someone to Watch Over Me|TTBB|Jay Giallombardo
+Someone To Watch Over Me (Linda Ronstadt)|TTBB|Steve Tramack
+Someone's Always After My Baby|TTBB|Jon Nicholas
+Someone'S Stuck In The Chimney|SSAA|Lorraine Rochefort
+Somethin' About Ya|SSAA|Joe Liles
+Somethin' About Ya|TTBB|Joe Liles
+Something|SSAA|Jim Kahlke
+Something|TTBB|George Avener
+Something|TTBB|Jim Kahlke
+Something|TTBB|Steven Armstrong
+Something|TTBB|Unspecified
+Something (Beatles)|TTBB|Jim Kahlke
+Something (In The Way He Moves)|SSAA|George Avener
+Something About a Soldier|SSAA|Jay Giallombardo
+Something Big|TTBB|Adam Reimnitz
+Something in the Water|SSAA|Michael Gellert
+Something Inside So Strong|SSAA|Tom Gentry
+Something Inside So Strong|TTBB|Tom Gentry
+Something Inside So Strong|TTBB|Tom Gentry / tag - Dale Kynaston
+Something To Write The Folks About|TTBB|Dennis Driscoll
+Something's Comin'|SSAA|Bev Sellers
+Something's Comin'-Tonight Medley|TTBB|Jay Giallombardo
+Something's Coming|SSAA|Bev Sellers
+Something's Coming|SSAA|David Wright
+Something's Coming|TTBB|David Wright
+Something's Gotta Give|TTBB|David Briner
+Sometime|TTBB|Jon Nicholas
+Somewhere|TTBB|Fred King
+Somewhere (West Side Story)|SSAA|Gina Ogden
+Somewhere (West Side Story)|SSAA|Tedda Lippincott
+Somewhere [A Broken Heart]|TTBB|Wayne Grimmer
+Somewhere My Love|TTBB|Aaron Dale
+Somewhere Only We Know|SSAA|Tom West
+Somewhere Only We Know (Keene)|SSAA|Peter Nugent
+Somewhere Out There|SSAA|Joey Minshall
+Somewhere Out There|SSAA|Marge Bailey
+Somewhere Out There|SSAA|Roger Von Haden
+Somewhere Over the Rainbow|SSAA|Andy Beck
+Somewhere Over the Rainbow|SSAA|Joni Bescos
+Somewhere Over the Rainbow|TTBB|Ed Waesche
+Song for Ireland|SSAA|Liz Garnett
+Song For The Little Guy, A (version 2)|TTBB|David Wright, Steven Armstrong
+Song For The Mira|TTBB|Roy Keys, Bob Pyper, Doug McLellan
+Song Of America|TTBB|Jay Giallombardo
+Song Of Blessing|TTBB|Brian Beck
+Song'S Gotta Come From The Heart|SSAA|Carolyn Healey
+Songbird|SSAA|Sharon Holmes
+Songbird|TTBB|Deke Sharon
+Songs For Hanukkah|SSAA|Anna Maria Parker
+Songs of Christmas|SSAA|Jim Clancy
+Songs Of Christmas|TTBB|Jim Clancy
+Sonny Boy|SSAA|Nancy Bergman
+Soon Ah Will Be Done|TTBB|William L. Dawson
+Sooner Or Later-Ask Me Medley|TTBB|Alan Gordon
+Sophisticated Lady|TTBB|Stash Rossi
+SOS|SSAA|Chris MacMartin
+Sound Celebration|SSAA|Tom Gentry
+Sound Celebration|TTBB|Tom Gentry
+Sound of Music Medley|SSAA|Unspecified
+Sound Of Music Medley|SSAA|Nancy Bergman
+Sound Of Music Medley|TTBB|Joe Liles
+South America, Take It Away|SSAA|Carolyn Schmidt
+South Pacific Medley 1|TTBB|Jay Giallombardo
+South Pacific Medley 2|TTBB|Jay Giallombardo
+South Rampart Street Parade|SSAA|Brian Beck
+South Rampart Street Parade|SSAA|David Wright
+South Rampart Street Parade|TTBB|David Wright
+Southern Nights|SSAA|Tedda Lippincott
+Spiderman Theme Song|TTBB|Unspecified
+Spiritual Medley|TTBB|The Imperials
+Spiritual Medley (Nobody Knows the trouble/Wade in the Water/Climbin Up the Mountain)|TTBB|Jay Giallombardo
+Spoonful Of Sugar|TTBB|Russ Foris
+Spread A Little Happiness|SSAA|Joan Adler
+Spreadin' Rhythm Around|SSAA|Tom Gentry
+Spreadin' Rhythm Around|TTBB|Tom Gentry
+Spring Can Really Hang You Up The Most (modified)|SSAA|Brian Beck and Mike Barrett
+Squeeze Box|TTBB|Steve Delehanty
+St Louis Blues|SSAA|Nancy Bergman
+St. Louis Blues|SSAA|Jim Massey
+St. Louis Blues|SSAA|Nancy Bergman
+St. Patrick's Day Medley|TTBB|Steve Jamison
+St. Pattie's Day Parade Medley|TTBB|Unspecified
+Stairway to Heaven|SSAA|Lorraine Rochefort
+Stand By Me|SSAA|Lorraine Rochefort
+Stand By Me|TTBB|Deke Sharon
+Stand By Me|TTBB|Steve Delehanty
+Stand By Your Man|SSAA|Tedda Lippincott
+Standing In The Need Of Prayer|TTBB|Burt Szabo
+Standing On The Corner|TTBB|Burt Szabo
+Standing On The Corner|TTBB|Walter Latzko
+Standing Outside the Fire|SSAA|Joey Minshall
+Star|SSAA|Steve Delehanty
+Star Spangled Banner|SSAA|Jim Clancy
+Star Spangled Banner|SSAA|Joni Bescos
+Star Spangled Banner|SSAA|Unspecified
+Star Spangled Banner|TTBB|Jim Clancy
+Star Spangled Banner|TTBB|Val Hicks
+Star Spangled Banner Medley|TTBB|Clay Hine
+Star Wars (John Williams is the Man)|TTBB|Mister Tim
+Star Wars (John Williams Is The Man)|TTBB|Moosebutter
+Star-Spangled Banner|SSAA|Joni Bescos
+Star-Spangled Banner|TTBB|Jim Clancy
+Star-Spangled Banner|TTBB|Val Hicks
+Stardust|TTBB|Walter Latzko
+Stars and Stripes Forever|SSAA|David Wright
+Stars and Stripes Forever|TTBB|David Wright
+Stars Fell On Alabama|SSAA|David Wright
+Stars Fell On Alabama|SSAA|Mary Coffman
+Stars Fell On Alabama|TTBB|David Wright
+Stars Over Texas|TTBB|Steve Jamison
+Stay With Me|SATB|Henrik Rosenberg
+Stay With Me|TTBB|Val Hicks, Shaun Agnew
+Steal Away|SSAA|David Wright
+Steal Away|TTBB|David Wright
+Steam Heat|SSAA|Anita Barzilla
+Steam Heat|SSAA|Bev Sellers
+Stella by Starlight|TTBB|Jeremey Johnson
+Step in Time|TTBB|Kevin Keller
+Step In Time|TTBB|David Wright
+Step To The Rear|TTBB|Jim Clancy
+Step to the Rear/Hey, Look Me Over Medley|SSAA|Joe Liles
+Step to the Rear/See Me Now Medley|SSAA|Joe Liles
+Steppin' Out with My Baby|TTBB|Clay Hine
+Steppin' Out With My Baby|SSAA|Dot Short
+Steppin' Out With My Baby|SSAA|Mark Hale
+Steppin' Out With My Baby|SSAA|Nancy Bergman
+Steppin' Out With My Baby|SSAA|Sylvia Alsbury
+Steppin' Out With My Baby|TTBB|Rob Hopkins
+Steppin' Out-Puttin' On The Ritz|TTBB|Darin Drown
+Steppin' Out/Every Body Loves My Baby Medley|TTBB|Ed Waesche
+Stepsisters' Lament|SSAA|Lynnell Diamond
+Still, Still, Still|SSAA|Sharon Holmes
+Stompin' at the Savoy|TTBB|Bob O'Connell
+Stompin' At The Savoy|TTBB|Kevin Keller
+Stop Callin' Me Baby|SSAA|Lynnell Diamond
+Stormy Weather|SSAA|Aaron Dale
+Stormy Weather|SSAA|Bev Sellers
+Stormy Weather|SSAA|Tedda Lippincott
+Stormy Weather|TTBB|Aaron Dale
+Stormy Weather|TTBB|Jay Giallombardo
+Story of the Rose|TTBB|Brian Beck
+Story of the Rose (Heart of My Heart)|TTBB|Brent Graham
+Stout-Hearted Men|TTBB|Dick Stuart
+Straighten Up and Fly Right|SSAA|Brian Beck
+Straighten Up and Fly Right|SSAA|Liz Garnett
+Straighten Up and Fly Right|SSAA|Mary Coffman
+Straighten Up And Fly Right|TTBB|Greg Volk
+Stranger In Paradise|TTBB|Mark Hale
+Strangers|SSAA|Bergman/Oakley
+Strangers|SSAA|Nancy Bergman
+Stray Cat Strut|SSAA|Bev Sellers
+Stray Cat Strut|SSAA|Sharon Carlson
+Strike Up the Band|SSAA|George Avener
+Strike Up The Band / Everybody Step Medley|SSAA|Aaron Dale
+Strike Up The Band / Everybody Step Medley|TTBB|Aaron Dale
+Strike Up the Band Medley|TTBB|David Harrington
+Strike Up the Band/Alexander's Ragtime Band Medley|TTBB|David Harrington
+Stuff Like That There|SSAA|Dave Briner
+Suddenly There's A Valley|SSAA|Bergman/Wright
+Sue Me|SATB|Don Gray
+Sugar (That Sugar Baby Of Mine)|TTBB|Adam Reimnitz
+Sugar Blues|SSAA|Anna Maria Parker
+Sugar Medley|SSAA|Nancy Bergman
+Sugar Medley|TTBB|Aaron Dale
+Sugar Medley|TTBB|Jay Giallombardo
+Sugar Medley|TTBB|Walter Latzko
+Sugarcane Jubilee|TTBB|Buzz Haeger
+Sugarcane Jubilee|TTBB|David Wright
+Sugartime|SSAA|Tom Gentry
+Summer Nights|SATB|Liz Garnett
+Summer Sounds|SSAA|Mary Grace Lodico
+Summer Sounds|TTBB|Val Hicks, Rob Hopkins
+Summertime|SSAA|Avis Fellows
+Summertime|SSAA|Jan-Ake Westin
+Summertime|SSAA|Nancy Bergman
+Summertime|SSAA|Renee Craig
+Summertime|TTBB|Hugh C. Hodgson
+Summertime|TTBB|Steve Jamison
+Sunday|TTBB|John Hohl
+Sunday Kind of Love|TTBB|Adam Reimnitz
+Sunny (SATB)|SATB|Dave King
+Sunny Side Medley|SSAA|Avis Fellows
+Sunny Side of the Street|SSAA|Nancy Bergman
+Sunny Side Up|TTBB|Ed Waesche
+Sunnyside Up|SSAA|Nancy Bergman
+Sunnyside Up Medley|SSAA|Nancy Bergman
+Sunrise, Sunset|SSAA|George Avener
+Sunrise, Sunset|SSAA|Nancy Bergman
+Sunrise, Sunset|TTBB|Unspecified
+Sunshine of Your Smile|TTBB|Tom Gentry
+Super Star Medley|SSAA|June Berg
+Super Trouper|SSAA|Elaine Gain
+Supercalifragilisticexpialidocious/Step In Time|SSAA|June Dale
+Sure On This Shining Night|TTBB|Jay Giallombardo
+Surfer Girl|TTBB|Aaron Dale
+Surfin' Safari with a hungry bass singer|TTBB|Jon Nicholas
+Surfin' USA Medley|SSAA|Carolyn Schmidt
+Surfin' With the Beach Boys|SSAA|Lorraine Rochefort
+Surrey With A Fringe On Top|TTBB|Don Gray
+Swanee|SSAA|Ed Waesche
+Swanee|SSAA|Ed Waesche/Joe Liles
+Swanee|TTBB|Ed Waesche
+Swanee|TTBB|Scott Werner
+Swanee (Prestige Quartet Style Version)|TTBB|Ed Waesche
+Sway|SSAA|Liz Garnet
+Sway|TTBB|Ken Hatton
+Sway (Quien Sera)|SSAA|Neil Watkins
+Sway (YWIH)|SSAA|Larry Wright
+Swedish House Mafia Medley|SATB|Emmanuel Roll
+Sweet Adeline|SSAA|Jay Giallombardo
+Sweet Adeline|TTBB|Dick Johnson
+Sweet Adeline|TTBB|Jay Giallombardo
+Sweet Adeline [Doo-Wop]|TTBB|Will Hamblet
+Sweet and Lovely|SSAA|Mac Huff
+Sweet and Lovely|TTBB|Mac Huff
+Sweet Beulah Land|TTBB|Jon Nicholas
+Sweet Caroline|SSAA|Lorraine Rochefort
+Sweet Caroline|TTBB|Adam Bock
+Sweet Caroline|TTBB|Don Gray
+Sweet Caroline|TTBB|Dylan Oxford
+Sweet Dreams|SSAA|Deke Sharon
+Sweet Dreams|SSAA|YWIH
+Sweet Georgia Brown|SSAA|Carolyn Schmidt
+Sweet Georgia Brown|SSAA|George Avener
+Sweet Georgia Brown|SSAA|Jim Massey
+Sweet Georgia Brown|SSAA|Joey Minshall
+Sweet Georgia Brown|SSAA|Joni Bescos
+Sweet Georgia Brown|SSAA|Mary Coffman
+Sweet Georgia Brown|TTBB|Aaron Dale
+Sweet Georgia Brown|TTBB|Clay Hine
+Sweet Georgia Brown|TTBB|Ed Waesche
+Sweet Heaven Medley (Sweet Heaven/When My Baby Smiles at Me)|TTBB|Adam Reimnitz
+Sweet Hour of Prayer|SSAA|Jim Clancy
+Sweet Hour of Prayer|TTBB|Jim Clancy
+Sweet Hour Of Prayer|TTBB|Joe Johnson
+Sweet Little Girl|TTBB|Kyle and Kohl Kitzmiller
+Sweet Little Jesus Boy|TTBB|David Wright
+Sweet Lorraine|TTBB|David Wright
+Sweet Lucy Brown|TTBB|Adam Reimnitz
+Sweet Mae|TTBB|Bob Jones
+Sweet Pea|TTBB|Aaron Dale
+Sweet Sugar Baby Medley|TTBB|David Wright
+Sweet Sweet Spirit|SSAA|The Idea of North
+Sweet Talkin' Guy|SSAA|Linda Edmondson
+Sweet, Sweet Roses Of Morn|TTBB|Floyd Connett
+Sweetheart of Sigma Chi|TTBB|Barbershop Harmony Society
+Swing Down Chario|SSAA|Traditional
+Swing Down Chariot|SSAA|Barbershop Harmony Society
+Swing Down Chariot|SSAA|Sharon Holmes
+Swing Down Chariot|SSAA|Sweet Adelines International
+Swing Down Chariot|SSAA|Vagabonds
+Swing Down Chariot|TTBB|Barbershop Harmony Society
+Swing Down Chariot|TTBB|Unspecified
+Swing Down Chariot|TTBB|Vagabonds
+Swing Low, Sweet Chariot|TTBB|Unspecified
+Swing Low, Sweet Chariot Medley|SSAA|Nancy Bergman
+Swing Medley|SSAA|Dave Briner
+Swing Medley|SSAA|Walter Latzko
+Swing Medley - Somebody Else/Slow Boat to China|SSAA|Dave Briner
+Swingin' on a Star|TTBB|Clay Hine
+Swingin' On a Star|SSAA|Walter Latzko
+Swingin' On A Star|SSAA|Bev Sellers
+Swingin' On A Star|SSAA|Tom Gentry
+Swingin' On A Star|TTBB|Tom Gentry
+Swinging on a Star|SSAA|Nancy Bergman
+Swinging On a Star|TTBB|David Harrington
+Swinging On A Star|TTBB|Tom Gentry
+Swingle Song|SATB|Darmon Meader
+Taint No Sin|SSAA|Penketh
+Take A Chance|SSAA|Joey Minshall
+Take A Chance on Me|SSAA|Joey Minshall
+Take a Chance on Me (4 part)|SSAA|Joey Minshall
+Take A Chance on Me (7 part)|SSAA|Joey Minshall
+Take Good Care of My Baby/Bye Bye Love Medley|TTBB|Zac Booles
+Take Me Back to the 1920's|SSAA|Gwen Schweitzer
+Take Me Home, Country Roads|SSAA|Sonny Steffan
+Take Me Home, Country Roads|TTBB|Renee Craig
+Take Me Out to the Ball Game|SSAA|Anna Maria Parker
+Take Me Out to the Ball Game|TTBB|Unspecified
+Take Me Out to the Ballgame|SSAA|Nancy Bergman
+Take Me To Exotic Lands|TTBB|Unspecified
+Take Me to the Land of Jazz|SSAA|Pete Wendling
+Take Me To The Land of Jazz|SSAA|Ann Minihane
+Take Me To The Land of Jazz|SSAA|Mary Coffman
+Take Me To The Land of Jazz|SSAA|Molly Rowland
+Take Me To The Land Of Jazz|TTBB|Ed Waesche
+Take Me To The Land Of Jazz|TTBB|Rob Campbell
+Take The 'A' Train|TTBB|Joe Johnson
+Take These Wings|SSAA|Vicki Uhr
+Take Your Girlie To The Movies|TTBB|Burt Szabo
+Take Your Girlie to the Movies!|SSAA|Nancy Bergman
+Takin' A Chance|SSAA|Dot Calvin
+Takin' a Chance on Love|TTBB|Jay Giallombardo
+Taking a Chance on Love|SSAA|Ed Waesche
+Taking a Chance on Love|TTBB|Jay Giallombardo
+Taking A Chance on Love|SSAA|Avis Fellows
+Taking A Chance on Love|SSAA|Jay Giallombardo
+Taking A Chance on Love|SSAA|Ruby Rhea
+Taking A Chance On Love|SSAA|Ann Minihane
+Taking A Chance On Love|TTBB|Ed Waesche
+Taking A Chance On Love|TTBB|Walter Latzko
+Taking Care of Business|SSAA|Corinna Garriock
+Talk to the Animals|TTBB|Al Parker
+Tangerine|SSAA|Joey Minshall
+Tangerine|TTBB|Mark Hale
+Taps|TTBB|R. Partin
+Taxes|TTBB|Edward Berg
+Tea For Two|SSAA|Lynnell Diamond
+Tea For Two|TTBB|Mark Hale
+Teach Everybody To Sing|TTBB|Joe Liles
+Teach The Children To Sing|TTBB|Joe Liles
+Tears For Souvenirs|SSAA|Nancy Bergman
+Tears In Heaven|SSAA|Tedda Lippincott
+Tears In Heaven|TTBB|Nick Schurmann
+Tears In Heaven|TTBB|Steve Delehanty
+Teddy Bear|TTBB|Aaron Dale
+Teddy Bear|TTBB|Will Hamblet
+Teddy Bears' Picnic|SSAA|Joey Minshall
+Tell Me Why (Parody)|TTBB|Burt Szabo
+Tell My Father|TTBB|Tom Gentry
+Ten Feet Off the Ground|SSAA|Barbara Bianchi
+Ten Feet Off the Ground|SSAA|Vicki Uhr
+Ten Feet Off The Ground|TTBB|Val Hicks
+Tenderly|TTBB|Jon Nicholas
+Tenebrae Factae Sunt|TTBB|G.P. Palestrina
+Tennessee Christmas|SSAA|June Berg
+Tennessee Christmas|TTBB|J Stanbery
+Tennessee Waltz|SSAA|Aaron Dale
+Tennessee Waltz|SSAA|Linda Masterson
+Tennessee Waltz|TTBB|Aaron Dale
+Testify To Love|SSAA|Avis Fellows
+Texas Medley|SATB|Brian Beck
+Texas Medley|TTBB|Jim Clancy
+Text Me Merry Christmas|SATB|Henrik Rosenberg
+Text Me Merry Christmas|TTBB|Adam Scott
+Thank God for Kids|TTBB|Dick Carr
+Thank You Dear Lord For Music|SSAA|Mary Coffman
+Thank You For Being A Friend|SSAA|Tedda Lippincott
+Thank You For Being A Friend (8 parts, chorus and quartet solo)|TTBB|Zac Booles
+Thank You for the Music|SSAA|Larry Wright
+Thank You For the Music|SSAA|Barbara McNeill
+Thank You For the Music|SSAA|Carolyn Healey
+Thank You For the Music|SSAA|Tedda Lippincott
+Thank You For the Music|SSAA|Tom Gentry
+Thank You For the Music|SSAA|Unspecified
+Thank You For The Music|SSAA|Nathan Peplinski
+Thank You For The Music|TTBB|Kirk Young
+Thank You For The Music|TTBB|Tom Gentry
+Thank You Lord|TTBB|Bob Dowma
+Thank You Very Much|SSAA|Suzy Lobaugh
+Thank You Very Much|TTBB|Unspecified
+Thank You World|SSAA|Charlene Yazurlo
+Thank You World|SSAA|Joni Bescos
+Thank You World|SSAA|Kraft/Debruycker
+Thank You, Dear Lord, For Music|SSAA|Mary Coffman
+Thank You, Lord|TTBB|Fred King
+Thankful|SATB|Gary Lewis
+Thanks for the Memory|TTBB|Chuck Brooks
+Thanks For The Memory|TTBB|Mel Knight
+That Certain Party|SSAA|Diane Clark
+That Girl Could Kiss!|TTBB|Jon Nicholas
+That Great Come and Get It Day|SSAA|Jarmela Speta
+That Lonesome Road|SATB|Simon Carrington
+That Lonesome Road|SSAA|Steve Jamison
+That Lonesome Road|TTBB|Simon Carrington
+That Lonesome Road (James Taylor)|SATB|Simon Carrington
+That Lonesome Road (SATB)|SATB|Simon Carrington
+That Lucky Old Sun|TTBB|David Wright
+That Lucky Old Sun|TTBB|Roy Keys
+That Lucky Old Sun|TTBB|Walter Latzko
+That Man (Caro Emerald) A Cappella|SSAA|Peter Nugent
+That Man (Caro Emerald) Backing Track|SSAA|Hans Reintjes
+That Old Black Magic|SSAA|June Berg
+That Old Black Magic|SSAA|June Dale
+That Old Black Magic|TTBB|Bill Wyatt
+That Old Black Magic|TTBB|Bob Wyatt
+That Old Black Magic|TTBB|Suntones
+That Old Black Magic|TTBB|William Wyatt
+That Old Boar Pet of Mine|TTBB|Unspecified
+That Old Feeling|SSAA|Ann Minihane
+That Old Feeling|SSAA|Dot Calvin
+That Old Feeling|SSAA|Nancy Bergman
+That Old Feeling|SSAA|Unspecified
+That Old Feeling|TTBB|David Wright
+That Old Gang of Mine|SSAA|Nancy Bergman
+That Old Quartet of Mine|SSAA|Joni Bescos
+That Old Quartet of Mine|SSAA|Lou Perry
+That Old Quartet of Mine|TTBB|Lou Perry
+That Railroad Rag|TTBB|Kirk Roose
+That Song Is Driving Me Crazy|SSAA|Bev Sellers
+That Summer When We Were Young|SSAA|Val Hicks
+That Summer When We Were Young|TTBB|Val Hicks
+That Tumble Down Shack In Athlone|TTBB|Brent Graham
+That Tumble-down Shack in Athlone|SSAA|Joni Bescos
+That Tumble-down Shack in Athlone|SSAA|Renee Craig
+That Tumble-Down Shack In Athlone|SSAA|Joe Liles
+That Wonderful Mother of Mine|SSAA|Nancy Bergman
+That Wonderful Mother Of Mine|TTBB|Jim Clancy
+That'll Be the Day|SSAA|Tom Gentry
+That'll Be The Day|SSAA|Carole Prietto
+That'll Be The Day|TTBB|Tom Gentry
+That's A Plenty|TTBB|Chris Arnold
+That's A Plenty|TTBB|Greg Volk
+That's All|SSAA|Nancy Bergman
+That's All|TTBB|Joe Johnson
+That's Amore|SSAA|Tedda Lippincott
+That's An Irish Lullaby|SSAA|Ed Waesche
+That's An Irish Lullaby|TTBB|Ed Waesche
+That's An Irish Lullabye|SSAA|Nancy Bergman
+That's Christmas to Me|SSAA|Dawn Haggerty
+That's Entertainment|SSAA|Renee Craig
+That's Entertainment|TTBB|Ray Danley
+That's Entertainment|TTBB|Unspecified
+That's How Rhythm Was Born|TTBB|David Wright
+That's How The Yodel Was Born|TTBB|Jon Nicholas
+That's How You Jazz & The Jam Medley|SSAA|Jo Lund
+That's How You Jazz Medley|SSAA|Jo Lund
+That's Life|SSAA|Barbershop Harmony Society
+That's Life|SSAA|David Harrington
+That's Life|SSAA|Mo Rector
+That's Life|SSAA|Steve Wolf
+That's Life|TTBB|Barbershop Harmony Society
+That's Life|TTBB|David Harrington
+That's Life|TTBB|Kevin Keller
+That's Life|TTBB|Mo Rector, Steve Tramack
+That's Life|TTBB|Roger Payne
+That's My Weakness Now|SSAA|Norma Andersen
+That's My Weakness Now / That Certain Party|TTBB|Tom Gentry
+That's My Weakness Now/That Certain Party|SSAA|Tom Gentry
+That's Someone You Never Forget|TTBB|Jon Nicholas
+That's What Dreams Are For|TTBB|Joe Liles
+That's What Friends Are For|SSAA|Bev Sellers
+That's What I Call A Pal|TTBB|Ed Waesche
+The 12 Days After Christmas|TTBB|Dennis Driscoll
+The 20s Dance Medley|TTBB|Ray Danley
+The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Don Gray
+The Ballad Of Springhill|TTBB|Steve Tramack
+The Banana Boat Song|TTBB|Don Gray
+The Band Played On|SSAA|Renee Craig
+The Band Played On|TTBB|Rob Hopkins
+The Band Played On|TTBB|Yesteryear
+The Barbershop Strut|SSAA|Earl Moon
+The Barbershop Strut|TTBB|Earl Moon
+The Bare Necessities|SSAA|Carolyn Healey
+The Bare Necessities|TTBB|Bill Eberius
+The Bare Necessities|TTBB|Don Rose
+The Baritone Blues|SSAA|Joe Liles
+The Baritone Blues|TTBB|Larry Bean
+The Baritone Blues|TTBB|The Management
+The Best Is Yet To Come|TTBB|Brent Graham
+The Best Of Doo Wop|TTBB|Unspecified
+The Best Things Happen While You're Dancing(Steve Tra|TTBB|Steve Tramack
+The Best Things In Life Are Free|TTBB|Marie Johnson
+The Big Brass Band From Brazil|TTBB|Dick Floersheimer
+The Birth of the Blues|SSAA|Carolyn Schmidt
+The Birth of the Blues|TTBB|David Wright
+The Birth of the Blues|TTBB|Tony Searle
+The Birth Of The Blues|TTBB|Buzz Haeger
+The Birth Of The Blues|TTBB|Don Gray
+The Birth Of The Blues|TTBB|Steve Jamison
+The Boy From New York City|SSAA|Barbara McNeill
+The Boy From New York City|SSAA|Tedda Lippincott
+The Candy Man|TTBB|Joe Johnson
+The Chipmunks Christmas Song|TTBB|The Grand Tradition/Reveille
+The Chordbuster March|TTBB|WA Wyatt
+The Chordbuster's March|SSAA|Joe Liles
+The Christmas Blues|TTBB|Steven Armstrong
+The Christmas Rap|SSAA|Judy Vidal
+The Christmas Song|SSAA|Dot Calvin
+The Christmas Song|SSAA|Joe Liles
+The Christmas Song|SSAA|R. Emley
+The Christmas Song|SSAA|Ruth Emley
+The Christmas Song|SSAA|Susan Kegley
+The Christmas Song|TTBB|Joe Liles
+The Christmas Song|TTBB|Pete Rupay
+The Christmas Waltz|SSAA|Anastasio Rossi
+The Christmas Waltz|SSAA|Jo Lund
+The Christmas Waltz|TTBB|Joe Johnson
+The Church Bells are Ringing For Mary|SSAA|Barbara Bianchi
+The Climb|SSAA|Carole Prietto
+The Climb|SSAA|June Dale
+The Climb/Go The Distance|SSAA|Nick Girard
+The Curtain Falls|SSAA|Tom Gentry
+The Curtain Falls|TTBB|Will Hamblet
+The Dance|SSAA|Tedda Lippincott
+The Darktown Strutters' Ball|TTBB|Ed Waesche
+The Darktown Strutters' Ball|TTBB|Steve Jamison
+The Day that the Circus Left Town|TTBB|Fred King
+The Dinosaur Strut|TTBB|Unspecified
+The Dream Is Carried On|TTBB|Jay Giallombardo
+The End Of The Road|TTBB|John Hohl
+The Entertainer|SSAA|Anna Maria Parker
+The First Noel|SSAA|David Harrington
+The First Noel|SSAA|Nancy Bergman
+The First Noel|TTBB|Joe Johnson
+The Fool On The Hill|TTBB|Jon Nicholas
+The Gambler|SSAA|Bev Sellers
+The Gift Carol|TTBB|Greg Lyne
+The Gift To Be Simple|TTBB|Bob Chilcott
+The Girl From Ipanema|SATB|Joanna Forbes
+The Girl From Ipanema|SSAA|Gloria Kuchenbecker
+The Girl that I Marry|TTBB|Unspecified
+The Glendy Burke|TTBB|Bryan Olson
+The Glory of Love|SSAA|Region 21
+The Glory of Love|SSAA|Region 21 Arr. Dev. Program
+The Glory of Love|TTBB|Clay Hine
+The Gloryland Way|TTBB|Mo Rector
+The Gold-Minin' Gang|SSAA|June Dale
+The Greatest Barbershop Chart|TTBB|Adam Reimnitz
+The Headless Horseman|TTBB|Aaron Dale
+The Headless Horseman|TTBB|David Wright
+The Heather On The Hill|TTBB|Bob Bohn
+The Holly And The Ivy|TTBB|Darin Drown
+The House I Live In|SSAA|Marge Bailey
+The House I Live In|SSAA|Sandy Sharpe
+The Impossible Dream|TTBB|Bob Bohn
+The Impossible Dream|TTBB|David Wright
+The Impossible Dream|TTBB|Jay Giallombardo
+The Impossible Dream|TTBB|Pete Rupay
+The Impossible Dream (The Quest)|TTBB|Ed Waesche
+The Infant King|TTBB|Steven Armstrong
+The Isle of Inisfree|SSAA|Tom Gentry
+The Jazz Me Blues|SSAA|Carolyn Schmidt
+The Joint Is Jumpin'|SSAA|Greg Volk
+The Joint Is Jumpin'|SSAA|Lorraine Rochefort
+The Joint Is Jumpin'|SSAA|Nancy Bergman
+The Jumpin' Jive|TTBB|Aaron Dale
+The Kazoo Concerto|TTBB|Tom Gentry
+The King Medley|TTBB|Webb Comfort
+The Lady Down the Hall|SSAA|Michael Gellert
+The Last Time I Saw Henry|TTBB|Barbershop Harmony Society
+The Letter|TTBB|Jon Nicholas
+The Letter (Women)|SSAA|Jon Nicholas
+The Lion Sleeps Tonight|SSAA|Tedda Lippincott
+The Lion Sleeps Tonight|TTBB|Jon Nicholas
+The Lion Sleeps Tonight|TTBB|Scott Turnbull
+The Lion Sleeps Tonight|TTBB|Unspecified
+The Little Boy|TTBB|Tom Gentry
+The Little Drummer Boy|SSAA|Tedda Lippincott
+The Little Drummer Boy|TTBB|David Wright
+The Little Drummer Boy|TTBB|Jon Nicholas
+The Little Drummer Boy|TTBB|Tracy Shirk
+The Little Girl|SSAA|Tom Gentry
+The Loco-Motion|SSAA|Joey Minshall
+The Long Day Closes|TTBB|Arthur Sullivan
+The Longest Time|SSAA|Carolyn Schmidt
+The Longest Time|TTBB|Darwin Scheel
+The Longest Time|TTBB|Tom Gentry
+The Lord Bless You and Keep You|SSAA|Avis Fellows
+The Lord Bless You and Keep You|SSAA|Fellows
+The Lord's Prayer|SSAA|Anna Maria Parker
+The Lord's Prayer|SSAA|Jim Clancy
+The Lord's Prayer|SSAA|June Dale
+The Lord's Prayer|SSAA|Kay Bromert
+The Lord's Prayer|SSAA|Nigel Williams
+The Lord's Prayer|TTBB|Barbershop Harmony Society
+The Lord's Prayer|TTBB|Jim Clancy
+The Lord's Prayer|TTBB|Joe Liles
+The Lords prayer|TTBB|Tom Gentry and Joe Liles
+The Love Bug|TTBB|Kirk Young
+The Lunatic's Lullaby|TTBB|Tom Gentry
+The Man With the Bag|SSAA|Marge Bailey
+The Man With the Bag|SSAA|Nancy Bergman
+The Man With The Bag|SSAA|Lorraine Rochefort
+The Man With The Bag|TTBB|Jon Nicholas
+The Man With The Bag|TTBB|Tom Gentry and Lorraine Rochefort
+The Mansions Of The Lord|TTBB|Jon Nicholas
+The Maple Leaf Forever|TTBB|Chris Arnold
+The Mardi Gras March|SATB|Aaron Dale
+The Mardi Gras March|SSAA|Aaron Dale
+The Mardi Gras March|TTBB|Aaron Dale
+The Marvelous Toy|SSAA|Twardowsky
+The Masquerade is Over|SSAA|Tedda Lippincott
+The Masquerade Is Over|SSAA|Ed Waesche
+The Masquerade is Over (as performed by Hillfoot Harmony)|SSAA|Arr Tedda Lippincot
+The Mississippi Squirrel Revival|TTBB|Archie Steen
+The Moment I Saw Your Eyes|SSAA|Joe Liles
+The Moment I Saw Your Eyes|TTBB|Joe Liles
+The Money Song|TTBB|Gene Cokeroft
+The More I See You|SSAA|Carolyn Schmidt
+The More I See You|SSAA|Ruby Rhea
+The More I See You|TTBB|Brent Graham
+The Most Wonderful Time Of The Year|SSAA|Nancy Bergman
+The Most Wonderful Time Of The Year|TTBB|Dave Plette
+The Most Wonderful Time Of The Year|TTBB|Jay Giallombardo
+The Movies|TTBB|Earl Moon
+The Muppet Show Theme|SSAA|Carolyn Johnson
+The Music and the Mirror|SSAA|Mary Ann Wydra
+The Music of the Night|SSAA|Tedda Lippincott
+The Music of the Night|TTBB|Ed Boehm
+The Music Of The Night|SSAA|David Wright
+The Music Of The Night|TTBB|David Wright
+The Naughty Lady Of Shady Lane|TTBB|Joe Johnson
+The Naughty Lady Of Shady Lane|TTBB|Unspecified
+The Nearness of You|SSAA|Carolyn Healey
+The Nearness of You|SSAA|John Brockman
+The Nearness of You|SSAA|Rob Hopkins
+The Nearness of You|SSAA|Susan Lamb Kegley
+The Nearness of You|TTBB|John Brockman
+The Nearness of You|TTBB|Kirby Shaw
+The Nearness of You|TTBB|Rob Hopkins
+The Nearness Of You|SATB|Kevin Keller
+The Nearness Of You|TTBB|Walter Latzko
+The Night Before Christmas|SSAA|Joan Melling
+The Night Has A Thousand Eyes|SSAA|David Wright
+The Night We Called It A Day|SSAA|Ruby Rhea
+The Old Man's Back in Town|SSAA|Joe Liles
+The Old Man's Back In Town|SSAA|Brian Beck
+The Old Piano Roll Blues|SSAA|Joni Bescos
+The Old Piano Roll Blues|TTBB|David Wright
+The Old Piano Roll Blues|TTBB|Mo Rector
+The Old Songs Medley|TTBB|David Zimmerman
+The Oldest Established|TTBB|Don Gray
+The One I Love Belongs to Somebody Else|TTBB|Clay Hine
+The Original Dixieland One Step|SSAA|Greg Volk
+The Original Dixieland One Step|SSAA|Renee Craig
+The Original Dixieland One-Step|TTBB|Renee Craig
+The Over 40 Waltz|TTBB|Chuck Brooks
+The Parting Glass|SSAA|The Wailin' Jennys
+The Parting Glass|TTBB|Chris Arnold
+The Parting Glass|TTBB|Nathan Peplinski
+The Party's Over|TTBB|Steven Armstrong
+The Party's Over/Send In The Clowns Medley|TTBB|Ralph Warman
+The Perfect Barbershop Song|SSAA|Lynnell Diamond
+The Pirate Song|TTBB|Darin Drown
+The Pirate's Life|TTBB|Mel Knight
+The Polar Express|TTBB|Joe Johnson
+The Power of the Dream|SSAA|Brian Beck
+The Power of the Dream|SSAA|Tedda Lippincott
+The Prayer|SSAA|Joan D'Agostino
+The Prayer|SSAA|Joe Liles
+The Prayer|TTBB|Kenny Ray Hatton
+The Prayer|TTBB|Steven Armstrong
+The Preacher and the Bear|TTBB|Bud Leabo
+The Quest (Impossible Dream)|SSAA|Ed Waesche
+The Rainbow Connection|SSAA|Joey Minshall
+The Rainbow Connection|SSAA|Judy Vidal
+The Reason/Everybody's Changing (Medley)|TTBB|Henrik Rosenberg
+The Red Rose Rag|SSAA|Margaret Raeside
+The Red Rose Rag|TTBB|Mel Knight
+The Rhythm Of Life|TTBB|Greg Volk
+The Rhythm of Life (SATB)|SATB|Roger Emerson
+The Rhythm of Love|TTBB|Jeremey Johnson
+The Riff Song|TTBB|Jon Nicholas
+The River|SSAA|Joey Minshall
+The River|TTBB|Rob Hopkins
+The River Of No Return|TTBB|Gene Cokeroft
+The Rooster Song|SSAA|Doris Twardosky
+The Rose|SSAA|Carole Prietto
+The Rose|SSAA|Jo Lund
+The Rose|SSAA|Joni Bescos
+The Rose|SSAA|Kay Bromert
+The Rose|SSAA|Kirby Shaw
+The Rose|SSAA|Unspecified
+The Rose|TTBB|B. Doepke
+The Rose|TTBB|The Old Vic
+The Rose (SSAA)|SSAA|Kirby Shaw
+The Rose Of Tralee|TTBB|Leo Larivee
+The Sadder But Wiser Girl|TTBB|Walter Latzko
+The Sally Gardens|TTBB|Philip Serino
+The Second Star From The Right|SSAA|Tom Gentry
+The Second Star To The Right|TTBB|Tom Gentry
+The Second Time Around|TTBB|Steve Delehanty
+The Secret of Christmas|SATB|Ruby Rhea
+The Secret of Christmas|SSAA|Nancy Bergman
+The Secret of Christmas|TTBB|James Van Heusen
+The Secret of Christmas|TTBB|Russ Foris
+The Secret Of Christmas|SSAA|Jarmela Speta
+The Secret Of Christmas|SSAA|Jim Clancy
+The Secret Of Christmas|TTBB|Jim Clancy
+The Secret of Christmas Medley|TTBB|Jim Clancy
+The Shadow of Your Smile|TTBB|Jeff Taylor
+The Shadow Of Your Smile|TTBB|Chris Arnold
+The Shoop Shoop Song|SSAA|Jo Lund
+The Skye Boat Song|TTBB|Paul Davies
+The Song is Ended|SSAA|Anna Maria Parker
+The Song is Ended|TTBB|Jay Giallombardo
+The Song Is Ended|SSAA|Joni Bescos
+The Song Is Ended|TTBB|Ed Waesche
+The Song Is You|TTBB|Joe Johnson
+The Song That Goes Like This|SSAA|Lorraine Rochefort
+The Song's Gotta Come From the Heart|TTBB|David Wright
+The Songs We Sang Together|TTBB|Steve Tramack
+The Sound of Music|SSAA|Nancy Bergman
+The Sound of Music Medley|SSAA|Nancy Bergman
+The Sound of Music Medley|TTBB|Clay Hine
+The Sound of Silence|SSAA|Tedda Lippincott
+The Star Spangled Banner|TTBB|Aaron Dale
+The Star Spangled Banner|TTBB|Jim Clancy
+The Star-Spangled Banner|TTBB|Jim Clancy
+The Stars and Stripes Forever|TTBB|David Wright
+The Story Of The Rose|TTBB|Jon Nicholas
+The Story Of The Rose (Women)|SSAA|Jon Nicholas
+The Sunshine of Your Smile|SSAA|Tom Gentry
+The Sunshine Of Your Smile|TTBB|Tom Gentry
+The Supreme Supremes Medley|SSAA|Kevin Keller
+The Sweetest Song in the World|SSAA|Walter Latzko/Gene Cokeroft
+The Sweetest Story Ever Told|TTBB|Unspecified
+The Sweetheart of Sigma Chi|TTBB|Ed Waesche
+The Sweetheart Of Sigma Chi|TTBB|Lou Perry
+The Sweetheart Of Sigma Chi|TTBB|Steve Tramack
+The Sweetheart Tree|TTBB|Mancini
+The Teddy Bear's Picnic|TTBB|Dave Briner
+The Telephone Song (Mixed Jazz)|SATB|Brian Beck
+The Tender Trap|TTBB|Steve Tramack
+The Themes of 007|SSAA|Joey Minshall
+The Time I Like Best|TTBB|Jon Nicholas
+The Trolley Song|TTBB|Adam Reimnitz
+The Trolley Song|TTBB|Renee Craig
+The Trolley Song|TTBB|Unspecified
+The Truth About Men|TTBB|Dennis Malone and Matt Swann
+The Twelve Days After Christmas|SSAA|Tedda Lippincott
+The Twelve Days of Christmas|TTBB|Greg Backwell
+The Ugly Bug Ball|SSAA|Betty Grant
+The Ugly Bug Ball|SSAA|Suzy Lobaugh
+The Very Thought Of You|TTBB|Adam Reimnitz
+The Virgin Mary Had A Baby Boy|TTBB|Jon Nicholas
+The Virgin Mary Had A Baby Boy|TTBB|Tom Gentry
+The Water Is Wide|TTBB|Joe Johnson
+The Water Is Wide|TTBB|Jon Nicholas
+The Water Is Wide|TTBB|Rick Spencer
+The Way|TTBB|Josh Ehrlich
+The Way We Were|SSAA|Brian Beck
+The Way We Were|TTBB|Brian Beck
+The Way We Were|TTBB|Roy Keys
+The Way You Look Tonight|SSAA|Diane Clark
+The Way You Look Tonight|SSAA|Tom Gentry
+The Way You Look Tonight|TTBB|Mark Hale
+The Way You Look Tonight|TTBB|Renee Craig
+The Whiffenpoof Song|TTBB|Blaine Mack
+The Whiffenpoof Song|TTBB|The Ritz
+The White Cliffs of Dover|SSAA|Renee Craig
+The White Cliffs Of Dover|TTBB|Don Gray
+The Wind Beneath My Wings|SSAA|Julie Starr
+The Wind Beneath My Wings|TTBB|Tom Gentry
+The World Is Waiting For The Sunrise|TTBB|Roy Keys
+The World Is Waiting For The Sunrise|TTBB|Steven Armstrong
+The Yankee Doodle Boy|TTBB|Unspecified
+Their Hearts Were Full of Spring|SSAA|Aaron Dale
+Their Hearts Were Full Of Spring|TTBB|Aaron Dale
+Their Hearts Were Full Of Spring|TTBB|Kirby Shaw
+Them There Eyes|SSAA|Dave Stevens
+Them There Eyes|SSAA|Stevens
+There Goes My Heart|SSAA|Ed Waesche
+There Goes My Heart|SSAA|Lloyd Steinkamp/Nancy Bergman
+There Goes My Heart|SSAA|Nancy Bergman
+There Goes My Heart|TTBB|Ed Waesche
+There Goes My Heart|TTBB|Lloyd Steinkamp
+There Goes My Heart|TTBB|Scott Kitzmiller
+There I've Said it Again|TTBB|Not Specified
+There I've Said It Again|SSAA|Tom Gentry
+There I've Said It Again|TTBB|Aaron Dale
+There Is Nothin' Like A Dame|TTBB|Don Gray
+There is Nothing Like a Dame|TTBB|Dennis Morrisey
+There is Nothing Like a Dame|TTBB|J. Speta
+There is Nothing Like a Dame|TTBB|Jay Giallombardo
+There is Nothing Like a Dame|TTBB|Unspecified
+There Is Nothing Like A Dame|SSAA|Tedda Lippincott
+There Is Nothing Like A Dame|TTBB|Pete Rupay
+There Never Was A Gang Like Mine|SSAA|Brian Beck
+There Never Was A Gang Like Mine|SSAA|Buzz Haeger
+There Used to Be a Ballpark|SSAA|Rich Hasty
+There Used to Be a Ballpark|TTBB|Ken Potter
+There Used to Be a Ballpark|TTBB|Roger Payne
+There Used To Be A Ballpark|TTBB|Val Hicks
+There Used to Be a Ballpark Here|SSAA|Doris Twardosky
+There, I've Said It Again|SSAA|Nancy Bergman
+There, I've Said It Again|TTBB|Bob Mattes
+There, I've Said It Again|TTBB|Rob Hopkins
+There, I've Said it Again (different tag)|SSAA|Nancy Bergman
+There'll Be No New Tunes On This Old Piano|TTBB|Tom Gentry
+There'll Be Now New Tunes On This Old Piano|SSAA|June Berg
+There'll Be Some Changes Made|SSAA|Nancy Bergman
+There'll Be Some Changes Made|TTBB|Charles E. Brooks
+There'll Be Some Changes Made|TTBB|Classic Collection
+There'll Be Some Changes Made/So Long Dearie Medley|SSAA|Nancy Bergman
+There'll No New Tunes On This Old Piano|TTBB|Rob Hopkins (mod. Larry Lane)
+There's A Brand New Gang On The Corner|TTBB|Gene Cokeroft
+There'S A Great Day Coming, Manana|SSAA|Judy Vidal
+There's A Hero|SSAA|Jim Arns
+There's a Kind of Hush|SSAA|Tedda Lippincott
+There's A Meetin' Here Tonight|TTBB|Burt Szabo
+There's A Rainbow 'Round My Shoulder|TTBB|Barbershop Harmony Society
+There's A Song in the Air|SSAA|Aileen Nightingale
+There's A Tag In The Old Quartet|SSAA|Lynnell Diamond
+There's Gonna Be the Devil to Pay|SSAA|Greg Volk
+There's Gotta Be Something Better Than This|SSAA|Renee Craig
+There's No Business Like Show Business|SSAA|Dot Calvin
+There's No Business Like Show Business|SSAA|Joni Bescos
+There's No Business Like Show Business|SSAA|Nancy Bergman
+There's No Business Like Show Business|TTBB|Russ Foris
+There's No Business Like Show Business|TTBB|Steve Jamison - Tag Randy Rogers
+There'S No Place Like Home 4 Holidays|SSAA|Carolyn Schmidt
+There's Something About A Soldier|SSAA|George Avener
+There's Something About A Soldier|SSAA|Jay Giallombardo
+There's Something I Like About Broadway|TTBB|Lou Perry
+There's Still A Touch of Texas in My Heart|SSAA|Lynnell Diamond
+These Boots Are Made For Walkin'|SSAA|Brian Beck
+They All Call It Canada|TTBB|M. Polis
+They All Laughed|SSAA|Walter Latzko
+They All Laughed|TTBB|David Wright
+They All Laughed|TTBB|Don Gray
+They All Laughed|TTBB|Ed Waesche
+They All Laughed|TTBB|Rob Hopkins
+They All Laughed|TTBB|Walter Latzko
+They All Laughed|TTBB|Will Hamblet
+They Call It Dancing|SSAA|Judy Vidal
+They Call It Dancing|TTBB|Tom Gentry
+They Call The Wind 'Mariah'|TTBB|Joe Johnson
+They Call The Wind Mariah|TTBB|Don Thomson
+They Call The Wind Mariah|TTBB|Joe Johnson
+They Call The Wind Mariah|TTBB|Kevin Keller
+They Call The Wind Mariah|TTBB|Steve Jamison
+They Can't Take That Away from Me|TTBB|Aaron Dale
+They Can't Take That Away from Me|TTBB|Mark Hale
+They Can't Take That Away From Me|TTBB|Aaron Dale, Mark Hale
+They Didn't Believe Me|TTBB|David Wright
+They Didn't Believe Me|TTBB|Dick Floersheimer
+They Go Wild Over Me|SSAA|June Berg
+They Go Wild Simply Wild Over Me|SSAA|June Berg
+They Go Wild, Simply Wild Over Me|SSAA|June Berg/Jo Kraut
+They Go Wild, Simply Wild Over Me|TTBB|Tom Gentry
+They Go Wild, Simply Wild, Over Me|TTBB|Barbershop Harmony Society
+They Just Keep Moving the Line|TTBB|Steve Tramack
+They Never Told Me|SSAA|Mary Ann Wydra
+They Remind Me Too Much Of You|TTBB|Liz Garnett
+They Say It's Wonderful|SSAA|Diane Clark
+They Say It's Wonderful|TTBB|Ed Waesche
+They Say It's Wonderful|TTBB|Katie Farrell
+They Were All Out of Step But Jim|TTBB|Barbershop Harmony Society
+They Wrote 'Em In The Good Ol' Days|TTBB|Gene Cokeroft
+They Wrote Em' in the Good Old Days|TTBB|Gene Cokeroft
+They'll Be Seeing You|TTBB|Unspecified
+They'll Be Seeing You (Hospital Gown)|TTBB|Chordiac Arrest
+They're Gonna Fight, Fight, Fight Over There|SSAA|June Dale
+Thinking Out Loud|TTBB|Henrik Rosenberg
+Third Wheel|TTBB|Steve Delehanty
+This Boy|TTBB|James Porter
+This Can't Be Love|SATB|Ruby Rhea
+This Can't Be Love|TTBB|Aaron Dale
+This Can't Be Love|TTBB|Jim Clancy
+This Could Be The Start Of Something Big|SSAA|Adam Reimnitz
+This Heart of Mine|SSAA|Anita Barzilla
+This Is All I Ask|TTBB|Buzz Haeger
+This Is It|TTBB|Brent Graham (Tag Mods Randy Rogers)
+This Is It (Bugs Bunny Overture)|TTBB|Unspecified
+This Is It! (Theme from Bugs Bunny)|SSAA|Corinna Garriock
+This is My Country|SSAA|Sharon Holmes
+This is My Country|TTBB|Barbershop Harmony Society
+This Is My Country|SSAA|Nancy Bergman
+This Is My Country|TTBB|Al Jacobs
+This Is My Night|SSAA|Nancy Bergman
+This is Some Lucky Day|SSAA|Greg Volk
+This is Some Lucky Day|TTBB|Greg Volk
+This Is The Army, Mr. Jones|TTBB|John Bober
+This is the Moment|SSAA|Tedda Lippincott
+This is the Moment|TTBB|Jeff Oxley
+This Is The Moment|SSAA|Fred King
+This Is The Moment|TTBB|Fred King
+This Joint Is Jumpin'|SSAA|Nancy Bergman
+This Joint Is Jumpin'|TTBB|David Wright
+This Joint is Jumpin' Medley|TTBB|Jay Giallombardo
+This Land is My Land|SSAA|Lorraine Rochefort
+This Land is Your Land|TTBB|Unspecified
+This Land Is Your Land|TTBB|Jay Giallombardo
+This Land Is Your Land Canadian|TTBB|Richard E. Whitehouse
+This Little Light / Do Lord Medley|TTBB|Val Hicks
+This Little Light Of Mine|TTBB|John Leavitt
+This Little Light Of Mine|TTBB|Val Hicks
+This Little Light of Mine/Do Lord|TTBB|Val Hicks
+This Little Light Of Mine/Do Lord Medley|SSAA|Val Hicks
+This Little Light Of Mine/Do Lord Medley (Val H|TTBB|Val Hicks
+This Little Piggy|SSAA|George Avener
+This Love|TTBB|Kyle Kitzmiller
+This Love of Mine|SSAA|Anita Barzilla
+This Masquerade|SSAA|Ase Hagerman
+This Nearly Was Mine|TTBB|Jay Giallombardo
+This Old House|SSAA|Carolyn Healey
+This Old House|TTBB|David Wright
+This Ole House|TTBB|David Wright
+This Ole House/When the Saints Go Marching In Medley|TTBB|Jay Giallombardo
+This World|SSAA|Tedda Lippincott
+Thoroughly Modern Millie / Charleston|SSAA|Nancy Bergman
+Those Days Are Over|TTBB|Joe Johnson
+Those Lazy, Hazy, Crazy Days of Summer|SSAA|Marge Bailey
+Those Magnificent Men in Their Flying Machines|SSAA|Ann Minihane
+Those Magnificent Men in There Flying Machines|TTBB|Tony Searle
+Those Were The Days|TTBB|Chris Arnold
+Three Carols for Christmas|SSAA|June Berg
+Three Coins In The Fountain|TTBB|David Ebersole
+Three Guy Medley|SSAA|Tom Gentil
+Three Steps To Heaven|TTBB|Steve Hall
+Thriller|SSAA|Barbara McNeill
+Thriller|SSAA|Dan Naumann
+Thriller|TTBB|Aaron Dale
+Through The Eyes Of Love|TTBB|John Hohl
+Through The Years|TTBB|Adam Reimnitz
+Through The Years|TTBB|Gene Puerling
+Ticket to Ride|SSAA|Lynnell Diamond
+Tico Tico|SSAA|Cheryl Dick
+Tie Me To Your Apron Strings Again|TTBB|Judy Seawood Jamison
+Tiger Rag|TTBB|Stan Harris
+Tiger Rag|TTBB|Will Hamblet
+Tijuana Taxi|SSAA|Renee Craig
+Til I Hear You Sing|SSAA|June Berg
+Til There Was You|SSAA|Roger Payne
+Til There Was You|TTBB|Bob Rund
+Till Then|TTBB|Ig Jakovac
+Till There Was You|SSAA|Roger Payne
+Till There Was You|TTBB|Bob Rund
+Till We Meet Again|SSAA|Ig Jakovac
+Time After Time|SSAA|David Wright
+Time After Time|SSAA|Deke Sharon
+Time After Time|SSAA|Ed Waesche
+Time After Time|SSAA|Jim Arns
+Time After Time|SSAA|Joan Adler
+Time After Time|SSAA|June Berg
+Time After Time|SSAA|Norma Andersen
+Time After Time|TTBB|Buzz Haeger
+Time After Time|TTBB|Ed Waesche
+Time After Time - Arns|SSAA|Jim Arns
+Time After Time - Berg|SSAA|June Berg
+Time For You|SSAA|Joe Liles
+Time In A Bottle|TTBB|Jon Nicholas
+Time To Say Goodbye|TTBB|Gary Lewis
+Time Waits for No One|SSAA|Nancy Bergman
+Time Was|TTBB|Mark Hale
+Tin Roof Blues|SSAA|Renee Craig
+Tin Roof Blues|TTBB|Don Gray
+Tired of the South|TTBB|Unspecified
+Titanium|SSAA|David Wright
+Titanium|TTBB|David Wright
+To a Swimmin' Hole with a Fishin' Pole|SSAA|Rich Hasty
+To Keep My Love Alive|SSAA|Jo Lund
+To Know Him is to Love Him|SSAA|Tedda Lippincott
+To Make You Feel My Love|SSAA|Hari Birtles
+To Make You Feel My Love|SSAA|Joey Minshall
+Today|SSAA|Jay Wright
+Together Wherever We Go|SSAA|Betty Oliver
+Together Wherever We Go|SSAA|Kevin Keller
+Together Wherever We Go|SSAA|Nancy Bergman
+Together Wherever We Go|TTBB|Walter Latzko
+Tomorrow|TTBB|Dick Floersheimer
+Tomorrow|TTBB|Richard Curtis, Mark Burnip, Zac Booles
+Tomorrow Is Promised to No One|TTBB|Freddy King and Robert Rund
+Tomorrow Is Promised To No One|TTBB|Robert Rund
+Tonight|TTBB|Jay Giallombardo
+Tonight (West Side Story)|SSAA|Jay Giallombardo
+Tonight (West Side Story)|SSAA|Tedda Lippincott
+Tonight, Tonight|TTBB|Jay Giallombardo
+Too Darn Hot|TTBB|Kevin Keller
+Too Long at the Fair|TTBB|Russ Foris
+Too Marvelous for Words|TTBB|Mark Hale
+Too Old To Fall In Love|TTBB|Don Gray
+Toora Loora Loora|SSAA|Lynnell Diamond
+Toot Toot Tootsie|SSAA|Carolyn Butler
+Toot Toot Tootsie|SSAA|Nancy Bergman
+Toot Toot Tootsie Goodbye|TTBB|Clay Hine
+Toot, Toot, Tootsie|SSAA|Carolyn Butler
+Toot, Toot, Tootsie|TTBB|Burt Szabo
+Toot, Toot, Tootsie Goodbye/When the Midnight Choo Choo|TTBB|Pete Rupay
+Tootsie/Lady Love Medley|TTBB|Don Gray
+Top Hat White Tie and Tails|TTBB|Ed Waesche
+Top Hat, White Tie And Tails|TTBB|Ed Waesche, Chris Arnold
+Top of the World|SATB|Liz Garnett
+Top of the World|SSAA|Don Gray
+Top of the World|SSAA|Joey Minshall
+Top of the World|SSAA|Joni Bescos
+Top Of The World|TTBB|John Hohl
+Toyland|SSAA|Judy Vidal Renee Craig
+Toyland|SSAA|Renee Craig
+Toyland|TTBB|Ed Waesche
+Traditional Carol Medley|SSAA|Carolyn Schmidt
+Train-Saints Medley|TTBB|Tom Gentry
+Tramp Medley|SSAA|Paul Davies
+Transylvania Mania|TTBB|Aaron Dale
+Tribute to the USA|SSAA|Nancy Bergman
+Tribute To World Peace|TTBB|Jay Giallombardo
+Trickle Trickle|SSAA|Dave Briner
+Trickle Trickle|SSAA|Lorraine Rochefort
+Trickle, Trickle|TTBB|Mel Knight
+Trim Up The Tree|TTBB|Hal Maples
+Trolley Song|SSAA|Renee Craig
+True Colors|SSAA|Elaine Gain
+True Colors|SSAA|Julie Starr
+True Colours|SSAA|Deke Sharon
+True Colours|TTBB|Bill Heigen
+True Love|TTBB|Val Hicks
+Try A Little Tenderness|SSAA|Unspecified
+Try A Little Tenderness|TTBB|Larry Wright
+Tumblin' Tumbleweeds|TTBB|Walter Latzko
+Tumbling Tumbleweeds|TTBB|Burt Szabo
+Tumbling Tumbleweeds|TTBB|Jon Nicholas
+Tumbling Tumbleweeds|TTBB|Unspecified
+Turn Around|SSAA|Jay Giallombardo
+Turn Around|SSAA|June Dale
+Turn Around|TTBB|Tom Gentil
+Turn Around, Look at Me|SSAA|Sylvia Alsbury
+Turn Your Radio On|SSAA|Joni Bescos
+Turn Your Radio On|TTBB|Burt Staffen
+Turn Your Radio On|TTBB|Unspecified
+Turn! Turn! Turn!|SSAA|Jonathan Wikeley
+Tuxedo Junction|SSAA|June Dale
+Tuxedo Junction|TTBB|Jay Giallombardo
+Tuxedo Junction|TTBB|Tom Gentry
+Tuxedo Junction|TTBB|Tony Nasto
+Tuxedo Junction|TTBB|Walter Latzko
+TV Monster|TTBB|Greg Volk
+Twas Only an Irishman's Dream|TTBB|Rennie Cormack
+Twas The Night Before Christmas|SSAA|Nancy Bergman
+Twelve Days After Christmas|SSAA|Nancy Bergman
+Twelve Days After Christmas|SSAA|Sylvia Alsbury
+Twenties Singalong|SSAA|Nancy Bergman
+Twenty Third Psalm|TTBB|Ted Hanna
+Twilight Time|SSAA|Mark Hale
+Twilight Time|SSAA|Nancy Bergman
+Twilight Time|TTBB|Don Gray
+Twist Medley|SSAA|Carole Prietto
+Two Tickets/Sentimental Gentleman|SSAA|Chari Pernert
+Unbelievable|SSAA|Aaron Dale
+Unbelievable|TTBB|Aaron Dale
+Unchained Melody|SSAA|Mary Coffman
+Unchained Melody|TTBB|Dave Strachan
+Unchained Melody|TTBB|Dennis Driscoll
+Uncorked|SSAA|Donya Metzger
+Undecided|SATB|David Wright
+Undecided|SSAA|Fred King
+Undecided|SSAA|Joyce Stanbery
+Undecided|TTBB|Ed Waesche
+Under the Boardwalk|SSAA|Charlene Yazurlo
+Under the Boardwalk|SSAA|Tom Gentry
+Under The Boardwalk|SSAA|Barbershop Harmony Society
+Under The Boardwalk|TTBB|Barbershop Harmony Society
+Under the Sea|SSAA|Joey Minshall
+Under the Sea|TTBB|Scott Turnbull
+Under The Sea|TTBB|Jay Giallombardo
+Unexpected Song|SATB|Michael Gellert
+Unfinished Songs|SSAA|June Berg
+Unforgettable|SSAA|Lorraine Rochefort
+Unforgettable|SSAA|Mary Coffman
+Unintended|TTBB|Chris MacMartin
+Until|TTBB|Chris Arnold
+Up on the Housetop|SSAA|Nancy Bergman
+Up On the Roof|SSAA|Lorraine Rochefort
+Up On the Roof|TTBB|Walter Latzko
+Up On The Roof|TTBB|Brent Graham
+Up The Ladder To The Roof|SSAA|Mo Field
+Up, Up and Away|SSAA|Marge Bailey
+Uptown Funk|TTBB|Steve Wolf
+Use It For Good (Fallulah)|SSAA|Malene Rigtrup
+Valentine|SSAA|Kay Bromert
+Valerie|SSAA|Liz Garnett
+Various Themes of Fa-La-La|SSAA|Tedda Lippincott
+Vaudeville|SSAA|Nancy Bergman
+Vaya Con Dios|SSAA|Kay Bromert
+Vaya Con Dios ( English)|SSAA|Kay Bromert
+Vaya Con Dios ( Spanish)|SSAA|Kay Bromert
+Very Last Day|TTBB|Jon Nicholas
+Vic'try Road|TTBB|David Wright
+Vict'ry Road|SSAA|David Wright
+Vict'ry Road|TTBB|David Wright
+Virginmary Had A Baby Boy|SSAA|Bev Sellers
+Viva Las Vegas|SSAA|Sylvia Alsbury
+Viva Las Vegas|TTBB|Jim Clancy
+Vocal Warmup|TTBB|Barbershop Harmony Society
+Voice Dance|SATB|Greg Jasperse
+Volare|SSAA|Jo Lund
+Wagon Wheel|TTBB|Jonathan Sparks
+Waikiki|SSAA|Nancy Bergman
+Wait 'Til the Sun Shines, Nellie|TTBB|Larry Triplett
+Wait Till The Sun Shines, Nellie|TTBB|Buzz Haeger
+Wait till You Get em' Up in the Air Boys|TTBB|John Hohl
+Wait Till You Get Them Up In The Air, Boys|TTBB|Don Gray
+Waitin' for the Robert E. Lee|TTBB|David Wright
+Waitin' For The Robert E. Lee|SSAA|Brian Beck
+Waiting At The End Of The Road|TTBB|Burt Szabo
+Waiting For The Robert E. Lee|TTBB|Jay Giallombardo
+Waiting For The Robert E. Lee|TTBB|Rob Campbell
+Wake Me Up Before You Go-Go|SSAA|Linda Edmondson
+Walkin' After Midnight|SSAA|Tedda Lippincott
+Walkin' My Baby Back Home|TTBB|Dave Briner, Buzz Haeger, Bob Shami
+Walkin' My Baby Back Home|TTBB|Val Hicks
+Walkin' With My Sweetness (Down Among The Sugar Cane)|SSAA|Brian Beck
+Walking My Baby Back Home (Boston Common Version)|TTBB|Val Hicks
+Walking My Baby Back Home (Society Stock Version)|TTBB|Val Hicks
+Walking on Sunshine|SSAA|Aaron Dale
+Walking On Sunshine|SSAA|Corinna Garriock
+Waltz For Debbie|TTBB|Joe Johnson
+Waltz for Debby|TTBB|Joe Johnson
+Wandrin' Star|TTBB|Unspecified
+Wanting Memories|SSAA|Ysaye M Barnwell
+Warm And Fuzzy|SSAA|Pete Benson
+Warm And Fuzzy|TTBB|Pete Benson
+Way Down On Tampa Bay|TTBB|Jon Nicholas
+Way Down Yonder in New Orleans|SSAA|Nancy Bergman
+Way Down Yonder In New Orleans|TTBB|Don Gray
+Way You Look Tonight|TTBB|Mark Hale
+Wayfaring Stranger|TTBB|Dan Tice
+We All Are Here|SSAA|C. Hayes
+We Are Family|SSAA|Anna-Marie Nystrom
+We Are Family|SSAA|Tedda Lippincott
+We Are Family (Nystrom)|SSAA|Anna-Marie Nystrom
+We Are One|SSAA|Jim Arns
+We Are One|SSAA|Sharon Holmes
+We Are The World (6 part)|SSAA|Kevin Keller
+We Are Two|SSAA|Joe Liles
+We Can Do It|SSAA|Lynnell Diamond
+We Can Work It Out|SSAA|Carolyn Schmidt
+We Go Together|SSAA|Jo Lund
+We Go Together|SSAA|Unspecified
+We Go Together (YWIH)|SSAA|Carolyn Schmidt
+We Kinda Miss Those Good Old Songs|TTBB|Lou Perry
+We Need a Little Christmas|SSAA|June Berg
+We Need a Little Christmas|TTBB|Anita Kerr
+We Need a Little Christmas|TTBB|Clay Hine
+We Need A Little Christmas|SSAA|Dave Briner
+We Need A Little Christmas|SSAA|Jim Massey
+We Need A Little Christmas|SSAA|Nancy Bergman
+We Need A Little Christmas|SSAA|Tedda Lippincott
+We Need A Little Christmas|TTBB|Dave Briner
+We Need A Little Christmas (Bergman)|SSAA|Nancy Bergman
+We Need A Little Christmas (Massey)|SSAA|Jim Massey
+We Rise Again|SSAA|Tedda Lippincott
+We Rise Again|SSAA|Tom Gentry
+We Rise Again|TTBB|Tedda Lippincott
+We Rise Again (alt. tag)|SSAA|Tedda Lippincott
+We Three|SSAA|Ig Jakovac
+We Three|TTBB|Walter Latzko
+We Three Kings|TTBB|Jon Nicholas
+We Three Kings|TTBB|Patrick Rose
+We Three Kings (solo)|TTBB|Jon Nicholas
+We Wish You a Merry Christmas|TTBB|Barbershop Harmony Society
+We Wish You A Merry Christmas|SSAA|Carolyn Schmidt
+We Wish You A Merry Christmas|SSAA|Marie Johnson
+We Wish You A Merry Christmas|SSAA|Renee Craig
+We Wish You A Merry Christmas|TTBB|David Harrington
+We Wish You A Merry Christmas!|TTBB|David Harrington
+We'll Be Seeing You|SSAA|Renee Craig
+We'll Be Together Again|TTBB|Richard Loebakka
+We'll Gather Lilacs|SSAA|Lynnell Diamond
+We'll Meet Again|SSAA|Carolyn Healey
+We'll Meet Again|TTBB|Kirk Roose
+We'll Meet Again|TTBB|Lou Perry
+We're All In This Together|SSAA|Lynnell Diamond
+We're Harmony We're Strong|SSAA|Russ Foris
+We're Harmony, We're Strong|SSAA|Unspecified
+We're Number One|SSAA|Tom Gentry
+We're off to see the wizard|TTBB|Lloyd Steinkamp
+We're Off to See the Wizard|SSAA|Nancy Bergman
+We're Working Our Way Through College|TTBB|Walter Latzko
+Wedding Bells|TTBB|Alan Siegal
+Wedding Bells|TTBB|David Wright
+Wedding Bells (Are Breaking Up That Old Gang Of Mine)|TTBB|David Wright
+Wedding Bells Are Breaking Up That Old Gang of Mine|TTBB|David Wright
+Wedding Song|SSAA|June Dale
+Weekend in New England|SSAA|Ann Minihane
+Weekend in New England|TTBB|Bob Mattes
+Welcome Christmas|TTBB|David Wright
+Welcome Song (Parody of the Irish Blessing)|TTBB|Barbershop Harmony Society
+Welcome To The Fold, Sweet Adeline|SSAA|Nancy Bergman
+Wells Fargo Wagon|TTBB|Walter Latzko
+West Of The Great Divide|TTBB|Lou Perry
+West Side Story Medley|TTBB|Walter Latzko
+Western Medley|TTBB|Tom Gentry
+What A Difference A Day Makes|TTBB|Adam Reimnitz
+What a Dream Can Do|SSAA|Steve Delehanty
+What A Wonderful Daddy You'd Be|SSAA|Lorraine Rochefort
+What a Wonderful World|SSAA|Laura Edmondson
+What a Wonderful World|TTBB|Russ Foris
+What A Wonderful World|SSAA|Bob Long
+What A Wonderful World|SSAA|Joey Minshall
+What A Wonderful World|SSAA|Linda Edmondson
+What A Wonderful World|SSAA|Marge Bailey
+What A Wonderful World|TTBB|Bill Mitchell
+What A Wonderful World|TTBB|Bob Long
+What A Wonderful World|TTBB|Stuart Sides
+What Are You Doing New Year's Eve|SSAA|Bergman/Wheeler
+What Are You Doing New Year's Eve|SSAA|Ruby Rhea
+What Are You Doing New Year's Eve?|SATB|Brian Beck
+What Are You Doing New Year's Eve?|SSAA|Nancy Bergman
+What Are You Doing New Year's Eve?|TTBB|Ruby Rhea
+What Are You Doing New Years Eve|TTBB|Aaron Dale
+What Are You Doing New Years Eve?|SSAA|Janice Wheeler
+What Child Is This|TTBB|Gary Lewis
+What Child Is This Medley|TTBB|Joe Johnson
+What Child Is This?|TTBB|Gary Lewis
+What Do I Need With Love|TTBB|Kirk Young
+What Doesn't Kill You (Stronger)|SSAA|Kevin Keller
+What I Did For Love|SSAA|Renee Craig
+What I Did For Love|TTBB|Scott Werner
+What I Did For Love (Chorus Line)|SSAA|Ann Minihane Judy Vidal
+What Kind of Fool Am I|SSAA|David Harrington
+What Kind of Fool Am I|SSAA|Kevin Keller
+What Kind Of Fool Am I?|SSAA|David Harrington
+What Kind Of Fool Am I?|TTBB|David Harrington
+What Kind Of Fool Am I?|TTBB|John Hohl
+What Kind Of Fool Am I?|TTBB|Kevin Keller
+What Kind Of Fool Am I?|TTBB|Steve Tramack
+What Kind Of King?|TTBB|Shaun Agnew
+What Makes You Beautiful|TTBB|Aaron Dale
+What Makes You Beautiful (One Direction)|SSAA|Shelley Gray
+What More Can a Soldier Give?|TTBB|Robert Rund
+What More Can a Woman Give|SSAA|Robert Rund
+What No Women Parody|TTBB|Ed Waesche
+What Shall We Do With the Drunken|TTBB|Sailor Unknown
+What Shall We Do With The Drunken Sailor|SSAA|Robert Shaw
+What Shall We Do With The Drunken Sailor|TTBB|Robert Shaw
+What Sweeter Music|TTBB|Steven Armstrong
+What Will I Tell My Heart|SSAA|Linda Edmondson
+What Wondrous Love Is This|SSAA|Kay Bromert
+What Wondrous Love Is This|TTBB|J. Harold Moyer
+What Would I Do Without my Music|SSAA|Tom Gentry
+What'll I Do|SSAA|Ed Waesche
+What'll I Do|SSAA|Ed Waesche and Renee Craig
+What'll I Do|SSAA|Renee Craig
+What'll I Do|TTBB|Ed Waesche
+What'll I Do|TTBB|Ed Waesche and Renee Craig
+What'll I Do|TTBB|Second Edition
+What'll I Do?|TTBB|Ed Waesche and Renee Craig
+What'll I Do?|TTBB|Ed Waesche, Renee Craig
+What'll I Do? Will|TTBB|Hamblett
+What's More American|TTBB|Fred Polnisch
+What's This?|TTBB|David Wright
+Whatever Happened to the Old Songs/Tootsie|SSAA|June Dale
+When A Child Is Born|SSAA|Tedda Lippincott
+When A Child Is Born|TTBB|Larry Triplett
+When Angels Sing|SSAA|Joe Liles
+When Christmas Comes To Town|TTBB|Patrick McAlexander
+When Day is Done|SSAA|Brent Graham
+When Day Is Done|SSAA|Ed Waesche
+When Day Is Done|TTBB|Ed Waesche
+When God Fearin' Women Get the Blues|SSAA|Cheryl Suhr
+When I Fall in Love|TTBB|David Wright
+When I Fall In Love|SSAA|Ann Minihane
+When I Fall In Love|SSAA|David Wright
+When I Fall In Love|SSAA|Kirby Shaw
+When I Fall In Love|TTBB|Jay Giallombardo
+When I Fall In Love|TTBB|Mac Huff
+When I Fall In Love|TTBB|Rich Hasty
+When I Get My Name in Lights|SSAA|Carole Prietto/June Berg
+When I Get My Name in Lights|SSAA|Mary Ann Wydra
+When I Get My Name In Lights|SSAA|Carole Prietto
+When I Grow Too Old to Dream|SSAA|Ardeth Fullmer
+When I Grow Too Old to Dream|SSAA|Nancy Bergman
+When I Grow Too Old To Dream|TTBB|Ed Waesche
+When I Grow Too Old To Sing|TTBB|Don Gray
+When I Grow Up|SATB|Tim Minchin
+When I Just Wear My Smile|SSAA|Tom Gentry
+When I Leave the World Behind|SSAA|Joni Bescos
+When I Leave The World Behind|SSAA|Nancy Bergman
+When I Leave The World Behind|TTBB|Barbershop Harmony Society
+When I Lift Up My Head|SSAA|David Wright
+When I Lift Up My Head|TTBB|David Wright
+When I Look At You|TTBB|Rob Hopkins
+When I Look At You (Scarlet Pimpernel)|SSAA|Judy Vidal
+When I Look In Your Eyes|SATB|Joe Mannherz
+When I Look Into Your Eyes|TTBB|Jon Nicholas
+When I Lost You|SSAA|Carolyn Schmidt
+When I Lost You|SSAA|Steve Tramack
+When I Lost You|TTBB|Ed Waesche
+When I Lost You|TTBB|Steve Tramack
+When I Lost You (Parody)|TTBB|Tom Gentry
+When I See an Elephant Fly|SSAA|Adam Scott
+When I See An Elephant Fly|SSAA|Aaron Dale
+When I See An Elephant Fly|TTBB|Aaron Dale
+When I Sing|SSAA|Tom Gentry
+When I Was A Dreamer|SSAA|Jan-Ake Westin
+When I'm 64|SSAA|Carolyn Schmidt
+When I'm 64|SSAA|Charlene Yazurlo
+When I'm 64|SSAA|Tedda Lippincott
+When I'm 64|TTBB|Tom Gentry
+When I'm Gone Medley|SSAA|Jim Arns
+When I'm Sixty Four|TTBB|Tom Gentry
+When I'm Sixty-Four|SSAA|Tom Gentry
+When I'm Sixty-Four|TTBB|Tom Gentry
+When It Comes To Lovin' the Girls/They're All Sweeties Medley|TTBB|Greg Lyne and Ed Wasche
+When It Comes To Lovin' The Girls/They're All Sweeties Medley(Ed Wae|TTBB|Ed Waesche
+When It's Night Time In Dixie Land|TTBB|Earl Moon
+When It's Night Time In Dixieland|TTBB|David Wright
+When It's Night Time In Dixieland|TTBB|Earl Moon
+When It's Sleepy Time Down South|TTBB|Darin Drown
+When Johnny Comes Marching Home|TTBB|Dave Stevens
+When Johnny Comes Marching Home/Apple Tree Medley|TTBB|Adam Reimnitz
+When My Baby Smiles At Me|SSAA|Mark Hale
+When My Baby Smiles At Me|TTBB|Mark Hale
+When My Baby Smiles At Me Medley|SSAA|June Berg
+When My Heart Finds Christmas|TTBB|Steve Tramack
+When My Sugar Walks Down The Street|SSAA|David Harrington
+When My Sugar Walks Down The Street|TTBB|David Harrington
+When October Goes|SATB|Dave Briner
+When October Goes|SSAA|Dave Briner
+When She Loved Me|SSAA|Kevin Keller
+When She Loved Me|SSAA|Randy Newman
+When She Loved Me|TTBB|Jim Kahlke
+When She Loved Me|TTBB|Richard Lewellen
+When She Loved Me|TTBB|Unspecified
+When That Midnight Choo Choo Leaves for Alabam|SSAA|Dot Calvin
+When That Midnight Choo Choo Leaves For Alabam(Jay Giallomb|TTBB|Jay Giallombardo
+When The Blue Of The Night Meets The Gold Of The Day|TTBB|Oliver and Campbell
+When The Girls Grow Up To Be Women|TTBB|Brian Beck
+When The Lights Go On Again (All Over The World)|TTBB|Percy Winedropper
+When the Midnight Choo Choo Leaves for Alabam'|TTBB|Paul Olguin
+When The Midnight Choo-Choo Leaves for Alabam'|TTBB|Paul Olguin, Clay Hine
+When The Red red Robin|SSAA|Greg Volk
+When The Red Red Robin|SSAA|Dave Briner
+When The Red Red Robin|SSAA|Dot Calvin
+When The Red Red Robin Comes Bob Bob Bobbin Along (Ed Wae|TTBB|Ed Waesche
+When the Red Red Robin Goes Bob-Bob-Bobbin' Along|SSAA|Dot Calvin
+When The Red, Red Robin Comes Bob, Bob, Bobbin' Along|TTBB|Barbershop Harmony Society
+When The Red, Red Robin Goes Bob, Bob Bobbin'|SSAA|Greg Volk
+When The River Meets The Sea|TTBB|Tom Gentry
+When The Roll Is Called Up Yonder|SSAA|Joe Liles
+When The Roll Is Called Up Yonder|TTBB|Joe Liles
+When the Saints Go Marchin' In|SSAA|Aileen Nightingale
+When The Saints Go Marchin' In|SSAA|Greg Volk
+When The Saints Go Marchin' In|TTBB|Greg Volk
+When The Saints Go Marchin' In|TTBB|Steven Armstrong
+When The Summer Sun Is Gone|TTBB|Aaron Dale
+When There's Love at Home|SSAA|Mo Rector
+When There's Love At Home|SSAA|Tom Gentry
+When There's Love At Home|TTBB|Mel Knight
+When There's Love At Home|TTBB|Tom Gentry
+When There's Love At Home (There Is Beauty All Around)|TTBB|Mel Knight
+When We Were Young|SSAA|Thomas J. West
+When Will I Be Loved|SSAA|David Wright
+When Will I Be Loved|SSAA|Tedda Lippincott
+When Will I Be Loved?|SSAA|David Wright
+When You Look in the Heart of a Rose|TTBB|Greg Lyne
+When You Say Nothing at All|TTBB|Peter Mumford
+When You Say Nothing At All|TTBB|Alex Kaiserman
+When You Were Sweet Sixteen|TTBB|Adam Reimnitz
+When You Wish Upon a Star|SATB|Nancy Bergman
+When You Wish Upon a Star|TTBB|Jay Giallombardo
+When You Wish Upon A Star|SSAA|JoAnne Ingles
+When You Wish Upon A Star|SSAA|Joni Bescos
+When You Wish Upon A Star|TTBB|Aaron Dale
+When You Wish Upon A Star|TTBB|Barbershop Harmony Society
+When You Wish Upon A Star|TTBB|Russ Young and Frasier Brown
+When You Wish Upon A Star|TTBB|Steven Armstrong
+When You Wish Upon a Star - SSAA|SSAA|Pete King
+When You Wore A Tulip|TTBB|Greg Lyne
+When You Wore A Tulip|TTBB|Greg Volk
+When You're A Long, Long Way From Home|TTBB|Scott Werner
+When You're Smiling|SSAA|David Harrington
+When You're Smiling|SSAA|Floyd Connett
+When You're Smiling|TTBB|David Harrington
+When Your Old Wedding Ring Was New|SSAA|Marge Bailey/Tom Williams
+When Your Old Wedding Ring Was New|TTBB|Unspecified
+Whenever I'm In Your Arms|TTBB|Joe Liles
+Where Are the Simple Joys of Maidenhood|SSAA|Lynnell Diamond
+Where Are You Christmas|SSAA|Joan D'Agostino
+Where Are You Christmas?|SSAA|Nancy Bergman
+Where Are You Christmas? (from The Polar Express)|TTBB|Dan Naumann
+Where Did the Circus Go|SSAA|Dorothy Herivel
+Where Does the Time Go|SSAA|Nancy Bergman
+Where Everybody Knows Your Name|SSAA|Lorraine Rochefort
+Where Everybody Knows Your Name|TTBB|Eric Ruthenberg
+Where Everybody Knows Your Name (Theme from Cheers)|SSAA|Lorraine Rochefort
+Where Have My Old Friends Gone?|SSAA|Joe Liles
+Where In The World|SSAA|Jean Flinn
+Where Is Love|SATB|Gene Puerling
+Where Is Love|SSAA|June Dale
+Where Is Love|TTBB|Tom Gentry
+Where Is Love?|TTBB|Adam Reimnitz
+Where Love Is|TTBB|Joe Johnson
+Where the Boys Are|SSAA|Elaine Gain
+Where The Heck Is Dixie?|SSAA|Joey Minshall
+Where the Southern Roses Grow|SSAA|David Wright
+Where The Southern Roses Grow|TTBB|David Wright
+Wherever There's Me, There's You|SSAA|Tom Gentry
+Whether The Weather Is Wet|TTBB|Jon Nicholas
+While By My Sheep|TTBB|Barbershop Harmony Society
+While Shephers Watched Medley|TTBB|Zac Booles
+Whispering|TTBB|Jim Kahlke
+Whispering|TTBB|Tom Gentry
+White Christmas|SSAA|Carolyn Schmidt
+White Christmas|SSAA|Nancy Bergman
+White Christmas|SSAA|Unspecified
+White Christmas|TTBB|Deke Sharon
+White Christmas|TTBB|Mac Huff
+White Christmas|TTBB|Tom Gentry
+White Christmas|TTBB|Unspecified
+White Cliffs of Dover|TTBB|Barbershop Harmony Society
+White Wings|SSAA|June Berg
+Whiter Than Snow|TTBB|Jon Nicholas
+Who Can I Turn To|TTBB|Roger Payne
+Who Can I Turn To?|SSAA|Kevin Keller
+Who Can Smile|TTBB|Simon Rylander
+Who Do You Think You're Foolin/I'm Nobody's|SSAA|Lynnell Diamond
+Who I Am|SSAA|Elaine Gain
+Who Loves You?|SSAA|Liz Garnett
+Who Put the Bomp|SSAA|S. Turnbull
+Who Put the Bomp|TTBB|Scott Turnbull
+Who Put The Bomp|TTBB|Aaron Dale
+Who Told You? / Side By Side|TTBB|David Harrington
+Who Will Buy|TTBB|Dave Briner
+Who Will Buy|TTBB|Phil Ordaz
+Who Will Buy?|SSAA|Ann Minihane
+Who Will Buy?|SSAA|Dave Briner
+Who Will Buy?|SSAA|Greg Volk
+Who Will Buy?|TTBB|Dave Briner
+Who Will Buy?|TTBB|Kirk Young
+Who Will Buy? / Where Is Love?|TTBB|Rod Sgrignoli
+Who Would Imagine A King|SSAA|K Andrews
+Who'll Dry Your Tears|TTBB|Dennis Driscoll
+Who'll Dry Your Tears (When You Cry)|TTBB|Unspecified
+Who'll Dry Your Tears When You Cry|TTBB|Dennis Driscoll/Rob Hopkins
+Who'll Take My Place|SSAA|Barbara Bianchi
+Who'll Take My Place (When I'm Gone)|TTBB|Greg Lyne
+Who'll Take My Place When I'm Gone|TTBB|Brian Beck
+Who'll Take My Place When I'm Gone|TTBB|Greg Lyne
+Who'll Take My Place When I'm Gone|TTBB|Jay Giallombardo
+Who'll Take My Place When I'm Gone?|TTBB|Greg Lyne
+Who's Lovin' You|TTBB|Aaron Dale
+Who's Sorry Now|SSAA|Dave Briner
+Who's Sorry Now|SSAA|Earl Moon/Dave Briner
+Who's Sorry Now|SSAA|Joni Bescos
+Who's Sorry Now|SSAA|Nancy Bergman
+Whose Honey Are You|SSAA|Jean Shook
+Whose Honey Are You?|SSAA|Jean Shook
+Why Did I Choose You|SSAA|Greg Volk
+Why Do Fools Fall in Love|SSAA|David Wright
+Why Do Fools Fall In Love?|SSAA|David Wright
+Why Do I Love You|TTBB|Mark Hale
+Why Don't My Dreams Come True|TTBB|Ted Hanna
+Why Don't We Just Dance|TTBB|Aaron Dale
+Why Don't You Fall in Love With Me|SSAA|Nancy Bergman
+Why Don't You Fall In Love With Me?/Undecided Medley|TTBB|Clay Hine
+Why Don't You Fall In Love With Me/Undecided Medley(Clay|TTBB|Clay Hine
+Why Haven't I Heard From You|SSAA|Tedda Lippincott
+Why Not Say Goodbye the Way We Said Hello|SSAA|Mel Knight
+Why Should I Cry Over You|TTBB|Ed Waesche
+Why We Sing|SSAA|Avis Fellows
+Wide Open Spaces|TTBB|Steve Jamison
+Wild and Wooly Son of the West|TTBB|Burt Szabo
+Wild West Woman|SSAA|Sylvia Alsbury
+Will I Ever Tell You|SSAA|Marie Johnson
+Will I Ever Tell You|SSAA|Nancy Bergman
+Will It Be Me This Time|SSAA|Lynnell Diamond
+Will It Be Me This Time?|SSAA|Lynnell Diamond
+Will The Circle Be Unbroken?|TTBB|Jon Nicholas
+Will The Sun Ever Shine Again?|TTBB|Kevin Keller
+Will You Still Love Me Tomorrow|SSAA|Elaine Gain
+Will You Still Love Me Tomorrow|TTBB|Chris MacMartin, Steve Tramack
+Will You Still Love Me Tomorrow?|TTBB|Chris MacMartin
+William Tell Overture|SSAA|Jay Giallombardo
+William Tell Overture|TTBB|Jay Giallombardo
+Willy Wonka Medley|TTBB|Kevin Keller
+Willy Wonka Medley|TTBB|Rob Hopkins
+Wimoweh (The Lion Sleeps Tonight)|SSAA|Charlene Yazurlo
+Win The Game / That's Life|TTBB|Jay Giallombardo
+Wind Beneath My Wings|SSAA|Julie Starr
+Windmill in old Amsterdam|TTBB|Tony Pelling
+Windy|TTBB|Jon Nicholas
+Wings|SSAA|Hari Birtles
+Wink and a Smile|TTBB|Kim Brittain
+Wink and A Smile|SSAA|Sharon Vitkovsky
+Wink And A Smile|SSAA|Jim Massey
+Winner's Song|SSAA|Mary Ann Wydra
+Winter Is The Loveliest Time Of The Year|SSAA|Renee Craig Emley
+Winter Weather/A Marshmallow World (medley)|SSAA|Dave Briner
+Winter Wonderland|SSAA|Adam Reimnitz
+Winter Wonderland|SSAA|June Berg
+Winter Wonderland|SSAA|Tedda Lippincott
+Winter Wonderland|SSAA|Valerie Hoy
+Winter Wonderland|TTBB|Adam Reimnitz
+Winter Wonderland|TTBB|Ed Waesche
+Winter Wonderland|TTBB|Steve Delehanty
+Wishing (YWIH)|SSAA|Avis Fellows
+Wishing You Were Somehow Here Again|SSAA|Julie Starr
+Witchcraft|SSAA|Dave Briner
+Witchcraft|TTBB|Dave Briner
+With a Little Help From My Friends|SSAA|Rich Hasty
+With A Little Help From My Friends|SSAA|Suzy Lobaugh
+With A Little Help From My Friends|SSAA|Unspecified
+With A Little Help From My Friends|TTBB|Rich Hasty
+With A Little Help From My Friends (YWIH)|SSAA|Suzy Lobaugh
+With A Smile And A Song|TTBB|Russ Foris, Dave Stevens
+With a Song in My Heart|SSAA|Nancy Bergman
+With A Song In My Heart|SATB|Jim Henry
+With One Look|SSAA|Tedda Lippincott
+With Plenty O' Money and You|SSAA|Nancy Bergman
+With Plenty of Money and You|SSAA|Nancy Bergman
+With Plenty of Money and You|TTBB|Walter Latzko
+With Plenty of Money/High Society Medley|SSAA|Brian Beck
+With Two Wings (8-Part Mixed)|SATB|Tom Gentry
+Without A Song|SSAA|Walter Latzko
+Without A Song|TTBB|Walter Latzko
+Without You / Lost Without Your Love Medley|SSAA|N Williams
+Wizard Of Oz Medley|TTBB|Kevin Keller
+Wizard Of Oz Medley|TTBB|Zac Booles
+Women Would Never Get Married|SSAA|John Hohl
+Wonderful Day Medley|SSAA|David Wright and Marty Griebel
+Wonderful Day Medley|SSAA|David Wright/Mike Griebel
+Wonderful Day Medley|TTBB|David Wright
+Wonderful Day Medley|TTBB|David Wright, Mike Gabriel, Mo Rector, Brian Beck, Bob Dowmy, Jim Clancy
+Wonderful One|TTBB|David Wright
+Words|TTBB|Pete Rupay
+World War I Medley|TTBB|Ed Waesche
+World War I Medley|TTBB|John Hohl, Val Hicks, Jack Baird
+World, Here I Am|SSAA|Nancy Bergman
+Would You Go With Me|TTBB|Adam Reimnitz
+Wouldn't It Be Nice|TTBB|Steve Delehanty
+Wrap Your Troubles in Dreams|SSAA|Joni Bescos
+Wrap Your Troubles in Dreams|TTBB|Ed Waesche
+Wrap Your Troubles In Dreams|SSAA|Mark Hale
+Wrap Your Troubles In Dreams|TTBB|Mark Hale
+WW1 Medley|SSAA|Nancy Bergman
+Y Viva Espana|SSAA|Mike Taylor
+Y.M.C.A|TTBB|Tom Gentry
+Ya Got Trouble|TTBB|Jay Giallombardo
+Ya Gotta Have Heart|SSAA|Larry Wright
+Ya Gotta Know How To Dance|SSAA|Clay Hine
+Ya Gotta Know How to Love|SSAA|Nancy Bergman
+Ya Gotta Know How To Love|TTBB|Nancy Bergman, Lloyd Steinkamp and Mike McGee
+Ya Gotta Know How To Love Em'/I Can't Give You Anything But Love Medley(Nancy Ber|SSAA|Nancy Bergman
+Ya Gotta Know/I Can't Give You Anything|SSAA|Nancy Bergman
+Ya' Got Trouble|TTBB|Bluegrass Student Union
+Yankee Doodle March|TTBB|Ed Hinkley
+Yellow Submarine|TTBB|Steve Delehanty
+Yes Indeed|SSAA|Renee Craig
+Yes Indeed|TTBB|Earl Moon
+Yes Indeed!|TTBB|David Wright
+Yes Sir That's My Baby|SSAA|David Wright
+Yes Sir That's My Baby|TTBB|Val Hicks
+Yes Sir, That's My Baby|SSAA|David Wright
+Yes Sir, That's My Baby|SSAA|W. Donaldson
+Yes Sir, That's My Baby|TTBB|David Wright
+Yes Sir, That's My Baby|TTBB|Jack Baird
+Yes Sir, That's My Baby/Ain't She Sweet (Medley)|TTBB|Larry Autenreith
+Yes, Indeed|SSAA|Earl Moon
+Yes, Indeed|TTBB|Earl Moon
+Yes, Indeed!|SSAA|Lorraine Rochefort
+Yes, We Have No Bananas|TTBB|Unspecified
+Yesterday|SSAA|Delyth Knight
+Yesterday|SSAA|Nancy Bergman/Aileen Nightingale
+Yesterday|TTBB|Brian Beck
+Yesterday|TTBB|Tom Gentry
+Yesterday (YWIH)|SSAA|Renee Craig
+Yesterday I Heard the Rain|SSAA|Sharon Carlson
+Yesterday I Heard The Rain|SSAA|Brent Graham
+Yesterday I Heard The Rain|SSAA|G Avener
+Yesterday I Heard The Rain|TTBB|Brent Graham
+YMCA|SSAA|Sandie Zalewski
+Yodel' Song ( Cowboy's Sweetheart)|SSAA|Jim Clancy
+Yona From Arizona|TTBB|Aaron Dale
+Yona From Arizona|TTBB|Barbershop Harmony Society
+You Ain't Gettin' Diddly Squat|SSAA|Tom Gentry
+You Ain't Gettin' Diddly Squat|TTBB|Tom Gentry
+You Always Hurt The One You Love|TTBB|Don Gray
+You and I|TTBB|Adam Reimnitz
+You and I|TTBB|Kyle Kitzmiller
+You and I|TTBB|Lou Perry
+You And I|TTBB|David Harrington
+You And Me|TTBB|Steve Tramack
+You and Me (But Mostly Me)|TTBB|Steve Tramack
+You Are Mine, All Mine|TTBB|Tony Nasto
+You are My Sunshine|TTBB|Clay Hine
+You Are My Sunshine|SSAA|Brian Beck
+You Are My Sunshine|SSAA|Elaine Gain
+You Are My Sunshine|SSAA|Vicki Uhr
+You Are My Sunshine|TTBB|Dave Briner, Ed Waesche
+You Are My Sunshine|TTBB|Jon Nicholas
+You Are My Sunshine|TTBB|Unspecified
+You Are My Sunshine|TTBB|Vicki Uhr
+You Are So Beautiful|SSAA|Mo Field
+You Are So Beautiful|TTBB|Jeremey Johnson
+You Are the New Day|SSAA|Kay Bromert
+You Are The New Day|TTBB|Peter Knight
+You are the One I Love|TTBB|Paul Olguin
+You Are the Sunshine of My Life|SSAA|Bev Sellers
+You Are The Sunshine Of My Life|TTBB|Jeremey Johnson
+You Belong to Me|SSAA|June Berg
+You Belong To Me|SSAA|Marsha Zwicker
+You Belong To Me|TTBB|Aaron Dale
+You Better Keep Babyin' Baby|SSAA|Nancy Bergman
+You Brought A New Kind Of Love To Me|TTBB|Brent Graham
+You Brought A New Kind Of Love To Me|TTBB|Larry Triplett
+You Can Fly|SSAA|Clay Hine
+You Can Fly|TTBB|Clay Hine
+You Can Have Every Light On Broadway|SSAA|Jean Shook
+You Can Have Every Light On Broadway|SSAA|Nancy Bergman
+You Can't Get a Man With a Gun|SSAA|Tom Gentry
+You Can't Get A Man With A Gun|SSAA|Nancy Bergman
+You Can't Hurry Love|SSAA|Joey Minshall
+You Can't Stop the Beat|SSAA|Carole Prietto
+You Can't Stop The Beat|TTBB|David Wright
+You Do Something to Me|SSAA|Marsha Zwicker
+You Don't Know Me|SATB|Ben Folds
+You Don't Know Me|SSAA|Jim Clancy
+You Don't Know Me|SSAA|Nancy Bergman
+You Don't Know Me|SSAA|Nancy Bergman (changes by Jim Arns)
+You Don't Know Me|TTBB|Curt Kimball
+You Don't Know Me|TTBB|David Harrington
+You Don't Know Me|TTBB|Jim Clancy
+You Don'T Know Me|SSAA|Tedda Lippincott
+You Don't Own Me|SSAA|Jo Lund
+You Don't Own Me|SSAA|Kay Bromert
+You Don't Own Me|SSAA|Tedda Lippincott
+You Don't You Won't|SSAA|Aaron Dale
+You Don't You Won't|TTBB|Aaron Dale
+You Dropped Me Like A Red Hot Penny|SSAA|Sharon Holmes
+You Gotta Be a Football Hero|TTBB|Jay Giallombardo
+You Gotta Be A Football Hero|TTBB|Jack Baird
+You Gotta Go South|TTBB|Lee Whitener
+You Gotta Have Skin|TTBB|Ed Waesche
+You Gotta Know How to Love Him|SSAA|Nancy Bergman
+You Keep Coming Back Like A Song|SSAA|Brian Beck
+You Keep Coming Back Like A Song|SSAA|Nancy Bergman
+You Keep Coming Back Like A Song|TTBB|Brent Graham
+You Keep Coming Back Like A Song|TTBB|Terry Shannon
+You Made Me Love You|SSAA|Avis Fellows
+You Made Me Love You|SSAA|Jim Arns
+You Made Me Love You|SSAA|Lorraine Rochefort
+You Made Me Love You|SSAA|Nancy Bergman
+You Made Me Love You|TTBB|Joni Bescos
+You Make Me Feel Like Dancing|SSAA|Anna Maria Parker
+You Make Me Feel So Young|SSAA|Anita Barzilla
+You Make Me Feel So Young|SSAA|Mark Hale
+You Make Me Feel So Young|SSAA|Ruth Emley
+You Make Me Feel So Young|TTBB|Mark Hale
+You Meet the Nicest People|SSAA|Tom Gentry
+You Meet the Nicest People|TTBB|Tom Gentry
+You Must Have Been a Beautiful Baby|SSAA|Renee Craig
+You Must Have Been a Beautiful Baby|TTBB|Jay Giallombardo
+You Must Have Been A Beautiful Baby|TTBB|Renee Craig
+You Must Have Been A Beautiful Baby|TTBB|Renee Craig/Ed Waesche
+You Needed Me|SSAA|Dennis Driscoll
+You Never Had It So Good|SSAA|Jim Massey
+You Raise Me Up|SSAA|Anna Maria Parker
+You Raise Me Up|SSAA|Jim Clancy
+You Raise Me Up|SSAA|Joe Liles
+You Raise Me Up|SSAA|June Dale
+You Raise Me Up|SSAA|Larry Wright
+You Raise Me Up|SSAA|Tedda Lippincott
+You Raise Me Up|TTBB|Ed Waesche
+You Raise Me Up|TTBB|Joe Liles
+You Raise Me Up|TTBB|Joe Liles, Pat Hannon
+You Raise Me Up|TTBB|Jon Nicholas
+You Really Got A Hold On Me|TTBB|Adam Scott
+You Started Me Dreaming|SSAA|Lorraine Rochefort
+You Tell Me Your Dream|SSAA|Clay Hine
+You Tell Me Your Dream|TTBB|Barbershop Harmony Society
+You Tell Me Your Dream|TTBB|Clay Hine
+You Tell Me Your Dream|TTBB|Phil Embury
+You Took Advantage of Me|TTBB|Jay Giallombardo
+You Took Advantage Of Me|SSAA|Unspecified
+You Took Advantage Of Me|TTBB|Aaron Dale
+You Turned the Tables on Me|SSAA|Nancy Bergman
+You Were Only Fooling|SSAA|Mo Rector
+You'll Never Know|SSAA|Nancy Bergman
+You'll Never Know|SSAA|Tedda Lippincott
+You'll Never Know|TTBB|Dave Briner
+You'll Never Know|TTBB|Einar Pedersen
+You'll Never Walk Alone|SSAA|Carolyn Schmidt
+You'll Never Walk Alone|SSAA|Nancy Bergman
+You'll Never Walk Alone|SSAA|Tedda Lippincott
+You'll Never Walk Alone|SSAA|Tony Searle
+You'll Never Walk Alone|TTBB|Adam Reimnitz
+You'll Never Walk Alone|TTBB|Chris Peterson
+You'll Never Walk Alone|TTBB|Don Gray
+You'll Never Walk Alone|TTBB|Jim Clancy
+You'll Never Walk Alone|TTBB|John Hohl
+You'll Never Walk Alone|TTBB|Jon Nicholas
+You'll Never Walk Alone|TTBB|Terry Phillips
+You're a Grand Old Flag|SSAA|Nancy Bergman
+You're A Grand Old Flag|TTBB|Barbershop Harmony Society
+You're A Mean One, Mr. Grinch|SATB|Chris Arnold
+You're A Mean One, Mr. Grinch|SSAA|June Berg
+You're A Mean One, Mr. Grinch|SSAA|Nancy Bergman
+You're A Mean One, Mr. Grinch|TTBB|Greg Volk
+You're A Mean One, Mr. Grinch|TTBB|Jon Nicholas
+You're A Mean One, Mr. Grinch|TTBB|Scott Turnbull, Shaun Agnew
+You're All The World To Me|TTBB|Larry Triplett
+You're an Education|TTBB|Bob Rund
+You're as Welcome as the Flowers in May|TTBB|Floyd Connett
+You're As Welcome as the Flowers In May|SSAA|Traditional
+You're Breaking In A New Heart|SSAA|Joni Bescos
+You're Breaking In A New Heart|SSAA|Rich Hasty
+You're Driving Me Crazy|SSAA|Anna Maria Parker
+You're From Heaven And You're Mine|TTBB|David Wright
+You're in Style When You're Wearing a Smile|SSAA|Ig Jakovac
+You're In Style When You're Wearing A Smile|TTBB|Dave Briner
+You're In Style With A Smile Medley|TTBB|Adam Reimnitz
+You're Just in Love|SATB|Joni Bescos
+You're Just in Love|SSAA|Tom Gentry
+You're Just In Love|SATB|Steve Jamison, Dan Falcone
+You're Just In Love (8-Part Mixed)|SATB|Tom Gentry
+You're My Baby|SSAA|Jim Arns
+You're Never Fully Dressed Without A Smile|SSAA|Ann Minihane
+You're Nobody 'Til Somebody Loves You|TTBB|Clay Hine
+You're Nobody 'Til Somebody Loves You / Ain't That A Kick In The Head|TTBB|Jay Giallombardo
+You're Nobody til Somebody Loves You|SSAA|Clay Hine
+You're Nobody til Somebody Loves You|SSAA|Greg Volk
+You're Nobody Til Somebody Loves You|TTBB|Clay Hine
+You're Nobody Til' Somebody Loves You|TTBB|Greg Volk
+You're Sixteen You're Beautiful and You're Mine|TTBB|Aaron Dale
+You're Sixteen, You're Beautiful And You're Mine(Aaron|TTBB|Aaron Dale
+You're Sixteen, You're Beautiful, And You're Mine|TTBB|Aaron Dale
+You're the Flower of My Heart Sweet Adeline|TTBB|Barbershop Harmony Society
+You're the Flower of My Heart, Sweet Adeline|TTBB|Barbershop Harmony Society
+You're The Flower Of My Heart, Sweet Adeline(Barbershop Harmony Soc|TTBB|Barbershop Harmony Society
+You're the Girl I Love|TTBB|Jay Giallombardo
+You're The Only Girl For Me|TTBB|Renee Craig
+You're The Spirit Of Sweet Adelines|SSAA|Lynnell Diamond
+You've Got a Friend|SSAA|Tom Gentry
+You've Got A Friend|SSAA|Tedda Lippincott
+You've Got A Friend|TTBB|Jon Colbath
+You've Got a Friend in Me|TTBB|Dan Wessler
+You've Got A Friend In Me|SSAA|David Harrington
+You've Got A Friend In Me|SSAA|Jo Lund
+You've Got A Friend In Me|TTBB|David Harrington
+You'Ve Got A Friend In Me|SSAA|Larry Wright
+You've Got to See Mama Ev'ry Night|SSAA|Tom Gentry
+You've Got To See Mama Ev'ry Night|SSAA|Janet Landstrom
+You've Got To See Mama Every Night|SSAA|Janet Landstrom
+Young and Foolish|SSAA|Marge Bailey
+Young and Foolish|TTBB|Brent Graham
+Young And Foolish|SSAA|Joni Bescos
+Young And Foolish|TTBB|Tom Gentry
+Young At Heart|TTBB|Dennis Malone
+Your Cheatin' Heart|TTBB|Aaron Dale
+Your Feet's Too Big|SSAA|Carolyn Schmidt
+Your First Day In Heaven|SSAA|Aaron Dale
+Your First Day In Heaven|TTBB|Aaron Dale
+Ziegfeld Medley|SSAA|Nancy Bergman
+Zing Went the Strings of My Heart|TTBB|Renee Craig
+Zing Went The Strings Of My Heart|SSAA|Renee Craig
+Zing Went The Strings Of My Heart|TTBB|Barbershop Harmony Society
+Zing! Went the String of My Heart|SSAA|Renee Craig
+Zing! Went the Strings of My Heart|SSAA|Renee Craig
+Zing! Went the Strings of My Heart|TTBB|Greg Volk
+Zing! Went The Strings Of My Heart|TTBB|Renee Craig
+Zing! Went The Strings Of My Heart|TTBB|Walter Latzko
+Zip-a-dee Doo-dah|TTBB|Joe Liles
+Zip-A-Dee-Doo-Dah|SSAA|Lorraine Rochefort
+Zip-A-Dee-Doo-Dah|TTBB|Jon Nicholas
+Zip-Ah-Dee-Doo-Dah|SSAA|Nancy Bergman
+Zombie Jamboree|SSAA|Dan Naumann
+Zombie Jamboree|SSAA|Lorraine Rochefort
+Zoom|SSAA|Alex Kaiserman

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -157,6 +157,81 @@ and literal `Unknown` stays `Unknown`. Dedupe uses normalized title + voicing +
 normalized arranger. This import adds optional suggestions only; it never writes
 to any user's My Songs.
 
+## BarbershopTracks Suggestions Refresh
+
+BarbershopTracks suggestions are scraped from the rendered browser page at:
+
+```text
+http://barbershoptracks.com/database.html
+```
+
+The scraper intentionally uses Chromium through Playwright. Do not replace this
+with curl, raw HTML, a sitemap, or detail-page URLs; the source contract is the
+rendered paginated list. Page 1 starts at:
+
+```text
+http://barbershoptracks.com/database.html?limit=50&order=name&dir=asc
+```
+
+Later pages add `p=2`, `p=3`, and so on. The scraper reads the rendered page
+count from text such as `Items 1 to 50 of 7910 total`; if that text is missing,
+it falls back to 159 pages.
+
+Run a small debug scrape before a full refresh:
+
+```bash
+npm run song-suggestions:scrape:barbershoptracks -- --max-pages=5 --debug
+```
+
+Debug page text snapshots are written under `tmp/barbershoptracks-debug/` and
+skipped rows are written to `tmp/barbershoptracks-skipped.json`; neither should
+be committed. The source PSV is written to:
+
+```text
+data/sources/barbershoptracks_song_suggestions.psv
+```
+
+The scraper imports only song title, supported voicing, and arranger. It does
+not import artist, artist website, genre, contestability, images, lyrics, or
+track media. Voicing labels are normalized as:
+
+- `Mens Track` / `Men's Track` -> `TTBB`
+- `Womens Track` / `Women's Track` / `Ladies Track` -> `SSAA`
+- `Mixed Track` -> `SATB`
+
+Unknown voicing values are skipped and reported in
+`tmp/barbershoptracks-skipped.json`.
+
+Title normalization fixes trailing articles, for example
+`Closest Thing To Crazy, The` becomes `The Closest Thing To Crazy`. Punctuation,
+apostrophes, parentheticals, and capitalization are otherwise preserved.
+Arranger normalization collapses whitespace, converts semicolon-separated names
+to comma-separated names, and changes ampersands between names to `and`.
+Multiple arrangers remain a single suggestion row.
+
+After reviewing the source PSV, merge it into the deployed suggestion catalog:
+
+```bash
+npm run song-suggestions:merge -- --dry-run
+npm run song-suggestions:merge
+```
+
+The merge script reads the existing `data/song_suggestion_catalog.psv` plus the
+BarbershopTracks source PSV, deduplicates by lowercased title + voicing +
+lowercased arranger, sorts the result, and writes a timestamped local backup to
+`data/backups/` before replacing the catalog. Backups are local safety files and
+should not be committed.
+
+Finally, dry-run and apply the Supabase catalog import:
+
+```bash
+npm run song-suggestions:import -- --dry-run
+SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import
+```
+
+This refresh affects only optional song-entry suggestions. It never writes to
+any user's My Songs and does not affect quartet matching.
+
 ## Harmony Brigade Songs
 
 Harmony Brigade data comes from Ross Wilkins' read-only Harmony Brigade MySQL

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -195,8 +195,9 @@ Established by migrations:
 
 Purpose: optional autocomplete reference data for song entry, imported from
 `data/song_suggestion_catalog.psv`. The PSV catalog is maintained from
-controlled metadata sources including `data/bhs_published_music_catalog.csv`
-and `data/international_songs_with_arranger.csv`; see `docs/imports.md`.
+controlled metadata sources including `data/bhs_published_music_catalog.csv`,
+`data/international_songs_with_arranger.csv`, and
+`data/sources/barbershoptracks_song_suggestions.psv`; see `docs/imports.md`.
 
 Code:
 - Imported by `scripts/import-song-suggestions.mjs`
@@ -205,11 +206,17 @@ Code:
 - International Songs source data is transformed by
   `scripts/import-international-songs.mjs` before being merged into
   `data/song_suggestion_catalog.psv`
+- BarbershopTracks source data is scraped from rendered Playwright pages by
+  `scripts/scrape-barbershoptracks-suggestions.mjs` into
+  `data/sources/barbershoptracks_song_suggestions.psv`
+- `scripts/merge-song-suggestion-sources.mjs` safely merges committed source
+  PSVs into `data/song_suggestion_catalog.psv` with a timestamped local backup
 - Preserved by `scripts/delete-user.mjs`; catalog rows are global suggestions,
   not user-owned data.
 - Read only through `public.search_repertoire_song_suggestions`
 - Parsed/deduplicated by `lib/__tests__/songSuggestionCatalogImport.test.ts`
-  and `lib/__tests__/bhsPublishedMusicImport.test.mjs`
+  and import-source tests including `lib/__tests__/bhsPublishedMusicImport.test.mjs`
+  and `lib/__tests__/barbershoptracksParser.test.mjs`
 
 Expected context:
 - Server/local import script with `SUPABASE_SERVICE_ROLE_KEY`

--- a/lib/__tests__/barbershoptracksParser.test.mjs
+++ b/lib/__tests__/barbershoptracksParser.test.mjs
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+const {
+  dedupeBarbershopTracksRows,
+  formatBarbershopTracksPsv,
+  normalizeBarbershopTracksArranger,
+  normalizeBarbershopTracksTitle,
+  normalizeBarbershopTracksVoicing,
+  parseBarbershopTracksRenderedText,
+} = await import("../../scripts/barbershoptracks-parser.mjs");
+
+describe("BarbershopTracks parser", () => {
+  it("normalizes supported BarbershopTracks voicing labels", () => {
+    expect(normalizeBarbershopTracksVoicing("Mens Track")).toBe("TTBB");
+    expect(normalizeBarbershopTracksVoicing("Women's Track")).toBe("SSAA");
+    expect(normalizeBarbershopTracksVoicing("Ladies Track")).toBe("SSAA");
+    expect(normalizeBarbershopTracksVoicing("Mixed Track")).toBe("SATB");
+  });
+
+  it("normalizes trailing title articles", () => {
+    expect(normalizeBarbershopTracksTitle("Closest Thing To Crazy, The")).toBe(
+      "The Closest Thing To Crazy"
+    );
+    expect(normalizeBarbershopTracksTitle("Winter's Tale, A")).toBe(
+      "A Winter's Tale"
+    );
+    expect(normalizeBarbershopTracksTitle("Example Song, An")).toBe(
+      "An Example Song"
+    );
+  });
+
+  it("normalizes arranger separators without splitting rows", () => {
+    expect(normalizeBarbershopTracksArranger("Sherwyn Heckt; Alden Parker")).toBe(
+      "Sherwyn Heckt, Alden Parker"
+    );
+    expect(normalizeBarbershopTracksArranger("Name One & Name Two")).toBe(
+      "Name One and Name Two"
+    );
+  });
+
+  it("parses multiple rendered text records", () => {
+    const parsed = parseBarbershopTracksRenderedText(`
+      First Song
+      Arranger: Arranger One
+      Voicing: Mens Track
+      Contestable: Yes
+      Genre: Ballad
+      Artist: Someone
+      Learn More
+      Second Song, The
+      Arranger: Arranger Two
+      Voicing: Mixed Track
+      Learn More
+    `);
+
+    expect(parsed.skipped).toEqual([]);
+    expect(parsed.rows).toEqual([
+      {
+        title: "First Song",
+        voicing: "TTBB",
+        arranger: "Arranger One",
+        source: "BarbershopTracks",
+      },
+      {
+        title: "The Second Song",
+        voicing: "SATB",
+        arranger: "Arranger Two",
+        source: "BarbershopTracks",
+      },
+    ]);
+  });
+
+  it("skips unknown voicing values instead of importing them", () => {
+    const parsed = parseBarbershopTracksRenderedText(`
+      Unknown Voicing Song
+      Arranger: Someone
+      Voicing: Octet Track
+      Learn More
+    `);
+
+    expect(parsed.rows).toEqual([]);
+    expect(parsed.skipped).toEqual([
+      expect.objectContaining({
+        title: "Unknown Voicing Song",
+        voicing: "Octet Track",
+        reason: "unknown_voicing",
+      }),
+    ]);
+  });
+
+  it("dedupes identical source rows but preserves arranger and voicing variants", () => {
+    const { rows, duplicateRows } = dedupeBarbershopTracksRows([
+      { title: "Same Song", voicing: "TTBB", arranger: "Writer" },
+      { title: "Same Song", voicing: "TTBB", arranger: "Writer" },
+      { title: "Same Song", voicing: "TTBB", arranger: "Other Writer" },
+      { title: "Same Song", voicing: "SSAA", arranger: "Writer" },
+    ]);
+
+    expect(duplicateRows).toBe(1);
+    expect(rows).toEqual([
+      { title: "Same Song", voicing: "SSAA", arranger: "Writer" },
+      { title: "Same Song", voicing: "TTBB", arranger: "Other Writer" },
+      { title: "Same Song", voicing: "TTBB", arranger: "Writer" },
+    ]);
+  });
+
+  it("replaces accidental pipe characters before writing PSV", () => {
+    expect(
+      formatBarbershopTracksPsv([
+        { title: "Pipe | Song", voicing: "TTBB", arranger: "Name | Two" },
+      ])
+    ).toBe("Song Title|Voicing|Arranger\nPipe / Song|TTBB|Name / Two\n");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-next": "16.2.4",
         "husky": "^9.1.7",
         "mysql2": "^3.22.3",
+        "playwright": "^1.57.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.5"
@@ -6664,6 +6665,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "harmony-brigade:export-source": "node scripts/export-harmony-brigade-source.mjs",
     "harmony-brigade:import": "node scripts/import-harmony-brigade-songs.mjs",
     "international-songs:import": "node scripts/import-international-songs.mjs",
+    "song-suggestions:merge": "node scripts/merge-song-suggestion-sources.mjs",
+    "song-suggestions:scrape:barbershoptracks": "node scripts/scrape-barbershoptracks-suggestions.mjs",
     "song-suggestions:import": "node scripts/import-song-suggestions.mjs",
     "test": "vitest",
     "test:run": "vitest run",
@@ -41,6 +43,7 @@
     "eslint-config-next": "16.2.4",
     "husky": "^9.1.7",
     "mysql2": "^3.22.3",
+    "playwright": "^1.57.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/scripts/barbershoptracks-parser.mjs
+++ b/scripts/barbershoptracks-parser.mjs
@@ -1,0 +1,210 @@
+const supportedVoicings = new Set(["TTBB", "SATB", "SSAA"]);
+
+function cleanText(value) {
+  const cleaned = String(value ?? "").replace(/\s+/g, " ").trim();
+  return cleaned || null;
+}
+
+export function normalizeBarbershopTracksTitle(value) {
+  const title = cleanText(value);
+  if (!title) return null;
+
+  const articleMatch = title.match(/^(.*),\s*(The|A|An)$/i);
+  if (!articleMatch) return title;
+
+  const baseTitle = articleMatch[1].trim();
+  const article = articleMatch[2];
+  return cleanText(`${article} ${baseTitle}`);
+}
+
+export function normalizeBarbershopTracksArranger(value) {
+  const arranger = cleanText(value);
+  if (!arranger) return null;
+
+  return cleanText(
+    arranger
+      .replace(/\s*;\s*/g, ", ")
+      .replace(/\s*&\s*/g, " and ")
+  );
+}
+
+export function normalizeBarbershopTracksVoicing(value) {
+  const voicing = cleanText(value);
+  if (!voicing) return null;
+
+  const normalized = voicing
+    .toLowerCase()
+    .replace(/[’']/g, "")
+    .replace(/[^a-z]+/g, " ")
+    .trim();
+
+  if (normalized === "mens track" || normalized === "men track") return "TTBB";
+  if (
+    normalized === "womens track" ||
+    normalized === "women track" ||
+    normalized === "ladies track" ||
+    normalized === "lady track"
+  ) {
+    return "SSAA";
+  }
+  if (normalized === "mixed track") return "SATB";
+
+  if (supportedVoicings.has(voicing.toUpperCase())) return voicing.toUpperCase();
+
+  return null;
+}
+
+function fieldValue(line, fieldName) {
+  const match = line.match(new RegExp(`^${fieldName}:\\s*(.*)$`, "i"));
+  return match ? match[1] : null;
+}
+
+function isRecordBoundary(line) {
+  return (
+    /^learn more$/i.test(line) ||
+    /^arranger:/i.test(line) ||
+    /^voicing:/i.test(line) ||
+    /^contestable:/i.test(line) ||
+    /^genre:/i.test(line) ||
+    /^artist:/i.test(line) ||
+    /^artist website:/i.test(line)
+  );
+}
+
+function renderedLines(text) {
+  return String(text ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function parseBarbershopTracksRenderedText(text) {
+  const lines = renderedLines(text);
+  const rows = [];
+  const skipped = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const arrangerValue = fieldValue(lines[index], "Arranger");
+    if (arrangerValue === null) continue;
+
+    const titleLine = lines[index - 1];
+    const title = titleLine && !isRecordBoundary(titleLine)
+      ? normalizeBarbershopTracksTitle(titleLine)
+      : null;
+    const arranger = normalizeBarbershopTracksArranger(arrangerValue);
+    let rawVoicing = null;
+
+    for (let nextIndex = index + 1; nextIndex < lines.length; nextIndex += 1) {
+      if (/^arranger:/i.test(lines[nextIndex])) break;
+      const voicingValue = fieldValue(lines[nextIndex], "Voicing");
+      if (voicingValue !== null) {
+        rawVoicing = voicingValue;
+        break;
+      }
+      if (/^learn more$/i.test(lines[nextIndex])) break;
+    }
+
+    const voicing = normalizeBarbershopTracksVoicing(rawVoicing);
+
+    if (!title) {
+      skipped.push({
+        lineNumber: index + 1,
+        arranger: arranger ?? arrangerValue,
+        voicing: rawVoicing,
+        reason: "missing_title",
+      });
+      continue;
+    }
+
+    if (!voicing) {
+      skipped.push({
+        lineNumber: index + 1,
+        title,
+        arranger,
+        voicing: rawVoicing,
+        reason: "unknown_voicing",
+      });
+      continue;
+    }
+
+    rows.push({
+      title,
+      voicing,
+      arranger,
+      source: "BarbershopTracks",
+    });
+  }
+
+  return { rows, skipped };
+}
+
+function sourceKey(row) {
+  return [
+    row.title.trim().toLowerCase(),
+    row.voicing,
+    String(row.arranger ?? "").trim().toLowerCase(),
+  ].join("|");
+}
+
+export function dedupeBarbershopTracksRows(rows) {
+  const deduped = new Map();
+  let duplicateRows = 0;
+
+  for (const row of rows) {
+    const key = sourceKey(row);
+    if (deduped.has(key)) {
+      duplicateRows += 1;
+      continue;
+    }
+    deduped.set(key, row);
+  }
+
+  return {
+    rows: sortBarbershopTracksRows(Array.from(deduped.values())),
+    duplicateRows,
+  };
+}
+
+export function sortBarbershopTracksRows(rows) {
+  return [...rows].sort((a, b) => {
+    return (
+      a.title.localeCompare(b.title) ||
+      a.voicing.localeCompare(b.voicing) ||
+      String(a.arranger ?? "").localeCompare(String(b.arranger ?? ""))
+    );
+  });
+}
+
+export function psvCell(value) {
+  return String(value ?? "").replace(/\|/g, "/").replace(/\r?\n/g, " ").trim();
+}
+
+export function formatBarbershopTracksPsv(rows) {
+  const lines = ["Song Title|Voicing|Arranger"];
+
+  for (const row of sortBarbershopTracksRows(rows)) {
+    lines.push(
+      [psvCell(row.title), psvCell(row.voicing), psvCell(row.arranger)].join("|")
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function pageCountFromRenderedText(text, { fallbackPages = 159 } = {}) {
+  const match = String(text ?? "").match(
+    /Items\s+([\d,]+)\s+to\s+([\d,]+)\s+of\s+([\d,]+)\s+total/i
+  );
+  if (!match) return fallbackPages;
+
+  const first = Number(match[1].replace(/,/g, ""));
+  const last = Number(match[2].replace(/,/g, ""));
+  const total = Number(match[3].replace(/,/g, ""));
+  const pageSize = last - first + 1;
+
+  if (!Number.isFinite(pageSize) || pageSize <= 0 || !Number.isFinite(total)) {
+    return fallbackPages;
+  }
+
+  return Math.ceil(total / pageSize);
+}

--- a/scripts/merge-song-suggestion-sources.mjs
+++ b/scripts/merge-song-suggestion-sources.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { formatSongSuggestionCatalog } from "./import-bhs-published-music.mjs";
+import { parseSongSuggestionCatalog } from "./import-song-suggestions.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const defaultCatalogPath = path.join(
+  repoRoot,
+  "data/song_suggestion_catalog.psv"
+);
+const defaultBackupDir = path.join(repoRoot, "data/backups");
+const defaultSourcePaths = [
+  path.join(repoRoot, "data/sources/barbershoptracks_song_suggestions.psv"),
+];
+
+function optionValue(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function timestamp() {
+  const now = new Date();
+  const date = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("");
+  const time = [
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("");
+  return `${date}-${time}`;
+}
+
+function catalogKey(row) {
+  return [
+    row.title.trim().toLowerCase(),
+    row.voicing,
+    String(row.arranger ?? "").trim().toLowerCase(),
+  ].join("|");
+}
+
+function mergeRows(rowSets) {
+  const deduped = new Map();
+  let duplicateRows = 0;
+
+  for (const rows of rowSets) {
+    for (const row of rows) {
+      const key = catalogKey(row);
+      if (deduped.has(key)) {
+        duplicateRows += 1;
+        continue;
+      }
+      deduped.set(key, row);
+    }
+  }
+
+  return {
+    rows: Array.from(deduped.values()).sort((a, b) => {
+      return (
+        a.title.localeCompare(b.title) ||
+        a.voicing.localeCompare(b.voicing) ||
+        String(a.arranger ?? "").localeCompare(String(b.arranger ?? ""))
+      );
+    }),
+    duplicateRows,
+  };
+}
+
+async function readCatalogRows(filePath) {
+  const contents = await readFile(filePath, "utf8");
+  return {
+    contents,
+    rows: parseSongSuggestionCatalog(contents),
+  };
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const dryRun = args.has("--dry-run");
+  const catalogPath = path.resolve(optionValue("catalog") ?? defaultCatalogPath);
+  const backupDir = path.resolve(optionValue("backup-dir") ?? defaultBackupDir);
+  const sourceArgs = process.argv
+    .filter((arg) => arg.startsWith("--source="))
+    .map((arg) => path.resolve(arg.slice("--source=".length)));
+  const sourcePaths = sourceArgs.length > 0 ? sourceArgs : defaultSourcePaths;
+
+  const existing = await readCatalogRows(catalogPath);
+  const sourceRows = [];
+
+  for (const sourcePath of sourcePaths) {
+    const source = await readCatalogRows(sourcePath);
+    sourceRows.push(source.rows);
+    console.log(`${path.relative(repoRoot, sourcePath)} rows: ${source.rows.length}`);
+  }
+
+  const merged = mergeRows([existing.rows, ...sourceRows]);
+  console.log(`${path.relative(repoRoot, catalogPath)} rows: ${existing.rows.length}`);
+  console.log(`Merged catalog rows: ${merged.rows.length}`);
+  console.log(`Duplicate rows collapsed: ${merged.duplicateRows}`);
+
+  if (dryRun) {
+    console.log("Dry run complete. Catalog was not written.");
+    return;
+  }
+
+  await mkdir(backupDir, { recursive: true });
+  const backupPath = path.join(
+    backupDir,
+    `song_suggestion_catalog.${timestamp()}.psv`
+  );
+  await writeFile(backupPath, existing.contents, "utf8");
+  await writeFile(catalogPath, formatSongSuggestionCatalog(merged.rows), "utf8");
+
+  console.log(`Backed up previous catalog to ${path.relative(repoRoot, backupPath)}.`);
+  console.log(`Wrote ${path.relative(repoRoot, catalogPath)}.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/scrape-barbershoptracks-suggestions.mjs
+++ b/scripts/scrape-barbershoptracks-suggestions.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  dedupeBarbershopTracksRows,
+  formatBarbershopTracksPsv,
+  pageCountFromRenderedText,
+  parseBarbershopTracksRenderedText,
+} from "./barbershoptracks-parser.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const sourceOutputPath = path.join(
+  repoRoot,
+  "data/sources/barbershoptracks_song_suggestions.psv"
+);
+const skippedOutputPath = path.join(
+  repoRoot,
+  "tmp/barbershoptracks-skipped.json"
+);
+const debugOutputDir = path.join(repoRoot, "tmp/barbershoptracks-debug");
+const fallbackPages = 159;
+const userAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+
+function argValue(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function pageUrl(pageNumber) {
+  const url = new URL("http://barbershoptracks.com/database.html");
+  url.searchParams.set("limit", "50");
+  url.searchParams.set("order", "name");
+  url.searchParams.set("dir", "asc");
+  if (pageNumber > 1) url.searchParams.set("p", String(pageNumber));
+  return url.toString();
+}
+
+async function importPlaywright() {
+  try {
+    return await import("playwright");
+  } catch {
+    throw new Error(
+      "Missing Playwright. Run `npm install` and, if needed, `npx playwright install chromium`."
+    );
+  }
+}
+
+async function scrapePage(page, pageNumber, { debug }) {
+  const url = pageUrl(pageNumber);
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+  await page.waitForSelector("body", { timeout: 30000 });
+  await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+  const text = await page.locator("body").innerText({ timeout: 30000 });
+
+  if (debug) {
+    await mkdir(debugOutputDir, { recursive: true });
+    await writeFile(
+      path.join(debugOutputDir, `page-${String(pageNumber).padStart(3, "0")}.txt`),
+      text,
+      "utf8"
+    );
+  }
+
+  return text;
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  if (args.has("--help") || args.has("-h")) {
+    console.log(`Usage: node scripts/scrape-barbershoptracks-suggestions.mjs [options]
+
+Options:
+  --headed       Show the Chromium browser while scraping.
+  --max-pages=N  Scrape only the first N rendered pages.
+  --debug        Write rendered page text snapshots to tmp/barbershoptracks-debug/.
+  --help         Show this help text.
+`);
+    return;
+  }
+
+  const headed = args.has("--headed");
+  const debug = args.has("--debug");
+  const maxPagesArg = argValue("max-pages");
+  const maxPages = maxPagesArg ? Number(maxPagesArg) : null;
+
+  if (maxPages !== null && (!Number.isInteger(maxPages) || maxPages < 1)) {
+    throw new Error("--max-pages must be a positive integer.");
+  }
+
+  const { chromium } = await importPlaywright();
+  const browser = await chromium.launch({ headless: !headed });
+  const context = await browser.newContext({
+    viewport: { width: 1366, height: 900 },
+    userAgent,
+  });
+  const page = await context.newPage();
+
+  try {
+    const allRows = [];
+    const allSkipped = [];
+
+    const firstPageText = await scrapePage(page, 1, { debug });
+    const totalPages = pageCountFromRenderedText(firstPageText, { fallbackPages });
+    const pageLimit = Math.min(totalPages, maxPages ?? totalPages);
+    const firstPageParsed = parseBarbershopTracksRenderedText(firstPageText);
+    allRows.push(...firstPageParsed.rows);
+    allSkipped.push(...firstPageParsed.skipped.map((skip) => ({ page: 1, ...skip })));
+
+    for (let pageNumber = 2; pageNumber <= pageLimit; pageNumber += 1) {
+      const text = await scrapePage(page, pageNumber, { debug });
+      const parsed = parseBarbershopTracksRenderedText(text);
+      allRows.push(...parsed.rows);
+      allSkipped.push(...parsed.skipped.map((skip) => ({ page: pageNumber, ...skip })));
+      console.log(`Scraped page ${pageNumber} of ${pageLimit}.`);
+    }
+
+    const deduped = dedupeBarbershopTracksRows(allRows);
+    await mkdir(path.dirname(sourceOutputPath), { recursive: true });
+    await writeFile(sourceOutputPath, formatBarbershopTracksPsv(deduped.rows), "utf8");
+
+    await mkdir(path.dirname(skippedOutputPath), { recursive: true });
+    await writeFile(
+      skippedOutputPath,
+      `${JSON.stringify(allSkipped, null, 2)}\n`,
+      "utf8"
+    );
+
+    const voicingCounts = deduped.rows.reduce((counts, row) => {
+      counts[row.voicing] = (counts[row.voicing] ?? 0) + 1;
+      return counts;
+    }, {});
+
+    console.log(`Detected pages: ${totalPages}. Scraped pages: ${pageLimit}.`);
+    console.log(`Raw imported rows: ${allRows.length}.`);
+    console.log(`Duplicate rows collapsed: ${deduped.duplicateRows}.`);
+    console.log(`Skipped rows: ${allSkipped.length}.`);
+    console.log(
+      `Imported rows by voicing: ${Object.entries(voicingCounts)
+        .sort()
+        .map(([voicing, count]) => `${voicing} ${count}`)
+        .join(", ")}`
+    );
+    console.log(`Wrote ${sourceOutputPath}.`);
+    console.log(`Wrote ${skippedOutputPath}.`);
+  } finally {
+    await browser.close();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- Add a Playwright/Chromium BarbershopTracks scraper that reads rendered paginated pages, normalizes title/arranger/voicing data, writes skipped rows to `tmp/`, and writes the committed source PSV at `data/sources/barbershoptracks_song_suggestions.psv`.
- Add a repeatable song suggestion source merge script with dry-run support and timestamped local catalog backups.
- Merge the full BarbershopTracks source into `data/song_suggestion_catalog.psv` and document the refresh workflow.

## Scrape and merge results
- Full scrape detected 159 pages and 7,910 raw rendered records.
- Source dedupe collapsed 1,360 duplicate BarbershopTracks rows, producing 6,550 source PSV rows including the header.
- No unknown voicing rows were skipped in the full scrape.
- Merge dry-run reported 21,972 existing catalog rows, 6,450 parsed BarbershopTracks source rows, 2,285 lowercased-key duplicates, and 26,137 merged catalog rows.
- `npm run song-suggestions:import -- --dry-run` parsed 25,928 final import rows after the app import normalizer deduped equivalent variants.

## Docs and tests
- Added parser/normalizer coverage for BarbershopTracks voicing, title articles, arranger separators, multi-record parsing, duplicate handling, variant preservation, unknown voicing skips, and PSV pipe escaping.
- Updated `README.md`, `docs/imports.md`, and `docs/supabase-contract.md`.
- No Supabase schema/RLS migration is required.

## Verification
- npm run song-suggestions:scrape:barbershoptracks -- --max-pages=5 --debug
- npm run song-suggestions:scrape:barbershoptracks
- npm run song-suggestions:merge -- --dry-run
- npm run song-suggestions:merge
- npm run song-suggestions:import -- --dry-run
- npm run test:run
- npm run build

## Required manual deployment step
- After this PR merges and deploys, run `SUPABASE_SERVICE_ROLE_KEY=... npm run song-suggestions:import` to replace the production `song_suggestion_catalog` rows with the updated PSV catalog.

Closes #331