### PR TITLE
Add acknowledgments and compact My Songs filters

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/lib/feedback";
 import {
   feedbackHelpCopy,
+  helpAcknowledgments,
+  helpAcknowledgmentsIntro,
   helpGuideSections,
   helpNavItems,
   helpWelcomeCopy,
@@ -204,6 +206,29 @@ export default function HelpPage() {
               </div>
             </article>
           ))}
+        </section>
+
+        <section
+          id="acknowledgments"
+          className="mt-10 scroll-mt-6 rounded-2xl border border-white/10 bg-white/5 p-5 sm:p-6"
+        >
+          <h2 className="text-2xl font-semibold">Acknowledgments</h2>
+          <p className="mt-3 text-base leading-7 text-slate-300">
+            {helpAcknowledgmentsIntro}
+          </p>
+          <p className="mt-4 text-sm font-semibold uppercase text-slate-300">
+            Special thanks to
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-base leading-7 text-slate-300">
+            {helpAcknowledgments.map((item) => (
+              <li key={item.name}>
+                <span className="font-semibold text-slate-100">
+                  {item.name}
+                </span>
+                , {item.contribution}
+              </li>
+            ))}
+          </ul>
         </section>
 
         <section

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -11,7 +11,6 @@ import type {
   Voicing,
 } from "@/lib/matching";
 import {
-  compactVoicingDisplayLabel,
   functionalPartNames,
   partAbbreviation,
   partButtonLabel,
@@ -138,6 +137,7 @@ export default function RepertoireManager() {
   const [partFilter, setPartFilter] = useState<FunctionalPartName | "">("");
   const [sungStatusFilter, setSungStatusFilter] =
     useState<SungStatusFilter>("all");
+  const [areFiltersOpen, setAreFiltersOpen] = useState(false);
   const [songTitle, setSongTitle] = useState("");
   const [songSuggestions, setSongSuggestions] = useState<SongSuggestion[]>([]);
   const [songSuggestionsOpen, setSongSuggestionsOpen] = useState(false);
@@ -1014,6 +1014,12 @@ export default function RepertoireManager() {
   };
   const visibleItems = filterAndSortRepertoire(items, repertoireFilters);
   const hasActiveFilters = hasActiveRepertoireFilters(repertoireFilters);
+  const activeFilterCount = [
+    searchQuery.trim(),
+    voicingFilter,
+    partFilter,
+    sungStatusFilter !== "all" ? sungStatusFilter : "",
+  ].filter(Boolean).length;
   const partFilterOptions = functionalPartNames;
   const hasSavedSongs = items.length > 0;
   const voicingOptions = suggestedVoicings ?? voicings;
@@ -1114,7 +1120,7 @@ export default function RepertoireManager() {
     sungStatusFilter === "marked"
       ? "marked sung"
       : sungStatusFilter === "not_marked"
-        ? "not marked yet"
+        ? "not marked sung"
         : "",
   ]
     .filter(Boolean)
@@ -1864,11 +1870,11 @@ export default function RepertoireManager() {
               </div>
 
               <div
-                className={`rounded-2xl border border-white/10 bg-white/5 p-4 ${
+                className={`rounded-2xl border border-white/10 bg-white/5 p-3 sm:p-4 ${
                   hasSmallRepertoire ? "opacity-75" : ""
                 }`}
               >
-                <div className="grid gap-3 lg:grid-cols-[minmax(18rem,1fr)_minmax(12rem,14rem)]">
+                <div className="grid gap-3 lg:grid-cols-[minmax(18rem,1fr)_minmax(10rem,13rem)_auto] lg:items-end">
                   <label className="block min-w-0">
                     <span className="text-sm font-semibold text-slate-200">
                       Search My Songs
@@ -1898,67 +1904,95 @@ export default function RepertoireManager() {
                       <option value="last_sung_asc">Least recently sung</option>
                     </select>
                   </label>
+                  <button
+                    type="button"
+                    onClick={() => setAreFiltersOpen((current) => !current)}
+                    aria-expanded={areFiltersOpen}
+                    className="rounded-xl border border-cyan-300/30 bg-cyan-300/10 px-4 py-3 text-sm font-bold text-cyan-100 hover:border-cyan-200 hover:bg-cyan-300/20"
+                  >
+                    {areFiltersOpen ? "Hide filters" : "Filters"}
+                    {!areFiltersOpen && activeFilterCount > 0
+                      ? ` · ${activeFilterCount}`
+                      : ""}
+                  </button>
                 </div>
 
-                <div className="mt-3 grid gap-3 md:grid-cols-3">
-                  <label className="block min-w-0">
-                    <span className="text-sm font-medium text-slate-300">
-                      Arrangement
-                    </span>
-                    <select
-                      value={voicingFilter}
-                      onChange={(e) =>
-                        updateVoicingFilter(e.target.value as Voicing | "")
-                      }
-                      className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                    >
-                      <option value="">All arrangements</option>
-                      {voicings.map((v) => (
-                        <option key={v} value={v}>
-                          {voicingDisplayLabel(v)}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="block min-w-0">
-                    <span className="text-sm font-medium text-slate-300">
-                      Part
-                    </span>
-                    <select
-                      value={partFilter}
-                      onChange={(e) =>
-                        setPartFilter(e.target.value as FunctionalPartName | "")
-                      }
-                      className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                    >
-                      <option value="">All parts</option>
-                      {partFilterOptions.map((part) => (
-                        <option key={part} value={part}>
-                          {part}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="block min-w-0">
-                    <span className="text-sm font-medium text-slate-300">
-                      Sung status
-                    </span>
-                    <select
-                      value={sungStatusFilter}
-                      onChange={(e) =>
-                        setSungStatusFilter(e.target.value as SungStatusFilter)
-                      }
-                      className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                    >
-                      <option value="all">All songs</option>
-                      <option value="marked">Marked sung</option>
-                      <option value="not_marked">Not marked yet</option>
-                    </select>
-                    <span className="mt-1 block text-xs text-slate-500">
-                      Based on songs you've marked as sung.
-                    </span>
-                  </label>
-                </div>
+                {areFiltersOpen && (
+                  <div className="mt-3 rounded-xl border border-white/10 bg-slate-950/40 p-3">
+                    <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end">
+                      <label className="block min-w-0">
+                        <span className="text-sm font-medium text-slate-300">
+                          Voicing
+                        </span>
+                        <select
+                          value={voicingFilter}
+                          onChange={(e) =>
+                            updateVoicingFilter(e.target.value as Voicing | "")
+                          }
+                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        >
+                          <option value="">All voicings</option>
+                          {voicings.map((v) => (
+                            <option key={v} value={v}>
+                              {voicingDisplayLabel(v)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block min-w-0">
+                        <span className="text-sm font-medium text-slate-300">
+                          Part
+                        </span>
+                        <select
+                          value={partFilter}
+                          onChange={(e) =>
+                            setPartFilter(
+                              e.target.value as FunctionalPartName | ""
+                            )
+                          }
+                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        >
+                          <option value="">All parts</option>
+                          {partFilterOptions.map((part) => (
+                            <option key={part} value={part}>
+                              {part}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block min-w-0">
+                        <span className="text-sm font-medium text-slate-300">
+                          Sung
+                        </span>
+                        <select
+                          value={sungStatusFilter}
+                          onChange={(e) =>
+                            setSungStatusFilter(
+                              e.target.value as SungStatusFilter
+                            )
+                          }
+                          className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                        >
+                          <option value="all">All songs</option>
+                          <option value="marked">Marked sung</option>
+                          <option value="not_marked">Not marked sung</option>
+                        </select>
+                      </label>
+                      {hasActiveFilters && (
+                        <button
+                          type="button"
+                          onClick={clearRepertoireFilters}
+                          className="rounded-xl bg-slate-800 px-4 py-3 text-sm font-bold text-slate-200 hover:bg-slate-700"
+                        >
+                          Clear filters
+                        </button>
+                      )}
+                    </div>
+                    <p className="mt-2 text-xs text-slate-500">
+                      Last sung appears after you mark a song as sung.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
 
@@ -1984,7 +2018,7 @@ export default function RepertoireManager() {
                     <span className="rounded-full bg-cyan-300/10 px-3 py-1 text-xs font-semibold text-cyan-100">
                       {sungStatusFilter === "marked"
                         ? "Marked sung"
-                        : "Not marked yet"}
+                        : "Not marked sung"}
                     </span>
                   )}
                   <button
@@ -2204,12 +2238,12 @@ export default function RepertoireManager() {
                 ) : (
                   <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center">
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
+                      <div className="flex flex-wrap items-center gap-2">
                         <h3 className="truncate text-base font-semibold text-white">
                           {item.song_title}
                         </h3>
-                        <span className="shrink-0 rounded-full bg-slate-900 px-2 py-0.5 text-xs font-semibold text-slate-300">
-                          {compactVoicingDisplayLabel(item.voicing)}
+                        <span className="rounded-full bg-slate-900 px-2 py-0.5 text-xs font-semibold text-slate-300">
+                          {voicingDisplayLabel(item.voicing)}
                         </span>
                       </div>
 

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  helpAcknowledgments,
+  helpAcknowledgmentsIntro,
   helpGuideSections,
   helpSections,
   feedbackHelpCopy,
@@ -86,8 +88,9 @@ describe("help content", () => {
     expect(guideText).toContain("Notes are for your own memory");
     expect(guideText).toContain("Last sung is based on songs");
     expect(guideText).toContain("sort by title");
-    expect(guideText).toContain("Sung status");
-    expect(guideText).toContain("Not marked yet");
+    expect(guideText).toContain("Sung filter");
+    expect(guideText).toContain("not marked sung");
+    expect(guideText).toContain("Open Filters");
   });
 
   it("explains quartet match details and management", () => {
@@ -119,11 +122,13 @@ describe("help content", () => {
       { id: "joining-a-quartet", label: "Joining a quartet" },
       { id: "quartet-matches", label: "Quartet matches" },
       { id: "managing-a-quartet", label: "Managing a quartet" },
+      { id: "acknowledgments", label: "Acknowledgments" },
       { id: "feedback", label: "Feedback" },
     ]);
 
     const sectionIds = new Set([
       ...helpGuideSections.map((section) => section.id),
+      "acknowledgments",
       "feedback",
     ]);
 
@@ -141,5 +146,28 @@ describe("help content", () => {
     expect(feedbackHelpCopy).toContain("just let us know how you are using the app");
     expect(feedbackHelpCopy).toContain("if it helped at a convention");
     expect(feedbackHelpCopy).toContain("General feedback");
+  });
+
+  it("includes a modest acknowledgments section for community contributors", () => {
+    expect(helpAcknowledgmentsIntro).toContain(
+      "people in the barbershop community"
+    );
+    expect(helpAcknowledgments.map((item) => item.name)).toEqual([
+      "Alex Koller",
+      "Amber Reimer",
+      "Ross Wilkins",
+      "Jessica Rodman",
+      "Scott Anderson",
+      "Marcie Jones and Ann Monaghan McAlexander",
+    ]);
+    expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
+      "Instant Quartet"
+    );
+    expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
+      "Event Mode"
+    );
+    expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
+      "voicing terminology"
+    );
   });
 });

--- a/lib/__tests__/repertoireEmptyState.test.ts
+++ b/lib/__tests__/repertoireEmptyState.test.ts
@@ -32,27 +32,38 @@ describe("repertoire empty state", () => {
     expect(repertoireManager).toContain("hasSavedSongs &&");
     expect(repertoireManager).toContain("Search My Songs");
     expect(repertoireManager).toContain("Filter songs you've already added");
-    expect(repertoireManager).toContain("Arrangement");
-    expect(repertoireManager).toContain("All arrangements");
+    expect(repertoireManager).toContain("aria-expanded={areFiltersOpen}");
+    expect(repertoireManager).toContain("Hide filters");
+    expect(repertoireManager).toContain("All voicings");
     expect(repertoireManager).toContain("All parts");
-    expect(repertoireManager).toContain("Sung status");
-    expect(repertoireManager).toContain("Not marked yet");
+    expect(repertoireManager).toContain("Sung");
+    expect(repertoireManager).toContain("Not marked sung");
     expect(repertoireManager).toContain("Mark sung today");
     expect(repertoireManager).toContain('hasSmallRepertoire ? "opacity-75"');
     expect(repertoireManager).not.toContain("Search by title");
+    expect(repertoireManager).not.toContain("All arrangements");
   });
 
-  it("keeps search primary and stacks filters cleanly", () => {
+  it("keeps search primary and hides secondary filters behind a disclosure", () => {
     expect(repertoireManager).toContain(
-      "lg:grid-cols-[minmax(18rem,1fr)_minmax(12rem,14rem)]"
+      "lg:grid-cols-[minmax(18rem,1fr)_minmax(10rem,13rem)_auto]"
     );
-    expect(repertoireManager).toContain("md:grid-cols-3");
+    expect(repertoireManager).toContain(
+      "md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto]"
+    );
     expect(repertoireManager).toContain("text-base text-white");
     expect(repertoireManager).toContain(
-      "Based on songs you've marked as sung."
+      "Last sung appears after you mark a song as sung."
     );
     expect(repertoireManager).not.toContain(
       "Use Sung status to find songs you have or have not marked"
+    );
+  });
+
+  it("uses full voicing labels on saved-song cards", () => {
+    expect(repertoireManager).toContain("voicingDisplayLabel(item.voicing)");
+    expect(repertoireManager).not.toContain(
+      "compactVoicingDisplayLabel(item.voicing)"
     );
   });
 });

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -22,6 +22,11 @@ export type HelpNavItem = {
   label: string;
 };
 
+export type HelpAcknowledgment = {
+  name: string;
+  contribution: string;
+};
+
 export const quickStartSteps = [
   "Add your display name so other singers know who is in the quartet.",
   "Add a few songs you are likely to sing. You can type songs in, copy songs from another singer, or add Harmony Brigade songs.",
@@ -118,7 +123,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "Last Sung",
         body: [
           "Last sung is based on songs you have marked as sung in the app, either from a quartet page or from My Songs. Not marked yet does not make any claim about your real-life singing history.",
-          "You can use Sung status to show all songs, marked-sung songs, or songs that are not marked yet.",
+          "You can use the Sung filter to show all songs, marked-sung songs, or songs that are not marked sung.",
         ],
       },
       {
@@ -126,7 +131,7 @@ export const helpGuideSections: HelpGuideSection[] = [
         body: [
           "Use search to filter by title. You can sort by title, newest or oldest added, sung recently, or least recently sung.",
           "Recently sung puts marked-sung songs first, newest to oldest. Least recently sung puts Not marked yet songs first, then marked-sung songs from oldest to newest.",
-          "You can filter by arrangement voicing, part, and Sung status. Active filters appear above the song list and can be cleared together.",
+          "Open Filters when you need to narrow My Songs by voicing, functional barbershop part, or Sung state. Active filters appear above the song list and can be cleared together.",
         ],
       },
     ],
@@ -258,7 +263,40 @@ export const helpNavItems: HelpNavItem[] = [
   { id: "joining-a-quartet", label: "Joining a quartet" },
   { id: "quartet-matches", label: "Quartet matches" },
   { id: "managing-a-quartet", label: "Managing a quartet" },
+  { id: "acknowledgments", label: "Acknowledgments" },
   { id: "feedback", label: "Feedback" },
+];
+
+export const helpAcknowledgmentsIntro =
+  "What Can We Sing exists because of the generosity, encouragement, and good ideas of people in the barbershop community.";
+
+export const helpAcknowledgments: HelpAcknowledgment[] = [
+  {
+    name: "Alex Koller",
+    contribution:
+      "for inspiring this app with his OG in the 2010s, Instant Quartet",
+  },
+  {
+    name: "Amber Reimer",
+    contribution:
+      "for encouraging this work and for her tireless support of Harmony Brigade singing",
+  },
+  {
+    name: "Ross Wilkins",
+    contribution: "for the use of his excellent Brigade song database",
+  },
+  {
+    name: "Jessica Rodman",
+    contribution: "for her enthusiastic support and suggesting Event Mode",
+  },
+  {
+    name: "Scott Anderson",
+    contribution: "for excellent early feedback and several feature suggestions",
+  },
+  {
+    name: "Marcie Jones and Ann Monaghan McAlexander",
+    contribution: "for crucial feedback on voicing terminology",
+  },
 ];
 
 export const helpWelcomeCopy =


### PR DESCRIPTION
## Summary
- Add a modest Acknowledgments section near the bottom of Help.
- Replace the always-visible My Songs filter panel with a compact search/sort toolbar and collapsible Filters disclosure.
- Restore `Voicing` / `All voicings` filter terminology while keeping #339 full voicing values.
- Keep Part filtering to one functional set: Tenor, Lead, Baritone, Bass.
- Show full voicing labels on My Songs list cards: Treble (SSAA), Mixed (SATB), Lower voice (TTBB).

## Docs and tests
- Updated Help content/tests for the new Acknowledgments section and Help navigation.
- Updated My Songs source-level UI tests for the collapsible filter toolbar, filter wording, and full card voicing labels.
- Existing functional-part filtering tests from #345 continue to cover SSAA/SATB/TTBB role mapping.
- No docs update needed beyond Help; this changes user-facing UI text/content but not setup, schema, analytics, deployment, imports, or matching.

## Verification
- npm run test:run
- npm run build

## Visual behavior not covered by automated tests
- The exact expanded/collapsed visual layout is covered by source-level class/content tests and build/type checks, not browser screenshot automation, because the My Songs page is auth-gated in this repo setup.

## Supabase / manual steps
- No migration required.
- No dashboard changes required.

Closes #344
Closes #347
Closes #348
