### PR TITLE
Correct Harmony Brigade picker search helper text

### DIFF
--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -1463,7 +1463,7 @@ export default function RepertoireManager() {
                           onChange={(event) =>
                             setHarmonyBrigadeSearchQuery(event.target.value)
                           }
-                          placeholder="Filter by title, arranger, quartet, or lyrics"
+                          placeholder="Filter by title, arranger, or Brigade acronym like NPHB"
                           className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                         />
                       </label>

--- a/lib/__tests__/harmonyBrigadeUi.test.ts
+++ b/lib/__tests__/harmonyBrigadeUi.test.ts
@@ -56,4 +56,13 @@ describe("Harmony Brigade repertoire UI", () => {
       "searchRepertoireSongSuggestions(harmonyBrigadeSearchQuery"
     );
   });
+
+  it("describes Brigade picker search without promising lyrics or quartet search", () => {
+    expect(repertoireManager).toContain(
+      "Filter by title, arranger, or Brigade acronym like NPHB"
+    );
+    expect(repertoireManager).not.toContain(
+      "Filter by title, arranger, quartet, or lyrics"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Update the Harmony Brigade picker search placeholder to mention title, arranger, and Brigade acronym like NPHB.
- Add a regression assertion so the old lyrics/quartet wording does not return.

## Docs and tests
- Docs not updated: this is a small UI copy correction and does not change setup, data behavior, Supabase contracts, analytics, or app flow semantics.
- Tests updated in `lib/__tests__/harmonyBrigadeUi.test.ts`.

## Verification
- npm run test:run
- npm run build

Closes #329
