### PR TITLE
Update barbershop voicing terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,11 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
 
 ## Core domain rules
 - A valid quartet match requires distinct singers assigned to distinct required parts.
-- TTBB parts: Tenor, Lead, Baritone, Bass.
-- SATB parts: Soprano, Alto, Tenor, Bass.
-- SSAA parts: Soprano 1, Soprano 2, Alto 1, Alto 2.
+- Canonical stored voicing values remain `SSAA`, `SATB`, and `TTBB`.
+- User-facing voicing labels are Treble (SSAA), Mixed (SATB), and
+  Lower voice (TTBB).
+- Use barbershop functional part names across all voicings: Tenor, Lead,
+  Baritone, Bass.
 - Same title + same voicing can be grouped. Different explicit arranger names
   should be flagged for confirmation, while missing arranger information should
   be shown as context rather than treated as a problem.
@@ -24,10 +26,17 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
 ## Barbershop-specific context
 - Pickup quartets often form informally at rehearsals, conventions, afterglows, or social singing events.
 - The core user question is: “What can we sing together right now?”
-- Barbershop voice parts are not interchangeable:
-  - TTBB: Tenor, Lead, Baritone, Bass
-  - SSAA: Soprano 1, Soprano 2, Alto 1, Alto 2
-  - SATB: Soprano, Alto, Tenor, Bass
+- Arrangement voicing describes the music's range family, not the singer's
+  identity:
+  - SSAA = Treble (SSAA)
+  - SATB = Mixed (SATB)
+  - TTBB = Lower voice (TTBB)
+- Barbershop functional parts are Tenor, Lead, Baritone, and Bass across all
+  voicings.
+- Mapping from printed notation:
+  - Treble / SSAA: S1 = Tenor, S2 = Lead, A1 = Baritone, A2 = Bass
+  - Mixed / SATB: Soprano = Tenor, Alto = Lead, Tenor = Baritone, Bass = Bass
+  - Lower voice / TTBB: T1 = Tenor, T2 = Lead, B1 = Baritone, B2 = Bass
 - “Lead” is the melody part in most TTBB barbershop arrangements; do not rename it to “Melody.”
 - Do not treat “Tenor” in TTBB and “Tenor” in SATB as equivalent across voicings.
 - A singer may know multiple parts to the same arrangement, but a single valid quartet assignment cannot use one singer for more than one part.
@@ -37,31 +46,47 @@ The app is for practical, in-the-room decision-making, not archival repertoire m
   information, not as an arrangement problem.
 - The app should be forgiving of imperfect data and help singers decide quickly, not enforce a perfect catalog.
 
-## Part abbreviations (UI standard)
+## Arrangement voicing and barbershop parts
 
-Use the following abbreviations consistently in all user-facing UI:
+Canonical stored voicing values remain:
+- SSAA
+- SATB
+- TTBB
 
-TTBB:
+User-facing labels:
+- SSAA = Treble (SSAA)
+- SATB = Mixed (SATB)
+- TTBB = Lower voice (TTBB)
+
+Use barbershop functional part names across all voicings:
 - T = Tenor
 - L = Lead
 - Bari = Baritone
 - Bass = Bass
 
-SATB:
-- S = Soprano
-- A = Alto
-- T = Tenor
-- Bass = Bass
+Mapping from printed notation:
+- Treble / SSAA: S1 = Tenor, S2 = Lead, A1 = Baritone, A2 = Bass
+- Mixed / SATB: Soprano = Tenor, Alto = Lead, Tenor = Baritone, Bass = Bass
+- Lower voice / TTBB: T1 = Tenor, T2 = Lead, B1 = Baritone, B2 = Bass
 
-SSAA:
-- S1 = Soprano 1
-- S2 = Soprano 2
-- A1 = Alto 1
-- A2 = Alto 2
+Do not use “women’s,” “men’s,” “male,” or “female” as primary voicing labels.
+Prefer range/arrangement labels. Do not treat same-named printed/choral parts
+across voicings as equivalent. Do not combine different voicings in matching.
+
+## Part abbreviations (UI standard)
+
+Use the following abbreviations consistently in all user-facing UI:
+
+Across all voicings:
+- T = Tenor
+- L = Lead
+- Bari = Baritone
+- Bass = Bass
 
 Notes:
 - Do not invent alternative abbreviations.
-- Do not spell out full part names in compact list views.
+- Do not make printed/choral notation labels such as S1, Alto, or T1 primary
+  in compact list views; show them only as helper context when useful.
 - Always prioritize readability and scannability on mobile.
 
 ## Tech stack

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ important question is "what can these singers sing right now?"
 Current source-of-truth model:
 
 - `profiles` stores the singer display name.
-- `user_repertoire` stores each singer's saved songs, voicing, parts,
+- `user_repertoire` stores each singer's saved songs, arrangement voicing,
+  parts,
   per-part confidence values, optional arranger, private notes, and personal
   sung metadata.
 - `repertoire_shares` stores opt-in private share codes for copying safe song
@@ -71,12 +72,13 @@ After changing auth settings or email templates, run the manual checklist in
 The Supabase project should have the current production schema applied:
 
 - `profiles` stores each user's required `display_name`.
-- `user_repertoire` stores each user's songs, voicing, part/confidence pairs,
+- `user_repertoire` stores each user's songs, arrangement voicing,
+  part/confidence pairs,
   optional arranger name, private notes, and personal sung-count metadata.
 - `repertoire_shares` stores private, revocable, six-character copy codes for
   copying song identity fields from another singer. Copy links expose song
-  title, voicing, and arranger only; recipients choose their own part and
-  confidence.
+  title, arrangement voicing, and arranger only; recipients choose their own
+  part and confidence.
 - `sessions` stores quartet codes and `last_activity_at` for 24-hour inactivity
   expiration.
 - `session_participants` stores participant repertoire snapshots and is keyed by
@@ -103,9 +105,9 @@ The Supabase project should have the current production schema applied:
   events can be discovered by signed-in users, unlisted events require a
   link/code, and creators can edit or close their own events.
 - `event_mode_availability` stores temporary, event-scoped "I'm available to
-  sing" rows keyed by `(event_id, user_id)`. Availability uses explicit labels
-  such as `TTBB Lead`, `SATB Tenor`, and `SSAA Alto 1`, expires automatically,
-  and does not expose repertoire or contact details.
+  sing" rows keyed by `(event_id, user_id)`. Availability displays arrangement
+  range plus barbershop functional parts, expires automatically, and does not
+  expose repertoire or contact details.
 
 The app/database contract is documented in
 [docs/supabase-contract.md](docs/supabase-contract.md). Any PR that changes

--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -7,6 +7,7 @@ import {
   eventModeVoicePartGroups,
   eventModeVoicePartOptions,
   filterEventModeAvailabilityByPart,
+  formatEventModeVoicePart,
   formatEventModeVoiceParts,
   formatEventModeDateRange,
   getEventModeAvailabilityByCode,
@@ -369,7 +370,7 @@ export default function EventModeDetailPage() {
                               className="rounded-xl border border-white/10 bg-slate-950/40 p-3"
                             >
                               <p className="text-xs font-bold uppercase text-cyan-200">
-                                {group.voicing}
+                                {group.label}
                               </p>
                               <div className="mt-2 grid gap-2 sm:grid-cols-2">
                                 {group.parts.map((part) => (
@@ -384,7 +385,7 @@ export default function EventModeDetailPage() {
                                       )}
                                       onChange={() => toggleAvailabilityPart(part)}
                                     />
-                                    <span>{part}</span>
+                                    <span>{formatEventModeVoicePart(part)}</span>
                                   </label>
                                 ))}
                               </div>
@@ -497,7 +498,7 @@ export default function EventModeDetailPage() {
                         <option value="all">All parts</option>
                         {eventModeVoicePartOptions.map((part) => (
                           <option key={part} value={part}>
-                            {part}
+                            {formatEventModeVoicePart(part)}
                           </option>
                         ))}
                       </select>

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -119,10 +119,11 @@ export default function HelpPage() {
             what can we sing together right now?
           </p>
           <p className={helpIntroParagraphClass}>
-            Each singer adds the songs they know, the voicing, the parts they
-            can sing, and how confident they feel. When singers join the same
-            quartet, the app compares everyone&apos;s saved songs and shows songs
-            where the required parts are covered by different people.
+            Each singer adds the songs they know, the arrangement voicing, the
+            barbershop parts they can sing, and how confident they feel. When
+            singers join the same quartet, the app compares everyone&apos;s saved
+            songs and shows songs where the required parts are covered by
+            different people.
           </p>
           <p className={helpIntroParagraphClass}>
             {helpWelcomeCopy}

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -18,7 +18,11 @@ import {
   type Part,
   type SingerEntry,
 } from "@/lib/matching";
-import { partAbbreviation } from "@/lib/partAbbreviations";
+import {
+  functionalPartName,
+  partAbbreviation,
+  voicingDisplayLabel,
+} from "@/lib/partAbbreviations";
 import {
   findParticipantByUserId,
   resolveParticipantForJoin,
@@ -1238,7 +1242,7 @@ export default function JoinSessionPage() {
           <div>
             <h4 className="font-semibold text-white">{starter.songTitle}</h4>
             <p className="mt-1 text-sm text-slate-300">
-              {starter.voicing}
+              {voicingDisplayLabel(starter.voicing)}
               {arrangerSummary ? ` · Arr. ${arrangerSummary}` : ""}
             </p>
           </div>
@@ -1284,7 +1288,7 @@ export default function JoinSessionPage() {
             <p className="mt-1">
               {starter.missingParts.length > 0
                 ? starter.missingParts
-                    .map((part) => partAbbreviation(starter.voicing, part))
+                    .map((part) => functionalPartName(starter.voicing, part))
                     .join(", ")
                 : "Distinct singers do not cover every required part yet."}
             </p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -24,10 +24,10 @@ export default function PrivacyPage() {
             <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
               <li>Your display name for profile and quartet screens.</li>
               <li>
-                Your My Songs entries, including song title, voicing, parts
-                known, confidence, arranger if entered, notes if entered, date
-                added or updated, and last-sung information when you mark a song
-                as sung in the app.
+                Your My Songs entries, including song title, arrangement
+                voicing, parts known, confidence, arranger if entered, notes if
+                entered, date added or updated, and last-sung information when
+                you mark a song as sung in the app.
               </li>
               <li>
                 Quartet/session data, including join codes, active membership,
@@ -47,9 +47,9 @@ export default function PrivacyPage() {
               manage My Songs, let you join or leave quartets, refresh
               quartet snapshots, and show songs the group may be able to sing.
               Song title suggestions are generated from distinct song title,
-              voicing, and arranger values that singers have entered before.
-              Those suggestions do not include who entered the song, notes,
-              parts, confidence, or other personal details.
+              arrangement voicing, and arranger values that singers have entered
+              before. Those suggestions do not include who entered the song,
+              notes, parts, confidence, or other personal details.
             </p>
           </div>
 
@@ -57,12 +57,12 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">Song suggestions</h2>
             <p className="mt-2 text-slate-300">
               Suggestions help singers enter songs faster. They may use safe song
-              identity fields such as title, voicing, and arranger from catalog
-              imports or previously saved song identities. Suggestions are not
-              authoritative, and adding a song to My Songs does not add it to
-              anyone else&apos;s My Songs. Personal details such as notes,
-              confidence, last-sung history, user identity, and email address are
-              not exposed as suggestions.
+              identity fields such as title, arrangement voicing, and arranger
+              from catalog imports or previously saved song identities.
+              Suggestions are not authoritative, and adding a song to My Songs
+              does not add it to anyone else&apos;s My Songs. Personal details
+              such as notes, confidence, last-sung history, user identity, and
+              email address are not exposed as suggestions.
             </p>
           </div>
 
@@ -71,11 +71,12 @@ export default function PrivacyPage() {
             <p className="mt-2 text-slate-300">
               If you choose Let another singer copy songs from My Songs, the app
               creates a private code/link. Anyone with an active code/link can
-              view safe song identity fields: title, voicing, and arranger. They
-              must sign in before copying songs, and copied songs become their
-              own My Songs entries with their chosen part and confidence. The
-              shared view does not expose notes, confidence, last-sung history,
-              email address, or account details, and you can revoke the link.
+              view safe song identity fields: title, arrangement voicing, and
+              arranger. They must sign in before copying songs, and copied songs
+              become their own My Songs entries with their chosen part and
+              confidence. The shared view does not expose notes, confidence,
+              last-sung history, email address, or account details, and you can
+              revoke the link.
             </p>
           </div>
 
@@ -108,10 +109,10 @@ export default function PrivacyPage() {
             <p className="mt-2 text-slate-300">
               When you join a quartet, other singers in that quartet may see
               your display name and saved-song information needed for
-              matching, such as songs, voicing, parts, confidence, and possible
-              arrangement details or warnings. This sharing is the core purpose
-              of the app: helping the quartet answer what can we sing together
-              right now.
+              matching, such as songs, arrangement voicing, parts, confidence,
+              and possible arrangement details or warnings. This sharing is the
+              core purpose of the app: helping the quartet answer what can we
+              sing together right now.
             </p>
             <p className="mt-2 text-slate-300">
               Personal notes are stored for you and are not included

--- a/components/MatchCard.test.tsx
+++ b/components/MatchCard.test.tsx
@@ -131,6 +131,48 @@ describe("MatchCard", () => {
     expect(html).toContain("Bass Singer (Arranger: No arranger entered)");
   });
 
+  it("displays treble and mixed parts as barbershop functional parts", () => {
+    const html = renderMatch({
+      songTitle: "Treble Song",
+      voicing: "SSAA",
+      arrangerNames: [],
+      hasMissingArrangerInfo: false,
+      category: "one_part_missing",
+      missingParts: ["Alto 2"],
+      assignments: {
+        "Soprano 1": [
+          singer({
+            displayName: "Tenor Singer",
+            voicing: "SSAA",
+            part: "Soprano 1",
+          }),
+        ],
+        "Soprano 2": [
+          singer({
+            displayName: "Lead Singer",
+            voicing: "SSAA",
+            part: "Soprano 2",
+          }),
+        ],
+        "Alto 1": [
+          singer({
+            displayName: "Bari Singer",
+            voicing: "SSAA",
+            part: "Alto 1",
+          }),
+        ],
+      },
+      warnings: [],
+      score: 0,
+    });
+
+    expect(html).toContain("Treble (SSAA)");
+    expect(html).toContain("Missing Bass");
+    expect(html).toContain("Bari:");
+    expect(html).not.toContain("Missing A2");
+    expect(html).not.toContain("Soprano 1:");
+  });
+
   it("shows a short success state and subtle music-note celebration", () => {
     const html = renderMatch(readyMatch(), {
       isSungCelebrating: true,

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -4,7 +4,11 @@ import {
   type MatchTitleVariantSinger,
   type MatchResult,
 } from "@/lib/matching";
-import { partAbbreviation } from "@/lib/partAbbreviations";
+import {
+  functionalPartName,
+  partAbbreviation,
+  voicingDisplayLabel,
+} from "@/lib/partAbbreviations";
 import {
   arrangerDisplayName,
   noArrangerEnteredLabel,
@@ -105,7 +109,7 @@ export function MatchCard({
             </h3>
             <div className="mt-0.5 flex flex-wrap items-center gap-2">
               <p className="text-xs font-semibold uppercase tracking-normal text-slate-400">
-                {match.voicing}
+                {voicingDisplayLabel(match.voicing)}
               </p>
               {isRecentlySung && (
                 <span className="rounded-full bg-white/10 px-2 py-0.5 text-xs font-semibold text-slate-200">
@@ -134,7 +138,11 @@ export function MatchCard({
                     : styles.part
                 }`}
               >
-                <span>{isMissing ? `Missing ${abbreviation}` : abbreviation}</span>
+                <span>
+                  {isMissing
+                    ? `Missing ${functionalPartName(match.voicing, part)}`
+                    : abbreviation}
+                </span>
                 {singers.length > 0 && (
                   <span className="truncate font-medium text-slate-200">
                     {singers.map((singer) => singer.displayName).join(", ")}

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -10,7 +10,13 @@ import type {
   PartConfidence,
   Voicing,
 } from "@/lib/matching";
-import { partAbbreviation, partButtonLabel } from "@/lib/partAbbreviations";
+import {
+  compactVoicingDisplayLabel,
+  partAbbreviation,
+  partButtonLabel,
+  printedNotationSummary,
+  voicingDisplayLabel,
+} from "@/lib/partAbbreviations";
 import {
   filterAndSortRepertoire,
   hasActiveRepertoireFilters,
@@ -102,6 +108,21 @@ function requiredFieldStateClass(isIncomplete: boolean) {
   return isIncomplete
     ? "border-rose-300/70 bg-rose-950/30 ring-rose-300"
     : "border-white/10 bg-slate-900 ring-cyan-300";
+}
+
+function repertoirePartFilterLabel(
+  part: Part,
+  selectedVoicing: Voicing | ""
+) {
+  if (selectedVoicing) return partButtonLabel(selectedVoicing, part);
+
+  return Array.from(
+    new Set(
+      voicings
+        .filter((voicing) => partsByVoicing[voicing].includes(part))
+        .map((voicing) => partButtonLabel(voicing, part))
+    )
+  ).join(" / ");
 }
 
 type RepertoireForm = {
@@ -597,7 +618,7 @@ export default function RepertoireManager() {
     }
 
     if (!voicing) {
-      setMessage("Choose a voicing before saving.");
+      setMessage("Choose an arrangement voicing before saving.");
       return;
     }
 
@@ -1226,7 +1247,8 @@ export default function RepertoireManager() {
                   </h2>
                   <p className="mt-2 max-w-xl text-sm leading-6 text-slate-300">
                     Create a private link or code another singer can use to copy
-                    song titles, voicings, and arrangers from My Songs.
+                    song titles, arrangement voicings, and arrangers from My
+                    Songs.
                   </p>
                 </div>
                 <button
@@ -1240,10 +1262,10 @@ export default function RepertoireManager() {
 
               <div className="mt-5 rounded-xl border border-white/10 bg-white/5 p-4">
                 <p className="text-sm leading-6 text-slate-300">
-                  Another singer can see song titles, voicings, and arrangers.
-                  They cannot see your notes, confidence, last-sung history, or
-                  email address. They choose their own part and confidence
-                  before saving anything.
+                  Another singer can see song titles, arrangement voicings, and
+                  arrangers. They cannot see your notes, confidence, last-sung
+                  history, or email address. They choose their own part and
+                  confidence before saving anything.
                 </p>
 
                 <div className="mt-4 flex flex-col gap-3">
@@ -1348,8 +1370,9 @@ export default function RepertoireManager() {
                     songs to My Songs.
                   </p>
                   <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
-                    These songs default to TTBB. You&apos;ll choose the part you
-                    usually sing and your confidence before adding them.
+                    These songs default to Lower voice (TTBB). You&apos;ll choose
+                    the barbershop part you usually sing and your confidence
+                    before adding them.
                   </p>
                   <p className="mt-2 text-sm text-slate-400">
                     Source: {HARMONY_BRIGADE_SOURCE}.
@@ -1502,7 +1525,7 @@ export default function RepertoireManager() {
                                 {row.song.songTitle}
                               </p>
                               <p className="mt-1 text-xs leading-5 text-slate-400">
-                                TTBB -{" "}
+                                {voicingDisplayLabel("TTBB")} -{" "}
                                 {row.song.arranger
                                   ? `Arr. ${arrangerDisplayName(row.song.arranger)}`
                                   : "No arranger entered"}
@@ -1724,8 +1747,8 @@ export default function RepertoireManager() {
                     Add &quot;{songTitle.trim()}&quot; manually
                   </button>
                   <p className="mt-2 text-xs leading-5 text-slate-300">
-                    Choose the voicing, arranger, part, and confidence
-                    yourself.
+                    Choose the arrangement voicing, arranger, part, and
+                    confidence yourself.
                   </p>
                 </div>
               </div>
@@ -1912,10 +1935,10 @@ export default function RepertoireManager() {
                     }
                     className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                   >
-                    <option value="">All voicings</option>
+                    <option value="">All arrangement voicings</option>
                     {voicings.map((v) => (
                       <option key={v} value={v}>
-                        {v}
+                        {voicingDisplayLabel(v)}
                       </option>
                     ))}
                   </select>
@@ -1932,9 +1955,7 @@ export default function RepertoireManager() {
                     <option value="">All parts</option>
                     {partFilterOptions.map((part) => (
                       <option key={part} value={part}>
-                        {voicingFilter
-                          ? partButtonLabel(voicingFilter, part)
-                          : part}
+                        {repertoirePartFilterLabel(part, voicingFilter)}
                       </option>
                     ))}
                   </select>
@@ -1973,14 +1994,12 @@ export default function RepertoireManager() {
                   )}
                   {voicingFilter && (
                     <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
-                      {voicingFilter}
+                      {voicingDisplayLabel(voicingFilter)}
                     </span>
                   )}
                   {partFilter && (
                     <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
-                      {voicingFilter
-                        ? partButtonLabel(voicingFilter, partFilter)
-                        : partFilter}
+                      {repertoirePartFilterLabel(partFilter, voicingFilter)}
                     </span>
                   )}
                   {sungStatusFilter !== "all" && (
@@ -2063,9 +2082,14 @@ export default function RepertoireManager() {
                           className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
                         >
                           {voicings.map((v) => (
-                            <option key={v}>{v}</option>
+                            <option key={v} value={v}>
+                              {voicingDisplayLabel(v)}
+                            </option>
                           ))}
                         </select>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {printedNotationSummary(editForm.voicing)}
+                        </p>
                       </label>
 
                       <label className="block md:col-span-2">
@@ -2209,7 +2233,7 @@ export default function RepertoireManager() {
                           {item.song_title}
                         </h3>
                         <span className="shrink-0 rounded-full bg-slate-900 px-2 py-0.5 text-xs font-semibold text-slate-300">
-                          {item.voicing}
+                          {compactVoicingDisplayLabel(item.voicing)}
                         </span>
                       </div>
 
@@ -2374,8 +2398,8 @@ export default function RepertoireManager() {
                           Add &quot;{songTitle.trim()}&quot; manually
                         </button>
                         <p className="mt-2 text-xs leading-5 text-slate-300">
-                          Choose the voicing, arranger, part, and confidence
-                          yourself.
+                          Choose the arrangement voicing, arranger, part, and
+                          confidence yourself.
                         </p>
                       </div>
                     </div>
@@ -2394,7 +2418,7 @@ export default function RepertoireManager() {
                     </h3>
                     {addSongSource === "suggestion" ? (
                       <p className="mt-1 text-sm text-slate-300">
-                        {voicing ? `${voicing} · ` : ""}
+                        {voicing ? `${voicingDisplayLabel(voicing)} · ` : ""}
                         Arr. {arrangerDisplayName(arrangerName)}
                       </p>
                     ) : (
@@ -2404,7 +2428,7 @@ export default function RepertoireManager() {
                     )}
                     <p className="mt-3 text-sm text-cyan-100">
                       {suggestedVoicings && !voicing
-                        ? "Next: choose the voicing you know."
+                        ? "Next: choose the arrangement voicing you know."
                         : "Next: choose the part you sing and your confidence."}
                     </p>
                   </div>
@@ -2414,8 +2438,8 @@ export default function RepertoireManager() {
                   <p className="text-sm font-medium text-slate-300">Voicing</p>
                   <p className="mt-1 text-xs text-slate-400">
                     {suggestedVoicings
-                      ? "This suggestion has multiple voicings. Choose the version you know."
-                      : "Suggestions are optional. You can always type your own title and choose the correct voicing."}
+                      ? "This suggestion has multiple arrangement voicings. Choose the version you know."
+                      : "Suggestions are optional. You can always type your own title and choose the correct arrangement voicing."}
                   </p>
                   <div className="mt-2 grid grid-cols-3 gap-2">
                     {voicingOptions.map((v) => (
@@ -2432,13 +2456,18 @@ export default function RepertoireManager() {
                             : "bg-slate-800 text-slate-200 ring-white/10 hover:bg-slate-700"
                         }`}
                       >
-                        {v}
+                        {voicingDisplayLabel(v)}
                       </button>
                     ))}
                   </div>
                   {!voicing && (
                     <p className="mt-2 text-sm text-rose-200">
-                      Choose a voicing to continue.
+                      Choose an arrangement voicing to continue.
+                    </p>
+                  )}
+                  {voicing && (
+                    <p className="mt-2 text-xs text-slate-400">
+                      {printedNotationSummary(voicing)}
                     </p>
                   )}
                 </div>
@@ -2522,7 +2551,7 @@ export default function RepertoireManager() {
                       ))
                     ) : (
                       <p className="text-sm text-slate-400">
-                        Choose a voicing first.
+                        Choose an arrangement voicing first.
                       </p>
                     )}
                   </div>

--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import { AppNav } from "@/components/AppNav";
 import type { Confidence, Part, Voicing } from "@/lib/matching";
 import { arrangerDisplayName } from "@/lib/arrangerDisplay";
-import { partButtonLabel } from "@/lib/partAbbreviations";
+import {
+  partButtonLabel,
+  printedNotationSummary,
+  voicingDisplayLabel,
+} from "@/lib/partAbbreviations";
 import { getCurrentUser } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
 import {
@@ -295,7 +299,10 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                         className="rounded-xl border border-white/10 bg-slate-950/60 p-3"
                       >
                         <p className="text-sm font-semibold text-white">
-                          {voicing} copied songs
+                          {voicingDisplayLabel(voicing)} copied songs
+                        </p>
+                        <p className="mt-1 text-xs text-slate-400">
+                          {printedNotationSummary(voicing)}
                         </p>
                         <div className="mt-3 grid gap-2 sm:grid-cols-2">
                           <label className="block">
@@ -405,7 +412,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                             {song.songTitle}
                           </span>
                           <span className="mt-1 block text-sm text-slate-300">
-                            {song.voicing} - Arr.{" "}
+                            {voicingDisplayLabel(song.voicing)} - Arr.{" "}
                             {arrangerDisplayName(song.arrangerName)}
                           </span>
                           {label && (

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -430,10 +430,13 @@ Expected context:
   link/code and filters it by voice part in the browser.
 - Display names come from `profiles.display_name`; availability rows do not
   own display names.
-- Voice parts are stored with unambiguous voicing-prefixed labels:
+- Voice parts are stored with unambiguous canonical voicing-prefixed labels:
   `TTBB Tenor`, `TTBB Lead`, `TTBB Baritone`, `TTBB Bass`,
   `SATB Soprano`, `SATB Alto`, `SATB Tenor`, `SATB Bass`,
   `SSAA Soprano 1`, `SSAA Soprano 2`, `SSAA Alto 1`, and `SSAA Alto 2`.
+- User-facing availability displays those stored values as arrangement range
+  family plus barbershop functional part, such as `Lower voice (TTBB) Lead`,
+  `Mixed (SATB) Baritone`, or `Treble (SSAA) Tenor`.
 - The UI may provide a Start Quartet shortcut after singers find each other,
   but Event Mode availability does not create quartet invitations.
 

--- a/lib/__tests__/eventMode.test.ts
+++ b/lib/__tests__/eventMode.test.ts
@@ -133,7 +133,7 @@ describe("Event Mode helpers", () => {
     expect(eventModeVoicePartOptions).not.toContain("Lead");
     expect(eventModeVoicePartOptions).not.toContain("Tenor");
     expect(formatEventModeVoiceParts(["TTBB Lead", "SATB Tenor"])).toBe(
-      "TTBB Lead, SATB Tenor"
+      "Lower voice (TTBB) Lead, Mixed (SATB) Baritone"
     );
   });
 

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -29,8 +29,8 @@ describe("Event Mode UI copy", () => {
     expect(detailPage).toContain("Filter by voice part");
     expect(detailPage).toContain("Found people to sing with?");
     expect(detailPage).toContain("Available until");
-    expect(eventModeSource).toContain("TTBB Lead");
-    expect(eventModeSource).toContain("SSAA Alto 1");
+    expect(eventModeSource).toContain("Lower voice (TTBB)");
+    expect(eventModeSource).toContain("Treble (SSAA)");
   });
 
   it("does not introduce deprecated pickup board or location-discovery language", () => {

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -72,7 +72,12 @@ describe("help content", () => {
     expect(guideText).toContain("Suggestions are optional");
     expect(guideText).toContain("does not add it to anyone else’s My Songs");
     expect(guideText).toContain("More Ways To Build My Songs");
-    expect(guideText).toContain("TTBB means Tenor, Lead, Baritone, Bass");
+    expect(guideText).toContain("Treble (SSAA)");
+    expect(guideText).toContain("Mixed (SATB)");
+    expect(guideText).toContain("Lower voice (TTBB)");
+    expect(guideText).toContain("S1 usually maps to Tenor");
+    expect(guideText).toContain("Alto to Lead");
+    expect(guideText).toContain("T2 to Lead");
     expect(guideText).toContain("add it more than once");
     expect(guideText).toContain("A singer may know multiple parts");
     expect(guideText).toContain("each singer can only cover one required part");
@@ -95,7 +100,7 @@ describe("help content", () => {
     expect(guideText).toContain("If the quartet is full");
     expect(guideText).toContain("Ready to Sing");
     expect(guideText).toContain("Possible matches");
-    expect(guideText).toContain("voicing, required part coverage");
+    expect(guideText).toContain("arrangement voicing, required part coverage");
     expect(guideText).toContain("distinct singers");
     expect(guideText).toContain("Title variants");
     expect(guideText).toContain("arranger differences");

--- a/lib/__tests__/partAbbreviations.test.ts
+++ b/lib/__tests__/partAbbreviations.test.ts
@@ -1,31 +1,69 @@
 import { describe, expect, it } from "vitest";
-import { partAbbreviation, partButtonLabel } from "../partAbbreviations";
+import {
+  compactVoicingDisplayLabel,
+  functionalPartName,
+  partAbbreviation,
+  partButtonLabel,
+  printedNotationSummary,
+  voicingDisplayLabel,
+} from "../partAbbreviations";
+
+describe("voicing labels", () => {
+  it("maps canonical voicings to user-facing arrangement labels", () => {
+    expect(voicingDisplayLabel("SSAA")).toBe("Treble (SSAA)");
+    expect(voicingDisplayLabel("SATB")).toBe("Mixed (SATB)");
+    expect(voicingDisplayLabel("TTBB")).toBe("Lower voice (TTBB)");
+  });
+
+  it("maps canonical voicings to compact arrangement labels", () => {
+    expect(compactVoicingDisplayLabel("SSAA")).toBe("Treble");
+    expect(compactVoicingDisplayLabel("SATB")).toBe("Mixed");
+    expect(compactVoicingDisplayLabel("TTBB")).toBe("Lower voice");
+  });
+});
 
 describe("partAbbreviation", () => {
-  it("uses the standard TTBB abbreviations", () => {
+  it("uses barbershop functional abbreviations for TTBB stored parts", () => {
     expect(partAbbreviation("TTBB", "Tenor")).toBe("T");
     expect(partAbbreviation("TTBB", "Lead")).toBe("L");
     expect(partAbbreviation("TTBB", "Baritone")).toBe("Bari");
     expect(partAbbreviation("TTBB", "Bass")).toBe("Bass");
   });
 
-  it("uses the standard SATB abbreviations", () => {
-    expect(partAbbreviation("SATB", "Soprano")).toBe("S");
-    expect(partAbbreviation("SATB", "Alto")).toBe("A");
-    expect(partAbbreviation("SATB", "Tenor")).toBe("T");
+  it("uses barbershop functional abbreviations for SATB stored parts", () => {
+    expect(partAbbreviation("SATB", "Soprano")).toBe("T");
+    expect(partAbbreviation("SATB", "Alto")).toBe("L");
+    expect(partAbbreviation("SATB", "Tenor")).toBe("Bari");
     expect(partAbbreviation("SATB", "Bass")).toBe("Bass");
   });
 
-  it("uses the standard SSAA abbreviations", () => {
-    expect(partAbbreviation("SSAA", "Soprano 1")).toBe("S1");
-    expect(partAbbreviation("SSAA", "Soprano 2")).toBe("S2");
-    expect(partAbbreviation("SSAA", "Alto 1")).toBe("A1");
-    expect(partAbbreviation("SSAA", "Alto 2")).toBe("A2");
+  it("uses barbershop functional abbreviations for SSAA stored parts", () => {
+    expect(partAbbreviation("SSAA", "Soprano 1")).toBe("T");
+    expect(partAbbreviation("SSAA", "Soprano 2")).toBe("L");
+    expect(partAbbreviation("SSAA", "Alto 1")).toBe("Bari");
+    expect(partAbbreviation("SSAA", "Alto 2")).toBe("Bass");
   });
 
-  it("includes full part names in button labels only when abbreviated", () => {
+  it("uses functional part names in button labels", () => {
     expect(partButtonLabel("TTBB", "Lead")).toBe("L Lead");
     expect(partButtonLabel("TTBB", "Bass")).toBe("Bass");
-    expect(partButtonLabel("SSAA", "Alto 2")).toBe("A2 Alto 2");
+    expect(partButtonLabel("SSAA", "Alto 2")).toBe("Bass");
+    expect(partButtonLabel("SATB", "Tenor")).toBe("Bari Baritone");
+  });
+
+  it("keeps printed notation available as helper context", () => {
+    expect(functionalPartName("SSAA", "Soprano 1")).toBe("Tenor");
+    expect(functionalPartName("SSAA", "Soprano 2")).toBe("Lead");
+    expect(functionalPartName("SSAA", "Alto 1")).toBe("Baritone");
+    expect(functionalPartName("SSAA", "Alto 2")).toBe("Bass");
+    expect(functionalPartName("SATB", "Soprano")).toBe("Tenor");
+    expect(functionalPartName("SATB", "Alto")).toBe("Lead");
+    expect(functionalPartName("SATB", "Tenor")).toBe("Baritone");
+    expect(functionalPartName("SATB", "Bass")).toBe("Bass");
+    expect(printedNotationSummary("SSAA")).toBe(
+      "S1 = T, S2 = L, A1 = Bari, A2 = Bass"
+    );
+    expect(printedNotationSummary("SATB")).toContain("Tenor = Bari");
+    expect(printedNotationSummary("TTBB")).toContain("T2 = L");
   });
 });

--- a/lib/__tests__/repertoireSongSuggestions.test.ts
+++ b/lib/__tests__/repertoireSongSuggestions.test.ts
@@ -18,7 +18,7 @@ describe("repertoire song suggestion UI", () => {
       'Add &quot;{songTitle.trim()}&quot; manually'
     );
     expect(repertoireManager).toContain(
-      "Choose the voicing, arranger, part, and confidence"
+      "Choose the arrangement voicing, arranger, part, and"
     );
     expect(repertoireManager).not.toContain("as your own song");
     expect(repertoireManager).toContain("max-h-80 overflow-y-auto");
@@ -27,7 +27,7 @@ describe("repertoire song suggestion UI", () => {
     expect(repertoireManager).toContain("songSuggestionSubtitle");
   });
 
-  it("requires choosing a voicing after selecting a grouped suggestion", () => {
+  it("requires choosing an arrangement voicing after selecting a grouped suggestion", () => {
     expect(repertoireManager).toContain(
       "const voicingOptions = suggestedVoicings ?? voicings"
     );
@@ -35,6 +35,7 @@ describe("repertoire song suggestion UI", () => {
       'suggestion.voicings.length === 1 ? (suggestion.voicings[0] ?? "") :'
     );
     expect(repertoireManager).toContain("voicingOptions.map((v) =>");
+    expect(repertoireManager).toContain("voicingDisplayLabel(v)");
   });
 
   it("closes suggestions into a selected-song summary", () => {

--- a/lib/__tests__/songSuggestions.test.ts
+++ b/lib/__tests__/songSuggestions.test.ts
@@ -88,9 +88,9 @@ describe("getSongSuggestions", () => {
       },
     ]);
     expect(suggestions.map(songSuggestionSubtitle)).toEqual([
-      "No arranger entered · TTBB",
-      "Joe Arranger · TTBB",
-      "Unknown · TTBB",
+      "No arranger entered · Lower voice (TTBB)",
+      "Joe Arranger · Lower voice (TTBB)",
+      "Unknown · Lower voice (TTBB)",
     ]);
   });
 

--- a/lib/eventMode.ts
+++ b/lib/eventMode.ts
@@ -1,5 +1,10 @@
 import { supabase } from "@/lib/supabase";
 import { getCurrentUser } from "@/lib/profileStore";
+import {
+  functionalPartName,
+  voicingDisplayLabel,
+} from "@/lib/partAbbreviations";
+import type { Part, Voicing } from "@/lib/matching";
 
 export type EventModeVisibility = "listed" | "unlisted";
 export type EventModeLifecycle = "upcoming" | "active" | "ended";
@@ -73,14 +78,17 @@ export type EventModeAvailabilityInput = {
 export const eventModeVoicePartGroups = [
   {
     voicing: "TTBB",
+    label: "Lower voice (TTBB)",
     parts: ["TTBB Tenor", "TTBB Lead", "TTBB Baritone", "TTBB Bass"],
   },
   {
     voicing: "SATB",
+    label: "Mixed (SATB)",
     parts: ["SATB Soprano", "SATB Alto", "SATB Tenor", "SATB Bass"],
   },
   {
     voicing: "SSAA",
+    label: "Treble (SSAA)",
     parts: [
       "SSAA Soprano 1",
       "SSAA Soprano 2",
@@ -88,7 +96,7 @@ export const eventModeVoicePartGroups = [
       "SSAA Alto 2",
     ],
   },
-] satisfies { voicing: string; parts: EventModeVoicePart[] }[];
+] satisfies { voicing: Voicing; label: string; parts: EventModeVoicePart[] }[];
 
 export const eventModeVoicePartOptions = eventModeVoicePartGroups.flatMap(
   (group) => group.parts
@@ -197,7 +205,18 @@ export function defaultEventModeAvailableUntil(
 }
 
 export function formatEventModeVoiceParts(parts: EventModeVoicePart[]) {
-  return parts.join(", ");
+  return parts.map(formatEventModeVoicePart).join(", ");
+}
+
+export function formatEventModeVoicePart(part: EventModeVoicePart) {
+  const [voicing, ...partWords] = part.split(" ");
+  const canonicalVoicing = voicing as Voicing;
+  const storedPart = partWords.join(" ") as Part;
+
+  return `${voicingDisplayLabel(canonicalVoicing)} ${functionalPartName(
+    canonicalVoicing,
+    storedPart
+  )}`;
 }
 
 export function isEventModeAvailabilityActive(

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -25,7 +25,7 @@ export type HelpNavItem = {
 export const quickStartSteps = [
   "Add your display name so other singers know who is in the quartet.",
   "Add a few songs you are likely to sing. You can type songs in, copy songs from another singer, or add Harmony Brigade songs.",
-  "For each song, choose the voicing and every part you can sing for that arrangement.",
+  "For each song, choose the arrangement voicing and every barbershop part you can sing for that arrangement.",
   "Start a quartet or join someone else with a code, QR code, or shared link.",
   "Use Matches to pick something everyone can sing right now.",
 ] as const;
@@ -59,41 +59,45 @@ export const helpGuideSections: HelpGuideSection[] = [
     eyebrow: "My Songs",
     title: "Manage The Songs You Know",
     intro:
-      "My Songs stores your songs, voicings, parts, confidence, arranger information, notes, and last-sung tracking.",
+      "My Songs stores your songs, arrangement voicings, barbershop parts, confidence, arranger information, notes, and last-sung tracking.",
     topics: [
       {
         title: "Song Title Autocomplete",
         body: [
           "Start typing to see suggestions. Suggestions are optional — you can always enter your own song title if the song is not listed or if your title is different.",
-          "Selecting a suggestion can prefill title, voicing, and arranger. If one suggestion covers multiple voicings, choose the voicing you know before saving.",
+          "Selecting a suggestion can prefill title, arrangement voicing, and arranger. If one suggestion covers multiple voicings, choose the arrangement voicing you know before saving.",
         ],
       },
       {
         title: "How Suggestions Are Shared",
         body: [
-          "When you add a song, the title, voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s My Songs.",
+          "When you add a song, the title, arrangement voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s My Songs.",
           "Suggestions do not expose private user details such as user IDs, singer names, notes, parts, confidence, timestamps, or your full personal song list.",
         ],
       },
       {
         title: "More Ways To Build My Songs",
         body: [
-          "Use Copy songs from another singer when someone gives you a private link or code. You can copy song titles, voicings, and arrangers, then choose your own part and confidence before saving.",
+          "Use Copy songs from another singer when someone gives you a private link or code. You can copy song titles, arrangement voicings, and arrangers, then choose your own part and confidence before saving.",
           "Use Let another singer copy songs from My Songs to create a private link/code. The other singer cannot see your notes, confidence, last-sung history, email address, or account details.",
-          "Use Add Harmony Brigade songs to choose a year and brigade, review TTBB songs from the reference data, and choose your own parts and confidence before adding anything.",
+          "Use Add Harmony Brigade songs to choose a year and brigade, review lower voice (TTBB) songs from the reference data, and choose your own parts and confidence before adding anything.",
         ],
       },
       {
-        title: "Voicing",
+        title: "Arrangement voicings and barbershop parts",
         body: [
-          "Choose the voicing for the arrangement you know. TTBB means Tenor, Lead, Baritone, Bass. SSAA means Soprano 1, Soprano 2, Alto 1, Alto 2. SATB means Soprano, Alto, Tenor, Bass.",
-          "If you know the same song in more than one voicing, add it more than once — one entry for each voicing.",
+          "Barbershop uses four functional voice parts: Tenor, Lead, Baritone, and Bass. That is true whether the music is published for treble voices, mixed voices, or lower voices.",
+          "Choose the arrangement voicing that matches the music you have: Treble (SSAA), Mixed (SATB), or Lower voice (TTBB).",
+          "Treble (SSAA) music is often printed as S1, S2, A1, A2. S1 usually maps to Tenor, S2 to Lead, A1 to Baritone, and A2 to Bass.",
+          "Mixed (SATB) music is often printed as Soprano, Alto, Tenor, Bass. Soprano usually maps to Tenor, Alto to Lead, Tenor to Baritone, and Bass to Bass.",
+          "Lower voice (TTBB) music is often printed as T1, T2, B1, B2. T1 usually maps to Tenor, T2 to Lead, B1 to Baritone, and B2 to Bass.",
+          "If you know the same song in more than one arrangement voicing, add it more than once — one entry for each voicing.",
         ],
       },
       {
         title: "Parts and Confidence",
         body: [
-          "Select every part you can sing for that arrangement and set your confidence for each part.",
+          "Select every barbershop part you can sing for that arrangement and set your confidence for each part.",
           "A singer may know multiple parts, but in a quartet match each singer can only cover one required part. The app looks for distinct singers covering the required parts.",
         ],
       },
@@ -122,7 +126,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         body: [
           "Use search to filter by title. You can sort by title, newest or oldest added, sung recently, or least recently sung.",
           "Recently sung puts marked-sung songs first, newest to oldest. Least recently sung puts Not marked yet songs first, then marked-sung songs from oldest to newest.",
-          "You can filter by voicing, part, and Sung status. Active filters appear above the song list and can be cleared together.",
+          "You can filter by arrangement voicing, part, and Sung status. Active filters appear above the song list and can be cleared together.",
         ],
       },
     ],
@@ -196,7 +200,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "Ready to Sing",
         body: [
           "Ready to Sing matches are the cleanest matches. All required parts are covered, and the app assigns distinct singers to distinct required parts.",
-          "For example, TTBB needs Tenor, Lead, Baritone, and Bass covered by four different singers.",
+          "For example, lower voice (TTBB) arrangements need Tenor, Lead, Baritone, and Bass covered by four different singers.",
         ],
       },
       {
@@ -209,7 +213,7 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "What Matters Most",
         body: [
-          "The strongest signals are voicing, required part coverage, and distinct singers for the required parts. Different voicings are not combined.",
+          "The strongest signals are arrangement voicing, required part coverage, and distinct singers for the required parts. Different voicings are not combined.",
           "Title variants, arranger differences, missing arranger information, confidence, and notes are context to help the quartet decide quickly. They are not all automatic blockers.",
         ],
       },
@@ -233,7 +237,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "Managing The Quartet",
         body: [
           "When the quartet is full, use Manage to see quartet members, edit My Songs, change your name, or leave the quartet.",
-          "If a song title, voicing, part, arranger, notes, or confidence looks wrong, update it from My Songs. If the name shown to others is wrong, use Change name.",
+          "If a song title, arrangement voicing, part, arranger, notes, or confidence looks wrong, update it from My Songs. If the name shown to others is wrong, use Change name.",
         ],
       },
       {

--- a/lib/loginContent.ts
+++ b/lib/loginContent.ts
@@ -3,6 +3,6 @@ export const loginIntro = {
   description:
     "What Can We Sing helps a pickup quartet quickly answer the question: what can we sing together right now?",
   details:
-    "Each singer adds the songs they know, the voicing, the parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's saved songs and shows songs where the required parts are covered by different people.",
+    "Each singer adds the songs they know, the arrangement voicing, the barbershop parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's saved songs and shows songs where the required parts are covered by different people.",
   signInReason: "Sign in to save My Songs and join or start a quartet.",
 } as const;

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -1,5 +1,6 @@
 import { isLikelySameSongTitle } from "./fuzzySongTitles";
 import { areLikelySameArrangerGroup } from "./arrangerDisplay";
+import { functionalPartName } from "./partAbbreviations";
 
 export type Voicing = "TTBB" | "SATB" | "SSAA";
 
@@ -147,7 +148,8 @@ function confidenceValueForPart(entry: SingerEntry, part: Part): number {
 }
 
 function confidenceWarning(
-  assignment: Record<Part, SingerEntry>
+  assignment: Record<Part, SingerEntry>,
+  voicing: Voicing
 ): string | null {
   const weak = Object.entries(assignment).filter(([part, entry]) => {
     const normalizedConfidence = confidenceForPart(entry, part as Part);
@@ -162,7 +164,10 @@ function confidenceWarning(
   return `Confidence warning: ${weak
     .map(([part, entry]) => {
       const normalizedConfidence = confidenceForPart(entry, part as Part);
-      return `${entry.displayName} marked ${normalizedConfidence} on ${part}`;
+      return `${entry.displayName} marked ${normalizedConfidence} on ${functionalPartName(
+        voicing,
+        part as Part
+      )}`;
     })
     .join(", ")}`;
 }
@@ -376,7 +381,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     const arrangerVariant = arrangerVariantNoteForGroup(knownArrangers);
 
     if (fullAssignment) {
-      const confidence = confidenceWarning(fullAssignment);
+      const confidence = confidenceWarning(fullAssignment, voicing);
       if (confidence) warnings.push(confidence);
 
       results.push({
@@ -417,7 +422,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
     }
 
     if (bestNearMatch) {
-      const confidence = confidenceWarning(bestNearMatch.assignment);
+      const confidence = confidenceWarning(bestNearMatch.assignment, voicing);
       if (confidence) warnings.push(confidence);
 
       results.push({
@@ -481,7 +486,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
       ];
       const missingArrangerInfo = hasMissingArrangerInfo(group);
       const arrangerVariant = arrangerVariantNoteForGroup(knownArrangers);
-      const confidence = confidenceWarning(fullAssignment);
+      const confidence = confidenceWarning(fullAssignment, first.voicing);
       if (confidence) warnings.push(confidence);
 
       results.push({

--- a/lib/partAbbreviations.ts
+++ b/lib/partAbbreviations.ts
@@ -1,31 +1,75 @@
 import type { Part, Voicing } from "@/lib/matching";
 
+export const voicingDisplayLabels: Record<Voicing, string> = {
+  SSAA: "Treble (SSAA)",
+  SATB: "Mixed (SATB)",
+  TTBB: "Lower voice (TTBB)",
+};
+
+export const compactVoicingDisplayLabels: Record<Voicing, string> = {
+  SSAA: "Treble",
+  SATB: "Mixed",
+  TTBB: "Lower voice",
+};
+
+export const printedNotationSummaries: Record<Voicing, string> = {
+  SSAA: "S1 = T, S2 = L, A1 = Bari, A2 = Bass",
+  SATB: "Soprano = T, Alto = L, Tenor = Bari, Bass = Bass",
+  TTBB: "T1 = T, T2 = L, B1 = Bari, B2 = Bass",
+};
+
+const functionalPartLabels: Record<Voicing, Partial<Record<Part, Part>>> = {
+  TTBB: {
+    Tenor: "Tenor",
+    Lead: "Lead",
+    Baritone: "Baritone",
+    Bass: "Bass",
+  },
+  SATB: {
+    Soprano: "Tenor",
+    Alto: "Lead",
+    Tenor: "Baritone",
+    Bass: "Bass",
+  },
+  SSAA: {
+    "Soprano 1": "Tenor",
+    "Soprano 2": "Lead",
+    "Alto 1": "Baritone",
+    "Alto 2": "Bass",
+  },
+};
+
+export function voicingDisplayLabel(voicing: Voicing): string {
+  return voicingDisplayLabels[voicing];
+}
+
+export function compactVoicingDisplayLabel(voicing: Voicing): string {
+  return compactVoicingDisplayLabels[voicing];
+}
+
+export function printedNotationSummary(voicing: Voicing): string {
+  return printedNotationSummaries[voicing];
+}
+
+export function functionalPartName(voicing: Voicing, part: Part): Part {
+  return functionalPartLabels[voicing][part] ?? part;
+}
+
 export function partAbbreviation(voicing: Voicing, part: Part): string {
-  if (voicing === "TTBB") {
-    if (part === "Tenor") return "T";
-    if (part === "Lead") return "L";
-    if (part === "Baritone") return "Bari";
-    if (part === "Bass") return "Bass";
-  }
+  const functionalPart = functionalPartName(voicing, part);
 
-  if (voicing === "SATB") {
-    if (part === "Soprano") return "S";
-    if (part === "Alto") return "A";
-    if (part === "Tenor") return "T";
-    if (part === "Bass") return "Bass";
-  }
+  if (functionalPart === "Tenor") return "T";
+  if (functionalPart === "Lead") return "L";
+  if (functionalPart === "Baritone") return "Bari";
+  if (functionalPart === "Bass") return "Bass";
 
-  if (part === "Soprano 1") return "S1";
-  if (part === "Soprano 2") return "S2";
-  if (part === "Alto 1") return "A1";
-  if (part === "Alto 2") return "A2";
-
-  return part;
+  return functionalPart;
 }
 
 export function partButtonLabel(voicing: Voicing, part: Part): string {
   const abbreviation = partAbbreviation(voicing, part);
+  const displayName = functionalPartName(voicing, part);
 
-  if (abbreviation === part) return part;
-  return `${abbreviation} ${part}`;
+  if (abbreviation === displayName) return displayName;
+  return `${abbreviation} ${displayName}`;
 }

--- a/lib/repertoireSharing.ts
+++ b/lib/repertoireSharing.ts
@@ -6,6 +6,7 @@ import {
   type RepertoireRow,
 } from "@/lib/repertoireStore";
 import { getCurrentUser } from "@/lib/profileStore";
+import { voicingDisplayLabel } from "@/lib/partAbbreviations";
 
 export type RepertoireShare = {
   id: string;
@@ -254,7 +255,9 @@ export async function copySharedSongsToMyRepertoire(
   for (const song of copyableSongs) {
     const selection = selectionsByVoicing[song.voicing];
     if (!selection) {
-      throw new Error(`Choose a part and confidence for ${song.voicing}.`);
+      throw new Error(
+        `Choose a part and confidence for ${voicingDisplayLabel(song.voicing)}.`
+      );
     }
 
     await addRepertoireItem({

--- a/lib/songSuggestions.ts
+++ b/lib/songSuggestions.ts
@@ -1,5 +1,6 @@
 import type { Voicing } from "@/lib/matching";
 import { arrangerDisplayName } from "./arrangerDisplay";
+import { voicingDisplayLabel } from "./partAbbreviations";
 
 export type SongSuggestionSource = {
   song_title: string;
@@ -18,9 +19,9 @@ export function songSuggestionArrangerLabel(suggestion: SongSuggestion) {
 }
 
 export function songSuggestionSubtitle(suggestion: SongSuggestion) {
-  return `${songSuggestionArrangerLabel(suggestion)} · ${suggestion.voicings.join(
-    ", "
-  )}`;
+  return `${songSuggestionArrangerLabel(suggestion)} · ${suggestion.voicings
+    .map(voicingDisplayLabel)
+    .join(", ")}`;
 }
 
 const validVoicings: Voicing[] = ["TTBB", "SATB", "SSAA"];


### PR DESCRIPTION
## Summary
- Update user-facing voicing labels to Treble (SSAA), Mixed (SATB), and Lower voice (TTBB) while preserving canonical stored values.
- Map SATB/SSAA/TTBB part display to barbershop functional parts across repertoire, shared repertoire, matches, join pages, event mode, suggestions, login/help/privacy copy, and docs.
- Keep printed/choral notation as helper context and leave matching/data storage behavior unchanged.

## Docs and tests
- Updated AGENTS.md, README.md, help content, privacy/login copy, and the Supabase contract note for event-mode stored voice parts.
- Added/updated tests for voicing labels, part abbreviations, song suggestion labels, match card display, event-mode part labels, help content, and repertoire suggestion UI expectations.

## Verification
- npm run test:run
- npm run build

## Supabase / manual steps
- No migration required.
- No dashboard changes required.

Closes #339
