### PR TITLE
Add Event Mode singer availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The Supabase project should have the current production schema applied:
 - `event_mode_events` stores user-created Event Mode event spaces. Listed
   events can be discovered by signed-in users, unlisted events require a
   link/code, and creators can edit or close their own events.
+- `event_mode_availability` stores temporary, event-scoped "I'm available to
+  sing" rows keyed by `(event_id, user_id)`. Availability uses explicit labels
+  such as `TTBB Lead`, `SATB Tenor`, and `SSAA Alto 1`, expires automatically,
+  and does not expose repertoire or contact details.
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes

--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -3,12 +3,22 @@
 import { AppNav } from "@/components/AppNav";
 import {
   closeEventModeEvent,
+  defaultEventModeAvailableUntil,
+  eventModeVoicePartGroups,
+  eventModeVoicePartOptions,
+  filterEventModeAvailabilityByPart,
+  formatEventModeVoiceParts,
   formatEventModeDateRange,
+  getEventModeAvailabilityByCode,
   getEventModeEventByCode,
   getEventModeLifecycle,
+  turnOffEventModeAvailability,
   updateEventModeEvent,
+  upsertEventModeAvailability,
+  type EventModeAvailability,
   type EventModeEvent,
   type EventModeVisibility,
+  type EventModeVoicePart,
 } from "@/lib/eventMode";
 import { getCurrentUser } from "@/lib/profileStore";
 import { useParams } from "next/navigation";
@@ -23,10 +33,31 @@ type EventFormState = {
   visibility: EventModeVisibility;
 };
 
+type AvailabilityFormState = {
+  voiceParts: EventModeVoicePart[];
+  availabilityNote: string;
+  meetupNote: string;
+  availableUntil: string;
+};
+
 function toLocalDateTimeValue(value: string) {
   const date = new Date(value);
   const offsetMs = date.getTimezoneOffset() * 60 * 1000;
   return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function availabilityFormFromEvent(
+  event: EventModeEvent,
+  availability?: EventModeAvailability | null
+): AvailabilityFormState {
+  return {
+    voiceParts: availability?.voice_parts ?? [],
+    availabilityNote: availability?.availability_note ?? "",
+    meetupNote: availability?.meetup_note ?? "",
+    availableUntil: toLocalDateTimeValue(
+      availability?.available_until ?? defaultEventModeAvailableUntil(event)
+    ),
+  };
 }
 
 function formFromEvent(event: EventModeEvent): EventFormState {
@@ -53,7 +84,15 @@ export default function EventModeDetailPage() {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [closing, setClosing] = useState(false);
+  const [savingAvailability, setSavingAvailability] = useState(false);
+  const [turningOffAvailability, setTurningOffAvailability] = useState(false);
   const [form, setForm] = useState<EventFormState | null>(null);
+  const [availabilityForm, setAvailabilityForm] =
+    useState<AvailabilityFormState | null>(null);
+  const [availability, setAvailability] = useState<EventModeAvailability[]>([]);
+  const [selectedPart, setSelectedPart] = useState<EventModeVoicePart | "all">(
+    "all"
+  );
   const [message, setMessage] = useState("");
   const [messageTone, setMessageTone] = useState<"error" | "success">("error");
 
@@ -64,9 +103,20 @@ export default function EventModeDetailPage() {
           getEventModeEventByCode(code),
           getCurrentUser().catch(() => null),
         ]);
+        let loadedAvailability: EventModeAvailability[] = [];
+        if (loadedEvent && user) {
+          loadedAvailability = await getEventModeAvailabilityByCode(code);
+        }
         setEvent(loadedEvent);
         setForm(loadedEvent ? formFromEvent(loadedEvent) : null);
         setCurrentUserId(user?.id ?? null);
+        setAvailability(loadedAvailability);
+        const myAvailability = loadedAvailability.find(
+          (item) => item.user_id === user?.id
+        );
+        setAvailabilityForm(
+          loadedEvent ? availabilityFormFromEvent(loadedEvent, myAvailability) : null
+        );
       } catch (err) {
         console.error("Could not load Event Mode event", err);
         setMessageTone("error");
@@ -83,12 +133,49 @@ export default function EventModeDetailPage() {
     event && currentUserId && event.created_by_user_id === currentUserId
   );
   const lifecycle = event ? getEventModeLifecycle(event) : null;
+  const currentAvailability = availability.find(
+    (item) => item.user_id === currentUserId
+  );
+  const visibleAvailability = filterEventModeAvailabilityByPart(
+    availability,
+    selectedPart
+  );
 
   function updateForm<K extends keyof EventFormState>(
     key: K,
     value: EventFormState[K]
   ) {
     setForm((current) => (current ? { ...current, [key]: value } : current));
+  }
+
+  function updateAvailabilityForm<K extends keyof AvailabilityFormState>(
+    key: K,
+    value: AvailabilityFormState[K]
+  ) {
+    setAvailabilityForm((current) =>
+      current ? { ...current, [key]: value } : current
+    );
+  }
+
+  function toggleAvailabilityPart(part: EventModeVoicePart) {
+    setAvailabilityForm((current) => {
+      if (!current) return current;
+      const selected = new Set(current.voiceParts);
+      if (selected.has(part)) selected.delete(part);
+      else selected.add(part);
+      return { ...current, voiceParts: Array.from(selected) };
+    });
+  }
+
+  async function reloadAvailability() {
+    const loadedAvailability = await getEventModeAvailabilityByCode(code);
+    setAvailability(loadedAvailability);
+    const myAvailability = loadedAvailability.find(
+      (item) => item.user_id === currentUserId
+    );
+    if (event) {
+      setAvailabilityForm(availabilityFormFromEvent(event, myAvailability));
+    }
   }
 
   async function saveEvent() {
@@ -130,6 +217,56 @@ export default function EventModeDetailPage() {
       setMessage(err instanceof Error ? err.message : "Could not close event.");
     } finally {
       setClosing(false);
+    }
+  }
+
+  async function saveAvailability() {
+    if (!event || !availabilityForm) return;
+    setSavingAvailability(true);
+    setMessage("");
+
+    try {
+      await upsertEventModeAvailability({
+        eventId: event.id,
+        voiceParts: availabilityForm.voiceParts,
+        availabilityNote: availabilityForm.availabilityNote,
+        meetupNote: availabilityForm.meetupNote,
+        availableUntil: availabilityForm.availableUntil,
+      });
+      await reloadAvailability();
+      setMessageTone("success");
+      setMessage("You are available to sing at this event.");
+    } catch (err) {
+      console.error("Could not save Event Mode availability", err);
+      setMessageTone("error");
+      setMessage(
+        err instanceof Error ? err.message : "Could not save availability."
+      );
+    } finally {
+      setSavingAvailability(false);
+    }
+  }
+
+  async function turnOffAvailability() {
+    if (!event) return;
+    setTurningOffAvailability(true);
+    setMessage("");
+
+    try {
+      await turnOffEventModeAvailability(event.id);
+      await reloadAvailability();
+      setMessageTone("success");
+      setMessage("Your Event Mode availability is turned off.");
+    } catch (err) {
+      console.error("Could not turn off Event Mode availability", err);
+      setMessageTone("error");
+      setMessage(
+        err instanceof Error
+          ? err.message
+          : "Could not turn off availability."
+      );
+    } finally {
+      setTurningOffAvailability(false);
     }
   }
 
@@ -209,20 +346,213 @@ export default function EventModeDetailPage() {
             )}
 
             {currentUserId && (
-              <section className="mt-8 rounded-2xl border border-white/10 bg-white/10 p-5">
-                <h2 className="text-2xl font-bold">Use this event</h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
-                  This event is ready for Event Mode. Availability and messaging
-                  arrive in follow-up work. For now, use this event as the shared
-                  place singers can find before starting a quartet.
-                </p>
-                <a
-                  href="/session"
-                  className="mt-4 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
-                >
-                  Start a quartet
-                </a>
-              </section>
+              <div className="mt-8 grid gap-6 lg:grid-cols-[1fr_1.1fr]">
+                <section className="rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5">
+                  <h2 className="text-2xl font-bold">
+                    I&apos;m available to sing
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-cyan-50/80">
+                    This is only shown for this event. Your availability expires
+                    automatically.
+                  </p>
+
+                  {availabilityForm && (
+                    <div className="mt-5 space-y-5">
+                      <fieldset>
+                        <legend className="text-sm font-semibold text-slate-100">
+                          Voice part(s)
+                        </legend>
+                        <div className="mt-3 space-y-3">
+                          {eventModeVoicePartGroups.map((group) => (
+                            <div
+                              key={group.voicing}
+                              className="rounded-xl border border-white/10 bg-slate-950/40 p-3"
+                            >
+                              <p className="text-xs font-bold uppercase text-cyan-200">
+                                {group.voicing}
+                              </p>
+                              <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                                {group.parts.map((part) => (
+                                  <label
+                                    key={part}
+                                    className="flex items-center gap-2 rounded-lg bg-white/5 px-3 py-2 text-sm"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={availabilityForm.voiceParts.includes(
+                                        part
+                                      )}
+                                      onChange={() => toggleAvailabilityPart(part)}
+                                    />
+                                    <span>{part}</span>
+                                  </label>
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </fieldset>
+
+                      <label className="block">
+                        <span className="text-sm font-semibold text-slate-100">
+                          When are you available?
+                        </span>
+                        <input
+                          value={availabilityForm.availabilityNote}
+                          onChange={(inputEvent) =>
+                            updateAvailabilityForm(
+                              "availabilityNote",
+                              inputEvent.target.value
+                            )
+                          }
+                          placeholder="After chorus contest"
+                          className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        />
+                      </label>
+
+                      <label className="block">
+                        <span className="text-sm font-semibold text-slate-100">
+                          Where should people find you?
+                        </span>
+                        <input
+                          value={availabilityForm.meetupNote}
+                          onChange={(inputEvent) =>
+                            updateAvailabilityForm(
+                              "meetupNote",
+                              inputEvent.target.value
+                            )
+                          }
+                          placeholder="Lobby near registration"
+                          className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        />
+                      </label>
+
+                      <label className="block">
+                        <span className="text-sm font-semibold text-slate-100">
+                          Available until
+                        </span>
+                        <input
+                          type="datetime-local"
+                          value={availabilityForm.availableUntil}
+                          onChange={(inputEvent) =>
+                            updateAvailabilityForm(
+                              "availableUntil",
+                              inputEvent.target.value
+                            )
+                          }
+                          className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        />
+                      </label>
+
+                      <div className="flex flex-col gap-3 sm:flex-row">
+                        <button
+                          type="button"
+                          onClick={saveAvailability}
+                          disabled={savingAvailability}
+                          className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"
+                        >
+                          {savingAvailability
+                            ? "Saving..."
+                            : "I\u2019m available to sing"}
+                        </button>
+                        {currentAvailability && (
+                          <button
+                            type="button"
+                            onClick={turnOffAvailability}
+                            disabled={turningOffAvailability}
+                            className="rounded-xl bg-slate-800 px-5 py-3 font-semibold text-slate-100 hover:bg-slate-700 disabled:opacity-50"
+                          >
+                            {turningOffAvailability
+                              ? "Turning off..."
+                              : "Turn off my availability"}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </section>
+
+                <section className="rounded-2xl border border-white/10 bg-white/10 p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <h2 className="text-2xl font-bold">Available singers</h2>
+                      <p className="mt-2 text-sm leading-6 text-slate-300">
+                        Event Mode shows only what singers choose to share for
+                        this event.
+                      </p>
+                    </div>
+                    <label className="block min-w-48">
+                      <span className="text-sm font-semibold text-slate-200">
+                        Filter by voice part
+                      </span>
+                      <select
+                        value={selectedPart}
+                        onChange={(inputEvent) =>
+                          setSelectedPart(
+                            inputEvent.target.value as EventModeVoicePart | "all"
+                          )
+                        }
+                        className="mt-2 w-full rounded-xl bg-slate-900 px-3 py-2 text-white outline-none ring-cyan-300 focus:ring-2"
+                      >
+                        <option value="all">All parts</option>
+                        {eventModeVoicePartOptions.map((part) => (
+                          <option key={part} value={part}>
+                            {part}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  </div>
+
+                  <div className="mt-5 space-y-3">
+                    {visibleAvailability.length === 0 && (
+                      <p className="rounded-xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                        No active available singers match this filter yet.
+                      </p>
+                    )}
+
+                    {visibleAvailability.map((item) => (
+                      <article
+                        key={item.id}
+                        className="rounded-xl border border-white/10 bg-slate-900/80 p-4"
+                      >
+                        <h3 className="text-lg font-bold text-white">
+                          {item.display_name}
+                        </h3>
+                        <p className="mt-1 text-sm font-semibold text-cyan-200">
+                          {formatEventModeVoiceParts(item.voice_parts)}
+                        </p>
+                        {item.availability_note && (
+                          <p className="mt-3 text-sm text-slate-200">
+                            {item.availability_note}
+                          </p>
+                        )}
+                        {item.meetup_note && (
+                          <p className="mt-1 text-sm text-slate-300">
+                            {item.meetup_note}
+                          </p>
+                        )}
+                      </article>
+                    ))}
+                  </div>
+
+                  <div className="mt-6 rounded-xl border border-cyan-300/30 bg-cyan-300/10 p-4">
+                    <p className="font-semibold text-white">
+                      Found people to sing with?
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-cyan-50/80">
+                      Start a quartet and have the others join by QR code or
+                      link.
+                    </p>
+                    <a
+                      href="/session"
+                      className="mt-3 inline-block rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+                    >
+                      Start a quartet
+                    </a>
+                  </div>
+                </section>
+              </div>
             )}
 
             {isCreator && form && (

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -340,7 +340,8 @@ repertoire sharing, a public profile system, or a formal invite-to-quartet
 workflow.
 
 Code:
-- Browser create/search/edit/close helpers: `lib/eventMode.ts`
+- Browser create/search/edit/close and availability helpers:
+  `lib/eventMode.ts`
 - Event Mode landing/search/create route: `app/event-mode/page.tsx`
 - Event detail/code route: `app/event-mode/[code]/page.tsx`
 - Tests: `lib/__tests__/eventMode.test.ts`,
@@ -351,8 +352,7 @@ Expected context:
 - Signed-in users can browse/search listed upcoming or active events.
 - Unlisted events are not returned by listed browse/search helpers.
 - Anyone with a valid event code or link can open the event route through
-  `get_event_mode_event_by_code`; seeing future availability/messaging may
-  require sign-in in follow-up work.
+  `get_event_mode_event_by_code`.
 - Event creators can edit event name, date/time, location note, and visibility.
 - Event creators can close their own event by setting `closed_at`.
 - Other users cannot edit or close events they did not create.
@@ -394,6 +394,80 @@ Required database contract:
 
 Established by migrations:
 - `20260502080000_add_event_mode_events.sql`
+
+### Event Mode Availability
+
+Purpose: temporary, opt-in, event-scoped singer availability for Event Mode.
+It helps singers at the same event see who is open to pickup singing, what
+voice parts they are comfortable covering, and lightweight meet-up context.
+
+Event Mode availability must remain separate from repertoire and quartet
+matching. It must not expose repertoire, notes from My Songs, email addresses,
+last-sung history, exact GPS coordinates, global availability, or a permanent
+public singer profile.
+
+Code:
+- Read active availability for an event code:
+  `lib/eventMode.ts#getEventModeAvailabilityByCode`, through
+  `public.get_event_mode_availability_by_code`
+- Create/update the current user's availability:
+  `lib/eventMode.ts#upsertEventModeAvailability`
+- Turn off the current user's availability:
+  `lib/eventMode.ts#turnOffEventModeAvailability`
+- Event detail UI: `app/event-mode/[code]/page.tsx`
+- Tests: `lib/__tests__/eventMode.test.ts`,
+  `lib/__tests__/eventModeUi.test.ts`, and this Supabase contract test
+
+Expected context:
+- Browser authenticated user.
+- Signed-in users can mark only themselves available for an event.
+- Signed-in users can update or turn off only their own availability row.
+- One row is stored per `(event_id, user_id)`. Updating availability upserts
+  that row and clears `turned_off_at`.
+- Availability is active only while `turned_off_at is null`,
+  `available_until > now()`, and the event is not closed or ended.
+- The event detail page reads active availability for the current event by
+  link/code and filters it by voice part in the browser.
+- Display names come from `profiles.display_name`; availability rows do not
+  own display names.
+- Voice parts are stored with unambiguous voicing-prefixed labels:
+  `TTBB Tenor`, `TTBB Lead`, `TTBB Baritone`, `TTBB Bass`,
+  `SATB Soprano`, `SATB Alto`, `SATB Tenor`, `SATB Bass`,
+  `SSAA Soprano 1`, `SSAA Soprano 2`, `SSAA Alto 1`, and `SSAA Alto 2`.
+- The UI may provide a Start Quartet shortcut after singers find each other,
+  but Event Mode availability does not create quartet invitations.
+
+Required database contract:
+- `event_mode_availability`
+  - `id uuid primary key`
+  - `event_id uuid references public.event_mode_events(id) on delete cascade`
+  - `user_id uuid references auth.users(id) on delete cascade`
+  - `voice_parts text[] not null`
+  - optional `availability_note text`
+  - optional `meetup_note text`
+  - `available_until timestamptz not null`
+  - `created_at timestamptz not null default now()`
+  - `updated_at timestamptz not null default now()`
+  - optional `turned_off_at timestamptz`
+- Check constraint requires at least one voice part.
+- Check constraint allows only the supported Event Mode voice-part labels.
+- Unique index on `(event_id, user_id)` for one active or historical row per
+  singer per event.
+- Active availability index on `(event_id, available_until)` where
+  `turned_off_at is null`.
+- RLS enabled.
+- Authenticated users can read their own rows.
+- Authenticated users can read other active rows for listed, open events.
+- Authenticated users can insert/update only rows where `user_id = auth.uid()`.
+- `public.get_event_mode_availability_by_code(text)` is a security-definer
+  function granted only to authenticated users. It returns active rows for the
+  event code, joins `profiles.display_name`, and must not return email,
+  repertoire, user notes, quartet membership, or song history.
+- No authenticated delete policy; turning availability off updates
+  `turned_off_at`.
+
+Established by migrations:
+- `20260502100000_add_event_mode_availability.sql`
 
 ### `sessions`
 

--- a/lib/__tests__/eventMode.test.ts
+++ b/lib/__tests__/eventMode.test.ts
@@ -1,15 +1,20 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { EventModeEvent } from "@/lib/eventMode";
+import type { EventModeAvailability, EventModeEvent } from "@/lib/eventMode";
 
 process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
 
 const {
+  defaultEventModeAvailableUntil,
+  eventModeVoicePartOptions,
   eventModeSearchMatches,
+  filterEventModeAvailabilityByPart,
   findEventModeDuplicateCandidates,
+  formatEventModeVoiceParts,
   getEventModeLifecycle,
+  isEventModeAvailabilityActive,
   normalizeEventModeText,
   parseEventModeCode,
 } = await import("@/lib/eventMode");
@@ -119,5 +124,110 @@ describe("Event Mode helpers", () => {
     expect(storeSource).toContain('.is("closed_at", null)');
     expect(storeSource).toContain('.gte("end_at", now.toISOString())');
     expect(storeSource).toContain("get_event_mode_event_by_code");
+  });
+
+  it("uses unambiguous Event Mode voice part labels", () => {
+    expect(eventModeVoicePartOptions).toContain("TTBB Lead");
+    expect(eventModeVoicePartOptions).toContain("SATB Tenor");
+    expect(eventModeVoicePartOptions).toContain("SSAA Alto 1");
+    expect(eventModeVoicePartOptions).not.toContain("Lead");
+    expect(eventModeVoicePartOptions).not.toContain("Tenor");
+    expect(formatEventModeVoiceParts(["TTBB Lead", "SATB Tenor"])).toBe(
+      "TTBB Lead, SATB Tenor"
+    );
+  });
+
+  it("defaults availability expiry to the event end when it is soon", () => {
+    expect(
+      defaultEventModeAvailableUntil(
+        event({ end_at: "2026-10-11T18:00:00.000Z" }),
+        new Date("2026-10-10T18:00:00.000Z")
+      )
+    ).toBe("2026-10-11T18:00:00.000Z");
+  });
+
+  it("falls back to a one-day availability expiry for far-future events", () => {
+    expect(
+      defaultEventModeAvailableUntil(
+        event({ end_at: "2026-11-11T18:00:00.000Z" }),
+        new Date("2026-10-10T18:00:00.000Z")
+      )
+    ).toBe("2026-10-11T18:00:00.000Z");
+  });
+
+  it("filters Event Mode availability by selected voice part", () => {
+    const items: EventModeAvailability[] = [
+      {
+        id: "availability-1",
+        event_id: "event-1",
+        user_id: "user-1",
+        display_name: "Tim",
+        voice_parts: ["TTBB Lead", "TTBB Bass"],
+        availability_note: null,
+        meetup_note: null,
+        available_until: "2026-10-10T20:00:00.000Z",
+        created_at: "2026-10-10T18:00:00.000Z",
+        updated_at: "2026-10-10T18:00:00.000Z",
+        turned_off_at: null,
+      },
+      {
+        id: "availability-2",
+        event_id: "event-1",
+        user_id: "user-2",
+        display_name: "Alex",
+        voice_parts: ["SSAA Alto 1"],
+        availability_note: null,
+        meetup_note: null,
+        available_until: "2026-10-10T20:00:00.000Z",
+        created_at: "2026-10-10T18:00:00.000Z",
+        updated_at: "2026-10-10T18:00:00.000Z",
+        turned_off_at: null,
+      },
+    ];
+
+    expect(filterEventModeAvailabilityByPart(items, "all")).toHaveLength(2);
+    expect(filterEventModeAvailabilityByPart(items, "TTBB Bass")).toEqual([
+      items[0],
+    ]);
+    expect(filterEventModeAvailabilityByPart(items, "SATB Alto")).toEqual([]);
+  });
+
+  it("treats expired, ended, and turned-off availability as inactive", () => {
+    const now = new Date("2026-10-10T18:00:00.000Z");
+    const active = {
+      available_until: "2026-10-10T20:00:00.000Z",
+      turned_off_at: null,
+    };
+
+    expect(isEventModeAvailabilityActive(active, event(), now)).toBe(true);
+    expect(
+      isEventModeAvailabilityActive(
+        { ...active, available_until: "2026-10-10T17:00:00.000Z" },
+        event(),
+        now
+      )
+    ).toBe(false);
+    expect(
+      isEventModeAvailabilityActive(
+        { ...active, turned_off_at: "2026-10-10T17:30:00.000Z" },
+        event(),
+        now
+      )
+    ).toBe(false);
+    expect(
+      isEventModeAvailabilityActive(
+        active,
+        event({ closed_at: "2026-10-10T17:30:00.000Z" }),
+        now
+      )
+    ).toBe(false);
+  });
+
+  it("writes availability as one row per user and event", () => {
+    expect(storeSource).toContain(".from(\"event_mode_availability\")");
+    expect(storeSource).toContain("{ onConflict: \"event_id,user_id\" }");
+    expect(storeSource).toContain("get_event_mode_availability_by_code");
+    expect(storeSource).toContain('.eq("user_id", user.id)');
+    expect(storeSource).not.toContain("event_mode_messages");
   });
 });

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -10,6 +10,10 @@ const detailPage = readFileSync(
   join(process.cwd(), "app/event-mode/[code]/page.tsx"),
   "utf8"
 );
+const eventModeSource = readFileSync(
+  join(process.cwd(), "lib/eventMode.ts"),
+  "utf8"
+);
 
 describe("Event Mode UI copy", () => {
   it("uses Event Mode terminology and the requested core actions", () => {
@@ -19,6 +23,14 @@ describe("Event Mode UI copy", () => {
     expect(landingPage).toContain("Enter with a link or code");
     expect(landingPage).toContain("Use this event");
     expect(detailPage).toContain("Start a quartet");
+    expect(detailPage).toContain("I&apos;m available to sing");
+    expect(detailPage).toContain("Available singers");
+    expect(detailPage).toContain("Turn off my availability");
+    expect(detailPage).toContain("Filter by voice part");
+    expect(detailPage).toContain("Found people to sing with?");
+    expect(detailPage).toContain("Available until");
+    expect(eventModeSource).toContain("TTBB Lead");
+    expect(eventModeSource).toContain("SSAA Alto 1");
   });
 
   it("does not introduce deprecated pickup board or location-discovery language", () => {

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -100,6 +100,13 @@ const eventModeMigration = readFileSync(
   ),
   "utf8"
 );
+const eventModeAvailabilityMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260502100000_add_event_mode_availability.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -113,6 +120,7 @@ describe("Supabase contract guardrails", () => {
     "harmony_brigade_events",
     "harmony_brigade_event_songs",
     "event_mode_events",
+    "event_mode_availability",
   ];
   const baseMigrationTables = tables.filter(
     (table) =>
@@ -122,6 +130,7 @@ describe("Supabase contract guardrails", () => {
         "harmony_brigade_events",
         "harmony_brigade_event_songs",
         "event_mode_events",
+        "event_mode_availability",
       ].includes(table)
   );
 
@@ -355,5 +364,52 @@ describe("Supabase contract guardrails", () => {
     expect(eventModeMigration).toContain("to anon");
     expect(eventModeMigration).not.toContain("event_mode_availability");
     expect(eventModeMigration).not.toContain("event_mode_messages");
+  });
+
+  it("documents and migrates Event Mode singer availability", () => {
+    expect(contract).toContain("Event Mode Availability");
+    expect(contract).toContain("event_mode_availability");
+    expect(contract).toContain("get_event_mode_availability_by_code");
+    expect(contract).toContain("profiles.display_name");
+    expect(contract).toContain("TTBB Lead");
+    expect(contract).toContain("SATB Tenor");
+    expect(contract).toContain("SSAA Alto 1");
+    expect(contract).toContain("must not expose repertoire");
+    expect(eventModeAvailabilityMigration).toContain(
+      "create table if not exists public.event_mode_availability"
+    );
+    expect(eventModeAvailabilityMigration).toContain(
+      "event_id uuid not null references public.event_mode_events(id)"
+    );
+    expect(eventModeAvailabilityMigration).toContain(
+      "user_id uuid not null references auth.users(id)"
+    );
+    expect(eventModeAvailabilityMigration).toContain(
+      "event_mode_availability_event_user_key"
+    );
+    expect(eventModeAvailabilityMigration).toContain("(event_id, user_id)");
+    expect(eventModeAvailabilityMigration).toContain(
+      "event_mode_availability_voice_parts_supported_chk"
+    );
+    expect(eventModeAvailabilityMigration).toContain("'TTBB Lead'");
+    expect(eventModeAvailabilityMigration).toContain("'SATB Tenor'");
+    expect(eventModeAvailabilityMigration).toContain("'SSAA Alto 1'");
+    expect(eventModeAvailabilityMigration).toContain(
+      "alter table public.event_mode_availability enable row level security"
+    );
+    expect(eventModeAvailabilityMigration).toContain("user_id = auth.uid()");
+    expect(eventModeAvailabilityMigration).toContain("available_until > now()");
+    expect(eventModeAvailabilityMigration).toContain("turned_off_at is null");
+    expect(eventModeAvailabilityMigration).toContain(
+      "get_event_mode_availability_by_code"
+    );
+    expect(eventModeAvailabilityMigration).toContain("security definer");
+    expect(eventModeAvailabilityMigration).toContain("auth.role() = 'authenticated'");
+    expect(eventModeAvailabilityMigration).toContain("profiles.display_name");
+    expect(eventModeAvailabilityMigration).toContain("grant execute");
+    expect(eventModeAvailabilityMigration).toContain("to authenticated");
+    expect(eventModeAvailabilityMigration).not.toContain("to anon");
+    expect(eventModeAvailabilityMigration).not.toContain("user_repertoire");
+    expect(eventModeAvailabilityMigration).not.toContain("session_participants");
   });
 });

--- a/lib/eventMode.ts
+++ b/lib/eventMode.ts
@@ -34,6 +34,66 @@ export type EventModeDuplicateCandidate = {
   reasons: string[];
 };
 
+export type EventModeVoicePart =
+  | "TTBB Tenor"
+  | "TTBB Lead"
+  | "TTBB Baritone"
+  | "TTBB Bass"
+  | "SATB Soprano"
+  | "SATB Alto"
+  | "SATB Tenor"
+  | "SATB Bass"
+  | "SSAA Soprano 1"
+  | "SSAA Soprano 2"
+  | "SSAA Alto 1"
+  | "SSAA Alto 2";
+
+export type EventModeAvailability = {
+  id: string;
+  event_id: string;
+  user_id: string;
+  display_name: string;
+  voice_parts: EventModeVoicePart[];
+  availability_note: string | null;
+  meetup_note: string | null;
+  available_until: string;
+  created_at: string;
+  updated_at: string;
+  turned_off_at: string | null;
+};
+
+export type EventModeAvailabilityInput = {
+  eventId: string;
+  voiceParts: EventModeVoicePart[];
+  availabilityNote?: string;
+  meetupNote?: string;
+  availableUntil: string;
+};
+
+export const eventModeVoicePartGroups = [
+  {
+    voicing: "TTBB",
+    parts: ["TTBB Tenor", "TTBB Lead", "TTBB Baritone", "TTBB Bass"],
+  },
+  {
+    voicing: "SATB",
+    parts: ["SATB Soprano", "SATB Alto", "SATB Tenor", "SATB Bass"],
+  },
+  {
+    voicing: "SSAA",
+    parts: [
+      "SSAA Soprano 1",
+      "SSAA Soprano 2",
+      "SSAA Alto 1",
+      "SSAA Alto 2",
+    ],
+  },
+] satisfies { voicing: string; parts: EventModeVoicePart[] }[];
+
+export const eventModeVoicePartOptions = eventModeVoicePartGroups.flatMap(
+  (group) => group.parts
+);
+
 const eventCodePattern = /^[A-Z0-9]{6}$/;
 
 function cleanText(value: string | null | undefined) {
@@ -115,6 +175,49 @@ export function formatEventModeDateRange(event: {
 
   if (sameDay) return startFormat.format(start);
   return `${startFormat.format(start)}-${endFormat.format(end)}`;
+}
+
+export function defaultEventModeAvailableUntil(
+  event: Pick<EventModeEvent, "end_at">,
+  now = new Date()
+) {
+  const eventEnd = new Date(event.end_at);
+  const fallback = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const sevenDaysFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  if (
+    !Number.isNaN(eventEnd.getTime()) &&
+    eventEnd > now &&
+    eventEnd <= sevenDaysFromNow
+  ) {
+    return eventEnd.toISOString();
+  }
+
+  return fallback.toISOString();
+}
+
+export function formatEventModeVoiceParts(parts: EventModeVoicePart[]) {
+  return parts.join(", ");
+}
+
+export function isEventModeAvailabilityActive(
+  availability: Pick<EventModeAvailability, "available_until" | "turned_off_at">,
+  event: Pick<EventModeEvent, "end_at" | "closed_at">,
+  now = new Date()
+) {
+  if (availability.turned_off_at || event.closed_at) return false;
+  return (
+    Date.parse(availability.available_until) > now.getTime() &&
+    Date.parse(event.end_at) > now.getTime()
+  );
+}
+
+export function filterEventModeAvailabilityByPart(
+  availability: EventModeAvailability[],
+  selectedPart: EventModeVoicePart | "all"
+) {
+  if (selectedPart === "all") return availability;
+  return availability.filter((item) => item.voice_parts.includes(selectedPart));
 }
 
 function rangesOverlap(aStart: string, aEnd: string, bStart: string, bEnd: string) {
@@ -239,6 +342,34 @@ function validateEventModeInput(input: EventModeEventInput) {
   };
 }
 
+function validateEventModeAvailabilityInput(input: EventModeAvailabilityInput) {
+  const availableUntil = new Date(input.availableUntil);
+  const uniqueVoiceParts = Array.from(new Set(input.voiceParts));
+
+  if (uniqueVoiceParts.length === 0) {
+    throw new Error("Choose at least one voice part.");
+  }
+  if (
+    uniqueVoiceParts.some((part) => !eventModeVoicePartOptions.includes(part))
+  ) {
+    throw new Error("Choose valid Event Mode voice parts.");
+  }
+  if (!input.availableUntil || Number.isNaN(availableUntil.getTime())) {
+    throw new Error("Choose when your availability should expire.");
+  }
+  if (availableUntil <= new Date()) {
+    throw new Error("Availability must expire in the future.");
+  }
+
+  return {
+    event_id: input.eventId,
+    voice_parts: uniqueVoiceParts,
+    availability_note: cleanText(input.availabilityNote),
+    meetup_note: cleanText(input.meetupNote),
+    available_until: availableUntil.toISOString(),
+  };
+}
+
 export async function searchEventModeEvents(query: string, now = new Date()) {
   const { data, error } = await supabase
     .from("event_mode_events")
@@ -337,4 +468,66 @@ export async function closeEventModeEvent(eventId: string) {
   if (error) throw error;
   if (!data) throw new Error("Only the event creator can close this event.");
   return data as EventModeEvent;
+}
+
+export async function getEventModeAvailabilityByCode(code: string) {
+  const parsedCode = parseEventModeCode(code);
+  if (!parsedCode) return [];
+
+  const { data, error } = await supabase.rpc(
+    "get_event_mode_availability_by_code",
+    {
+      p_code: parsedCode,
+    }
+  );
+
+  if (error) throw error;
+  return (data ?? []) as EventModeAvailability[];
+}
+
+export async function upsertEventModeAvailability(
+  input: EventModeAvailabilityInput
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error("You must be logged in to mark yourself available.");
+  }
+
+  const values = validateEventModeAvailabilityInput(input);
+  const { data, error } = await supabase
+    .from("event_mode_availability")
+    .upsert(
+      {
+        ...values,
+        user_id: user.id,
+        turned_off_at: null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "event_id,user_id" }
+    )
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Omit<EventModeAvailability, "display_name">;
+}
+
+export async function turnOffEventModeAvailability(eventId: string) {
+  const user = await getCurrentUser();
+  if (!user) throw new Error("You must be logged in to turn off availability.");
+
+  const { data, error } = await supabase
+    .from("event_mode_availability")
+    .update({
+      turned_off_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("event_id", eventId)
+    .eq("user_id", user.id)
+    .is("turned_off_at", null)
+    .select()
+    .maybeSingle();
+
+  if (error) throw error;
+  return data as Omit<EventModeAvailability, "display_name"> | null;
 }

--- a/supabase/migrations/20260502100000_add_event_mode_availability.sql
+++ b/supabase/migrations/20260502100000_add_event_mode_availability.sql
@@ -1,0 +1,137 @@
+create table if not exists public.event_mode_availability (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.event_mode_events(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  voice_parts text[] not null default '{}'::text[],
+  availability_note text,
+  meetup_note text,
+  available_until timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  turned_off_at timestamptz,
+  constraint event_mode_availability_voice_parts_nonempty_chk check (
+    cardinality(voice_parts) > 0
+  ),
+  constraint event_mode_availability_voice_parts_supported_chk check (
+    voice_parts <@ array[
+      'TTBB Tenor',
+      'TTBB Lead',
+      'TTBB Baritone',
+      'TTBB Bass',
+      'SATB Soprano',
+      'SATB Alto',
+      'SATB Tenor',
+      'SATB Bass',
+      'SSAA Soprano 1',
+      'SSAA Soprano 2',
+      'SSAA Alto 1',
+      'SSAA Alto 2'
+    ]::text[]
+  )
+);
+
+create unique index if not exists event_mode_availability_event_user_key
+on public.event_mode_availability (event_id, user_id);
+
+create index if not exists event_mode_availability_active_idx
+on public.event_mode_availability (event_id, available_until)
+where turned_off_at is null;
+
+alter table public.event_mode_availability enable row level security;
+
+grant select, insert, update on public.event_mode_availability to authenticated;
+
+drop policy if exists "Users can read their own event mode availability"
+on public.event_mode_availability;
+drop policy if exists "Users can read listed event mode availability"
+on public.event_mode_availability;
+drop policy if exists "Users can create their own event mode availability"
+on public.event_mode_availability;
+drop policy if exists "Users can update their own event mode availability"
+on public.event_mode_availability;
+
+create policy "Users can read their own event mode availability"
+on public.event_mode_availability
+for select
+to authenticated
+using (user_id = auth.uid());
+
+create policy "Users can read listed event mode availability"
+on public.event_mode_availability
+for select
+to authenticated
+using (
+  turned_off_at is null
+  and available_until > now()
+  and exists (
+    select 1
+    from public.event_mode_events
+    where event_mode_events.id = event_mode_availability.event_id
+      and event_mode_events.visibility = 'listed'
+      and event_mode_events.closed_at is null
+      and event_mode_events.end_at > now()
+  )
+);
+
+create policy "Users can create their own event mode availability"
+on public.event_mode_availability
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+create policy "Users can update their own event mode availability"
+on public.event_mode_availability
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create or replace function public.get_event_mode_availability_by_code(p_code text)
+returns table (
+  id uuid,
+  event_id uuid,
+  user_id uuid,
+  display_name text,
+  voice_parts text[],
+  availability_note text,
+  meetup_note text,
+  available_until timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  turned_off_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    event_mode_availability.id,
+    event_mode_availability.event_id,
+    event_mode_availability.user_id,
+    profiles.display_name,
+    event_mode_availability.voice_parts,
+    event_mode_availability.availability_note,
+    event_mode_availability.meetup_note,
+    event_mode_availability.available_until,
+    event_mode_availability.created_at,
+    event_mode_availability.updated_at,
+    event_mode_availability.turned_off_at
+  from public.event_mode_availability
+  join public.event_mode_events
+    on event_mode_events.id = event_mode_availability.event_id
+  join public.profiles
+    on profiles.id = event_mode_availability.user_id
+  where auth.role() = 'authenticated'
+    and event_mode_events.join_code = upper(btrim(p_code))
+    and event_mode_events.closed_at is null
+    and event_mode_events.end_at > now()
+    and event_mode_availability.turned_off_at is null
+    and event_mode_availability.available_until > now()
+  order by
+    profiles.display_name asc,
+    event_mode_availability.updated_at desc;
+$$;
+
+revoke all on function public.get_event_mode_availability_by_code(text) from public;
+grant execute on function public.get_event_mode_availability_by_code(text) to authenticated;


### PR DESCRIPTION
## Summary
- Add Event Mode singer availability helpers, voice-part labels, expiry handling, filtering, and the event detail UI for marking yourself available.
- Add the `event_mode_availability` Supabase migration with one row per event/user, RLS, active-row filtering, and an authenticated RPC that joins `profiles.display_name`.
- Update Supabase contract/README docs and add regression coverage for helper behavior, UI copy, and migration guardrails.

## Docs and tests
- Updated `docs/supabase-contract.md` and `README.md` for the Event Mode availability table/RLS contract.
- Added Event Mode helper, UI copy, and Supabase contract tests.

## Verification
- npm run test:run
- npm run build

## Supabase / manual steps
- Production Deploy should apply `supabase/migrations/20260502100000_add_event_mode_availability.sql` before the Vercel production deploy.
- If deploying manually, run `supabase db push` against the linked Supabase project.

Closes #311
