### PR TITLE
Add Event Mode event discovery and creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ The Supabase project should have the current production schema applied:
   The app reads dedicated Supabase reference tables for the secondary
   **Add Harmony Brigade songs** repertoire flow. Adding songs writes only to
   the current user's `user_repertoire`.
+- `event_mode_events` stores user-created Event Mode event spaces. Listed
+  events can be discovered by signed-in users, unlisted events require a
+  link/code, and creators can edit or close their own events.
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes

--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { AppNav } from "@/components/AppNav";
+import {
+  closeEventModeEvent,
+  formatEventModeDateRange,
+  getEventModeEventByCode,
+  getEventModeLifecycle,
+  updateEventModeEvent,
+  type EventModeEvent,
+  type EventModeVisibility,
+} from "@/lib/eventMode";
+import { getCurrentUser } from "@/lib/profileStore";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type EventFormState = {
+  name: string;
+  city: string;
+  venueOrLocationNote: string;
+  startAt: string;
+  endAt: string;
+  visibility: EventModeVisibility;
+};
+
+function toLocalDateTimeValue(value: string) {
+  const date = new Date(value);
+  const offsetMs = date.getTimezoneOffset() * 60 * 1000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function formFromEvent(event: EventModeEvent): EventFormState {
+  return {
+    name: event.name,
+    city: event.city ?? "",
+    venueOrLocationNote: event.venue_or_location_note ?? "",
+    startAt: toLocalDateTimeValue(event.start_at),
+    endAt: toLocalDateTimeValue(event.end_at),
+    visibility: event.visibility,
+  };
+}
+
+function eventLocation(event: EventModeEvent) {
+  return [event.city, event.venue_or_location_note].filter(Boolean).join(" · ");
+}
+
+export default function EventModeDetailPage() {
+  const params = useParams<{ code: string }>();
+  const code = params.code;
+  const [event, setEvent] = useState<EventModeEvent | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [form, setForm] = useState<EventFormState | null>(null);
+  const [message, setMessage] = useState("");
+  const [messageTone, setMessageTone] = useState<"error" | "success">("error");
+
+  useEffect(() => {
+    async function loadEvent() {
+      try {
+        const [loadedEvent, user] = await Promise.all([
+          getEventModeEventByCode(code),
+          getCurrentUser().catch(() => null),
+        ]);
+        setEvent(loadedEvent);
+        setForm(loadedEvent ? formFromEvent(loadedEvent) : null);
+        setCurrentUserId(user?.id ?? null);
+      } catch (err) {
+        console.error("Could not load Event Mode event", err);
+        setMessageTone("error");
+        setMessage("Could not load this event. Check the link or code.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadEvent();
+  }, [code]);
+
+  const isCreator = Boolean(
+    event && currentUserId && event.created_by_user_id === currentUserId
+  );
+  const lifecycle = event ? getEventModeLifecycle(event) : null;
+
+  function updateForm<K extends keyof EventFormState>(
+    key: K,
+    value: EventFormState[K]
+  ) {
+    setForm((current) => (current ? { ...current, [key]: value } : current));
+  }
+
+  async function saveEvent() {
+    if (!event || !form) return;
+    setSaving(true);
+    setMessage("");
+
+    try {
+      const updated = await updateEventModeEvent(event.id, form);
+      setEvent(updated);
+      setForm(formFromEvent(updated));
+      setEditing(false);
+      setMessageTone("success");
+      setMessage("Event updated.");
+    } catch (err) {
+      console.error("Could not update Event Mode event", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not update event.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function closeEvent() {
+    if (!event) return;
+    setClosing(true);
+    setMessage("");
+
+    try {
+      const updated = await closeEventModeEvent(event.id);
+      setEvent(updated);
+      setForm(formFromEvent(updated));
+      setEditing(false);
+      setMessageTone("success");
+      setMessage("Event closed.");
+    } catch (err) {
+      console.error("Could not close Event Mode event", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not close event.");
+    } finally {
+      setClosing(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
+      <div className="mx-auto max-w-4xl">
+        <AppNav variant={currentUserId ? "app" : "public"} />
+
+        {loading && <p className="mt-8 text-slate-300">Loading event...</p>}
+
+        {!loading && !event && (
+          <section className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-5">
+            <h1 className="text-2xl font-bold">Event not found</h1>
+            <p className="mt-2 text-rose-100">
+              Check the Event Mode code or ask the singer who shared it.
+            </p>
+            <a
+              href="/event-mode"
+              className="mt-4 inline-block rounded-xl bg-rose-100 px-5 py-3 font-semibold text-slate-950 hover:bg-white"
+            >
+              Find my event
+            </a>
+          </section>
+        )}
+
+        {event && (
+          <>
+            <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
+              Event Mode
+            </p>
+            <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div>
+                <h1 className="text-4xl font-bold tracking-tight">
+                  {event.name}
+                </h1>
+                <p className="mt-3 text-lg text-slate-300">
+                  {[eventLocation(event), formatEventModeDateRange(event)]
+                    .filter(Boolean)
+                    .join(" · ")}
+                </p>
+                <p className="mt-2 text-sm font-semibold uppercase text-cyan-200">
+                  {lifecycle} · {event.visibility}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-slate-200">
+                <p className="font-semibold text-white">Event code</p>
+                <p className="mt-1 text-2xl font-bold tracking-widest text-cyan-200">
+                  {event.join_code}
+                </p>
+              </div>
+            </div>
+
+            {message && (
+              <p
+                className={`mt-4 text-sm ${
+                  messageTone === "success" ? "text-cyan-200" : "text-rose-200"
+                }`}
+              >
+                {message}
+              </p>
+            )}
+
+            {!currentUserId && (
+              <section className="mt-8 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5">
+                <h2 className="text-xl font-bold">Sign in to use this event</h2>
+                <p className="mt-2 text-sm leading-6 text-cyan-50/80">
+                  Event Mode helps singers find pickup singing opportunities at
+                  an event. Sign in to use this event.
+                </p>
+                <a
+                  href={`/login?redirect=/event-mode/${event.join_code}`}
+                  className="mt-4 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
+                >
+                  Sign in
+                </a>
+              </section>
+            )}
+
+            {currentUserId && (
+              <section className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-5">
+                <h2 className="text-2xl font-bold">Use this event</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+                  This event is ready for Event Mode. Availability and messaging
+                  arrive in follow-up work. For now, use this event as the shared
+                  place singers can find before starting a quartet.
+                </p>
+                <a
+                  href="/session"
+                  className="mt-4 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
+                >
+                  Start a quartet
+                </a>
+              </section>
+            )}
+
+            {isCreator && form && (
+              <section className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="text-2xl font-bold">Event settings</h2>
+                    <p className="mt-1 text-sm text-slate-300">
+                      Event creators can edit details or close the event.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setEditing((current) => !current)}
+                    className="rounded-xl bg-slate-800 px-4 py-2 font-semibold text-slate-100 hover:bg-slate-700"
+                  >
+                    {editing ? "Cancel editing" : "Edit event"}
+                  </button>
+                </div>
+
+                {editing && (
+                  <div className="mt-5 grid gap-4 md:grid-cols-2">
+                    <label className="md:col-span-2">
+                      <span className="text-sm font-semibold text-slate-200">
+                        Event name
+                      </span>
+                      <input
+                        value={form.name}
+                        onChange={(inputEvent) =>
+                          updateForm("name", inputEvent.target.value)
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
+                    <label>
+                      <span className="text-sm font-semibold text-slate-200">
+                        City or location note
+                      </span>
+                      <input
+                        value={form.city}
+                        onChange={(inputEvent) =>
+                          updateForm("city", inputEvent.target.value)
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
+                    <label>
+                      <span className="text-sm font-semibold text-slate-200">
+                        Venue or room note
+                      </span>
+                      <input
+                        value={form.venueOrLocationNote}
+                        onChange={(inputEvent) =>
+                          updateForm(
+                            "venueOrLocationNote",
+                            inputEvent.target.value
+                          )
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
+                    <label>
+                      <span className="text-sm font-semibold text-slate-200">
+                        Start date/time
+                      </span>
+                      <input
+                        type="datetime-local"
+                        value={form.startAt}
+                        onChange={(inputEvent) =>
+                          updateForm("startAt", inputEvent.target.value)
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
+                    <label>
+                      <span className="text-sm font-semibold text-slate-200">
+                        End date/time
+                      </span>
+                      <input
+                        type="datetime-local"
+                        value={form.endAt}
+                        onChange={(inputEvent) =>
+                          updateForm("endAt", inputEvent.target.value)
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                      />
+                    </label>
+                    <fieldset className="md:col-span-2">
+                      <legend className="text-sm font-semibold text-slate-200">
+                        Visibility
+                      </legend>
+                      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                        {(["listed", "unlisted"] as const).map((visibility) => (
+                          <label
+                            key={visibility}
+                            className="flex items-center gap-3 rounded-xl border border-white/10 bg-slate-900/80 px-4 py-3"
+                          >
+                            <input
+                              type="radio"
+                              name="detail-visibility"
+                              checked={form.visibility === visibility}
+                              onChange={() => updateForm("visibility", visibility)}
+                            />
+                            <span className="font-semibold capitalize">
+                              {visibility}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </fieldset>
+
+                    <div className="flex flex-col gap-3 sm:flex-row md:col-span-2">
+                      <button
+                        type="button"
+                        onClick={saveEvent}
+                        disabled={saving}
+                        className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"
+                      >
+                        {saving ? "Saving..." : "Save event"}
+                      </button>
+                      {!event.closed_at && (
+                        <button
+                          type="button"
+                          onClick={closeEvent}
+                          disabled={closing}
+                          className="rounded-xl bg-rose-200 px-5 py-3 font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-50"
+                        >
+                          {closing ? "Closing..." : "Close event"}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/event-mode/page.tsx
+++ b/app/event-mode/page.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { AppNav } from "@/components/AppNav";
+import {
+  createEventModeEvent,
+  eventModePathFromCode,
+  findEventModeDuplicateCandidates,
+  formatEventModeDateRange,
+  getEventModeLifecycle,
+  searchEventModeEvents,
+  type EventModeDuplicateCandidate,
+  type EventModeEvent,
+  type EventModeVisibility,
+} from "@/lib/eventMode";
+import { getCurrentUser } from "@/lib/profileStore";
+import { useEffect, useMemo, useState } from "react";
+
+type EventFormState = {
+  name: string;
+  city: string;
+  venueOrLocationNote: string;
+  startAt: string;
+  endAt: string;
+  visibility: EventModeVisibility;
+};
+
+const emptyForm: EventFormState = {
+  name: "",
+  city: "",
+  venueOrLocationNote: "",
+  startAt: "",
+  endAt: "",
+  visibility: "listed",
+};
+
+function eventLocation(event: EventModeEvent) {
+  return [event.city, event.venue_or_location_note].filter(Boolean).join(" · ");
+}
+
+function eventSummary(event: EventModeEvent) {
+  const location = eventLocation(event);
+  const dateRange = formatEventModeDateRange(event);
+  return location ? `${location} · ${dateRange}` : dateRange;
+}
+
+export default function EventModePage() {
+  const [authChecked, setAuthChecked] = useState(false);
+  const [signedIn, setSignedIn] = useState(false);
+  const [events, setEvents] = useState<EventModeEvent[]>([]);
+  const [query, setQuery] = useState("");
+  const [codeInput, setCodeInput] = useState("");
+  const [form, setForm] = useState<EventFormState>(emptyForm);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [duplicates, setDuplicates] = useState<EventModeDuplicateCandidate[]>([]);
+  const [message, setMessage] = useState("");
+  const [messageTone, setMessageTone] = useState<"error" | "success">("error");
+  const [loadingEvents, setLoadingEvents] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  async function loadEvents(searchQuery = query) {
+    setLoadingEvents(true);
+    try {
+      const listedEvents = await searchEventModeEvents(searchQuery);
+      setEvents(listedEvents);
+    } catch (err) {
+      console.error("Could not load Event Mode events", err);
+      setMessageTone("error");
+      setMessage("Could not load events. Check your connection and try again.");
+    } finally {
+      setLoadingEvents(false);
+    }
+  }
+
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const user = await getCurrentUser();
+        setSignedIn(Boolean(user));
+        setAuthChecked(true);
+        if (user) await loadEvents("");
+      } catch (err) {
+        console.error("Could not check Event Mode access", err);
+        setAuthChecked(true);
+        setSignedIn(false);
+      }
+    }
+
+    checkAuth();
+  }, []);
+
+  const visibleEvents = useMemo(() => events, [events]);
+
+  function updateForm<K extends keyof EventFormState>(
+    key: K,
+    value: EventFormState[K]
+  ) {
+    setForm((current) => ({ ...current, [key]: value }));
+    setDuplicates([]);
+  }
+
+  function goToCode() {
+    const path = eventModePathFromCode(codeInput);
+    if (!path) {
+      setMessageTone("error");
+      setMessage("Enter a valid Event Mode link or six-character code.");
+      return;
+    }
+
+    window.location.href = path;
+  }
+
+  async function createEvent({ skipDuplicateCheck = false } = {}) {
+    setCreating(true);
+    setMessage("");
+
+    try {
+      if (!skipDuplicateCheck) {
+        const duplicateSource = await searchEventModeEvents("");
+        setEvents(duplicateSource);
+        const possibleDuplicates = findEventModeDuplicateCandidates(
+          form,
+          duplicateSource
+        );
+        if (possibleDuplicates.length > 0) {
+          setDuplicates(possibleDuplicates);
+          setCreating(false);
+          return;
+        }
+      }
+
+      const event = await createEventModeEvent(form);
+      setMessageTone("success");
+      setMessage("Event created.");
+      window.location.href = `/event-mode/${event.join_code}`;
+    } catch (err) {
+      console.error("Could not create Event Mode event", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not create event.");
+      setCreating(false);
+    }
+  }
+
+  if (!authChecked) {
+    return (
+      <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
+        <div className="mx-auto max-w-4xl">
+          <AppNav />
+          <p className="mt-8 text-slate-300">Loading Event Mode...</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
+        <div className="mx-auto max-w-2xl">
+          <AppNav variant="public" />
+          <p className="mt-10 text-sm font-semibold uppercase text-cyan-300">
+            Event Mode
+          </p>
+          <h1 className="mt-3 text-4xl font-bold tracking-tight">
+            Find singers at an event
+          </h1>
+          <p className="mt-4 text-lg leading-8 text-slate-300">
+            Event Mode helps singers find pickup singing opportunities at an
+            event. Sign in to find or create an event.
+          </p>
+          <a
+            href="/login?redirect=/event-mode"
+            className="mt-6 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
+          >
+            Sign in
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
+      <div className="mx-auto max-w-5xl">
+        <AppNav />
+
+        <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
+          Event Mode
+        </p>
+        <h1 className="mt-3 text-4xl font-bold tracking-tight">
+          Find singers at an event
+        </h1>
+        <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">
+          Find singers at a convention, afterglow, Brigade weekend, or other
+          singing event.
+        </p>
+
+        {message && (
+          <p
+            className={`mt-4 text-sm ${
+              messageTone === "success" ? "text-cyan-200" : "text-rose-200"
+            }`}
+          >
+            {message}
+          </p>
+        )}
+
+        <div className="mt-8 grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+          <section className="rounded-2xl border border-white/10 bg-white/10 p-5">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <label className="flex-1">
+                <span className="text-sm font-semibold text-slate-200">
+                  Find my event
+                </span>
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") loadEvents(query);
+                  }}
+                  placeholder="Search by event name, city, or shorthand like AHB"
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() => loadEvents(query)}
+                disabled={loadingEvents}
+                className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50 sm:self-end"
+              >
+                {loadingEvents ? "Searching..." : "Find my event"}
+              </button>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {visibleEvents.length === 0 && (
+                <p className="rounded-xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                  No active or upcoming listed events found yet.
+                </p>
+              )}
+
+              {visibleEvents.map((event) => (
+                <article
+                  key={event.id}
+                  className="rounded-xl border border-white/10 bg-slate-900/80 p-4"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <h2 className="text-lg font-semibold text-white">
+                        {event.name}
+                      </h2>
+                      <p className="mt-1 text-sm text-slate-300">
+                        {eventSummary(event)}
+                      </p>
+                      <p className="mt-1 text-xs font-semibold uppercase text-cyan-200">
+                        {getEventModeLifecycle(event)}
+                      </p>
+                    </div>
+                    <a
+                      href={`/event-mode/${event.join_code}`}
+                      className="rounded-xl bg-cyan-300 px-4 py-2 text-center text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+                    >
+                      Use this event
+                    </a>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <aside className="space-y-4">
+            <section className="rounded-2xl border border-white/10 bg-white/10 p-5">
+              <h2 className="text-xl font-bold">Enter with a link or code</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Use this for an unlisted event someone shared with you.
+              </p>
+              <label className="mt-4 block">
+                <span className="text-sm font-semibold text-slate-200">
+                  Event code or link
+                </span>
+                <input
+                  value={codeInput}
+                  onChange={(event) => setCodeInput(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") goToCode();
+                  }}
+                  autoCapitalize="characters"
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={goToCode}
+                className="mt-4 w-full rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-100 hover:bg-slate-700"
+              >
+                Use this event
+              </button>
+            </section>
+
+            <section className="rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5">
+              <h2 className="text-xl font-bold">Create an event</h2>
+              <p className="mt-2 text-sm leading-6 text-cyan-50/80">
+                Create an event so singers using WCWS can find each other while
+                they&apos;re there. This does not create an official event
+                listing.
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowCreateForm((current) => !current)}
+                className="mt-4 w-full rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
+              >
+                {showCreateForm ? "Hide event form" : "Create an event"}
+              </button>
+            </section>
+          </aside>
+        </div>
+
+        {showCreateForm && (
+          <section className="mt-6 rounded-2xl border border-white/10 bg-white/10 p-5">
+            <h2 className="text-2xl font-bold">Create an event</h2>
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <label className="md:col-span-2">
+                <span className="text-sm font-semibold text-slate-200">
+                  Event name
+                </span>
+                <input
+                  value={form.name}
+                  onChange={(event) => updateForm("name", event.target.value)}
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <label>
+                <span className="text-sm font-semibold text-slate-200">
+                  City or location note
+                </span>
+                <input
+                  value={form.city}
+                  onChange={(event) => updateForm("city", event.target.value)}
+                  placeholder="Denver, CO"
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <label>
+                <span className="text-sm font-semibold text-slate-200">
+                  Venue or room note
+                </span>
+                <input
+                  value={form.venueOrLocationNote}
+                  onChange={(event) =>
+                    updateForm("venueOrLocationNote", event.target.value)
+                  }
+                  placeholder="Hotel lobby, afterglow, hospitality room"
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <label>
+                <span className="text-sm font-semibold text-slate-200">
+                  Start date/time
+                </span>
+                <input
+                  type="datetime-local"
+                  value={form.startAt}
+                  onChange={(event) => updateForm("startAt", event.target.value)}
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+              <label>
+                <span className="text-sm font-semibold text-slate-200">
+                  End date/time
+                </span>
+                <input
+                  type="datetime-local"
+                  value={form.endAt}
+                  onChange={(event) => updateForm("endAt", event.target.value)}
+                  className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                />
+              </label>
+            </div>
+
+            <fieldset className="mt-5">
+              <legend className="text-sm font-semibold text-slate-200">
+                Visibility
+              </legend>
+              <p className="mt-1 text-sm text-slate-300">
+                Listed events can be found by other signed-in WCWS users.
+                Unlisted events require a link or code.
+              </p>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                {(["listed", "unlisted"] as const).map((visibility) => (
+                  <label
+                    key={visibility}
+                    className="flex items-center gap-3 rounded-xl border border-white/10 bg-slate-900/80 px-4 py-3"
+                  >
+                    <input
+                      type="radio"
+                      name="visibility"
+                      checked={form.visibility === visibility}
+                      onChange={() => updateForm("visibility", visibility)}
+                    />
+                    <span className="font-semibold capitalize">{visibility}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            {duplicates.length > 0 && (
+              <div className="mt-5 rounded-xl border border-amber-300/30 bg-amber-300/10 p-4">
+                <h3 className="text-lg font-bold text-amber-100">
+                  This might already exist
+                </h3>
+                <div className="mt-3 space-y-3">
+                  {duplicates.map((candidate) => (
+                    <div
+                      key={candidate.event.id}
+                      className="rounded-xl bg-slate-950/50 p-4"
+                    >
+                      <p className="font-semibold text-white">
+                        {candidate.event.name}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-300">
+                        {eventSummary(candidate.event)}
+                      </p>
+                      <p className="mt-1 text-xs text-amber-100">
+                        Similar because of {candidate.reasons.join(", ")}.
+                      </p>
+                      <a
+                        href={`/event-mode/${candidate.event.join_code}`}
+                        className="mt-3 inline-block rounded-xl bg-amber-200 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-100"
+                      >
+                        Use existing event
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => createEvent()}
+                disabled={creating}
+                className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"
+              >
+                {creating ? "Creating..." : "Create an event"}
+              </button>
+              {duplicates.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => createEvent({ skipDuplicateCheck: true })}
+                  disabled={creating}
+                  className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-100 hover:bg-slate-700 disabled:opacity-50"
+                >
+                  Create new event anyway
+                </button>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -326,6 +326,75 @@ Required database contract:
 Established by migrations:
 - `20260501200000_add_harmony_brigade_reference_tables.sql`
 
+### Event Mode Events
+
+Purpose: source of truth for user-created Event Mode event spaces. Event Mode
+helps signed-in singers find the right convention, afterglow, Brigade weekend,
+chapter event, retreat, or informal singing event without requiring an
+admin-created listing or a private quartet code.
+
+Event Mode is temporary, opt-in, event-scoped, and a bridge back to the
+existing Start/Join quartet flow. It must not become GPS tracking, exact
+location discovery, a global singer directory, permanent availability,
+repertoire sharing, a public profile system, or a formal invite-to-quartet
+workflow.
+
+Code:
+- Browser create/search/edit/close helpers: `lib/eventMode.ts`
+- Event Mode landing/search/create route: `app/event-mode/page.tsx`
+- Event detail/code route: `app/event-mode/[code]/page.tsx`
+- Tests: `lib/__tests__/eventMode.test.ts`,
+  `lib/__tests__/eventModeUi.test.ts`, and this Supabase contract test
+
+Expected context:
+- Signed-in users can create listed or unlisted events.
+- Signed-in users can browse/search listed upcoming or active events.
+- Unlisted events are not returned by listed browse/search helpers.
+- Anyone with a valid event code or link can open the event route through
+  `get_event_mode_event_by_code`; seeing future availability/messaging may
+  require sign-in in follow-up work.
+- Event creators can edit event name, date/time, location note, and visibility.
+- Event creators can close their own event by setting `closed_at`.
+- Other users cannot edit or close events they did not create.
+- Lifecycle is derived from `start_at`, `end_at`, and `closed_at` as upcoming,
+  active, or ended.
+- Duplicate prevention is an app helper that compares normalized name, date
+  overlap, and location context before final create.
+
+Required database contract:
+- `event_mode_events`
+  - `id uuid primary key`
+  - `name text not null`
+  - `normalized_name text not null`
+  - optional `city text`
+  - optional `venue_or_location_note text`
+  - `start_at timestamptz not null`
+  - `end_at timestamptz not null`
+  - `visibility text not null default 'listed'`
+  - `join_code text not null`
+  - `created_by_user_id uuid references auth.users(id)`
+  - `created_at timestamptz not null default now()`
+  - `updated_at timestamptz not null default now()`
+  - optional `closed_at timestamptz`
+- Check constraint keeps `end_at > start_at`.
+- Check constraint keeps visibility to `listed` or `unlisted`.
+- Check constraint keeps join codes to six uppercase alphanumeric characters.
+- Unique index on `join_code`.
+- Browse index on visibility and event dates for open events.
+- Creator index on `created_by_user_id`.
+- RLS enabled.
+- Authenticated users can select listed events and their own events.
+- Authenticated users can insert rows only with
+  `created_by_user_id = auth.uid()`.
+- Event creators can update only their own rows.
+- No authenticated delete policy; closing an event updates `closed_at`.
+- `get_event_mode_event_by_code(text)` is a security-definer function granted
+  to anon and authenticated users so unlisted events can be opened by link/code
+  without appearing in browse/search.
+
+Established by migrations:
+- `20260502080000_add_event_mode_events.sql`
+
 ### `sessions`
 
 Purpose: source of truth for quartet join codes and session activity.

--- a/lib/__tests__/eventMode.test.ts
+++ b/lib/__tests__/eventMode.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { EventModeEvent } from "@/lib/eventMode";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+
+const {
+  eventModeSearchMatches,
+  findEventModeDuplicateCandidates,
+  getEventModeLifecycle,
+  normalizeEventModeText,
+  parseEventModeCode,
+} = await import("@/lib/eventMode");
+
+const storeSource = readFileSync(
+  join(process.cwd(), "lib/eventMode.ts"),
+  "utf8"
+);
+
+function event(overrides: Partial<EventModeEvent> = {}): EventModeEvent {
+  return {
+    id: "event-1",
+    name: "Rocky Mountain District Fall Convention",
+    normalized_name: "rocky mountain district fall convention",
+    city: "Denver, CO",
+    venue_or_location_note: "Convention hotel",
+    start_at: "2026-10-09T18:00:00.000Z",
+    end_at: "2026-10-11T18:00:00.000Z",
+    visibility: "listed",
+    join_code: "ABC123",
+    created_by_user_id: "user-1",
+    created_at: "2026-05-02T00:00:00.000Z",
+    updated_at: "2026-05-02T00:00:00.000Z",
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+describe("Event Mode helpers", () => {
+  it("normalizes search text without making Event Mode GPS-like", () => {
+    expect(normalizeEventModeText("  BHS Midwinter—San Antonio! ")).toBe(
+      "bhs midwinter san antonio"
+    );
+  });
+
+  it("parses six-character event codes and event-mode links", () => {
+    expect(parseEventModeCode(" ab12cd ")).toBe("AB12CD");
+    expect(parseEventModeCode("https://example.com/event-mode/xy98zz")).toBe(
+      "XY98ZZ"
+    );
+    expect(parseEventModeCode("https://example.com/join/xy98zz")).toBeNull();
+  });
+
+  it("derives upcoming, active, and ended lifecycle from event dates and closure", () => {
+    const now = new Date("2026-10-10T12:00:00.000Z");
+
+    expect(getEventModeLifecycle(event(), now)).toBe("active");
+    expect(
+      getEventModeLifecycle(
+        event({
+          start_at: "2026-10-12T18:00:00.000Z",
+          end_at: "2026-10-14T18:00:00.000Z",
+        }),
+        now
+      )
+    ).toBe("upcoming");
+    expect(
+      getEventModeLifecycle(
+        event({ closed_at: "2026-10-10T13:00:00.000Z" }),
+        now
+      )
+    ).toBe("ended");
+  });
+
+  it("matches listed event searches by name, city, or location note", () => {
+    const candidate = event();
+
+    expect(eventModeSearchMatches(candidate, "Rocky Mountain")).toBe(true);
+    expect(eventModeSearchMatches(candidate, "Denver")).toBe(true);
+    expect(eventModeSearchMatches(candidate, "hotel")).toBe(true);
+    expect(eventModeSearchMatches(candidate, "Midwinter")).toBe(false);
+  });
+
+  it("finds possible duplicates by similar name plus overlapping date or location", () => {
+    const candidates = findEventModeDuplicateCandidates(
+      {
+        name: "RMD Fall Convention",
+        city: "Denver",
+        venueOrLocationNote: "",
+        startAt: "2026-10-10T00:00:00.000Z",
+        endAt: "2026-10-12T00:00:00.000Z",
+      },
+      [
+        event({
+          name: "Rocky Mountain District Fall Convention",
+          normalized_name: "rocky mountain district fall convention",
+        }),
+        event({
+          id: "event-2",
+          name: "Sunshine District Spring Convention",
+          normalized_name: "sunshine district spring convention",
+          city: "Orlando, FL",
+        }),
+      ],
+      new Date("2026-05-02T00:00:00.000Z")
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].event.name).toBe(
+      "Rocky Mountain District Fall Convention"
+    );
+    expect(candidates[0].reasons).toContain("similar location");
+  });
+
+  it("keeps Event Mode browsing scoped to listed active or upcoming events", () => {
+    expect(storeSource).toContain('.eq("visibility", "listed")');
+    expect(storeSource).toContain('.is("closed_at", null)');
+    expect(storeSource).toContain('.gte("end_at", now.toISOString())');
+    expect(storeSource).toContain("get_event_mode_event_by_code");
+  });
+});

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const landingPage = readFileSync(
+  join(process.cwd(), "app/event-mode/page.tsx"),
+  "utf8"
+);
+const detailPage = readFileSync(
+  join(process.cwd(), "app/event-mode/[code]/page.tsx"),
+  "utf8"
+);
+
+describe("Event Mode UI copy", () => {
+  it("uses Event Mode terminology and the requested core actions", () => {
+    expect(landingPage).toContain("Event Mode");
+    expect(landingPage).toContain("Find my event");
+    expect(landingPage).toContain("Create an event");
+    expect(landingPage).toContain("Enter with a link or code");
+    expect(landingPage).toContain("Use this event");
+    expect(detailPage).toContain("Start a quartet");
+  });
+
+  it("does not introduce deprecated pickup board or location-discovery language", () => {
+    const combined = `${landingPage}\n${detailPage}`;
+
+    expect(combined).not.toContain("Pickup Board");
+    expect(combined).not.toContain("Create an event board");
+    expect(combined).not.toContain("Open event");
+    expect(combined).not.toContain("Nearby singers");
+    expect(combined).not.toContain("Location discovery");
+    expect(combined).not.toContain("Public profile");
+    expect(combined).not.toContain("Invite to quartet");
+  });
+});

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -93,6 +93,13 @@ const harmonyBrigadeMigration = readFileSync(
   ),
   "utf8"
 );
+const eventModeMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260502080000_add_event_mode_events.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -105,6 +112,7 @@ describe("Supabase contract guardrails", () => {
     "harmony_brigade_songs",
     "harmony_brigade_events",
     "harmony_brigade_event_songs",
+    "event_mode_events",
   ];
   const baseMigrationTables = tables.filter(
     (table) =>
@@ -113,6 +121,7 @@ describe("Supabase contract guardrails", () => {
         "harmony_brigade_songs",
         "harmony_brigade_events",
         "harmony_brigade_event_songs",
+        "event_mode_events",
       ].includes(table)
   );
 
@@ -322,5 +331,29 @@ describe("Supabase contract guardrails", () => {
     expect(harmonyBrigadeMigration).not.toContain("for insert");
     expect(harmonyBrigadeMigration).not.toContain("for update");
     expect(harmonyBrigadeMigration).not.toContain("for delete");
+  });
+
+  it("documents and migrates Event Mode event discovery", () => {
+    expect(contract).toContain("Event Mode Events");
+    expect(contract).toContain("event_mode_events");
+    expect(contract).toContain("get_event_mode_event_by_code");
+    expect(contract).toContain("listed");
+    expect(contract).toContain("unlisted");
+    expect(contract).toContain("Event creators can update");
+    expect(eventModeMigration).toContain(
+      "create table if not exists public.event_mode_events"
+    );
+    expect(eventModeMigration).toContain("visibility in ('listed', 'unlisted')");
+    expect(eventModeMigration).toContain("join_code ~ '^[A-Z0-9]{6}$'");
+    expect(eventModeMigration).toContain("end_at > start_at");
+    expect(eventModeMigration).toContain("enable row level security");
+    expect(eventModeMigration).toContain("visibility = 'listed'");
+    expect(eventModeMigration).toContain("created_by_user_id = auth.uid()");
+    expect(eventModeMigration).toContain("get_event_mode_event_by_code");
+    expect(eventModeMigration).toContain("security definer");
+    expect(eventModeMigration).toContain("grant execute");
+    expect(eventModeMigration).toContain("to anon");
+    expect(eventModeMigration).not.toContain("event_mode_availability");
+    expect(eventModeMigration).not.toContain("event_mode_messages");
   });
 });

--- a/lib/eventMode.ts
+++ b/lib/eventMode.ts
@@ -1,0 +1,340 @@
+import { supabase } from "@/lib/supabase";
+import { getCurrentUser } from "@/lib/profileStore";
+
+export type EventModeVisibility = "listed" | "unlisted";
+export type EventModeLifecycle = "upcoming" | "active" | "ended";
+
+export type EventModeEvent = {
+  id: string;
+  name: string;
+  normalized_name: string;
+  city: string | null;
+  venue_or_location_note: string | null;
+  start_at: string;
+  end_at: string;
+  visibility: EventModeVisibility;
+  join_code: string;
+  created_by_user_id: string;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+};
+
+export type EventModeEventInput = {
+  name: string;
+  city?: string;
+  venueOrLocationNote?: string;
+  startAt: string;
+  endAt: string;
+  visibility: EventModeVisibility;
+};
+
+export type EventModeDuplicateCandidate = {
+  event: EventModeEvent;
+  reasons: string[];
+};
+
+const eventCodePattern = /^[A-Z0-9]{6}$/;
+
+function cleanText(value: string | null | undefined) {
+  const cleaned = String(value ?? "").replace(/\s+/g, " ").trim();
+  return cleaned || null;
+}
+
+export function normalizeEventModeText(value: string | null | undefined) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\u2019']/g, "'")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function parseEventModeCode(value: string) {
+  const trimmed = value.trim();
+  const directCode = trimmed.toUpperCase();
+
+  if (eventCodePattern.test(directCode)) return directCode;
+
+  try {
+    const url = new URL(trimmed);
+    const [, route, code] = url.pathname.split("/");
+    if (route !== "event-mode" || !code) return null;
+
+    const parsedCode = decodeURIComponent(code).trim().toUpperCase();
+    return eventCodePattern.test(parsedCode) ? parsedCode : null;
+  } catch {
+    return null;
+  }
+}
+
+export function eventModePathFromCode(code: string) {
+  const parsedCode = parseEventModeCode(code);
+  return parsedCode ? `/event-mode/${parsedCode}` : null;
+}
+
+export function makeEventModeJoinCode() {
+  return Math.random().toString(36).slice(2, 8).toUpperCase();
+}
+
+export function getEventModeLifecycle(
+  event: Pick<EventModeEvent, "start_at" | "end_at" | "closed_at">,
+  now = new Date()
+): EventModeLifecycle {
+  if (event.closed_at) return "ended";
+
+  const nowTime = now.getTime();
+  const startTime = Date.parse(event.start_at);
+  const endTime = Date.parse(event.end_at);
+
+  if (nowTime < startTime) return "upcoming";
+  if (nowTime <= endTime) return "active";
+  return "ended";
+}
+
+export function formatEventModeDateRange(event: {
+  start_at: string;
+  end_at: string;
+}) {
+  const start = new Date(event.start_at);
+  const end = new Date(event.end_at);
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = sameYear && start.getMonth() === end.getMonth();
+  const sameDay = sameMonth && start.getDate() === end.getDate();
+  const startFormat = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+  const endFormat = new Intl.DateTimeFormat(undefined, {
+    month: sameMonth ? undefined : "short",
+    day: sameDay ? undefined : "numeric",
+    year: "numeric",
+  });
+
+  if (sameDay) return startFormat.format(start);
+  return `${startFormat.format(start)}-${endFormat.format(end)}`;
+}
+
+function rangesOverlap(aStart: string, aEnd: string, bStart: string, bEnd: string) {
+  return Date.parse(aStart) <= Date.parse(bEnd) && Date.parse(bStart) <= Date.parse(aEnd);
+}
+
+function hasUsefulTokenOverlap(left: string, right: string) {
+  const genericEventTokens = new Set([
+    "convention",
+    "district",
+    "event",
+    "weekend",
+    "singing",
+  ]);
+  const isUsefulToken = (token: string) =>
+    token.length >= 3 && !genericEventTokens.has(token);
+  const leftTokens = new Set(left.split(" ").filter(isUsefulToken));
+  const rightTokens = right.split(" ").filter(isUsefulToken);
+
+  return rightTokens.some((token) => leftTokens.has(token));
+}
+
+export function eventModeSearchMatches(event: EventModeEvent, query: string) {
+  const normalizedQuery = normalizeEventModeText(query);
+  if (!normalizedQuery) return true;
+
+  return [
+    event.normalized_name,
+    event.city,
+    event.venue_or_location_note,
+  ].some((value) => normalizeEventModeText(value).includes(normalizedQuery));
+}
+
+export function findEventModeDuplicateCandidates(
+  input: Pick<EventModeEventInput, "name" | "city" | "venueOrLocationNote" | "startAt" | "endAt">,
+  existingEvents: EventModeEvent[],
+  now = new Date()
+): EventModeDuplicateCandidate[] {
+  const inputName = normalizeEventModeText(input.name);
+  const inputLocation = normalizeEventModeText(
+    [input.city, input.venueOrLocationNote].filter(Boolean).join(" ")
+  );
+
+  if (!inputName) return [];
+
+  return existingEvents
+    .filter((event) => getEventModeLifecycle(event, now) !== "ended")
+    .map((event) => {
+      const reasons: string[] = [];
+      const eventName = normalizeEventModeText(event.name);
+      const eventLocation = normalizeEventModeText(
+        [event.city, event.venue_or_location_note].filter(Boolean).join(" ")
+      );
+
+      if (
+        eventName === inputName ||
+        eventName.includes(inputName) ||
+        inputName.includes(eventName) ||
+        hasUsefulTokenOverlap(eventName, inputName)
+      ) {
+        reasons.push("similar name");
+      }
+
+      if (rangesOverlap(input.startAt, input.endAt, event.start_at, event.end_at)) {
+        reasons.push("overlapping dates");
+      }
+
+      if (
+        inputLocation &&
+        eventLocation &&
+        (eventLocation.includes(inputLocation) ||
+          inputLocation.includes(eventLocation) ||
+          hasUsefulTokenOverlap(eventLocation, inputLocation))
+      ) {
+        reasons.push("similar location");
+      }
+
+      return { event, reasons };
+    })
+    .filter((candidate) => {
+      const hasName = candidate.reasons.includes("similar name");
+      const hasDates = candidate.reasons.includes("overlapping dates");
+      const hasLocation = candidate.reasons.includes("similar location");
+      return hasName && (hasDates || hasLocation);
+    })
+    .sort((a, b) => {
+      return (
+        b.reasons.length - a.reasons.length ||
+        Date.parse(a.event.start_at) - Date.parse(b.event.start_at) ||
+        a.event.name.localeCompare(b.event.name)
+      );
+    });
+}
+
+function validateEventModeInput(input: EventModeEventInput) {
+  const name = cleanText(input.name);
+  const startAt = new Date(input.startAt);
+  const endAt = new Date(input.endAt);
+
+  if (!name) throw new Error("Event name is required.");
+  if (!input.startAt || Number.isNaN(startAt.getTime())) {
+    throw new Error("Start date and time are required.");
+  }
+  if (!input.endAt || Number.isNaN(endAt.getTime())) {
+    throw new Error("End date and time are required.");
+  }
+  if (endAt <= startAt) {
+    throw new Error("End date and time must be after the start.");
+  }
+  if (input.visibility !== "listed" && input.visibility !== "unlisted") {
+    throw new Error("Choose listed or unlisted visibility.");
+  }
+
+  return {
+    name,
+    normalized_name: normalizeEventModeText(name),
+    city: cleanText(input.city),
+    venue_or_location_note: cleanText(input.venueOrLocationNote),
+    start_at: startAt.toISOString(),
+    end_at: endAt.toISOString(),
+    visibility: input.visibility,
+  };
+}
+
+export async function searchEventModeEvents(query: string, now = new Date()) {
+  const { data, error } = await supabase
+    .from("event_mode_events")
+    .select("*")
+    .eq("visibility", "listed")
+    .is("closed_at", null)
+    .gte("end_at", now.toISOString())
+    .order("start_at", { ascending: true })
+    .limit(200);
+
+  if (error) throw error;
+  return ((data ?? []) as EventModeEvent[]).filter((event) =>
+    eventModeSearchMatches(event, query)
+  );
+}
+
+export async function createEventModeEvent(input: EventModeEventInput) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in to create an event.");
+
+  const values = validateEventModeInput(input);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const { data, error } = await supabase
+      .from("event_mode_events")
+      .insert({
+        ...values,
+        join_code: makeEventModeJoinCode(),
+        created_by_user_id: user.id,
+      })
+      .select()
+      .single();
+
+    if (!error) return data as EventModeEvent;
+    lastError = error;
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Could not create the event.");
+}
+
+export async function getEventModeEventByCode(code: string) {
+  const parsedCode = parseEventModeCode(code);
+  if (!parsedCode) return null;
+
+  const { data, error } = await supabase.rpc("get_event_mode_event_by_code", {
+    p_code: parsedCode,
+  });
+
+  if (error) throw error;
+  const rows = (data ?? []) as EventModeEvent[];
+  return rows[0] ?? null;
+}
+
+export async function updateEventModeEvent(
+  eventId: string,
+  input: EventModeEventInput
+) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in to edit this event.");
+
+  const values = validateEventModeInput(input);
+  const { data, error } = await supabase
+    .from("event_mode_events")
+    .update({
+      ...values,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", eventId)
+    .eq("created_by_user_id", user.id)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new Error("Only the event creator can edit this event.");
+  return data as EventModeEvent;
+}
+
+export async function closeEventModeEvent(eventId: string) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in to close this event.");
+
+  const { data, error } = await supabase
+    .from("event_mode_events")
+    .update({
+      closed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", eventId)
+    .eq("created_by_user_id", user.id)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new Error("Only the event creator can close this event.");
+  return data as EventModeEvent;
+}

--- a/supabase/migrations/20260502080000_add_event_mode_events.sql
+++ b/supabase/migrations/20260502080000_add_event_mode_events.sql
@@ -1,0 +1,109 @@
+create table if not exists public.event_mode_events (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (length(btrim(name)) > 0),
+  normalized_name text not null,
+  city text,
+  venue_or_location_note text,
+  start_at timestamptz not null,
+  end_at timestamptz not null,
+  visibility text not null default 'listed',
+  join_code text not null check (join_code ~ '^[A-Z0-9]{6}$'),
+  created_by_user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  closed_at timestamptz,
+  constraint event_mode_events_time_order_chk check (end_at > start_at),
+  constraint event_mode_events_visibility_chk check (
+    visibility in ('listed', 'unlisted')
+  )
+);
+
+create unique index if not exists event_mode_events_join_code_key
+on public.event_mode_events (join_code);
+
+create index if not exists event_mode_events_browse_idx
+on public.event_mode_events (visibility, start_at, end_at)
+where closed_at is null;
+
+create index if not exists event_mode_events_creator_idx
+on public.event_mode_events (created_by_user_id, start_at desc);
+
+create index if not exists event_mode_events_normalized_name_idx
+on public.event_mode_events (normalized_name);
+
+alter table public.event_mode_events enable row level security;
+
+grant select, insert, update on public.event_mode_events to authenticated;
+
+drop policy if exists "Signed-in users can read listed event mode events"
+on public.event_mode_events;
+drop policy if exists "Users can create their own event mode events"
+on public.event_mode_events;
+drop policy if exists "Event creators can update their own event mode events"
+on public.event_mode_events;
+
+create policy "Signed-in users can read listed event mode events"
+on public.event_mode_events
+for select
+to authenticated
+using (
+  visibility = 'listed'
+  or created_by_user_id = auth.uid()
+);
+
+create policy "Users can create their own event mode events"
+on public.event_mode_events
+for insert
+to authenticated
+with check (created_by_user_id = auth.uid());
+
+create policy "Event creators can update their own event mode events"
+on public.event_mode_events
+for update
+to authenticated
+using (created_by_user_id = auth.uid())
+with check (created_by_user_id = auth.uid());
+
+create or replace function public.get_event_mode_event_by_code(p_code text)
+returns table (
+  id uuid,
+  name text,
+  normalized_name text,
+  city text,
+  venue_or_location_note text,
+  start_at timestamptz,
+  end_at timestamptz,
+  visibility text,
+  join_code text,
+  created_by_user_id uuid,
+  created_at timestamptz,
+  updated_at timestamptz,
+  closed_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    event_mode_events.id,
+    event_mode_events.name,
+    event_mode_events.normalized_name,
+    event_mode_events.city,
+    event_mode_events.venue_or_location_note,
+    event_mode_events.start_at,
+    event_mode_events.end_at,
+    event_mode_events.visibility,
+    event_mode_events.join_code,
+    event_mode_events.created_by_user_id,
+    event_mode_events.created_at,
+    event_mode_events.updated_at,
+    event_mode_events.closed_at
+  from public.event_mode_events
+  where event_mode_events.join_code = upper(btrim(p_code))
+  limit 1;
+$$;
+
+revoke all on function public.get_event_mode_event_by_code(text) from public;
+grant execute on function public.get_event_mode_event_by_code(text) to anon;
+grant execute on function public.get_event_mode_event_by_code(text) to authenticated;


### PR DESCRIPTION
## Summary
- Add the Event Mode foundation with `/event-mode` search/create/code entry and `/event-mode/[code]` event detail/edit/close routes.
- Add `event_mode_events` schema, RLS, indexes, and `get_event_mode_event_by_code` so unlisted events can be opened by link/code without appearing in browse/search.
- Add Event Mode helpers for lifecycle, code parsing, search matching, duplicate prevention, and event CRUD.
- Document the Supabase contract and add regression tests for helpers, UI terminology, and migration guardrails.

## Scope / impact audit
- Navigation/home: intentionally deferred to #313; this PR adds the route but does not add final nav/home placement.
- Onboarding/copy: final copy polish remains deferred to #314; this PR uses the issue's Event Mode terminology.
- Help/Privacy: deferred to #316; README and Supabase contract were updated because this PR adds schema and a new flow.
- Analytics: deferred to #315; no analytics events added here.
- Mobile/accessibility: forms use labeled controls, keyboard-enter search/code behavior, and responsive single-column layouts on narrow screens.
- Supabase/RLS: migration added for `event_mode_events` with listed/unlisted visibility, creator-only update, no delete policy, and code lookup RPC.
- Tests: added helper, UI terminology, and Supabase contract/migration tests.
- Deployment/env: no new environment variables required. Production migration must be applied through the existing deployment workflow.
- Matching/repertoire/quartet logic: unchanged.

## Verification
- npm run test:run
- npm run build

Closes #310
