### PR TITLE
Fix article-insensitive song suggestion dedupe

### DIFF
--- a/data/song_suggestion_catalog.psv
+++ b/data/song_suggestion_catalog.psv
@@ -69,8 +69,8 @@ Song Title|Voicing|Arranger
 (There's No Place Like) Home for the Holidays|SATB|Russ Foris & Burt Szabo
 (There's No Place Like) Home for the Holidays|SSAA|Russ Foris & Burt Szabo
 (There's No Place Like) Home for the Holidays|TTBB|Russ Foris & Burt Szabo
+(They Long to Be) Close to You|TTBB|Joe Liles
 (They Long To Be) Close To You|TTBB|Jeremey Johnson
-(They Long To Be) Close To You|TTBB|Joe Liles
 (This Is) Dedicated to The One I Love|TTBB|Jeremey Johnson
 (Up A) Lazy River|TTBB|Clay Hine
 (When It's) Darkness on the Delta|SATB|Barbershop Harmony Society
@@ -180,6 +180,7 @@ A Dream (the Lost Ant)|SATB|David Avshalomov
 A Dream Come True|SSAA|Tom Gentry
 A Dream Come True|TTBB|Tom Gentry
 A Dream is a Wish Your Heart Makes|SSAA|Lorraine Rochefort
+A Dream Is a Wish Your Heart Makes|TTBB|Gene Cokeroft
 A Dream Is A Wish Your Heart Makes|SATB|Larry Triplett
 A Dream Is A Wish Your Heart Makes|SSAA|Joe Mannherz
 A Dream Is A Wish Your Heart Makes|SSAA|Joey Minshall
@@ -189,7 +190,6 @@ A Dream Is A Wish Your Heart Makes|SSAA|Lorraine Rochefort Joey Minshall
 A Dream Is A Wish Your Heart Makes|SSAA|Tom Gentry
 A Dream Is A Wish Your Heart Makes|TTBB|David Wright
 A Dream Is A Wish Your Heart Makes|TTBB|Derric Johnson
-A Dream Is A Wish Your Heart Makes|TTBB|Gene Cokeroft
 A Dream Is A Wish Your Heart Makes|TTBB|Joe Mannherz
 A Dream Is A Wish Your Heart Makes|TTBB|Larry Triplett
 A Dream Is A Wish Your Heart Makes|TTBB|Tom Gentry
@@ -211,7 +211,7 @@ A Fool Such As I|TTBB|Aaron Dale
 A Friend of Yours|SSAA|Mary Ann Wydra
 A G-Nu|TTBB|Bob Dowma
 A Gaelic Blessing|TTBB|Jon Nicholas
-A Garden In The Rain|SSAA|David Harrington
+A Garden in the Rain|SSAA|David Harrington
 A Garden In The Rain|SSAA|Diane Clark
 A Garden In The Rain|TTBB|Bud Arberg
 A Garden In The Rain|TTBB|David Harrington
@@ -220,8 +220,8 @@ A Garden In The Rain|TTBB|Walter Latzko
 A Garland Of Old Fashioned Roses|TTBB|Louis Perry
 A Gathering Montage|SSAA|Jay Giallombardo
 A Girl Whose Name Begins With 'M'|TTBB|Rob Hopkins
+A Good Man is Hard to Find|SSAA|Walter Latzko
 A Good Man Is Hard To Find|SSAA|Floyd Connett
-A Good Man Is Hard To Find|SSAA|Walter Latzko
 A Good Old Barbershop Song|SSAA|Larry Wright
 A Good Old Barbershop Song|TTBB|Burt Szabo
 A Good Old Barbershop Song|TTBB|Larry Wright
@@ -250,7 +250,7 @@ A House Is Not A Home|SSAA|Peg Millard
 A House Is Not A Home|TTBB|Larry Triplett
 A House Is Not A Home|TTBB|Steve Tramack
 A House With Love In It|SATB|Joe Mannherz
-A Hundred And Sixty Acres|TTBB|Jordan Johnson
+A Hundred and Sixty Acres|TTBB|Jordan Johnson
 A Hundred Years from Now|SSAA|Diane Clark
 A Hundred Years From Today|SSAA|Marsha Zwicker
 A Hundred Years From Today|TTBB|Walter Latzko
@@ -283,7 +283,7 @@ A Little Street Where Old Friends Meet|TTBB|Aaron Dale
 A Little Street Where Old Friends Meet|TTBB|Burt Szabo
 A Little Street Where Old Friends Meet|TTBB|Rob Hopkins
 A Little Street Where Old Friends Meet|TTBB|Sam Breedon
-A Little Talk With Jesus|TTBB|Burt Szabo
+A Little Talk with Jesus|TTBB|Burt Szabo
 A Long, Long Time|SSAA|Jay Giallombardo
 A Long, Long Time|TTBB|Jay Giallombardo
 A Long, Slow Train|TTBB|Jon Nicholas
@@ -337,11 +337,11 @@ A New York Medley In Three Quarter Time|TTBB|Burt Szabo
 A Newfangled Tango|TTBB|Patrick McAlexander
 A Night Like This|SSAA|Liz Garnett
 A Nightingale Sang In Berekely Square|SSAA|Joni Bescos
+A Nightingale Sang in Berkeley Square|SSAA|Ann Minihane
 A Nightingale Sang in Berkeley Square|SSAA|Joni Bescos
 A Nightingale Sang In Berkeley Square|SATB|Anders Lindqvist
 A Nightingale Sang In Berkeley Square|SATB|Gene Puerling
 A Nightingale Sang In Berkeley Square|SATB|Joe Mannherz
-A Nightingale Sang In Berkeley Square|SSAA|Ann Minihane
 A Nightingale Sang In Berkeley Square|SSAA|David Harrington
 A Nightingale Sang In Berkeley Square|SSAA|Larry Wright
 A Nightingale Sang In Berkeley Square|SSAA|Takako Fuke
@@ -383,7 +383,6 @@ A Quiet Place|SATB|Jerry Rubino
 A Quiet Place|SSAA|Tedda Lippincott
 A Quiet Place|TTBB|Walter Latzko
 A Rainy Night In Rio|TTBB|Kevin Keller
-A Red Red Rose|TTBB|David Wright
 A Red, Red Rose|TTBB|David Wright
 A Ride With Glen Miller (Medley)|TTBB|Paul Davies
 A Ring to the Name of Rosie|TTBB|Lloyd Steinkamp
@@ -392,12 +391,12 @@ A Room With A View|TTBB|Rob Campbell
 A Rose And A Prayer|TTBB|Dennis Driscoll
 A Shanty in Old Shanty Town|SSAA|Sylvia Alsbury
 A Shanty In Old Shanty Town|TTBB|Unspecified
+A Shine on Your Shoes|SSAA|Nancy Bergman
 A Shine On Your Shoes|SATB|Melody Hine
 A Shine On Your Shoes|SSAA|Aaron Dale
 A Shine On Your Shoes|SSAA|Joy McGregor
 A Shine On Your Shoes|SSAA|Melody Hine
 A Shine On Your Shoes|SSAA|Michael Gellert
-A Shine On Your Shoes|SSAA|Nancy Bergman
 A Shine On Your Shoes|TTBB|Aaron Dale
 A Shine On Your Shoes|TTBB|Don Gray
 A Shine On Your Shoes|TTBB|Melody Hine
@@ -405,7 +404,7 @@ A Simple Song|TTBB|Aaron Dale
 A Sky Full of Stars|SATB|Jon Nicholas
 A Sky Full of Stars|SATB|Nicholas Wright
 A Soldier's Medley|TTBB|Rex Jamieson
-A Son Of The Sea|TTBB|Ed Waesche
+A Son of the Sea|TTBB|Ed Waesche
 A Son Of The Sea|TTBB|SPEBSQSA
 A Song For Mary|TTBB|Jay Giallombardo
 A Song For The Little Guy|TTBB|David Wright
@@ -416,12 +415,12 @@ A Song For You|TTBB|Kevin Keller
 A Song Like Daddy Used To Play|TTBB|Brian Beck
 A Song of Friendship|SSAA|Joanne Chambers
 A Special Wish|SSAA|Linda Smith
+A Spoonful of Sugar|TTBB|Russ Foris
 A Spoonful Of Sugar|SSAA|Joe Mannherz
 A Spoonful Of Sugar|SSAA|June Dale
 A Spoonful Of Sugar|SSAA|Loretta Martin
 A Spoonful Of Sugar|TTBB|David Zimmerman
 A Spoonful Of Sugar|TTBB|Joe Mannherz
-A Spoonful Of Sugar|TTBB|Russ Foris
 A Spoonful Of Sugar (from Mary Poppins)|TTBB|David Zimmerman
 A Stable Prayer|SSAA|June Berg
 A Starry Night|TTBB|Derric Johnson
@@ -438,10 +437,10 @@ A Thousand Stars in the Sky|SSAA|Joan D 'Agostino
 A Thousand Things|SSAA|Melody Hine
 A Thousand Things|TTBB|Adam Scott
 A Thousand Things|TTBB|Melody Hine
+A Thousand Thoughts of You|TTBB|Larry Triplett
 A Thousand Thoughts Of You|SATB|Larry Triplett
 A Thousand Thoughts Of You|SSAA|Larry Triplett
 A Thousand Thoughts Of You|SSAA|Tom Gentry
-A Thousand Thoughts Of You|TTBB|Larry Triplett
 A Thousand Thoughts Of You|TTBB|Tom Gentry
 A Thousand Years|SSAA|Carole Prietto
 A Thousand Years|SSAA|Deke Sharon
@@ -481,12 +480,12 @@ A Whole New World|TTBB|Derric Johnson
 A Whole New World|TTBB|Kevin Keller
 A Whole New World|TTBB|Larry Wright
 A Whole New World|TTBB|Tom Gentry
+A Wink and a Smile|SATB|Kim Brittain
+A Wink and a Smile|SSAA|Kim Brittain
 A Wink and a Smile|TTBB|Steve Jamison
 A Wink and A Smile|SSAA|Dave Briner
-A Wink And A Smile|SATB|Kim Brittain
 A Wink And A Smile|SSAA|David Briner
 A Wink And A Smile|SSAA|Jan Meyer
-A Wink And A Smile|SSAA|Kim Brittain
 A Wink And A Smile|SSAA|Michael Gellert
 A Wink And A Smile|TTBB|Kim Brittain
 A Wink And A Smile|TTBB|Robert Rund
@@ -547,6 +546,7 @@ Absolutely Everybody|SSAA|Alex Morris
 Absolutely Everybody|SSAA|Glenda Lloyd
 Ac-cent-chu-ate the Positive|TTBB|Jim West
 Ac-cent-tch-uate the Positive|TTBB|Buzz Haeger
+Ac-cent-tchu-ate the Positive|TTBB|Tom Gentry
 Ac-cent-tchu-ate The Positive|SSAA|Diana DeBruycker
 Ac-cent-tchu-ate The Positive|SSAA|Tedda Lippincott
 Ac-cent-tchu-ate The Positive|SSAA|Tom Gentry
@@ -555,7 +555,6 @@ Ac-cent-tchu-ate The Positive|TTBB|Jeremey Johnson
 Ac-cent-tchu-ate The Positive|TTBB|Jim Shubert
 Ac-cent-tchu-ate The Positive|TTBB|Jim West
 Ac-cent-tchu-ate The Positive|TTBB|Marilyn Penketh
-Ac-cent-tchu-ate The Positive|TTBB|Tom Gentry
 Ac-cent-tchu-ate The Positive|TTBB|Walter Latzko
 Ac-cent-tchu-ate The Positive|TTBB|Warren 'Buzz' Haeger
 Accentchuate The Positive|TTBB|Buzz Haeger
@@ -622,11 +621,11 @@ After The Ball|TTBB|Ted Hanna
 After The Ball|TTBB|Tom Gentry
 After the Curtain Comes Down|SSAA|Mary Coffman
 After The Disco|TTBB|Gabriel Lawson
+After the Gold Rush|SSAA|Donna Stewart
 After The Gold Rush|SATB|Joey Minshall
 After The Gold Rush|SATB|Peter Knight
-After The Gold Rush|SSAA|Donna Stewart
 After The Gold Rush|SSAA|Sheryl Neal
-After The Lovin'|SSAA|Jean Flinn
+After the Lovin'|SSAA|Jean Flinn
 After The Lovin'|TTBB|Tom Gentry
 After The Roses Have Faded Away|SSAA|Jay Giallombardo
 After The Roses Have Faded Away|SSAA|Joey Minshall
@@ -840,7 +839,7 @@ Alice Blue Gown|TTBB|SPEBSQSA
 Alive|SATB|Nicholas Wright
 Alive|SSAA|Emily Moriarty
 All 4 Love|TTBB|III Eddie Holmes
-All Aboard For Dixie Land|TTBB|David Wright
+All Aboard for Dixie Land|TTBB|David Wright
 All Aboard For Dixie Land|TTBB|Earl Moon
 All Aboard For Dixieland|TTBB|David Wright
 All Aboard For Slumberland|TTBB|Tom Gentry
@@ -866,7 +865,6 @@ All Alone|TTBB|Jim Shubert
 All Alone|TTBB|Robert Meyer
 All Alone|TTBB|Tom Gentry
 ALL ALONE|SSAA|Jean McFayden
-ALL ALONE|SSAA|Joan D'Agostino
 All Alone / What'll I Do?|TTBB|Walter Latzko
 All American Girl|SSAA|Jay Giallombardo
 All American Girl|SSAA|Joni Bescos
@@ -986,15 +984,15 @@ All Nations Rise|TTBB|Jay Giallombardo
 All Night Long|SATB|Deke Sharon
 All Night Long|SSAA|Tom Gentry
 All Night Long|TTBB|Tom Gentry
+All of Me|SSAA|Carole Prietto
 All of Me|SSAA|Joan D'Agostino
-All Of Me|SSAA|Carole Prietto
+All of Me|SSAA|Tedda Lippincott
 All Of Me|SSAA|Dawn Haggerty
 All Of Me|SSAA|Elaine Gain
 All Of Me|SSAA|Jen Squires
 All Of Me|SSAA|Joe Mannherz
 All Of Me|SSAA|Lauren Kahn
 All Of Me|SSAA|Sofia De Rama
-All Of Me|SSAA|Tedda Lippincott
 All Of Me|TTBB|Alan Levine
 All Of Me|TTBB|Deke Sharon
 All Of Me|TTBB|Dennis Driscoll
@@ -1007,10 +1005,10 @@ All Of Me|TTBB|Scott Kitzmiller
 ALL OF ME|SSAA|Sophia de Rama
 ALL OF ME (LEAD OR BASS VERSION)|SSAA|Tedda Lippincott
 All of Me (Loves All of You)|SSAA|Elaine Gain
+All of My Life|SSAA|Mary Grace Lodico
+All of My Life|SSAA|Nancy Bergman
 All Of My Life|SSAA|June Berg
 All Of My Life|SSAA|Larry Wright
-All Of My Life|SSAA|Mary Grace Lodico
-All Of My Life|SSAA|Nancy Bergman
 All Of My Life|TTBB|Larry Wright
 ALL OF MY LIFE Mary|SSAA|Grace Lodico
 All Of The Lights|TTBB|Nicholas Wright
@@ -1050,11 +1048,11 @@ All That She Wants|TTBB|Tom Gentry
 All The Gifts I Need|TTBB|Kohl Kitzmiller
 All the Little Toy Soldiers|TTBB|Jay Giallombardo
 All The Small Things|SATB|Nicholas Wright
+All the Things You Are|SSAA|Elaine Gain
 All The Things You Are|SATB|Kevin Keller
 All The Things You Are|SSAA|Brent Graham
 All The Things You Are|SSAA|David Wright
 All The Things You Are|SSAA|Dorothy Herivel
-All The Things You Are|SSAA|Elaine Gain
 All The Things You Are|SSAA|Janice Wheeler
 All The Things You Are|SSAA|Joey Minshall
 All The Things You Are|SSAA|Liz Garnett
@@ -1072,10 +1070,10 @@ All The Time|SSAA|Jay Giallombardo
 All The Time|SSAA|Susan Kegley
 All The Time|TTBB|Jay Giallombardo
 All The Time|TTBB|Steve Tramack
+All the Way|SSAA|Brent Graham
 All the Way|SSAA|Clay Hine
 All the Way|SSAA|Dave Briner
 All the Way|TTBB|Dave Briner
-All The Way|SSAA|Brent Graham
 All The Way|SSAA|David Briner
 All The Way|SSAA|Joni Bescos
 All The Way|SSAA|Larry Wright
@@ -1213,11 +1211,9 @@ Am I Blue?|SSAA|Nancy Bergman
 Am I Blue?|TTBB|David Harrington
 Am I Ever Gonna See Your Face Again|SSAA|Emily Moriarty
 Am I Ever Gonna See Your Face Again|SSAA|Glenda Lloyd
-Am I Ready|TTBB|Jon Nicholas
 Am I Ready?|TTBB|Jon Nicholas
 Am I Wasting My Time On You|SSAA|Jo Lund
 Am I Wasting My Time On You|TTBB|Dennis Driscoll
-Am I Wasting My Time On You|TTBB|Kirk Roose
 Am I Wasting My Time On You|TTBB|Wayne Grimmer
 Am I Wasting My Time On You?|TTBB|Kirk Roose
 Am I Wrong|SATB|Nicholas Wright
@@ -1291,8 +1287,11 @@ America I Love You|TTBB|Ed Waesche
 America In Song|SATB|Deke Sharon
 America Medley|SSAA|Mary Coffman
 America Medley (Am The Beautiful God Bless Am)|SSAA|Judy Vidal
+America the Beautiful|SATB|Rob Hopkins
 America the Beautiful|SSAA|Joe Liles
 America the Beautiful|SSAA|Nancy Bergman, Joni Bescos
+America the Beautiful|SSAA|Rob Hopkins
+America the Beautiful|SSAA|Suzy Buerer
 America the Beautiful|TTBB|John Hayden
 America the Beautiful|TTBB|Sean Milligan
 America The Beautiful|SATB|Burt Szabo
@@ -1300,15 +1299,11 @@ America The Beautiful|SATB|Deke Sharon
 America The Beautiful|SATB|Derric Johnson
 America The Beautiful|SATB|James Hoover
 America The Beautiful|SATB|Nancy Bergman
-America The Beautiful|SATB|Rob Hopkins
 America The Beautiful|SSAA|Bergman/Bescos
 America The Beautiful|SSAA|Carolyn Johnson
 America The Beautiful|SSAA|Deke Sharon
 America The Beautiful|SSAA|Dianne Goldrick
 America The Beautiful|SSAA|Joni Bescos
-America The Beautiful|SSAA|Nancy Bergman
-America The Beautiful|SSAA|Rob Hopkins
-America The Beautiful|SSAA|Suzy Buerer
 America The Beautiful|SSAA|Tom Gentry
 America The Beautiful|TTBB|Deke Sharon
 America The Beautiful|TTBB|Dianne Goldrick
@@ -1325,7 +1320,6 @@ America, The Beautiful|TTBB|Mark Hayes
 AMERICA, THE BEAUTIFUL|SSAA|Nancy Bergman
 AMERICA, THE BEAUTIFUL|SSAA|Nancy Bergman and Joni Bescos
 America, The Beautiful / Liberty Anthem Medley|TTBB|Shaun Agnew
-America, The Dream Goes On|SSAA|Tedda Lippincott
 AMERICA... THE DREAM GOES ON|SSAA|Tedda Lippincott
 America/Give Me Your Tired|TTBB|Jim Clancy
 America/God Bless the USA Medley|TTBB|Unspecified
@@ -1347,10 +1341,7 @@ American Revolution Medley|TTBB|Dave Stevens
 American Revolution Medley - with narration|TTBB|Barbershop Harmony Society
 American Rock n' Roll|TTBB|Larry Wright
 American Tears|SSAA|Gene Cokeroft
-American Trilogy|TTBB|Jim Clancy
 American Tune|TTBB|David Wright
-American Tune|TTBB|Steve Tramack
-American-Canadian Ode To Joy|TTBB|Jay Giallombardo
 American/Canadian Anthems-Ode to Joy|TTBB|Jay Giallombardo
 Among My Souvenirs|SSAA|Mary K. Coffman Music Fund
 Among My Souvenirs|SSAA|Tom Gentry
@@ -1441,12 +1432,12 @@ ANGELS FROM THE REALMS OF GLORY|SSAA|Carolyn E. Johnson
 Angels Medley|SSAA|Jeremey Johnson
 Angels Medley|TTBB|Jeremey Johnson
 Angels On Your Pillow|TTBB|Cary Burns
+Angels We Have Heard on High|SSAA|Sylvia Alsbury
 Angels We Have Heard On High|SATB|David Wallace
 Angels We Have Heard On High|SATB|Deke Sharon
 Angels We Have Heard On High|SSAA|Carole Prietto
 Angels We Have Heard On High|SSAA|Mark Rusch
 Angels We Have Heard On High|SSAA|Renee Craig
-Angels We Have Heard On High|SSAA|Sylvia Alsbury
 Angels We Have Heard On High|TTBB|Aaron Dale
 Angels We Have Heard On High|TTBB|Barbershop Harmony Society
 Angels We Have Heard On High|TTBB|Burt Szabo
@@ -1499,7 +1490,6 @@ Another Hallelujah|SSAA|Takako Fuke
 Another Hallelujah|TTBB|Paul Jorg
 Another Op'nin|SSAA|Dot Calvin
 Another Op'nin, Another Show|SSAA|Ann Minihane
-Another Op'nin' Another Show|SSAA|Dot Calvin
 Another Op'nin' Another Show|SSAA|Tom Gentry
 Another Op'nin', Another Show|TTBB|Tom Gentry
 ANOTHER OP'NIN', ANOTHER SHOW|SSAA|Dot Calvin
@@ -1571,7 +1561,6 @@ Anything You Can Do I Can Do Better|SATB|Tom Gentry
 Anything You Can Do I Can Do Better|SATB|Walter Latzko
 Anything You Can Do I Can Do Better|SSAA|Charlene Yazurlo
 Anything You Can Do I Can Do Better|SSAA|Larry Wright
-Anything You Can Do I Can Do Better|TTBB|Don Gray
 Anything You Can Do I Can Do Better|TTBB|Jay Giallombardo
 Anything You Can Do I Can Do Better|TTBB|Steve Jamison
 Anything You Can Do I Can Do Better|TTBB|Tom Gentry
@@ -1631,9 +1620,7 @@ Are You From Dixie?|TTBB|Barbershop Harmony Society
 Are You From Dixie? (Cause I'm From Dixie Too)|TTBB|Lloyd Steinkamp
 Are You Havin' Any Fun|SATB|Kevin Keller
 Are You Havin' Any Fun|SATB|Melody Hine
-Are You Havin' Any Fun|SSAA|Kevin Keller
 Are You Havin' Any Fun|SSAA|Melody Hine
-Are You Havin' Any Fun|TTBB|Kevin Keller
 Are You Havin' Any Fun|TTBB|Melody Hine
 Are You Havin' Any Fun|TTBB|Tom Gentry
 Are You Havin' Any Fun?|SSAA|Kevin Keller
@@ -1764,7 +1751,6 @@ AS WITH GLADNESS - YW|SSAA|Carolyn Johnson
 As With Gladness Men Of Old|SSAA|Carolyn Johnson
 As You Desire Me|SSAA|Ig Jakovac
 As You Go On Your Way - A Benediction|TTBB|Heimer Swanson
-Ash Grove|SSAA|Carolyn Johnson
 Ash Grove|SSAA|Diane Clark
 Ashokan Farewell|TTBB|Paul Jorg
 Asleep In The Deep|TTBB|Barbershop Harmony Society
@@ -1790,7 +1776,7 @@ At Last|TTBB|Walter Latzko
 At Last (from Sun Valley Serenade)|TTBB|Clay Hine
 At Long Last Love (from You Never Know)|TTBB|Andrew Carolan
 At The Ball, That's All|TTBB|Mark Goodney
-At The Beginning|SSAA|Carolyn Schmidt
+At the Beginning|SSAA|Carolyn Schmidt
 At the Beginning (from Anastasia)|SSAA|Carolyn Schmidt
 At The Codfish Ball|SSAA|Doris Twardosky
 At The Codfish Ball|SSAA|Jeff Veteto
@@ -1808,8 +1794,8 @@ At The End Of The Day With You|TTBB|Ed Waesche
 At The End Of The Day With You|TTBB|Renee Craig
 At the End of the Road|TTBB|Burt Szabo
 At the End of the Road|TTBB|Fred King
+At the Hop|TTBB|Gary Thiel
 At The Hop|SSAA|Sonny Steffan
-At The Hop|TTBB|Gary Thiel
 At the Jazz Band Ball|SSAA|Joni Bescos
 At The Jazz Band Ball|TTBB|Brian Beck
 At The Jazz Band Ball|TTBB|David Wright
@@ -1870,7 +1856,6 @@ Aura Lee|TTBB|Barbershop Harmony Society
 Aura Lee|TTBB|SPEBSQSA
 Aura Lee / Love Me Tender|TTBB|Tom Gentry
 Aura Lee / Love Me Tender Medley|TTBB|Tom Gentry
-Aura Lee/Love Me Tender Medley|TTBB|Tom Gentry
 Aussie Road Medley|TTBB|Tom Gentry
 Autumn In New Hampshire|TTBB|Brad Taylor
 Autumn In New York|TTBB|Kohl Kitzmiller
@@ -1901,6 +1886,7 @@ Awake My Soul|SSAA|Nicholas Wright
 Away In A Manager / Cradle Song Medley|TTBB|Paul Jorg
 Away In a Manger|TTBB|Barbershop Harmony Society
 Away In a Manger|TTBB|Bradley Ellingboe
+Away In A manger|TTBB|Jon Nicholas
 Away In A Manger|SATB|Brian Doepke
 Away In A Manger|SATB|Derric Johnson
 Away In A Manger|SATB|Simon Lubkowski
@@ -1918,7 +1904,6 @@ Away In A Manger|TTBB|Aaron Dale
 Away In A Manger|TTBB|Adam Reimnitz
 Away In A Manger|TTBB|Chris Arnold
 Away In A Manger|TTBB|David Briner
-Away In A Manger|TTBB|Jon Nicholas
 Away In A Manger|TTBB|Nick Bryant
 Away In A Manger|TTBB|Paul Jorg
 Away In A Manger/Amazing Grace Medley|SSAA|Jay Giallombardo
@@ -2003,7 +1988,7 @@ Baby's Request|SSAA|Sam Hubbard
 Baby's Request|TTBB|Jon Nicholas
 Baby's Request|TTBB|Sam Hubbard
 Babys Request|SSAA|Unspecified
-Bach Fugue In D Minor|SSAA|Larry Wright
+Bach Fugue in D Minor|SSAA|Larry Wright
 Bach Fugue In D Minor|TTBB|Larry Wright
 Back At One|TTBB|Lance Fisher
 Back Home|TTBB|Nicholas Wright
@@ -2023,22 +2008,22 @@ Back In Business|SSAA|Larry Wright
 Back In Business|TTBB|David Wright
 Back In Business|TTBB|Larry Wright
 Back In Business (from Dick Tracy)|TTBB|David Wright
-Back In Dad And Mother's Day|TTBB|Louis Perry
+Back in Dad and Mother's Day|TTBB|Louis Perry
 Back In Dixie Again|TTBB|Earl Moon
 Back In My Home Town|TTBB|S. K. Grundy
 Back In The Good Old Days|TTBB|Burt Szabo
 Back In The High Life Again|TTBB|Deke Sharon
 Back In The Old Neighborhood|SSAA|Lauren Lindeman
+Back in the Old Routine|SSAA|Nancy Bergman
 Back in the Old Routine|SSAA|Renee Craig
 Back in the Old Routine|TTBB|Renee Craig
-Back In The Old Routine|SSAA|Nancy Bergman
 Back In The Old Routine|TTBB|Dallas Town North
 Back In The Old Routine|TTBB|Greg Backwell
 Back In The Old Routine|TTBB|Greg Blackwell
 Back In The Old Routine|TTBB|R. J. Margison
 Back In The Old Routine|TTBB|Steve Tramack
 Back In The Roaring 20s|SSAA|Nancy Bergman
-Back In The Saddle Again|TTBB|Jon Nicholas
+Back in the Saddle Again|TTBB|Jon Nicholas
 Back In The Saddle Again|TTBB|Todd Troutman
 Back In The USA|SATB|Deke Sharon
 Back In Those Days Gone By|SSAA|Mike Senter Music
@@ -2057,7 +2042,6 @@ Back When Dad And Mother's Mother And Dad Were Young|TTBB|Mark Goodney
 Back Where I Come From|TTBB|Lance Fisher
 Backwards|TTBB|Greg Mallett
 Backwards|TTBB|Matt Astle
-Bad Bad Leroy Brown|TTBB|Fran Wilson
 Bad Bad Leroy Brown|TTBB|Tony Nasto
 Bad Blood|SATB|Nicholas Wright
 Bad Blood|TTBB|Nicholas Wright
@@ -2112,7 +2096,7 @@ Bandstand Boogie|SSAA|Renee Craig
 Bandstand Boogie|TTBB|Jay Giallombardo
 Bandstand Boogie|TTBB|Jon Nicholas
 Bandstand Boogie|TTBB|Todd Troutman
-Bandstand In Central Park|SSAA|Nancy Bergman
+Bandstand in Central Park|SSAA|Nancy Bergman
 Bandstand In Central Park|TTBB|Nancy Bergman
 Bang Bang|SSAA|Kohl Kitzmiller
 Bang Bang|SSAA|Nicholas Wright
@@ -2149,17 +2133,13 @@ Barbershop Joe|SSAA|Karen Penketh
 Barbershop Memories|TTBB|Kevin Keller
 Barbershop Rag|TTBB|Louis Perry
 Barbershop Song|TTBB|Steve Hall
-Barbershop Time of Your Life|TTBB|Joe Liles
 Barbershopper of Seville|SSAA|Jay Giallombardo
 Barbershopper of Seville|TTBB|Jay Giallombardo
-Barbershoppin Cowgirl|SSAA|Carolyn Johnson
 Barbershoppin' Cowgirl|SSAA|Carolyn E. Johnson
 Barbershoppin' Cowgirl|SSAA|Johnson
 BARBERSHOPPIN' COWGIRL|SSAA|Carolyn Johnson
 Bare Necessities|SATB|Tom Gentry
-Bare Necessities|SSAA|Carolyn Healey
 Bare Necessities|SSAA|Jay Giallombardo
-Bare Necessities|SSAA|Sylvia Alsbury
 Bare Necessities|SSAA|Thomas Gentry
 Bare Necessities|SSAA|Tom Gentry
 Bare Necessities|TTBB|Clay Hine
@@ -2195,23 +2175,22 @@ Basin Street!|TTBB|Joe Mannherz
 Basin Street!|TTBB|Steve Jamison
 Basin Street/Bye Bye Blues|SSAA|Lorraine Rochefort
 Basketcase|TTBB|Deke Sharon
+Battle Hymn of the Republic|SSAA|Judy West
+Battle Hymn Of the Republic|TTBB|Barbershop Harmony Society
 Battle Hymn Of The Republic|SATB|Derric Johnson
-Battle Hymn Of The Republic|SSAA|Judy West
-Battle Hymn Of The Republic|TTBB|Barbershop Harmony Society
 Battle Hymn Of The Republic|TTBB|Clay Hine
 Battle Hymn Of The Republic|TTBB|Joe Liles
 Battle Hymn Of The Republic|TTBB|Jon Nicholas
 Battle Hymn Of The Republic|TTBB|Paul Jorg
 Battlefield|SATB|Deke Sharon
+Be a Clown|TTBB|Ed Waesche
 Be A Clown|TTBB|Bob Benson
 Be A Clown|TTBB|Dennis Driscoll
-Be A Clown|TTBB|Ed Waesche
 Be A Clown|TTBB|Joe Mannherz
 Be A Clown|TTBB|Kevin Keller
 Be A Clown / Make 'Em Laugh Medley|SSAA|Jay Giallombardo
 Be A Clown / Make 'Em Laugh Medley|TTBB|Jay Giallombardo
 Be A Clown/Make 'em Laugh|SSAA|Joni Bescos
-Be A Clown/Make Em' Laugh Medley|TTBB|Jay Giallombardo
 Be A Santa|SSAA|Joey Minshall
 Be Anything (But Be Mine)|TTBB|Dick Barrett
 Be Careful What You Eat|TTBB|Deke Sharon
@@ -2315,7 +2294,6 @@ Beautiful Eyes|TTBB|Steve Jamison
 Beautiful Girl|SSAA|Mike Menefee
 Beautiful Girls|TTBB|Deke Sharon
 Beautiful Isle Of Somewhere|TTBB|Paul Jorg
-Beautiful Lady In Blue|TTBB|Chris Arnold
 Beautiful Ohio|TTBB|Lee Crews
 Beautiful Ohio|TTBB|Tom Gentry
 Beautiful Savior|SSAA|Dotty Hougen
@@ -2330,11 +2308,11 @@ Beautiful Thang|TTBB|Melody Hine
 Beautiful Things|SATB|Mark Stevens
 Beautiful Things|TTBB|Mark Stevens
 Beautiful/Just The Way You Are Medley|SSAA|Hari Birtles
+Beauty and the Beast|SSAA|Nina Herdes
+Beauty And the Beast|SSAA|Carolyn Schmidt
 Beauty And The Beast|SSAA|Betty Grant
 Beauty And The Beast|SSAA|Bitsy Bacon
-Beauty And The Beast|SSAA|Carolyn Schmidt
 Beauty And The Beast|SSAA|Gayle Rastorfer
-Beauty And The Beast|SSAA|Nina Herdes
 Beauty And The Beast|TTBB|Carol Kingsbury
 Beauty And The Beast|TTBB|Fred and Carol Kingsbury
 Beauty And The Beast|TTBB|Fred Kingsbury
@@ -2396,10 +2374,10 @@ Before He Cheats|SATB|Nicholas Wright
 Before He Cheats|SSAA|Nicholas Wright
 Before He Cheats|TTBB|Deke Sharon
 Before I Grew Up To Love You|TTBB|Burt Szabo
+Before the Parade Passes By|SSAA|Carolyn Schmidt
+Before the Parade Passes By|SSAA|Jay Giallombardo
 Before the Parade Passes By|SSAA|Lorraine Rochefort
 Before The Parade Passes By|SSAA|Aaron Dale
-Before The Parade Passes By|SSAA|Carolyn Schmidt
-Before The Parade Passes By|SSAA|Jay Giallombardo
 Before The Parade Passes By|SSAA|Liz Garnett
 Before The Parade Passes By|TTBB|Aaron Dale
 Before The Parade Passes By|TTBB|Adam Scott
@@ -2434,7 +2412,7 @@ Being Alive|TTBB|Lance Fisher
 Being Alive|TTBB|Theo Hicks
 Being Alive|TTBB|Theodore Hicks
 Being Good Isn't Good Enough|TTBB|Kevin Keller
-Being With You|TTBB|Steve Delehanty
+Being with You|TTBB|Steve Delehanty
 Believe|SATB|Cay Outerbridge
 Believe|SATB|Kevin Keller
 Believe|SSAA|Joey Minshall
@@ -2480,12 +2458,10 @@ Best of Doo-Wop|TTBB|Ed Lojeski
 Best Of Me|TTBB|Rasmus Krigström
 Best Of My Love|SSAA|Deke Sharon
 Best Of Times|SSAA|Jo Lund
-Best Of Times|SSAA|Tedda Lippincott
 Best Of Times|TTBB|James Bongard
 Best Seat In The House|SSAA|Larry Wright
 Best Seat In The House|TTBB|Larry Wright
 Best things happen while you dance/ Dance Medley|SSAA|Joe Mannherz
-Best Things In Life Are Free|TTBB|Marie Johnson
 Bestest Friend|TTBB|Cay Outerbridge
 Betelehemu (TTBB)|TTBB|Olatunji / Whalum
 Beth|TTBB|Kohl Kitzmiller
@@ -2519,8 +2495,8 @@ Between The Devil And The Deep Blue Sea|TTBB|David Wright
 Between The Devil And The Deep Blue Sea|TTBB|Jon Nicholas
 Between The Devil And The Deep Blue Sea|TTBB|Pete Rupay
 Between The Lines|SATB|Deke Sharon
+Between You and the Birds and the Bees and Cupid|TTBB|Aaron Dale
 Between You And The Birds And The Bees And Cupid|SSAA|Aaron Dale
-Between You And The Birds And The Bees And Cupid|TTBB|Aaron Dale
 Bewitched|SSAA|Doris Twardosky
 Bewitched|SSAA|Emily Moriarty
 Bewitched|SSAA|Joey Minshall
@@ -2635,17 +2611,14 @@ Birdland|SSAA|Ann Minihane
 Birdland|SSAA|Jim Arns
 Birdland|TTBB|Jay Dougherty
 Birds Medley|TTBB|Tom Gentry
+Birth of the Blues|SSAA|Carolyn Schmidt
 Birth of the Blues|SSAA|David Wright
 Birth Of the Blues|TTBB|J. Rae Jamieson
+Birth Of the Blues|TTBB|Roger Payne
 Birth Of The Blues|SSAA|Brian Beck
-Birth Of The Blues|SSAA|Carolyn Schmidt
 Birth Of The Blues|SSAA|Lyle Pilcher
-Birth Of The Blues|TTBB|David Wright
-Birth Of The Blues|TTBB|Don Gray
 Birth Of The Blues|TTBB|Einar Pedersen
 Birth Of The Blues|TTBB|Joe Mannherz
-Birth Of The Blues|TTBB|Roger Payne
-Birth Of The Blues|TTBB|Steve Jamison
 Birth Of The Blues|TTBB|Walter Latzko
 Birthday Of A King|SSAA|Matt Swann
 Birthday Of A King|TTBB|Matt Swann
@@ -2688,14 +2661,14 @@ Blame It On The Boogie|SSAA|Jean Kane
 Blame It On The Boogie|SSAA|Jen Squires
 Blame It On The Boogie|SSAA|Kohl Kitzmiller
 Blame It On The Boogie|TTBB|Kohl Kitzmiller
+Blame It On the Bossa Nova|SSAA|Cheryl Suhr
 Blame It On The Bossa Nova|SSAA|Carolyn Schmidt
-Blame It On The Bossa Nova|SSAA|Cheryl Suhr
 Blame It On The Summer Night|TTBB|Walter Latzko
 Blank Space|SATB|Nicholas Wright
 Blaydon Races|SATB|Matthew Spinner
 Bleeding Love|SATB|Deke Sharon
 Bless 'Em All|TTBB|R. J. Margison
-Bless The Broken Road|SSAA|Carole Prietto
+Bless the Broken Road|SSAA|Carole Prietto
 Bless The Broken Road|TTBB|Deke Sharon
 Bless The Telephone|SSAA|Simon Arnott
 Bless This House|TTBB|A Polaneczky
@@ -2720,7 +2693,6 @@ Bling It On!|SSAA|Jan Meyer
 Blossom|SATB|David Avshalomov
 Blossom|TTBB|Robert Rund
 Blow Gabriel Blow|SSAA|Jay Giallombardo
-Blow Gabriel Blow|SSAA|Jo Lund
 Blow Gabriel Blow|TTBB|Aaron Dale
 Blow Gabriel Blow|TTBB|Jay Giallombardo
 Blow The Man Down|TTBB|Jim West
@@ -2728,7 +2700,7 @@ Blow The Winds Southerly|SATB|Matthew Spinner
 Blow, Gabriel Blow|SSAA|Jo Lund
 Blow, Gabriel Blow|SSAA|Renee Craig
 Blow, Gabriel, Blow|TTBB|Rasmus Krigström
-Blowin' In the Wind|SSAA|Kay Bromert
+Blowin' in the Wind|SSAA|Kay Bromert
 Blue|SSAA|Jo Lund
 Blue|SSAA|Tedda Lippincott
 Blue|TTBB|Deke Sharon
@@ -2772,8 +2744,8 @@ Blue Moon|TTBB|David Briner
 Blue Moon|TTBB|Joe Browne
 Blue Moon|TTBB|Paul Laurenz
 Blue Moon|TTBB|Tom Gentry
-Blue Moon Of Kentucky|SSAA|Aaron Dale
-Blue Moon Of Kentucky|TTBB|Aaron Dale
+Blue Moon of Kentucky|SSAA|Aaron Dale
+Blue Moon of Kentucky|TTBB|Aaron Dale
 Blue Ocean Floor|TTBB|Nicholas Wright
 Blue Rondo A La Turk|SATB|Anders Lindqvist
 Blue Shadows|TTBB|Jon Nicholas
@@ -2822,13 +2794,13 @@ Blues (My Naughty Sweetie Gives To Me)|TTBB|Robert Rund
 Blues (Stay Away From Me)|SSAA|Walter Latzko
 Blues Brothers Medley|TTBB|Tom Gentry
 Blues in the Night|SSAA|Dave Briner
+Blues in the Night|TTBB|Dave Briner
 Blues In The Night|SSAA|Ann Minihane
 Blues In The Night|SSAA|David Briner
 Blues In The Night|SSAA|Mary Coffman
 Blues In The Night|SSAA|Mary K. Coffman Music Fund
 Blues In The Night|SSAA|Tom Gentry
 Blues In The Night|TTBB|Dan Wessler
-Blues In The Night|TTBB|Dave Briner
 Blues In The Night|TTBB|David Briner
 Blues In The Night|TTBB|David Wright
 Blues In The Night|TTBB|Don Gray
@@ -2874,7 +2846,6 @@ Boogie Woogie Bugle Boy|TTBB|David Wright
 Boogie Woogie Bugle Boy|TTBB|Deke Sharon
 Boogie Woogie Bugle Boy|TTBB|Tom Gentry
 Booglie Wooglie Piggy|TTBB|Cay Outerbridge
-Book Of Love|SSAA|Katherine Hardie
 Book Of Love|SSAA|Kevin Koehl
 Book Of Love|SSAA|Marsha Zwicker
 Book Of Love|SSAA|Rosemary Frerking
@@ -2887,7 +2858,6 @@ Boot Scootin' Boogie|SSAA|Dan Wessler
 Boot Scootin' Boogie|SSAA|Tedda Lippincott
 Boot Scootin' Boogie|TTBB|Dan Wessler
 Bop 'Til You Drop|SSAA|BTM
-Bop 'Til You Drop|SSAA|BTM?,
 Bop Til You Drop|SSAA|Barbara McNeill
 Bop Till You Drop|SSAA|Barbara McNeill
 Border Song|TTBB|Anders Lindqvist
@@ -2897,7 +2867,7 @@ Born This Way|SSAA|Liz Garnett
 Born to Be Blue|TTBB|Theo Hicks
 Born To Be Blue|TTBB|Melody Hine
 Born To Be Blue|TTBB|Theodore Hicks
-Born To Be Wild|SSAA|Joey Minshall
+Born to be Wild|SSAA|Joey Minshall
 Bosom Buddies|SSAA|Marsha Zwicker
 Bosom Buddies|SSAA|Sonny Steffan
 Both Sides Now|SATB|Alex Morris
@@ -2921,7 +2891,6 @@ Bourke Street on Saturday Night|TTBB|Tom Gentry
 Bowery Medley|TTBB|Joe Mannherz
 Boy Band Medley|TTBB|Deke Sharon
 Boy Band Medley|TTBB|Jeremey Johnson
-BOY FROM NEW YORK CITY|SSAA|Tedda Lippincott
 Boy of Mine|TTBB|Brent Graham
 Boyfriend Medley|SSAA|David Wright
 Boyfriend Medley|SSAA|Jan Meyer
@@ -2949,7 +2918,7 @@ Brazil|SATB|Joe Mannherz
 Brazil|SSAA|Nancy Bergman
 Brazil|TTBB|Patrick McAlexander
 BRAZIL (AQUARELA DO BRASIL)|SSAA|Nancy Bergman
-Bread And Gravy|TTBB|David Wright
+Bread and Gravy|TTBB|David Wright
 Bread And Gravy|TTBB|Wayne Grimmer
 Bread and Roses|SSAA|Fran Carter
 Break Forth, O Beauteous Heavenly Light|TTBB|Walter Latzko
@@ -2977,6 +2946,7 @@ Breakin' Up Is Hard To Do (YWIH)|SSAA|Anna Maria Parker
 Breakin' Up Is Hard To Do (YWIH)|SSAA|Tedda Lippincott
 Breaking Free|SATB|Soren Detlefsen
 Breaking Free|TTBB|Soren Detlefsen
+Breaking Up is Hard to Do|SSAA|Tedda Lippincott
 Breaking Up Is Hard To Do|SATB|Tom Campbell
 Breaking Up Is Hard To Do|SSAA|Anna Maria Parker
 Breaking Up Is Hard To Do|SSAA|Bev Sellers
@@ -2987,7 +2957,6 @@ Breaking Up Is Hard To Do|SSAA|Kim Brittain
 Breaking Up Is Hard To Do|SSAA|Larry Wright
 Breaking Up Is Hard To Do|SSAA|LaVeda Redfield
 Breaking Up Is Hard To Do|SSAA|Nancy Bergman
-Breaking Up Is Hard To Do|SSAA|Tedda Lippincott
 Breaking Up Is Hard To Do|SSAA|Tom Campbell
 Breaking Up Is Hard To Do|SSAA|Tom Gentry
 Breaking Up Is Hard To Do|TTBB|Adam Reimnitz
@@ -3018,7 +2987,7 @@ Brians song|TTBB|Joe Mannherz
 Brick House|SSAA|Melody Hine
 Bricklayer Song|TTBB|Al Fisk
 Bridal Chorus from Lohengrin|SATB|Deke Sharon
-Bridge Of Light|SSAA|June Berg
+Bridge of Light|SSAA|June Berg
 Bridge Over Troubled Water|SATB|Deke Sharon
 Bridge Over Troubled Water|SATB|Kirby Shaw
 Bridge Over Troubled Water|SSAA|Asuka Ichikawa
@@ -3042,14 +3011,14 @@ Brigadoon Medley|TTBB|Jay Giallombardo
 Bright College Days|TTBB|W. Engelke
 Bright Lights and Cityscapes|SATB|Nicholas Wright
 Bright Lights Bigger City/Magic|TTBB|Deke Sharon
-Bright Was The Night|TTBB|David Wright
+Bright Was the Night|TTBB|David Wright
 Bright Was The Night|TTBB|Ed Waesche
 Bright Was The Night|TTBB|Inc. SPEBSQSA
 Bright Was The Night|TTBB|SPEBSQSA
 Brighter Than The Sun|SSAA|Carole Prietto
 Brighter Than The Sun|SSAA|Nicholas Wright
 Brighter Than the Sun/We Are Young|SSAA|Carole Prietto
-Bring A Torch, Jeanette, Isabella|SSAA|Carolyn Johnson
+Bring a Torch, Jeanette, Isabella|SSAA|Carolyn Johnson
 Bring A Torch, Jeanette, Isabella|SSAA|Jay Giallombardo
 Bring A Torch, Jeanette, Isabella|SSAA|Marshall Webb
 Bring A Torch, Jeanette, Isabella|TTBB|Jay Giallombardo
@@ -3129,7 +3098,6 @@ Broadway Rose|TTBB|Louis Perry
 Broadway Rose|TTBB|Steve Jamison
 Broadway Rose|TTBB|Tom Gentry
 Broadway Show Opener|TTBB|J Rae Jamieson
-Broadway Show Opener|TTBB|J. Rae Jamieson
 Broadway Star|SSAA|Wydra Joni Bescos
 Broadway Star Medley|SSAA|Joni Bescos / Mary Ann Wydra
 Broadway USA/Razzle Dazzle Medley|SSAA|Jay Giallombardo
@@ -3152,10 +3120,8 @@ Brooklyn Kind Of Love|TTBB|Michael Webber
 Brother|TTBB|Nicholas Wright
 Brother Can You Spare A Dime|SSAA|Jo Lund
 Brother Can You Spare A Dime|TTBB|Bob Dowma
-Brother Can You Spare A Dime|TTBB|David Wright
 Brother Can You Spare A Dime|TTBB|Jim Clancy, Bob Shami
 Brother Can You Spare A Dime|TTBB|Joe Mannherz
-Brother Can You Spare A Dime|TTBB|Steven Armstrong
 BROTHER LOVE'S TRAVELIN' SALVATION SHOW|SSAA|Jean Shook
 Brother Loves Travelin' Salvation Show|SSAA|Jean Shook
 Brother Noah Gave Out Checks for Rain|TTBB|Toban Dvoretsky
@@ -3202,12 +3168,9 @@ Build Me Up Buttercup|TTBB|Dan Wessler
 Build Me Up Buttercup|TTBB|Rob Hopkins
 Build Me Up Buttercup|TTBB|Wayne Grimmer
 Bulletproof|SSAA|Nicholas Wright
-Bundle Of Old Love Letters|SSAA|Carolyn Schmidt
-Bundle Of Old Love Letters|SSAA|David Wright
 Bundle Of Old Love Letters|TTBB|Barbershop Harmony Society
 Bundle Of Old Love Letters|TTBB|D. C. Macintyre
 Bundle Of Old Love Letters|TTBB|J. I. Ruehle
-Bundle Of Old Love Letters|TTBB|SPEBSQSA
 Buona Sera|TTBB|Janne Olsson
 Burn|SATB|Nicholas Wright
 Burn|SSAA|Nicholas Wright
@@ -3231,7 +3194,6 @@ But The World Goes Around|TTBB|Kevin Keller
 Butter|SSAA|Avis Fellows
 Butter|SSAA|Joan D 'Agostino
 BUTTER|SSAA|Jerilee Inghram
-BUTTER|SSAA|Joan D'Agostino
 Butter Outta Cream|TTBB|Dan Wessler
 Butter Outta Cream|TTBB|Steve Tramack
 Butterfly|SSAA|Linda Samuelsson
@@ -3253,10 +3215,10 @@ Buy Dirt|TTBB|Mark Stevens
 By My Side|TTBB|Dennis Driscoll
 By Myself|TTBB|Walter Latzko
 By Strauss|SSAA|Dianne Goldrick
-By The Beautiful Sea|SSAA|Dot Calvin
+By the Beautiful Sea|SSAA|Dot Calvin
+By the Beautiful Sea|TTBB|Val Hicks
 By The Beautiful Sea|TTBB|Dennis Driscoll
 By The Beautiful Sea|TTBB|Dot Calvin
-By The Beautiful Sea|TTBB|Val Hicks
 By The Beautiful Sea (YWIH)|SSAA|Dot Calvin
 By The Light Of The Silvery Moon|SSAA|Joni Bescos
 By The Light Of The Silvery Moon|SSAA|Walter Latzko
@@ -3290,7 +3252,6 @@ Bye Bye Blackbird|SSAA|Carolyn Schmidt
 Bye Bye Blackbird|SSAA|David Wright
 Bye Bye Blackbird|SSAA|Larry Wright
 Bye Bye Blackbird|SSAA|Mike Senter
-Bye Bye Blackbird|TTBB|Brian Beck
 Bye Bye Blackbird|TTBB|Brian Kotval
 Bye Bye Blackbird|TTBB|Jon Nicholas
 Bye Bye Blackbird|TTBB|Larry Wright
@@ -3312,7 +3273,6 @@ Bye Bye Love|SATB|Tom Gentry
 Bye Bye Love|SSAA|Anna Maria Parker
 Bye Bye Love|SSAA|Barbershop Harmony Society
 Bye Bye Love|SSAA|Tom Gentry
-Bye Bye Love|TTBB|Barbershop Harmony Society
 Bye Bye Love|TTBB|Larry Wright
 Bye Bye Love|TTBB|Tom Gentry
 Bye Bye, Love|TTBB|Barbershop Harmony Society
@@ -3370,7 +3330,6 @@ California Dreaming|SSAA|Lynnell Diamond
 California Dreaming|TTBB|Mike Taylor
 California Girls|TTBB|Jon Nicholas
 California Here I Come|SSAA|Joe Mannherz
-California Here I Come|SSAA|Nancy Bergman
 California Here I Come|TTBB|Dave Stevens
 California Here I Come|TTBB|David Wright
 California Here I Come|TTBB|Jim Gay
@@ -3426,17 +3385,13 @@ Can He, Could He, Would He|TTBB|Kevin Keller
 Can He, Could He, Would He|TTBB|Paul Jorg
 Can I Interest You In Hannukah?|TTBB|Dom Finetti
 Can I Steal A Little Love|TTBB|Wayne Grimmer
-Can You Bring Back The Heart I Gave You|TTBB|Burt Szabo
 Can You Bring Back The Heart I Gave You?|TTBB|Burt Szabo
-Can You Feel the Love Tonight|SSAA|June Dale
-Can You Feel the Love Tonight|SSAA|Tedda Lippincott
 Can You Feel The Love Tonight|SSAA|Marge Bailey
-Can You Feel The Love Tonight|TTBB|June Dale
 CAN YOU FEEL THE LOVE TONIGHT|SSAA|June Berg
 Can You Feel The Love Tonight (YWIH)|SSAA|Marge Bailey
+Can You Feel the Love Tonight?|SATB|June Dale
 Can You Feel the Love Tonight?|SSAA|June Dale
 Can You Feel the Love Tonight?|TTBB|June Dale
-Can You Feel The Love Tonight?|SATB|June Dale
 Can You Feel The Love Tonight?|SATB|Kevin Koehl
 Can You Feel The Love Tonight?|SSAA|Kevin Koehl
 Can You Feel The Love Tonight?|TTBB|Kevin Koehl
@@ -3444,7 +3399,6 @@ Can You Feel The Love Tonight?|TTBB|Luke Stevenson
 CAN YOU FEEL THE LOVE TONIGHT?|SSAA|Louise Hamilton
 CAN YOU FEEL THE LOVE TONIGHT?|SSAA|Tedda Lippincott
 Can You Imagine That?|SSAA|Melody Hine
-Can You Tame Wild Wimmen|TTBB|Bob Benson
 Can You Tame Wild Wimmen|TTBB|David Briner
 Can You Tame Wild Wimmen|TTBB|Jim Shubert
 Can You Tame Wild Wimmen|TTBB|Tom Gentry
@@ -3502,8 +3456,8 @@ Can't Smile Without You|SSAA|Larry Wright
 Can't Smile Without You|TTBB|Chris Arnold
 Can't Stop Singing|TTBB|Patrick McAlexander
 Can't Stop Talking|SSAA|Larry Wright
-Can't Stop The Feeling|SSAA|Aaron Dale
-Can't Stop The Feeling|TTBB|Aaron Dale
+Can't Stop the Feeling|SSAA|Aaron Dale
+Can't Stop the Feeling|TTBB|Aaron Dale
 CAN'T STOP THE FEELING|SSAA|Elaine Gain
 Can't Stop the Feeling!|SATB|Aaron Dale
 Can't Stop the Feeling!|SATB|Nicholas Wright
@@ -3550,9 +3504,9 @@ Candle in the Wind|TTBB|Tom Gentry
 Candle In The Window|SSAA|Joe Liles
 Candle In The Window|TTBB|Joe Liles
 Candle Light|TTBB|Walter Latzko
-Candle On The Water|SSAA|Anna Maria Parker
+Candle on the Water|SSAA|Anna Maria Parker
+Candle on the Water|SSAA|June Dale
 Candle On The Water|SSAA|Connie Nickel
-Candle On The Water|SSAA|June Dale
 Candle On The Water|SSAA|Larry Wright
 Candle On The Water|SSAA|Tom Gentry
 Candle On The Water|TTBB|Tom Gentry
@@ -3598,18 +3552,17 @@ Carol From An Irish Cabin|SATB|Jon Nicholas
 Carol From An Irish Cabin|TTBB|Dale Wood
 Carol From An Irish Cabin|TTBB|Joe Grimme
 Carol Me|SSAA|Kay Bromert
-Carol Medley|SSAA|Floyd Connett
 Carol Medley|SSAA|Larry Wright
 Carol Medley|TTBB|Larry Wright
 Carol of the Bells|SSAA|Avis Fellows
 Carol of the Bells|SSAA|Kirby Shaw
+Carol of the Bells|SSAA|Liz Garnett
 Carol of the Bells|TTBB|Peter Wilhousky/Greg Lyne
 Carol Of The Bells|SATB|Brian Doepke
 Carol Of The Bells|SATB|Deke Sharon
 Carol Of The Bells|SATB|Joe Mannherz
 Carol Of The Bells|SSAA|Adam Bock
 Carol Of The Bells|SSAA|David Wright
-Carol Of The Bells|SSAA|Liz Garnett
 Carol Of The Bells|SSAA|Takako Fuke
 Carol Of The Bells|TTBB|David Wright
 Carol Of The Bells|TTBB|Derric Johnson
@@ -3623,8 +3576,8 @@ Carol Of The Russian Children|SATB|Derric Johnson
 Carolina Blues|TTBB|Robert Rund
 Carolina In My Mind|TTBB|David Naddor
 Carolina In My Mind|TTBB|Melody Hine
+Carolina in the Morning|SSAA|Nancy Bergman
 Carolina In The Morning|SSAA|Jean Shook
-Carolina In The Morning|SSAA|Nancy Bergman
 Carolina In The Morning|TTBB|Ed Waesche
 Carolina In The Morning|TTBB|Eric Jackson
 Carolina In The Morning|TTBB|Frank Sysel
@@ -3648,7 +3601,6 @@ Caroline|TTBB|Rudy Newman
 Caroline|TTBB|Wally Cluett
 Caroline (TTBB) (as sung by the Boston Common)|TTBB|Cole, Cluett, and the Boston Common
 Caroline, I'm Coming Back To You|TTBB|Rob Hopkins
-Caroling Caroling|TTBB|David Wright
 Caroling, Caroling|SATB|Joe Mannherz
 Caroling, Caroling|SSAA|Brian Beck
 Caroling, Caroling|SSAA|David Wright
@@ -3718,7 +3670,6 @@ Chances Ares|TTBB|Greg Volk
 Chandelier|SATB|Nicholas Wright
 Chandelier|SSAA|Emily Moriarty
 Chandelier|SSAA|Nicholas Wright
-Change Is Gonna Come|TTBB|Patrick McAlexander
 Change My Heart, Oh God|SSAA|Tom Gentry
 Change My Heart, Oh God|TTBB|Tom Gentry
 Change the World|SATB|Deke Sharon & David Wright
@@ -3745,10 +3696,10 @@ Chanson D'Amour|SSAA|Bob O'Connell
 Chantez, Chantez|TTBB|Ken Bastien
 Chantez, Chantez|TTBB|Walter Latzko
 Chanukah Is Here|TTBB|Alan Josephson
+Chapel of Love|SSAA|Anna Maria Parker
 Chapel of Love|SSAA|Charlene Yazurlo
 Chapel of Love|SSAA|Dotty Hougen
 Chapel Of Love|SATB|Joe Mannherz
-Chapel Of Love|SSAA|Anna Maria Parker
 Chapel Of Love|TTBB|Adam Bock
 Chaplin Medley|TTBB|David Wright
 Chapters Of Life|TTBB|Walter Latzko
@@ -3805,11 +3756,11 @@ Chattanoogie Shoe Shine Boy|TTBB|Jeremey Johnson
 Cheap Thrills|SSAA|Deke Sharon
 Cheap Thrills|SSAA|Emily Moriarty
 Cheatin, On Me|TTBB|Dennis Driscoll
+Cheek to Cheek|SSAA|Ed Waesche
 Cheek to Cheek|SSAA|Ruby Rhea
 Cheek to Cheek|TTBB|Ed Waesche
 Cheek To Cheek|SSAA|Brian Beck
 Cheek To Cheek|SSAA|Carolyn Johnson
-Cheek To Cheek|SSAA|Ed Waesche
 Cheek To Cheek|SSAA|Elaine Gain
 Cheek To Cheek|SSAA|Walter Latzko
 Cheek To Cheek|TTBB|Mark Goodney
@@ -3886,13 +3837,12 @@ Choc'late In My Stocking|SSAA|Lynnell Diamond
 Chocolate|SSAA|Jan Meyer
 Chocolate|SSAA|Marge Bailey
 Chocolate Ice Cream Cone|TTBB|Tom Gentry
-Chocolate In My Stocking|SSAA|Aaron Dale
+Chocolate in My Stocking|SSAA|Aaron Dale
 Chocolate In My Stocking|TTBB|Aaron Dale
 Choo Choo Ch' Boogie|TTBB|Walter Latzko
 Choo Choo Ch'Boogie|SSAA|Becky Wilkins
 Choo Choo Ch'Boogie|SSAA|Cheryl Suhr
 Choo Choo Ch'Boogie|SSAA|LaVeda Redfield
-Choo Choo Train|SSAA|Joan Adler
 Choo Choo Train!|SSAA|Joan Adler
 Choose Your Fighter|TTBB|Gabriel Lawson
 Chordbuster March|SSAA|Joe Liles
@@ -4010,8 +3960,6 @@ Christmas Time Is Here|TTBB|Ken Potter
 Christmas Time Is Here|TTBB|Kohl Kitzmiller
 CHRISTMAS TIME IS HERE (Qt. or Ch.)|SSAA|Sharon Holmes
 Christmas Tree Farm|SSAA|Sheryl Neal
-Christmas Waltz|SSAA|Anastasio Rossi
-Christmas Waltz|SSAA|Jo Lund
 Christmas Waltz|SSAA|June Berg
 Christmas Waltz|SSAA|Kay Bromert
 Christmas Waltz|SSAA|Steve Tramack
@@ -4036,7 +3984,6 @@ Christmastime is here|TTBB|Carole Prietto
 Chuck E's In Love|SATB|Deke Sharon
 Chugwater|TTBB|Todd Troutman
 Church Bells|SSAA|Clay Hine
-Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
 Church Bells Parody|TTBB|Clay Hine
 Cielito Lindo|SATB|Deke Sharon
 Cinderella|TTBB|Adam Bock
@@ -4117,8 +4064,8 @@ Close To You|SATB|Mark Stevens
 Close To You|SSAA|Deke Sharon
 Close To You|TTBB|Jeremey Johnson
 Close Your Eyes|SSAA|Kyle Snook
+Closer to Fine|SSAA|Jay Dougherty
 Closer To Fine|SATB|Jay Dougherty
-Closer To Fine|SSAA|Jay Dougherty
 Closest Thing To Crazy (Katie Melua)|SSAA|Linda Corcoran
 Cloud|SSAA|Nicholas Wright
 Cloudburst|SATB|Joe Mannherz
@@ -4167,7 +4114,6 @@ Color The Children|SSAA|June Berg
 Colorado Christmas|SSAA|Kim Andrews
 Colorado Christmas|TTBB|Jay Giallombardo
 Colorado My Home|TTBB|Darin Drown
-COLORADO MY HOME|SSAA|Sylvia Alsbury
 Colorado Trail|TTBB|Todd Troutman
 Colorado, My Home|SSAA|Sylvia Alsbury
 Colors of the Wind|SSAA|Tedda Lippincott
@@ -4204,12 +4150,11 @@ Come Dance With Me|TTBB|Larry Wright
 Come Dance With Me|TTBB|Patrick McAlexander
 Come Dance With Me / Come Fly With Me Medley|TTBB|Kevin Keller
 Come Dance with Me with Come Fly with Me|TTBB|Kevin Keller
-Come Dance With Me/Come Fly With Me Medley|TTBB|Kevin Keller
+Come Fly with Me|SSAA|Kevin Keller
+Come Fly with Me|TTBB|Kevin Keller
 Come Fly With Me|SATB|Deke Sharon
 Come Fly With Me|SATB|Kevin Keller
 Come Fly With Me|SSAA|Carolyn Schmidt
-Come Fly With Me|SSAA|Kevin Keller
-Come Fly With Me|TTBB|Kevin Keller
 Come Fly With Me|TTBB|Unspecified
 Come Fly With Me/Fly Me To The Moon Medley|SATB|Joel T. Rutherford
 Come Fly With Me/Fly Me To The Moon Medley(Joel T. Ruther|SATB|Joel T. Rutherford
@@ -4225,7 +4170,6 @@ Come In From The Cold|TTBB|Kyle Snook
 Come In From the Rain|SSAA|Betty Oliver
 Come In From The Rain|SSAA|David Wright
 Come In From The Rain|SSAA|Jo Lund
-Come Josephine In My Flying Machine|TTBB|Burt Szabo
 Come Live with Me|SSAA|Jay Giallombardo
 Come Live with Me|TTBB|Jay Giallombardo
 Come On And Sing!|SSAA|June Dale
@@ -4240,7 +4184,7 @@ Come On-A My House|SSAA|Walter Latzko
 Come On, Ring Those Bells|SSAA|Joey Minshall
 Come On, Ring Those Bells|TTBB|Paul Jorg
 Come Rain or Come Shine|SSAA|Ardeth Fullmer
-Come Rain Or Come Shine|SSAA|Jo Lund
+Come Rain or Come Shine|SSAA|Jo Lund
 Come Rain Or Come Shine|SSAA|Scott Kitzmiller
 Come Rain Or Come Shine|SSAA|Steve Tramack
 Come Rain Or Come Shine|SSAA|Tom Gentry
@@ -4370,7 +4314,6 @@ Corner Of The Sky|TTBB|Melody Hine
 Corner Of The Sky|TTBB|Patrick McAlexander
 Corner Of The Sky (from Pippin)|TTBB|Patrick McAlexander
 Cornflake Girl|SSAA|Adam Bock
-Cottage For Sale|SSAA|Sharon Holmes
 Cottage For Sale|TTBB|Brent Graham
 Cottage For Sale|TTBB|Theodore Hicks
 Cotton Candy And A Toy Balloon|TTBB|Norm Benson
@@ -4474,7 +4417,6 @@ Crazy|TTBB|Walter Latzko
 Crazy 'Bout Ya Baby|TTBB|Don Gillespie
 Crazy 'Bout Ya Baby|TTBB|Don Gray
 Crazy 'Bout Ya Baby|TTBB|Larry Wright
-Crazy 'Bout Ya Baby|TTBB|Rob Campbell
 Crazy 'Bout Ya, Baby|TTBB|Rob Campbell
 Crazy Amazing|SATB|Deke Sharon
 Crazy Dreams|SSAA|Jen Squires
@@ -4543,9 +4485,9 @@ Cry Baby Blues|SSAA|Charlotte Pernert
 Cry Baby Blues|SSAA|Marsha Zwicker
 CRY BABY BLUES|SSAA|Chari Pernert
 Cry Baby/So Long Dearie|SSAA|Nancy Bergman
+Cry Me a River|SSAA|Carolyn Healey
 Cry Me A River|SATB|Deke Sharon
 Cry Me A River|SSAA|Brent Graham
-Cry Me A River|SSAA|Carolyn Healey
 Cry Me A River|SSAA|Jo Lund
 Cry Me A River|SSAA|Liz Garnett
 Cry Me A River|SSAA|Peter W Godfrey
@@ -4563,8 +4505,8 @@ Crying|TTBB|Unspecified
 Crying for You|TTBB|Fred King
 Crying in the Rain|SSAA|Tom Gentry
 Crying in the Rain|TTBB|Tom Gentry
-Crying My Heart Out For You|TTBB|Kevin Keller
-Crying Myself To Sleep|SSAA|Nancy Bergman
+Crying My Heart Out for You|TTBB|Kevin Keller
+Crying Myself to Sleep|SSAA|Nancy Bergman
 Cuando Calienta El Sol|SSAA|Carol Lord
 Cuando Nos Volvamos A Encontrar|SATB|Dan Wessler
 Cuanto Le Gusta|SSAA|Zona Snyder
@@ -4577,7 +4519,6 @@ Cuddle Up A Little Closer|TTBB|Burt Szabo
 Cuddle Up A Little Closer|TTBB|Clay Hine
 Cuddle Up A Little Closer|TTBB|Walter Latzko
 Cuddle Up A Little Closer, Lovey Mine|TTBB|Burt Szabo
-Cup Of Coffee, A Sandwich and You|TTBB|Walter Latzko
 Cup Song|SSAA|J. Mariano
 Cupid Shuffle|TTBB|Kyle Kitzmiller
 Cups (Pitch Perfect)|SSAA|Kirby Shaw
@@ -4743,11 +4684,9 @@ Darktown Strutter's Ball|TTBB|Ed Waesche
 Darktown Strutters' Ball|SSAA|Don Gray
 Darktown Strutters' Ball|SSAA|Walter Latzko
 Darktown Strutters' Ball|TTBB|Don Gray
-Darktown Strutters' Ball|TTBB|Ed Waesche
 Darktown Strutters' Ball|TTBB|Jack Baird
 Darktown Strutters' Ball|TTBB|Joe Mannherz
 Darktown Strutters' Ball|TTBB|Milton Teitel
-Darktown Strutters' Ball|TTBB|Steve Jamison
 Darktown Strutters' Ball|TTBB|Tom Gentry
 Darktown Strutters' Ball|TTBB|Walter Latzko
 Darling Medley|TTBB|Steve Shannon
@@ -4802,8 +4741,8 @@ Dean Martin Medley|TTBB|Jay Giallombardo
 Dear Heart|TTBB|Dennis Driscoll
 Dear Heart|TTBB|Nancy Bergman
 Dear Heart|TTBB|Paul Jorg
+Dear Hearts and Gentle People|TTBB|Rob Campbell
 Dear Hearts And Gentle People|TTBB|Jim West
-Dear Hearts And Gentle People|TTBB|Rob Campbell
 Dear Hearts And Gentle People|TTBB|SPEBSQSA
 Dear Little Boy / Soldier Medley|SSAA|Dave Briner
 Dear Little Boy Of Mine|SSAA|Joe Liles and Floyd Connett
@@ -4851,6 +4790,7 @@ December 1963 (Oh, What A Night)|TTBB|Jay Giallombardo
 Deck the Hall|TTBB|Mark Patterson
 DECK THE HALL|SSAA|Carolyn Johnson
 Deck the Halls|SATB|Burt Szabo
+Deck the Halls|TTBB|Burt Szabo
 Deck The Halls|SATB|Bryan W. Pulver
 Deck The Halls|SATB|Deke Sharon
 Deck The Halls|SATB|Derric Johnson
@@ -4864,7 +4804,6 @@ Deck The Halls|SSAA|Nancy Bergman
 Deck The Halls|SSAA|Renee Craig
 Deck The Halls|TTBB|Adam Scott
 Deck The Halls|TTBB|Andreas Weiland
-Deck The Halls|TTBB|Burt Szabo
 Deck The Halls|TTBB|Jay Giallombardo
 Deck The Halls|TTBB|Jon Nicholas
 Deck The Halls|TTBB|Mark Rusch
@@ -4887,8 +4826,8 @@ Deep In My Heart, Dear|SSAA|Jay Giallombardo
 Deep In My Heart, Dear|TTBB|Don Gray
 Deep In My Heart, Dear|TTBB|Jay Giallombardo
 Deep In My Heart, Dear|TTBB|Kevin Keller
+Deep in The Heart of Texas|TTBB|Jack Baird
 Deep In The Heart Of Texas|SSAA|Nancy Bergman
-Deep In The Heart Of Texas|TTBB|Jack Baird
 Deep In The Heart Of Texas|TTBB|Patrick McAlexander
 Deep In The Heart Of Texas / Back In The Saddle Again Medley|TTBB|Ken Wimbish
 Deep Purple|SATB|Joe Mannherz
@@ -5080,25 +5019,18 @@ Do You Believe in Magic|SSAA|Joan D'Agostino
 Do You Believe In Magic|TTBB|Ken Potter
 Do You Ever Think Of Me?|SSAA|June Dale
 Do You Ever Think Of Me?|TTBB|Walter Latzko
-Do You Hear The People Sing|TTBB|Tom Gentry
 DO YOU HEAR THE PEOPLE SING|SSAA|Gene Bender
-Do You Hear The People Sing?|SATB|Tom Gentry
+Do You Hear the People Sing?|SATB|Tom Gentry
+Do You Hear the People Sing?|TTBB|Tom Gentry
 Do You Hear The People Sing?|SSAA|Tom Gentry
 Do You Hear The People Sing?|TTBB|Jay Giallombardo
-Do You Hear The People Sing?|TTBB|Tom Gentry
 Do You Hear What I Hear|SSAA|Brian Doepke
 Do You Hear What I Hear|SSAA|Carolyn Schmidt
 Do You Hear What I Hear|SSAA|Gas House Gang
-Do You Hear What I Hear|SSAA|Judy Vidal
-Do You Hear What I Hear|SSAA|Kim Andrews
 Do You Hear What I Hear|SSAA|Larry Wright
 Do You Hear What I Hear|SSAA|Marie Johnson
-Do You Hear What I Hear|SSAA|Susan Kegley
-Do You Hear What I Hear|SSAA|Tedda Lippincott
 Do You Hear What I Hear|TTBB|Derric Johnson
 Do You Hear What I Hear|TTBB|Jay Giallombardo
-Do You Hear What I Hear|TTBB|Joe Liles
-Do You Hear What I Hear|TTBB|Jon Nicholas
 Do You Hear What I Hear|TTBB|Larry Wright
 Do You Hear What I Hear|TTBB|Phil Ordaz
 Do You Hear What I Hear|TTBB|Unspecified
@@ -5145,9 +5077,7 @@ Do You See What I See?|SSAA|Nancy Bergman/Aileen Nightingale
 Do You Take This Woman for Your Lawful Wife|TTBB|Joe Simone
 Do You Want To Know a Secret!|SSAA|Jan-Ake Westin
 Do You Want To Know a Secret!|TTBB|Steve Jamison
-Do-Re-Mi|TTBB|Howard Mesecher
 Dock Of The Bay, The (Sittin On)|SATB|Deke Sharon
-Dock Of The Bay, The (Sittin On)|SSAA|Charlene Yazurlo
 Dock Of The Bay, The (Sittin On)|TTBB|Aaron Dale
 Dock Of The Bay, The (Sittin On)|TTBB|Deke Sharon
 Dock Of The Bay, The (Sittin On)|TTBB|Jon Nicholas
@@ -5193,7 +5123,7 @@ DON'T BE ANYBODY'S SOLDIER BOY BUT MINE|SSAA|Bitsy Bacon
 Don't Be Anybodys Soldier Boy But Mine|SSAA|Bitsy Bacon
 Don't Be Cruel (To A Heart That's True)|TTBB|Greg Gilpin
 Don't Be Cruel (To A Heart That's True)|TTBB|Tom Gentry
-Don't Be So Mean To Baby|SSAA|Ig Jakovac
+Don't Be So Mean to Baby|SSAA|Ig Jakovac
 Don't Blame Me|SATB|Nicholas Wright
 Don't Blame Me|SSAA|Carolyn Healey
 Don't Blame Me|SSAA|Diane Landry
@@ -5209,8 +5139,8 @@ Don't Blame Me|TTBB|Walter Latzko
 Don't Blame Me For What Happens In The Moonlight|TTBB|Burt Szabo
 Don't Break My Heart With Goodbye|TTBB|Burt Szabo
 Don't Break the Heart that Loves You|TTBB|Greg Volk
+Don't Break the Heart That Loves You|SSAA|Greg Volk
 Don't Break the Heart That Loves You|SSAA|Unspecified
-Don't Break The Heart That Loves You|SSAA|Greg Volk
 Don't Break the Rules|TTBB|Aaron Dale
 Don't Break the Rules|TTBB|Dan Wessler
 Don't Bring Lulu|SSAA|Jo Lund
@@ -5303,9 +5233,9 @@ Don't Nobody Bring Me No Bad News|SSAA|Rowena Harper
 Don't Pay The Ferryman|SATB|Don Staffin
 Don't Pay The Ferryman|TTBB|Don Staffin
 Don't Put a Tax On My Barbershop Chords|TTBB|Tom Gentry
-Don't Put A Tax On The Beautiful Girls|TTBB|Burt Szabo
+Don't Put a Tax on the Beautiful Girls|TTBB|Burt Szabo
+Don't Put a Tax On the Beautiful Girls|TTBB|Tom Gentry
 Don't Put A Tax On The Beautiful Girls|TTBB|Kevin Keller
-Don't Put A Tax On The Beautiful Girls|TTBB|Tom Gentry
 Don't Rain on My Parade|SATB|Kohl Kitzmiller
 Don't Rain on My Parade|SSAA|David Harrington
 Don't Rain on My Parade|SSAA|Larry Wright
@@ -5397,11 +5327,11 @@ Doris|TTBB|Tom Gentry
 Down Among The Sheltering Palms|SSAA|Walter Latzko
 Down And Out|TTBB|Deke Sharon
 Down and Out Blues|SSAA|Nancy Bergman
-Down At The Barbecue|SSAA|Marie Johnson
+Down At the Barbecue|SSAA|Marie Johnson
 DOWN AT THE BARBECUE|SSAA|Marie B. Johnson
 Down At The Long Branch Saloon|SSAA|Nancy Bergman
 Down At The Twist & Shout|SSAA|Barbara McNeill
-Down At The Twist And Shout|SSAA|Barbara McNeill
+Down at the Twist and Shout|SSAA|Barbara McNeill
 Down At The Twist And Shout|SSAA|June Dale
 Down By The Erie Canal|TTBB|Burt Szabo
 Down By The Lazy River|SATB|Anders Lindqvist
@@ -5423,10 +5353,10 @@ Down By The Old Mill Stream|TTBB|Kirk Roose
 DOWN BY THE OLD MILL STREAM|SSAA|Marie B Johnson
 Down By The Old Mill Stream/In The Good Old Summer Time|TTBB|Nick Kozel
 Down By The Old Red Mill|TTBB|Bob Demchak
+Down By the Riverside|SATB|Tom Gentry
+Down By the Riverside|SSAA|Tom Gentry
 Down By The Riverside|SATB|Manoj Padki
-Down By The Riverside|SATB|Tom Gentry
 Down By The Riverside|SSAA|Renee Craig
-Down By The Riverside|SSAA|Tom Gentry
 Down By The Riverside|TTBB|Joe Liles
 Down By The Riverside|TTBB|Thomas Gentry
 Down By The Riverside|TTBB|Todd Troutman
@@ -5453,7 +5383,7 @@ Down the Lane and Home Again|SSAA|Jay Giallombardo
 Down the Lane and Home Again|TTBB|Jay Giallombardo
 Down The Old Ox Road|TTBB|Dennis Driscoll
 Down The River To Pray|SSAA|Sharon Holmes
-Down The Trail To Home Sweet Home|TTBB|Barbershop Harmony Society
+Down the Trail to Home Sweet Home|TTBB|Barbershop Harmony Society
 Down to the River to Pray|SSAA|Sharon Holmes
 Down To The River To Pray|SSAA|Marge Bailey
 Down To The River To Pray|TTBB|Jim West
@@ -5495,20 +5425,20 @@ Dream|TTBB|Bud Arberg
 Dream|TTBB|Gerald Hooper
 Dream|TTBB|Jim Shubert
 Dream|TTBB|Walter Latzko
+Dream a Little Dream of Me|SATB|Tom Gentry
 Dream a Little Dream of Me|SSAA|Gentry/Ramsson
+Dream a Little Dream of Me|SSAA|Tom Gentry
 Dream a Little Dream of Me|SSAA|Tom Gentry/Beth Ramsson
+Dream a Little Dream of Me|TTBB|Clay Hine
 Dream a Little Dream of Me|TTBB|Thomas Gentry
 Dream A Little Dream of Me|SSAA|Don Gray
+Dream A Little Dream of Me|SSAA|Norma Andersen
 Dream A Little Dream Of Me|SATB|Joe Mannherz
 Dream A Little Dream Of Me|SATB|Kohl Kitzmiller
 Dream A Little Dream Of Me|SATB|Rob Campbell
-Dream A Little Dream Of Me|SATB|Tom Gentry
 Dream A Little Dream Of Me|SSAA|Jon Nicholas
 Dream A Little Dream Of Me|SSAA|Kohl Kitzmiller
-Dream A Little Dream Of Me|SSAA|Norma Andersen
-Dream A Little Dream Of Me|SSAA|Tom Gentry
 Dream A Little Dream Of Me|TTBB|Brent Graham
-Dream A Little Dream Of Me|TTBB|Clay Hine
 Dream A Little Dream Of Me|TTBB|Dennis Driscoll
 Dream A Little Dream Of Me|TTBB|Jack Bridges
 Dream A Little Dream Of Me|TTBB|Joe Johnson
@@ -5525,7 +5455,6 @@ DREAM BABY (HOW LONG MUST I DREAM)|SSAA|Tedda Lippincott
 Dream Days (Take Me Back to Those)|SSAA|Jay Giallombardo
 Dream Days (Take Me Back to Those)|TTBB|Jay Giallombardo
 Dream Is A Wish Your Heart Makes|SSAA|Tony Nasto
-Dream Is A Wish Your Heart Makes|TTBB|David Wright
 Dream Is A Wish, A (YWIH)|SSAA|Lorraine Rochefort
 Dream Lover|SATB|Kohl Kitzmiller
 Dream Lover|SSAA|Kohl Kitzmiller
@@ -5620,7 +5549,6 @@ Dumb Ways To Die|TTBB|Nicholas Wright
 Dungaree Doll|SSAA|Marsha Zwicker
 Dungaree Doll|SSAA|Rebecca J. Wood
 Dungaree Doll|TTBB|Walter Latzko
-Dunk-Dunk-Dunk|SSAA|Zona Snyder
 DUNK, DUNK, DUNK|SSAA|Zona Snyder
 Dust In The Wind|SSAA|David Zimmerman
 Dust In The Wind|SSAA|Kay Bromert
@@ -5671,7 +5599,6 @@ Easy Street|SSAA|Joe Mannherz
 Easy Street|SSAA|Joey Minshall
 Easy Street|TTBB|Joe Mannherz
 Easy Street|TTBB|Warren 'Buzz' Haeger
-Easy Street|TTBB|Warren Buzz Haeger
 Ebb Tide|SSAA|Fred King
 Ebb Tide|TTBB|Fred King
 Ebb Tide|TTBB|Freddie King
@@ -5764,12 +5691,10 @@ Embraceable You|TTBB|Rob Hopkins
 Embraceable You|TTBB|Steve Jamison
 Embraceable You|TTBB|Steven Armstrong
 Embraceable You / You Do Something To Me|SSAA|Ed Hinkley
-Embraceable You/You Do Something to Me|SSAA|Ed Hinkley
 Emily|TTBB|Bob Pyper
 Emily|TTBB|Jon Nicholas
 Emily I'm Sorry|SATB|Nicholas Wright
 Emily Remembers|SSAA|Joan D 'Agostino
-EMILY REMEMBERS|SSAA|Joan D'Agostino
 Empire State Of Mind|SSAA|Larry Wright
 Empire State Of Mind (Alicia Keys)|SSAA|H Zimmerman
 Empire State of Mind (part II) Broken Dawn|SSAA|Nicholas Wright
@@ -5856,8 +5781,8 @@ Every Little Thing She Does Is Magic|SATB|Simon Lubkowski
 Every Little Thing She Does Is Magic|TTBB|Adam Scott
 Every Night|TTBB|Walter Latzko
 Every Second|TTBB|Gabriel Lawson
+Every Street's a Boulevard|SSAA|Jarmela Speta
 Every Street's A Boulevard|SSAA|Al Baker
-Every Street's A Boulevard|SSAA|Jarmela Speta
 Every Street's A Boulevard|SSAA|Jo Lund
 Every Tear Is A Smile|TTBB|Burt Szabo
 Every Time I Feel The Spririt|SATB|Derric Johnson
@@ -5871,10 +5796,10 @@ Every Woman's Song|SSAA|Joey Minshall
 Everybody (backstreet's Back)|TTBB|Nicholas Wright
 Everybody Eats When They Come to My House|TTBB|Melody Hine
 Everybody Loves a Hero|TTBB|Drayton Justus
+Everybody Loves a Lover|SSAA|Anna Maria Parker
+Everybody Loves a Lover|TTBB|Drayton Justus
 Everybody Loves a Lover|TTBB|Unspecified
-Everybody Loves A Lover|SSAA|Anna Maria Parker
 Everybody Loves A Lover|SSAA|Joey Minshall
-Everybody Loves A Lover|TTBB|Drayton Justus
 Everybody Loves A Lover|TTBB|Jim West
 Everybody Loves My Baby|SSAA|David Wright
 Everybody Loves My Baby|TTBB|Jim Shubert
@@ -6065,8 +5990,8 @@ Fattig Bonddrang|TTBB|Johan Wikstrom
 Favourite Pair of Pants|TTBB|Dom Finetti
 Feast Of Lights|SSAA|Greg Lyne
 Feast of Lights Medley|TTBB|Barbershop Harmony Society
+Feast of Lights Medley|TTBB|Gregory Lyne
 Feast Of Lights Medley|SSAA|Gregory Lyne
-Feast Of Lights Medley|TTBB|Gregory Lyne
 Feed The Birds|SATB|Kevin Keller
 Feed The Birds|SATB|Larry Triplett
 Feed The Birds|SSAA|Diana DeBruycker
@@ -6149,9 +6074,9 @@ Fido Is A Hot Dog Now|TTBB|Dennis Morrissey
 Fields of Athenry|TTBB|Neil Watkins
 Fields of Athenry|TTBB|Reed Sampson
 Fields of Gold|SSAA|Anna-Marie Nystrom
+Fields of Gold|SSAA|June Dale
 Fields Of Gold|SSAA|Anna-Maria Nystrom
 Fields Of Gold|SSAA|Deke Sharon
-Fields Of Gold|SSAA|June Dale
 Fields Of Gold|SSAA|Liz Garnett
 Fields Of Gold|TTBB|Marilyn Penketh
 Fields Of Gold|TTBB|Matt Astle
@@ -6287,8 +6212,8 @@ Floatin' Along|TTBB|Dan Wessler
 Floatin' Down The River Medley|TTBB|Ed Waesche
 Floatin' Down to Cotton Town|SSAA|David Wright
 Floatin' Down to Cotton Town|SSAA|Renee Craig
+Floatin' Down to Cotton Town|TTBB|Rob Campbell
 Floatin' Down To Cotton Town|SSAA|Walter Latzko
-Floatin' Down To Cotton Town|TTBB|Rob Campbell
 Floatin' Down To Cotton Town|TTBB|Walter Latzko
 Flower Garden Ball|TTBB|Toban Dvoretsky
 Flowers|SATB|Deke Sharon
@@ -6348,7 +6273,6 @@ Follow Me|TTBB|Mark Goodney
 Follow Me|TTBB|Nicholas Wright
 Follow Me|TTBB|Todd Troutman
 Follow The Crowd|SSAA|Joan D 'Agostino
-FOLLOW THE CROWD|SSAA|Joan D'Agostino
 Follow The Drinking Gourd|SSAA|Bob Jones
 Follow The Flag|TTBB|Doug Nichol
 Follow the Fold|TTBB|Walter Latzko
@@ -6364,7 +6288,6 @@ Fool On The Hill|SATB|Joe Mannherz
 Fool On The Hill|SSAA|Jay Giallombardo
 Fool On The Hill|TTBB|Anders Lindqvist
 Fool On The Hill|TTBB|Jay Giallombardo
-Fool On The Hill|TTBB|Jon Nicholas
 Fools Fall In Love|TTBB|Kohl Kitzmiller
 Fools Rush In|TTBB|Joe Johnson
 Football Hero Medley|SSAA|Jay Giallombardo
@@ -6419,7 +6342,6 @@ For Good|TTBB|Aaron Dale
 For Good|TTBB|Steve Tramack
 For Good|TTBB|Steven Armstrong
 For Good|TTBB|Tom Gentry
-FOR GOOD|SSAA|Joan D'Agostino
 For Good (from Wicked)|TTBB|Steve Tramack
 For Her|TTBB|Dan Wessler
 For Just A Little While|SSAA|Larry Wright
@@ -6432,11 +6354,11 @@ For Me And My Gal|TTBB|Jay Giallombardo
 For Me And My Gal|TTBB|SPEBSQSA
 For Me And My Gal|TTBB|the Barbershop Harmony Society
 For Me And My Gal|TTBB|Walter Latzko
+For Once in My Life|SSAA|Joni Bescos
 For Once In My Life|SATB|David Wright
 For Once In My Life|SATB|Luke Stevenson
 For Once In My Life|SSAA|David Wright
 For Once In My Life|SSAA|Joey Minshall
-For Once In My Life|SSAA|Joni Bescos
 For Once In My Life|SSAA|Lyndal Thorburn
 For Once In My Life|SSAA|Staffan Paulson
 For Once In My Life|SSAA|Steve Tramack
@@ -6469,9 +6391,9 @@ For the Longest Time|SSAA|Tom Gentry
 For the Longest Time|TTBB|Roger Emerson
 For the Sake of Auld Lang Syne|SSAA|Joni Bescos
 For the Sake of Auld Lang Syne|SSAA|Renee Craig
+For The Sake of Auld Lang Syne|TTBB|Ed Waesche
 For The Sake Of Auld Lang Syne|SSAA|Mark Rusch
 For The Sake Of Auld Lang Syne|TTBB|Don Hewey
-For The Sake Of Auld Lang Syne|TTBB|Ed Waesche
 For The Sake Of Auld Lang Syne|TTBB|Jay Giallombardo
 For The Sake Of Auld Lang Syne|TTBB|Jim Clancy
 For The Sake Of Auld Lang Syne|TTBB|John Hohl, Ed Waesche
@@ -6491,13 +6413,13 @@ Forest Lawn|TTBB|Matt Astle
 Forest Lawn|TTBB|Tom Gentry
 Forever|SATB|Nicholas Wright
 Forever|TTBB|Nicholas Wright
+Forever and a Day|TTBB|Tom Gentry
 Forever And A Day|SSAA|Tom Gentry
 Forever And A Day|TTBB|Fran Wilson
-Forever And A Day|TTBB|Tom Gentry
+Forever and Ever, Amen|TTBB|Kevin Keller
 Forever And Ever, Amen|SSAA|Jay Dougherty
 Forever And Ever, Amen|SSAA|Kevin Keller
 Forever And Ever, Amen|TTBB|Jim Shubert
-Forever And Ever, Amen|TTBB|Kevin Keller
 Forever Friends|SSAA|Cynthia Becker
 Forever Friends|SSAA|Joe Mannherz
 FOREVER FRIENDS|SSAA|Cynthia K Becker
@@ -6638,10 +6560,9 @@ From Sunrise to Sunset|SSAA|Joan D 'Agostino
 From the First Hello|TTBB|Lou Perry
 From The First Hello|TTBB|Ed Waesche
 From The First Hello (To The Last Goodbye)|TTBB|Lou Perry
+From the First Hello to the Last Goodbye|SSAA|Jim Arns
 From The First Hello To The Last Goodbye|SSAA|Brent Graham
-From The First Hello To The Last Goodbye|SSAA|Jim Arns
 From The First Hello To The Last Goodbye|TTBB|Brent Graham
-From The First Hello To The Last Goodbye|TTBB|Lou Perry
 From The First Hello To The Last Goodbye|TTBB|Louis Perry
 From The Ground Up|SSAA|Melody Hine
 From The Land Of Sky Blue Water|TTBB|Howard Dale
@@ -6661,15 +6582,15 @@ From This Moment On|TTBB|Joe Mannherz
 From This Moment On|TTBB|John Hohl
 From This Moment On|TTBB|Steve Tramack
 Frosty / Santa Medley|TTBB|Roger Payne
+Frosty the Snowman|SATB|Rob Campbell
+Frosty the Snowman|SSAA|Carolyn Schmidt
 Frosty the Snowman|SSAA|Donna Shorkey
+Frosty the Snowman|SSAA|Rob Campbell
 Frosty the Snowman|SSAA|Sandy Sharpe
-Frosty The Snowman|SATB|Rob Campbell
-Frosty The Snowman|SSAA|Carolyn Schmidt
-Frosty The Snowman|SSAA|Rob Campbell
+Frosty the Snowman|TTBB|Rob Campbell
 Frosty The Snowman|TTBB|Aaron Dale
 Frosty The Snowman|TTBB|Derric Johnson
 Frosty The Snowman|TTBB|G. Chelemedos
-Frosty The Snowman|TTBB|Rob Campbell
 Frosty The Snowman/Santa Clause Is Coming To Town|TTBB|Roger Payne
 Frozen Heart|TTBB|Gabriel Lawson
 Fugue for Tinhorns|TTBB|Mark Goodney
@@ -6719,7 +6640,6 @@ Gang That Sang Heart Of My Heart|TTBB|Ed Waesche
 Gang That Sang Heart Of My Heart|TTBB|Jarmela Speta
 Gang That Sang Heart Of My Heart Parody|TTBB|John Muir
 Garland Of Old Fashioned Roses|TTBB|Ed Waesche
-Garland Of Old Fashioned Roses|TTBB|Louis Perry
 Garland Of Old Fashioned Roses|TTBB|Robert Strand
 Gary, Indiana|TTBB|Walter Latzko
 Gaston (from Beauty And The Beast)(Parody)|TTBB|Anthony Bartholomew
@@ -6731,7 +6651,6 @@ Gay Nineties Medley|TTBB|Bud Arberg
 Gee But I Hate To Go Home Alone|TTBB|Dennis Driscoll
 Gee But I'm Blue|TTBB|Munson Hinman
 Gee But I'm Lonesome Tonight|TTBB|John Hohl
-Gee But It's Good To Be Here|SSAA|Joey Minshall
 Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Burt Szabo
 Gee But It's Great To Meet A Friend From Your Home Town|TTBB|Jack Baird
 Gee But There's Class To A Girl Like You|TTBB|Dennis Driscoll
@@ -6765,9 +6684,11 @@ Georgia May|SSAA|Aaron Dale
 Georgia May|TTBB|Aaron Dale
 Georgia Medley|TTBB|Tom Gentry
 Georgia on my Mind|SSAA|Brian Beck
+Georgia on My Mind|SATB|Steve Jamison
+Georgia on My Mind|SSAA|Steve Jamison
+Georgia on My Mind|TTBB|Steve Jamison
 Georgia On My Mind|SATB|Jay Giallombardo
 Georgia On My Mind|SATB|Kevin Keller
-Georgia On My Mind|SATB|Steve Jamison
 Georgia On My Mind|SATB|Walter Latzko
 Georgia On My Mind|SSAA|David Harrington
 Georgia On My Mind|SSAA|Jim Massey
@@ -6775,12 +6696,10 @@ Georgia On My Mind|SSAA|Joni Bescos
 Georgia On My Mind|SSAA|Mary Coffman
 Georgia On My Mind|SSAA|Mary K. Coffman Music Fund
 Georgia On My Mind|SSAA|Sheryl Neal
-Georgia On My Mind|SSAA|Steve Jamison
 Georgia On My Mind|SSAA|Susan Lamb
 Georgia On My Mind|TTBB|David Harrington
 Georgia On My Mind|TTBB|Jim Clancy
 Georgia On My Mind|TTBB|Scott Kitzmiller
-Georgia On My Mind|TTBB|Steve Jamison
 Geronimo|SSAA|Thomas J. West
 Gershwin Love Song Medley|TTBB|Jay Giallombardo
 Gershwin Medley|SATB|Jay Giallombardo
@@ -6791,9 +6710,9 @@ Gesu Bambino|SATB|Joe Liles
 Gesu Bambino|SSAA|Jarmela Speta
 Gesu Bambino|SSAA|Joe Liles
 Gesu Bambino|TTBB|Gabriel Lawson
+Get a Job|TTBB|Jon Nicholas
 Get A Job|SATB|Manoj Padki
 Get A Job|SSAA|Charlene Yazurlo
-Get A Job|TTBB|Jon Nicholas
 Get Happy|SATB|Kohl Kitzmiller
 Get Happy|SATB|Roland Sharette
 Get Happy|SSAA|Ann Minihane
@@ -6808,16 +6727,16 @@ Get Home|SATB|Nicholas Wright
 Get Lost|SATB|Richard Curtis
 Get Lucky|TTBB|Nicholas Wright
 Get Me to the Church on Time|SSAA|Nancy Bergman
+Get Me to the Church on Time|SSAA|Tom Gentry
+Get Me to the Church on Time|TTBB|Tom Gentry
+Get Me To the Church on Time|SSAA|Carolyn Schmidt
 Get Me To The Church On Time|SSAA|Aaron Dale
-Get Me To The Church On Time|SSAA|Carolyn Schmidt
 Get Me To The Church On Time|SSAA|Jay Giallombardo
-Get Me To The Church On Time|SSAA|Tom Gentry
 Get Me To The Church On Time|TTBB|Aaron Dale
 Get Me To The Church On Time|TTBB|Don Gray
 Get Me To The Church On Time|TTBB|Gary Lewis
 Get Me To The Church On Time|TTBB|Jay Giallombardo
 Get Me To The Church On Time|TTBB|Kohl Kitzmiller
-Get Me To The Church On Time|TTBB|Tom Gentry
 Get Me To The Church On Time Medley|TTBB|David Wright
 Get Me To The Church On Time/The Joint is Jumpin|TTBB|David Wright
 Get Me to the Girl Medley|TTBB|Tom Gentry
@@ -6835,9 +6754,8 @@ Get Out Those Old Records Medley|TTBB|Mo Rector
 Get Ready|SSAA|Kevin McMahon
 Get Ready|TTBB|James Henry
 Get Together|SSAA|Lauren Kahn
+Get Up and Go|TTBB|Kevin Keller
 Get Up And Go|SSAA|Kevin Keller
-Get Up And Go|TTBB|Kevin Keller
-Get Your Happy Days On Medley|TTBB|Aaron Dale
 Get Your Happy Days On!|TTBB|Aaron Dale
 Get Your Happy Days On! Medley|TTBB|Aaron Dale
 Get'cha Head in the Game|SATB|Deke Sharon
@@ -6845,15 +6763,14 @@ Getting Some Fun Out Of Life|SSAA|David Briner
 Getting Some Fun Out Of Life|TTBB|Kyle Snook
 GETTING SOME FUN OUT OF LIFE|SSAA|Dave Briner
 Getting There|SATB|Deke Sharon
-Getting To Know You|SSAA|Brent Graham
+Getting to Know You|SSAA|Brent Graham
+Getting to Know You|SSAA|Tedda Lippincott
 Getting To Know You|SSAA|Larry Wright
-Getting To Know You|SSAA|Tedda Lippincott
 Getting To Know You|SSAA|Walter Latzko
 Getting To Know You|TTBB|Larry Wright
 Ghost|SSAA|Joey Minshall
 Ghost Riders|TTBB|Unspecified
 Ghost Riders in the Sky|TTBB|Unspecified
-Ghost Riders In the Sky|TTBB|Larry Wright
 Ghost Story|TTBB|Deke Sharon
 Ghostbusters|TTBB|Brian Doepke
 Ghosts (How Can I Move On)|SSAA|Liz Garnett
@@ -6876,11 +6793,11 @@ Girl|TTBB|Deke Sharon
 Girl Child Born|SSAA|Joey Minshall
 Girl I Left Behind|TTBB|Todd Troutman
 Girl Next Door|TTBB|Michael Webber
+Girl of My Dreams|TTBB|Jay Giallombardo
 Girl Of My Dreams|SSAA|Walter Latzko
 Girl Of My Dreams|TTBB|Barbershop Harmony Society
 Girl Of My Dreams|TTBB|Inc. SPEBSQSA
 Girl Of My Dreams|TTBB|Jack Baird
-Girl Of My Dreams|TTBB|Jay Giallombardo
 Girl Of My Dreams|TTBB|Jim West
 Girl Of My Dreams|TTBB|Lloyd McClure
 Girl Of My Dreams|TTBB|Phil Embury
@@ -6922,8 +6839,8 @@ Give Me A Basketball|TTBB|Paul Olquin
 Give Me A Girl|TTBB|Joe Liles
 Give Me A Kiss By The Number|TTBB|Toban Dvoretsky
 Give Me A Million Beautiful Girls|TTBB|Alden Parker
+Give Me a Night in June|TTBB|Mark Hale
 Give Me a Night in June|TTBB|Maurice Reagan & The Pittsburghers
-Give Me A Night In June|TTBB|Mark Hale
 Give Me A Night In June|TTBB|Maurice Reagan
 Give Me Forever (I Do)|TTBB|Steve Jamison
 Give Me Jesus|TTBB|Derric Johnson
@@ -6936,6 +6853,7 @@ Give Me That Barbershop Style|TTBB|Einar Pedersen
 Give Me That Smile|TTBB|Adam Scott
 Give Me The Circus Life|SSAA|Joey Minshall
 Give Me The Moonlight, Give Me The Girl|TTBB|Dennis Driscoll
+Give Me the Simple Life|TTBB|Liz Garnett
 Give Me the Simple Life|TTBB|Walter Latzko
 Give Me The Simple Life|SATB|Aaron Dale
 Give Me The Simple Life|SSAA|Aaron Dale
@@ -6944,7 +6862,6 @@ Give Me The Simple Life|TTBB|Aaron Dale
 Give Me The Simple Life|TTBB|Dennis Driscoll
 Give Me The Simple Life|TTBB|Harry Swenson
 Give Me The Simple Life|TTBB|Lee Sutter
-Give Me The Simple Life|TTBB|Liz Garnett
 Give Me The Simple Life|TTBB|T. W. De Crow
 Give Me Wings|SSAA|Joan D 'Agostino
 Give Me Your Tired, Your Poor|SSAA|Donna Stewart
@@ -6955,13 +6872,13 @@ Give Me Your Tired, Your Poor|TTBB|Derric Johnson
 Give Me Your Tired, Your Poor|TTBB|Jay Giallombardo
 Give Me Your Tired, Your Poor|TTBB|Jim West
 Give Me Your Tired, Your Poor|TTBB|SPEBSQSA
+Give My Regards to Broadway|TTBB|Burt Szabo
 Give My Regards To Broadway|SSAA|Betty Owens
 Give My Regards To Broadway|SSAA|Jay Giallombardo
 Give My Regards To Broadway|TTBB|Al Baker, Steve Tramack
-Give My Regards To Broadway|TTBB|Burt Szabo
 Give My Regards To Broadway|TTBB|Jay Giallombardo
 Give My Regards To Broadway|TTBB|Toban Dvoretsky
-Give My Regards To Broadway Medley|SSAA|Nancy Bergman
+Give My Regards to Broadway Medley|SSAA|Nancy Bergman
 Give Us This Day|SSAA|Doris Twardosky
 Give Us This Day|SSAA|Tedda Lippincott
 Give Us Your Blessing, Lord|SSAA|Muriel Berg
@@ -6973,19 +6890,14 @@ GLAD TIDINGS ALL TO YOU - YW|SSAA|Carolyn Johnson
 Glenn Miller Medley|TTBB|Dick Rode
 Glenn Miller Medley|TTBB|Unspecified
 Glimpse Of Us|SSAA|Sheryl Neal
-Glitter In The Air|SSAA|Joey Minshall
+Glitter in the Air|SSAA|Joey Minshall
 Gloria|SSAA|Jay Giallombardo
 Gloria|TTBB|David Wright
 Gloria|TTBB|Jay Giallombardo
-Glory Of Love|SSAA|Bitsy Bacon
-Glory Of Love|SSAA|Charlene Yazurlo
-Glory Of Love|SSAA|Greta Somers
-Glory Of Love|SSAA|Jean McFadyen
 Glory Of Love|SSAA|Mike Menefee
 Glory Of Love|SSAA|Tom Gentry
 Glory Of Love|SSAA|Tony Nasto
 Glory Of Love|TTBB|Dan Wessler
-Glory Of Love|TTBB|Dennis Driscoll
 Glory Of Love|TTBB|Ed Waesche
 Glory Of Love|TTBB|Gene Cokeroft
 Glory Of Love|TTBB|Tom Gentry
@@ -6995,7 +6907,6 @@ Glory To God (The Echo Carol)|TTBB|Derric Johnson
 Gloucester Wassail|SATB|Larry Triplett
 Gloucester Wassail|SSAA|Larry Triplett
 Gloucester Wassail|TTBB|Larry Triplett
-Glow Worm|SSAA|Jim Massey
 Glow Worm|TTBB|Dan Wessler
 Glow Worm|TTBB|Mark Vile
 Glow Worm|TTBB|Walter Latzko
@@ -7030,11 +6941,11 @@ Go Tell It On The Mountain|TTBB|Joe Liles
 Go Tell It On The Mountain|TTBB|Jon Nicholas
 Go Tell It On The Mountain|TTBB|Roger Payne
 Go Tell It On The Mountain|TTBB|Wendy Hofmann
+Go the Distance|SSAA|Aaron Dale
+Go the Distance|SSAA|Joey Minshall
+Go the Distance|TTBB|Aaron Dale
 Go The Distance|SATB|Deke Sharon
-Go The Distance|SSAA|Aaron Dale
-Go The Distance|SSAA|Joey Minshall
 Go The Distance|SSAA|Larry Wright
-Go The Distance|TTBB|Aaron Dale
 Go The Distance|TTBB|Larry Wright
 Go The Distance (Disney)|SSAA|Aaron Dale
 Go Where I Send Thee|SATB|Vince Peterson
@@ -7076,6 +6987,7 @@ God Bless The Child|TTBB|Jim Shubert
 God Bless The Child|TTBB|Joe Mannherz
 God Bless The Child|TTBB|Tom Gentry
 God Bless The Human Elbow|TTBB|Dennis Driscoll
+God Bless the U.S.A.|TTBB|Brian Beck
 God Bless The U.S.A.|SATB|Deke Sharon
 God Bless The U.S.A.|SATB|Larry Wright
 God Bless The U.S.A.|SSAA|Carolyn Healey
@@ -7084,7 +6996,6 @@ God Bless The U.S.A.|SSAA|Larry Wright
 God Bless The U.S.A.|SSAA|Linda Smith
 God Bless The U.S.A.|SSAA|Mary K. Coffman Music Fund
 God Bless The U.S.A.|SSAA|Tedda Lippincott
-God Bless The U.S.A.|TTBB|Brian Beck
 God Bless The U.S.A.|TTBB|Derric Johnson
 God Bless The U.S.A.|TTBB|Larry Wright
 GOD BLESS THE U.S.A.|SSAA|Linda M. Smith
@@ -7310,9 +7221,7 @@ Good Vibrations|TTBB|David Wright
 Good Vibrations|TTBB|Larry Wright
 Good Vibrations|TTBB|Staffan Paulson
 Good-Bye Boys|TTBB|Unknown
-Good-Bye My Honey Love|SSAA|Carolyn Johnson
 Good-bye My Lady Love|TTBB|Renee Craig, Joe Liles
-Good-Bye My Treasure Chest|SSAA|Carolyn Johnson
 Good-Bye Rose|TTBB|Inc. SPEBSQSA
 GOOD-BYE, MY HONEY LOVE|SSAA|Carolyn Johnson
 GOOD-BYE, MY TREASURE CHEST|SSAA|Carolyn Johnson
@@ -7338,7 +7247,7 @@ Goodbye Dixie, Goodbye|TTBB|Gary Parker
 Goodbye Earl|SSAA|Deke Sharon
 Goodbye In Her Eyes|TTBB|Nicholas Wright
 Goodbye Means the End of My World|SSAA|Joe Liles
-Goodbye Means The End Of My World|TTBB|Joe Liles
+Goodbye Means the End of My World|TTBB|Joe Liles
 Goodbye Medley|SSAA|Mary Coffman
 Goodbye Medley|SSAA|Mary K. Coffman Music Fund
 Goodbye Medley|SSAA|Tom Gentry
@@ -7355,11 +7264,8 @@ Goodbye Rose|TTBB|Tom Gentry
 Goodbye To Yesterday|SSAA|Kevin Koehl
 Goodbye Wild Women Goodbye|TTBB|Dennis Morrissey
 Goodbye World Goodbye|SSAA|Dave Briner
-Goodbye World Goodbye|SSAA|David Wright
 Goodbye World Goodbye|SSAA|Jay Giallombardo
-Goodbye World Goodbye|TTBB|David Wright
 Goodbye World Goodbye|TTBB|Jay Giallombardo
-Goodbye World, Goodbye|SSAA|David Wright
 Goodbye Yellow Brick Road|SATB|Dan Wessler
 Goodbye Yellow Brick Road|SSAA|Dan Wessler
 Goodbye Yellow Brick Road|SSAA|Lauren Kahn
@@ -7387,7 +7293,6 @@ Goodnight My Angel|TTBB|Dan Naumann
 Goodnight My Angel|TTBB|David Wright
 Goodnight My Angel|TTBB|Mike Menefee
 Goodnight My Someone|TTBB|SK Grundy
-Goodnight Saigon|TTBB|Tom Gentry
 Goodnight Sweetheart|SSAA|June Berg
 Goodnight Sweetheart|TTBB|Willis Diekema
 Goodnight Sweetheart Goodnight|SSAA|Becky Wilkins
@@ -7476,13 +7381,13 @@ Gran Torino|TTBB|Theodore Hicks
 Granada|TTBB|Tom Gentry
 Grand Knowing You|TTBB|J Rae Jamieson
 Grand Old Flag This Is My Country Medley|SSAA|Judy Vidal
+Grandma Got Run Over by a Reindeer|TTBB|Jon Nicholas
 Grandma Got Run Over By A Reindeer|SATB|Joe Mannherz
 Grandma Got Run Over By A Reindeer|SSAA|Carolyn Healey
 Grandma Got Run Over By A Reindeer|SSAA|Joe Mannherz
 Grandma Got Run Over By A Reindeer|SSAA|Larry Wright
 Grandma Got Run Over By A Reindeer|TTBB|Jim West
 Grandma Got Run Over By A Reindeer|TTBB|Joe Mannherz
-Grandma Got Run Over By A Reindeer|TTBB|Jon Nicholas
 Grandma Got Run Over By A Reindeer|TTBB|Larry Wright
 Grandma Got Run Over By A Reindeer|TTBB|Todd Troutman
 GRANDMA GOT RUN OVER BY A REINDEER|SSAA|Louise Hamilton
@@ -7550,7 +7455,6 @@ Great Lakes Song|TTBB|Tom Gentry
 Great Race|SSAA|Joni Bescos
 Greatest Day|SSAA|Rosalind Johnson
 Greatest Day|TTBB|Simon Lubkowski
-Greatest Love of All|SSAA|Jo Lund
 Greatest Mistake Of My Life|TTBB|Roy Keys
 Greedy|SATB|Nicholas Wright
 Green Acres Theme|SSAA|Doris Twardosky
@@ -7571,22 +7475,19 @@ Grim Grinning Ghosts|TTBB|Arthur Sauls
 Grim Grinning Ghosts|TTBB|Brent Graham
 Grim Grinning Ghosts|TTBB|Kyle Williamson
 Grim Grinning Ghosts|TTBB|Larry Wright
-Grinch Medley|SSAA|Nancy Bergman
 Grizzly Bear|TTBB|Todd Troutman
 Groove 66 Disney Medley|TTBB|Deke Sharon
 Groove Is In The Heart|SATB|Deke Sharon
 Groovy Kind Of Love|SATB|Tom Gentry
 Groovy Kind Of Love|SSAA|Chris Moyer
-Groovy Kind Of Love|SSAA|Tom Gentry
-Groovy Kind Of Love|TTBB|Tom Gentry
 Grouch Anthem|SSAA|Dianne Goldrick
 Grouch Anthem|TTBB|Dianne Goldrick
 Grow As We Go|SATB|Justin Miller
 Grow Old With Me|SATB|John Cowlishaw
 Grow Old With Me|TTBB|Aaron Dale
 Grow Old With Me|TTBB|Andrew Carolan
-Grow Old With You|SSAA|Aaron Dale
-Grow Old With You|TTBB|Aaron Dale
+Grow Old with You|SSAA|Aaron Dale
+Grow Old with You|TTBB|Aaron Dale
 Grow Old With You|TTBB|Larry Wright
 Growin' Old|TTBB|Unspecified
 Growin' Old Can Be Fun|TTBB|Dennis Driscoll
@@ -7684,9 +7585,9 @@ Hallelujah, I Love Her So|TTBB|Jay Giallombardo
 Hallelujah, I Love Her So|TTBB|Kohl Kitzmiller
 Hallelujah, I Love Her So|TTBB|Tom Gentry
 Halloween Medley|SSAA|M. Penketh
+Halls of Ivy|TTBB|Jay Giallombardo
 Halls Of Ivy|SSAA|Jay Giallombardo
 Halls Of Ivy|TTBB|Don Gray
-Halls Of Ivy|TTBB|Jay Giallombardo
 Halo|SATB|Deke Sharon
 Hand In Hand|TTBB|Matt Astle
 Hand Medley|TTBB|Dennis Driscoll
@@ -7697,8 +7598,8 @@ Hands|SATB|Deke Sharon
 Hang Fire|SATB|Don Staffin
 Hang Fire|TTBB|Don Staffin
 Hang Me Up To Dry|SATB|Nicholas Wright
-Hang On Little Tomato|SSAA|Eric Ruthenberg
-Hang On Little Tomato|TTBB|Eric Ruthenberg
+Hang on Little Tomato|SSAA|Eric Ruthenberg
+Hang on Little Tomato|TTBB|Eric Ruthenberg
 Hang On Sloopy|TTBB|Tom Gentry
 Hang On The Bell, Nellie|TTBB|Barbershop Harmony Society
 Hang On The Bell, Nellie|TTBB|SPEBSQSA
@@ -7817,7 +7718,6 @@ Happy Feet|SSAA|Jim Arns
 Happy Feet Medley|TTBB|Ed Waesche
 Happy Go Lucky Lane|TTBB|Jay Giallombardo
 Happy Go Lucky Lane|TTBB|Jay Giallombardo/Greg Volk
-Happy Hanukkah My Friend|SSAA|Nancy Bergman
 Happy Hanukkah, My Friend|SSAA|Jeanne Elmuccio
 HAPPY HANUKKAH, MY FRIEND|SSAA|Nancy Bergman
 Happy Happy Birthday Baby|TTBB|Aaron Dale
@@ -7906,7 +7806,6 @@ Hard Hearted Hannah|TTBB|Walter Latzko
 Hard Times (No One Knows Better Than I)|TTBB|Kevin Keller
 Hard Times (No One Knows Better Than I)|TTBB|Theo Hicks
 Hard Times Come Again No More|SATB|Thomas Degan
-Hard Times Come Again No More|TTBB|David Wright
 Hard Times Come Again No More|TTBB|Patrick Rose
 Hard Times, Come Again No More|TTBB|David Wright
 Hard To Get Gertie|TTBB|Ed Waesche
@@ -7917,8 +7816,6 @@ Hard To Say I'm Sorry|TTBB|Deke Sharon
 Hard To Say I'm Sorry (from Summer Lovers)|TTBB|David Mastrull
 Hard To Say I'm Sorry/You're The Inspiration|TTBB|Justin Miller
 Hard-Hearted Hannah|SSAA|Lorraine Rochefort
-Hard-Hearted Hannah|SSAA|Marge Bailey
-Hard-Hearted Hannah|SSAA|Michael Gellert
 Harder To Breathe|TTBB|Deke Sharon
 Hark The Angels Sing Gloria|SSAA|Judy Vidal Renee Craig
 Hark the Herald Angels Sing|TTBB|Barbershop Harmony Society
@@ -7936,7 +7833,7 @@ Hark! The Herald Angels Sing|TTBB|Walter Latzko
 Harlem Sandman / Mr. Sandman Medley|SSAA|Jo Lund
 Harley Davidson Medley|SSAA|Gene Cokeroft
 Harmonisch im Abgang|TTBB|Tom Gentry
-Harmonize The World|SSAA|Nancy Bergman
+Harmonize the World|SSAA|Nancy Bergman
 Harmony|SATB|Doug Miller
 Harmony|SATB|Douglas Miller
 Harmony|SSAA|David Wright
@@ -7972,8 +7869,8 @@ Have A Good Time|SSAA|Becky Cartine
 Have A Happy Day|TTBB|Mac Huff
 Have a Holly Jolly Christmas|SSAA|Sandy Sharpe
 Have A Little Talk With Jesus|TTBB|Derric Johnson
+Have a Little Talk with Myself|TTBB|Gary Parker
 Have A Little Talk With Myself|SSAA|Aileen Nightingale
-Have A Little Talk With Myself|TTBB|Gary Parker
 Have a Nice Day|SSAA|Beth Rothwell
 Have A Nice Day|TTBB|Tom Gentry
 Have A Smile|TTBB|Steve Sutherland
@@ -7987,7 +7884,6 @@ Have I Told You Lately That I Love You?|SSAA|Henrik Rosenberg
 Have It All|TTBB|Dan Wessler
 Have to Say I Love You in a Song, I'll|SATB|Jay Giallombardo
 Have You Even Been In Heaven?|TTBB|Dennis Driscoll
-Have you Ever Been Lonely|SSAA|Aileen Nightingale
 Have You Ever Been Lonely|TTBB|Unspecified
 Have You Ever Been Lonely?|SSAA|Aileen Nightingale Music
 Have You Ever Been Lonely?|TTBB|Roger Craig
@@ -7996,7 +7892,6 @@ Have You Ever Been Lonely? (Have You Ever Been Blue?)|TTBB|Roger Craig
 Have you Ever Heard the Swanee River Cry|SSAA|Dot Calvin
 Have You Ever Seen The Rain?|SSAA|Kay Bromert
 Have You Got Any Castles, Baby?|SSAA|June Berg
-Have You Met Miss Jones|SSAA|Jo Lund
 Have You Met Miss Jones|TTBB|Dan Wessler
 Have You Met Miss Jones|TTBB|Rasmus Krigstrom
 Have You Met Miss Jones|TTBB|Walter Latzko
@@ -8005,6 +7900,8 @@ Have You Met Miss Jones?|TTBB|Rasmus Krigström
 Have You See the Child?|TTBB|Jay Giallombardo
 Have You Seen The Child|TTBB|Jay Giallombardo
 Have Yourself a Mary Little Christmas|TTBB|M. Gill
+Have Yourself a Merry Little Christmas|TTBB|Brent Graham
+Have Yourself a Merry Little Christmas|TTBB|David Harrington
 Have Yourself A Merry Little Christmas|SATB|Chris Arnold
 Have Yourself A Merry Little Christmas|SATB|Clay Hine
 Have Yourself A Merry Little Christmas|SATB|Deke Sharon
@@ -8026,8 +7923,6 @@ Have Yourself A Merry Little Christmas|SSAA|Steve Delehanty
 Have Yourself A Merry Little Christmas|TTBB|Adam Scott
 Have Yourself A Merry Little Christmas|TTBB|Andrew Wittenberg
 Have Yourself A Merry Little Christmas|TTBB|Blaine Mack
-Have Yourself A Merry Little Christmas|TTBB|Brent Graham
-Have Yourself A Merry Little Christmas|TTBB|David Harrington
 Have Yourself A Merry Little Christmas|TTBB|Derric Johnson
 Have Yourself A Merry Little Christmas|TTBB|Greg Mallett
 Have Yourself A Merry Little Christmas|TTBB|Jay Giallombardo
@@ -8090,7 +7985,6 @@ He Will Carry You|SSAA|Larry Triplett
 He Will Carry You|TTBB|Larry Triplett
 He Will Set Your Fields On Fire|TTBB|John Hale
 He'd Have To Get Under - Get Out And Get Under|TTBB|Burt Szabo
-He'd Have To Get Under, Get Out And Get Under|TTBB|Burt Szabo
 He'd Keep On Saying Good Night|TTBB|Steve Jamison
 He'll Be Coming Down the Chimney|SSAA|Nancy Bergman
 He'll Be Coming Down The Chimney (When He Comes)|SSAA|Nancy Bergman
@@ -8128,9 +8022,9 @@ Heart (You Gotta Have)|TTBB|Larry Wright
 Heart (You Gotta Have)|TTBB|Walter Latzko
 Heart (You've Gotta Have)|SSAA|Barbara McNeill
 Heart (You've Gotta Have)|SSAA|Larry Wright
+Heart and Soul|SSAA|Bryan Ziegler
 Heart And Soul|SATB|Bryan Ziegler
 Heart And Soul|SATB|Kohl Kitzmiller
-Heart And Soul|SSAA|Bryan Ziegler
 Heart And Soul|SSAA|Carolyn Johnson
 Heart And Soul|SSAA|Marsha Zwicker
 Heart And Soul|TTBB|Bryan Ziegler
@@ -8213,15 +8107,12 @@ Hello Darlin'|TTBB|Mason Eubank
 Hello Dolly|SSAA|Carolyn Schmidt
 Hello Dolly|TTBB|Dick Barrett
 Hello Dolly|TTBB|Don Gray
-Hello Dolly|TTBB|Ed Waesche
 Hello Hollywood Hello|SSAA|Nancy Bergman
 Hello Ma Baby|SSAA|Jay Giallombardo
 Hello Ma Baby|TTBB|Bill Diekema
 Hello Ma Baby|TTBB|Burt Szabo
 Hello Ma Baby|TTBB|Jay Giallombardo
 Hello Mary Lou|SSAA|Tedda Lippincott
-Hello Mary Lou|TTBB|David Wright
-Hello Mary Lou|TTBB|Tom Gentry
 Hello Mary Lou (Goodbye Heart)|TTBB|David Wright
 Hello Muddah, Hello Faddah|SSAA|Tedda Lippincott
 Hello Muddah, Hello Faddah|SSAA|Tom Gentry
@@ -8230,7 +8121,6 @@ Hello My Baby|SSAA|Betty Oliver
 Hello My Baby|SSAA|David Harrington
 Hello My Baby|SSAA|Kevin Keller
 Hello My Baby|SSAA|Walter Latzko
-Hello My Baby|TTBB|Burt Szabo
 Hello My Baby|TTBB|David Harrington
 Hello My Baby|TTBB|Kevin Keller
 Hello My Baby|TTBB|Val Hicks
@@ -8238,7 +8128,6 @@ Hello My Baby|TTBB|Walter Latzko
 Hello My Baby|TTBB|Willis Diekema
 Hello My Baby Through the Years|SSAA|Clay Hine
 Hello My Baby, Won't You Please Come Home|TTBB|Steven Armstrong, Jan-Ake Westin
-Hello Young Lovers|SSAA|Anna Maria Parker
 Hello Young Lovers|SSAA|David Briner
 Hello Young Lovers|SSAA|Tom Gentry
 Hello Young Lovers|TTBB|Tom Gentry
@@ -8251,11 +8140,9 @@ Hello! My Baby|TTBB|Burt Szabo
 Help Is On The Way|SSAA|Michael Gellert
 Help Me Rhonda|SSAA|Deke Sharon
 Help Me Rhonda|TTBB|Deke Sharon
-Help Me Rhonda|TTBB|Jon Nicholas
 Help Me To Help My Neighbor|TTBB|Burt Szabo
 Help Me, Rhonda|TTBB|Jon Nicholas
 Help, I'm Turning Into My Parents|SSAA|Jim Massey
-Help, I'm Turning Into My Parents|SSAA|Nancy Shumard
 Help!|SATB|Clay Hine
 Help!|SATB|Emily Moriarty
 Help!|SATB|Manoj Padki
@@ -8277,7 +8164,7 @@ HERCULES|SSAA|Lauren Kahn
 Here Am I, Brokenhearted|SSAA|Brent Graham
 Here Am I, Brokenhearted|TTBB|Brent Graham
 HERE AM I, BROKENHEARTED|SSAA|Brent A. Graham
-Here And Now|SSAA|Joey Minshall
+Here and Now|SSAA|Joey Minshall
 Here And Now|SSAA|Kyle Kitzmiller
 Here Come The Clowns|SSAA|Jean McFadyen
 Here Comes Elastigirl|SATB|Deke Sharon
@@ -8302,11 +8189,11 @@ Here Comes That Rainy Day Feeling|TTBB|Mark Stevens
 Here Comes The Flood|SATB|Anders Lindqvist
 Here Comes The Show Boat|TTBB|Barbershop Harmony Society
 HERE COMES THE SHOW BOAT|SSAA|David Briner
+Here Comes the Showboat|TTBB|David Wright
 Here Comes The Showboat|SSAA|David Briner
-Here Comes The Showboat|TTBB|David Wright
+Here Comes the Sun|SSAA|Deke Sharon
 Here Comes The Sun|SATB|Deke Sharon
 Here Comes The Sun|SATB|Manoj Padki
-Here Comes The Sun|SSAA|Deke Sharon
 Here Comes The Sun|SSAA|Glenda Lloyd
 Here Comes The Sun|SSAA|Jay Giallombardo
 Here Comes The Sun|SSAA|Joan D 'Agostino
@@ -8338,7 +8225,6 @@ Here, There And Everywhere|SATB|Jay Giallombardo
 Here, There And Everywhere|SATB|Richard Curtis
 Here, There And Everywhere|SSAA|Carolyn Johnson
 Here, There And Everywhere|SSAA|Jay Giallombardo
-Here, There And Everywhere|SSAA|June Berg
 Here, There And Everywhere|TTBB|Alex Kaiserman
 Here, There And Everywhere|TTBB|Jay Giallombardo
 Here, There And Everywhere|TTBB|Rob Campbell
@@ -8365,7 +8251,6 @@ Here's To The Heroes|TTBB|Jay Giallombardo
 Here's To The Winners|SSAA|Joni Bescos
 Here's To The Winners|TTBB|Renee Craig
 Heritage Medley|TTBB|Barbershop Harmony Society
-Heritage Medley|TTBB|SPEBSQSA
 Hernando's Hideaway|SSAA|Bev Sellers
 Hernando's Hideaway|SSAA|Marge Bailey
 Hernando's Hideaway|TTBB|Walter Latzko
@@ -8382,12 +8267,7 @@ Heroes (we could be)|SATB|Nicholas Wright
 Heroes (we could be)|SSAA|Nicholas Wright
 Hey Daddy|SSAA|Nancy Bergman
 Hey Daddy (You Oughta Get the Best For Me)|SSAA|Nancy Bergman
-Hey Good Lookin'|SSAA|David Wright
-Hey Good Lookin'|SSAA|Tom Gentry
-Hey Good Lookin'|TTBB|David Wright
 Hey Good Lookin'|TTBB|Jim Shubert
-Hey Good Lookin'|TTBB|Jon Nicholas
-Hey Good Lookin'|TTBB|Tom Gentry
 Hey Jude|SATB|Jay Dougherty
 Hey Jude|SSAA|Deke Sharon
 Hey Jude|SSAA|Jay Dougherty
@@ -8395,25 +8275,20 @@ Hey Jude|SSAA|Jay Giallombardo
 Hey Jude|TTBB|Deke Sharon
 Hey Jude|TTBB|Jay Dougherty
 Hey Jude|TTBB|Jay Giallombardo
-Hey Little Baby O' Mine|TTBB|Joe Liles
 Hey Little Baby of Mine|SSAA|Joe Liles
 Hey Look Ma, I Made It|SATB|Nicholas Wright
 Hey Look Me Over|SSAA|Jay Giallombardo
-Hey Look Me Over|SSAA|Nancy Bergman
 Hey Look Me Over|SSAA|Tom Gentry
 Hey Look Me Over|TTBB|Barbershop Harmony Society
 Hey Look Me Over|TTBB|Bob Dowma
-Hey Look Me Over|TTBB|David Wright
 Hey Look Me Over|TTBB|Ellsworth Morey
 Hey Look Me Over|TTBB|Jay Giallombardo
 Hey Look Me Over|TTBB|John Hohl
-Hey Look Me Over|TTBB|Tom Gentry
 Hey Look Me Over / If My Friends Could See Me Now Medley|TTBB|Tom Gentry
 Hey Look me Over / If They Could See Me Now (Medley)|TTBB|Tom Gentry
 Hey Mister! Stay!|SSAA|Joey Minshall
 Hey Pretty Moon|TTBB|Kyle Snook
 Hey Santa|SATB|Joe Mannherz
-Hey Soul Sister|SSAA|Elaine Gain
 Hey There|SSAA|David Wright
 Hey There|SSAA|Joan D 'Agostino
 Hey There|SSAA|Joe Mannherz
@@ -8445,7 +8320,6 @@ Hey, Won't You Play Another Somebody|SSAA|Tedda Lippincott
 Hey!|TTBB|Tom Gentry
 Hey! Baby!|TTBB|Jim Shubert
 Hey! Baby!|TTBB|Jon Nicholas
-Hey! Look Me Over|SSAA|Nancy Bergman
 Hi Ho|SATB|Deke Sharon
 Hi Neighbor|SSAA|Marge Bailey
 Hi Neighbor|TTBB|Fred King
@@ -8457,7 +8331,6 @@ Hi Neighbor|TTBB|Joe Mannherz
 Hi Neighbor|TTBB|Mike Sotiriou
 Hi Neighbor|TTBB|Richard Gray
 Hi Neighbor|TTBB|Rob Ozman
-Hi Neighbor|TTBB|Walter Latzko
 Hi Neighbor / One Of Those Songs|TTBB|Walter Latzko
 Hi Neighbor/Consider Yourself Medley|TTBB|Joe Simone
 Hi-De-Ho (That Old Sweet Roll)|TTBB|Joe Mannherz
@@ -8509,12 +8382,11 @@ Hit Me With Your Best Shot|SATB|Deke Sharon
 Hit Me With Your Best Shot|SSAA|Deke Sharon
 Hit That Jive Jack|SATB|Joe Mannherz
 Hit That Jive Jack|SSAA|Greg Volk
-Hit That Jive Jack|TTBB|Aaron Dale
 Hit That Jive Jack|TTBB|Dan Wessler
 Hit That Jive Jack|TTBB|Greg Volk
 Hit That Jive, Jack|TTBB|Aaron Dale
+Hit the Road Jack|SATB|Tom Gentry
 Hit The Road Jack|SATB|Joe Mannherz
-Hit The Road Jack|SATB|Tom Gentry
 Hit The Road Jack|SSAA|Tom Gentry
 Hit The Road Jack|TTBB|Jud Finley
 Hit The Road Jack|TTBB|Tom Gentry
@@ -8591,12 +8463,10 @@ Holly Jolly Christmas|SATB|Deke Sharon
 Holly Jolly Christmas|SATB|Joe Mannherz
 Holly Jolly Christmas|SATB|Kevin Keller
 Holly Jolly Christmas|SSAA|Betty Oliver
-Holly Jolly Christmas|SSAA|Carolyn Johnson
 Holly Jolly Christmas|SSAA|Dianne Goldrick
 Holly Jolly Christmas|SSAA|Jan Meyer
 Holly Jolly Christmas|SSAA|Jay Giallombardo
 Holly Jolly Christmas|SSAA|Kevin Keller
-Holly Jolly Christmas|SSAA|Tedda Lippincott
 Holly Jolly Christmas|SSAA|Tom Gentry
 Holly Jolly Christmas|TTBB|Andrew Wittenberg
 Holly Jolly Christmas|TTBB|Dianne Goldrick
@@ -8629,11 +8499,11 @@ HOME (WHERE SHADOWS FALL)|SSAA|Elaine Gain
 Home Again|SSAA|Kay Bromert
 Home Among The Gumtrees|SSAA|Emily Moriarty
 Home Christmas Medley|SSAA|Carmen Youra
+Home For the Holidays|SSAA|Carolyn Schmidt
 Home For The Holidays|SATB|Burt Szabo
 Home For The Holidays|SATB|Kay Bromert
 Home For The Holidays|SATB|Russ Foris
 Home For The Holidays|SSAA|Burt Szabo
-Home For The Holidays|SSAA|Carolyn Schmidt
 Home For The Holidays|SSAA|Carolyn Schmidt Tedda Lippincott
 Home For The Holidays|SSAA|Debbie Porter
 Home For The Holidays|SSAA|Jay Giallombardo
@@ -8647,13 +8517,13 @@ Home For The Holidays|TTBB|Russ Foris
 HOME FOR THE HOLIDAYS (THERE'S NO PLACE LIKE)|SSAA|Debbie A Porter
 Home on the Range|SSAA|Brian Beck
 Home on the Range|TTBB|Don Gray
+Home on the Range|TTBB|Jack Baird
 Home On The Range|SSAA|Jay Giallombardo
 Home On The Range|SSAA|Nancy Bergman
-Home On The Range|TTBB|Jack Baird
 Home On The Range|TTBB|Jay Giallombardo
 Home On The Range|TTBB|Jim Clancy
 Home On The Range|TTBB|Jon Nicholas
-Home To Stay|SSAA|Joey Minshall
+Home to Stay|SSAA|Joey Minshall
 Home Town|TTBB|Cal Sexton
 HOME TOWN BAND|SSAA|LaVeda Redfield
 HOME TOWN BAND|SSAA|Sonny Steffan
@@ -8680,7 +8550,6 @@ Honey (Open That Door)/Hey Good Lookin'|TTBB|Aaron Dale
 Honey / Little 'Lize Medley|TTBB|Floyd Connett
 Honey Boy|SSAA|Walter Latzko
 Honey Bun|TTBB|Dennis Driscoll
-Honey I'm Home|SSAA|Corinna Garriock
 Honey Medley|SSAA|David Harrington
 Honey Medley|TTBB|David Harrington
 Honey Medley|TTBB|Tom Gentry
@@ -8698,7 +8567,6 @@ Honey, That I Love So Well|TTBB|Tom Gentry
 Honey's Arms Medley|TTBB|Al Leroy
 Honey's Arms Medley|TTBB|Dennis Driscoll
 Honey/Little 'Lize Medley|TTBB|Barbershop Harmony Society
-Honey/Little 'Lize Medley|TTBB|Floyd Connett
 Honeycomb|TTBB|Paul Jorg
 Honeymoon|TTBB|Walter Latzko
 Honeysuckle Rose|TTBB|Aaron Dale
@@ -8711,14 +8579,14 @@ Honneur A Toi|TTBB|Deke Sharon
 Honolulu City Lights|SSAA|Brian Beck
 Hooch|TTBB|Deke Sharon
 Hooey|TTBB|Tom Gentry
-Hooked On A Feeling|SATB|Jon Nicholas
+Hooked on a Feeling|SATB|Jon Nicholas
+Hooked on a Feeling|SSAA|Jon Nicholas
+Hooked on a Feeling|TTBB|Deke Sharon
+Hooked on a Feeling|TTBB|Jon Nicholas
 Hooked On A Feeling|SSAA|Corinna Garriock
 Hooked On A Feeling|SSAA|Jim Arns
-Hooked On A Feeling|SSAA|Jon Nicholas
 Hooked On A Feeling|SSAA|Tedda Lippincott
-Hooked On A Feeling|TTBB|Deke Sharon
 Hooked On A Feeling|TTBB|Gabriel Lawson
-Hooked On A Feeling|TTBB|Jon Nicholas
 Hooked On A Feeling|TTBB|Nicholas Wright
 Hooked On Classics medley|SSAA|Larry Wright
 Hooked On Classics medley|SSAA|Steve Delehanty
@@ -8726,16 +8594,16 @@ Hooked On Classics medley|TTBB|Larry Wright
 Hoop Dee Doo!|TTBB|Nancy Bergman
 Hooray For Captain Spaulding|TTBB|Dick Rode
 Hooray For Christmas|SSAA|Avis Fellows
+Hooray for Hollywood|SSAA|Joni Bescos
 Hooray For Hollywood|SSAA|Jo Lund
-Hooray For Hollywood|SSAA|Joni Bescos
 Hooray For Hollywood|TTBB|Dennis Driscoll
 Hooray For Hollywood|TTBB|Edward Boehm
 Hooray For Hollywood|TTBB|Jay Giallombardo
 Hooray For Hollywood/That's Entertainment Medley|TTBB|Jay Giallombardo
 Hooray For Hollywood/That's Entertainment Medley(Jay Giallomb|TTBB|Jay Giallombardo
+Hooray for Love|TTBB|Alan Gordon
 Hooray For Love|SSAA|Aaron Dale
 Hooray For Love|SSAA|Larry Wright
-Hooray For Love|TTBB|Alan Gordon
 Hooray For Love|TTBB|Larry Wright
 Hooray For Love|TTBB|Walter Latzko
 Hooray For Love/Glory Of Love|SSAA|Marsha Zwicker
@@ -8771,7 +8639,6 @@ House At Pooh Corner|SSAA|Carolyn Schmidt
 House At Pooh Corner|TTBB|Anthony Nasto
 House At Pooh Corner|TTBB|Jeremey Johnson
 House I Live In|SSAA|Jay Giallombardo
-House I Live In|SSAA|Tedda Lippincott
 House I Live In|SSAA|Tom Gentry
 House I Live In|TTBB|Jay Giallombardo
 House I Live In|TTBB|Kirk Roose
@@ -8790,7 +8657,6 @@ How About You?|TTBB|Patrick McAlexander
 How Am I Supposed To Live Without You|TTBB|Theodore Hicks
 How Am I To Know|TTBB|Walter Latzko
 How Are Things In Glocca Morra|SATB|Kevin Keller
-How Are Things In Glocca Morra|TTBB|Don Gray
 How Are Things In Glocca Morra|TTBB|Joe Mannherz
 How Are Things In Glocca Morra|TTBB|Mark Goodney
 How Are Things in Glocca Morra?|TTBB|Don Gray
@@ -8842,16 +8708,15 @@ How D'Ya Like Your Eggs in the Morning|SSAA|Tom Gentry
 How D'Ya Like Your Eggs in the Morning|TTBB|Michael Webber
 How D'Ya Like Your Eggs in the Morning|TTBB|Tom Gentry
 How Deep is the Ocean|SSAA|Ed Waesche
+How Deep is the Ocean|TTBB|Rob Hopkins
 How Deep Is the Ocean|SSAA|Lynn McCord
+How Deep Is the Ocean|SSAA|Rob Hopkins
 How Deep Is The Ocean|SATB|Anders Lindqvist
 How Deep Is The Ocean|SATB|Rob Hopkins
 How Deep Is The Ocean|SSAA|Kevin Keller
-How Deep Is The Ocean|SSAA|Rob Hopkins
 How Deep Is The Ocean|TTBB|Ed Waesche
 How Deep Is The Ocean|TTBB|Jay Giallombardo
-How Deep Is The Ocean|TTBB|Jim Clancy
 How Deep Is The Ocean|TTBB|Kevin Keller
-How Deep Is The Ocean|TTBB|Rob Hopkins
 How Deep is the Ocean (How High is the Sky)|SATB|Rob Hopkins
 How Deep Is the Ocean (How High Is the Sky)|SSAA|Ed Waesche
 How Deep Is the Ocean (How High Is the Sky)|TTBB|Ed Waesche
@@ -8927,7 +8792,6 @@ How Lucky You Are|TTBB|Dan Wessler
 How Lucky You Are|TTBB|Katie Farrell
 How Lucky You Are|TTBB|Patrick McAlexander
 How Lucky You Are (from Seussical)|TTBB|Dan Wessler
-How Many Hearts Have You Broken|SSAA|Jim Arns
 How Many Hearts Have You Broken?|SSAA|Marie Johnson
 How Many Hearts Have You Broken?|SSAA|Steve Jamison
 How Many Hearts Have You Broken?|TTBB|Dennis Driscoll
@@ -8951,7 +8815,6 @@ How Sweet It Is To Be Loved By You|TTBB|Larry Wright
 How To Build A Chorus|TTBB|Val Hicks
 How To Stay Married|TTBB|Louis Perry
 How We Sang Today|SSAA|Unspecified
-How We Sang Today|SSAA|Vicki Uhr
 HOW WE SANG TODAY!|SSAA|Vicki Uhr
 How Wonderful to Know|SSAA|Tom Gentry
 How Wonderful to Know|TTBB|Tom Gentry
@@ -9036,7 +8899,7 @@ I Almost Do|TTBB|Matt Astle
 I Always Knew The Girl I'd Love Would Be A Girl Like You|TTBB|Toban Dvoretsky
 I am A Child of God/I wonder When He Comes Again Medley|SSAA|Aaron Dale
 I am A Child of God/I wonder When He Comes Again Medley|TTBB|Aaron Dale
-I Am A Man of Constant Sorrow|TTBB|Aaron Dale
+I Am a Man of Constant Sorrow|TTBB|Aaron Dale
 I am Australian|TTBB|Unspecified
 I Am Changing|SSAA|Simon Arnott
 I Am Not American|TTBB|Steven Armstrong
@@ -9100,7 +8963,6 @@ I Can Cook Too|SSAA|Joey Minshall
 I Can Cook Too|SSAA|Lorraine Rochefort
 I Can Do That|SATB|Deke Sharon
 I Can Dream About You|TTBB|Mark Stevens
-I Can Dream, Can't I|TTBB|Ed Waesche
 I Can Dream, Can't I?|SSAA|Brad Rees
 I Can Dream, Can't I?|SSAA|Dede Nibler
 I Can Dream, Can't I?|SSAA|Don Gray
@@ -9124,8 +8986,8 @@ I Can See Clearly Now|TTBB|Mark Stevens
 I Can See Clearly Now|TTBB|Steve Armstrong
 I Can See Clearly Now|TTBB|Steven Armstrong
 I Can Sing A Rainbow|SSAA|Carole Prietto
+I Can't Begin to Tell You|SSAA|Carolyn Schmidt
 I Can't Begin To Tell You|SSAA|Burt Szabo
-I Can't Begin To Tell You|SSAA|Carolyn Schmidt
 I Can't Begin To Tell You|TTBB|Duane Enders
 I Can't Begin To Tell You|TTBB|Joe Liles
 I Can't Believe I'm Losing You|SSAA|Joni Bescos
@@ -9160,7 +9022,6 @@ I Can't Give You Anything But Love|TTBB|Mark Goodney
 I Can't Give You Anything But Love|TTBB|Walter Latzko
 I Can't Give You Anything But Love / L-O-V-E|SSAA|Nancy Bergman
 I Can't Give You Anything But Love & Steppin' Out With My Baby Medley|SSAA|Nancy Bergman
-I Can't Give You Anything But Love-L.O.V.E.|SSAA|Nancy Bergman
 I Can't Give You Anything But Love-LOVE|SSAA|Nancy Bergman
 I Can't Give You Anything But Love, Baby|TTBB|David Harrington
 I Can't Give You Anything but Love/Cuddle Up a Little Closer|TTBB|Tom Gentry
@@ -9221,7 +9082,7 @@ I Didn't Wanna Fall|SSAA|Joe Liles
 I Didn't Want To Fall|SSAA|Joe Liles
 I Didn't Want To Fall|TTBB|Joe Liles
 I Didn't Want to Fall - modified words|SSAA|Joe Liles
-I Dig Rock And Roll Music|SSAA|Kevin Keller
+I Dig Rock and Roll Music|SSAA|Kevin Keller
 I Dig Rock And Roll Music|TTBB|Kevin Keller
 I Do Wanna Know|SATB|Don Staffin
 I Do Wanna Know|TTBB|Don Staffin
@@ -9229,8 +9090,8 @@ I Don't Care|SSAA|Nicholas Wright
 I Don't Care|SSAA|Tom Gentry
 I Don't Care|TTBB|Tom Gentry
 I Don't Care About You|SSAA|Melody Hine
+I Don't Care if the Sun Don't Shine|SSAA|Nancy Bergman
 I Don't Care If The Sun Don't Shine|SSAA|Michael Gellert
-I Don't Care If The Sun Don't Shine|SSAA|Nancy Bergman
 I Don't Care If The Sun Don't Shine|SSAA|Steve Tramack
 I Don't Care If The Sun Don't Shine|TTBB|Steve Tramack
 I Don't Care/Steppin Out|SSAA|Nancy Bergman
@@ -9278,7 +9139,6 @@ I Don't Know Why (I Just Do)|SSAA|Haeger
 I DON'T KNOW WHY (I JUST DO)|SSAA|Buzz Haeger
 I Don't Know Why (I Love You Like I Do)|SSAA|Buzz Haeger
 I Don't Know Why Medley|SSAA|Mary Coffman
-I Don't Know Why, I Just Do|SSAA|Buzz Haeger
 I Don't Know Why/You Made Me Love You|SSAA|Mary Coffman
 I DON'T KNOW WHY/YOU MADE ME MED.|SSAA|Mary K. Coffman
 I Don't Know Why/You Made Me Medley|SSAA|Mary K. Coffman Music Fund
@@ -9321,10 +9181,10 @@ I Don't Want To Set The World On Fire|TTBB|Joe Johnson
 I Don't Want To Set The World On Fire|TTBB|Lloyd McClur
 I Don't Want To Set The World On Fire|TTBB|Melody Hine
 I Don't Want To Set The World On Fire|TTBB|Tom Gentry
+I Don't Want to Walk Without You|SSAA|Renee Craig
 I Don't Want to Walk Without You|TTBB|Joe Johnson
 I Don't Want to Walk Without You|TTBB|Tom Gentry
 I Don't Want To Walk Without You|SSAA|Nancy Bergman
-I Don't Want To Walk Without You|SSAA|Renee Craig
 I Don't Want To Walk Without You|TTBB|Dennis Driscoll
 I Don't Want To Walk Without You|TTBB|Jim Shubert
 I Don't Want To Walk Without You|TTBB|Mark Goodney
@@ -9343,9 +9203,9 @@ I Enjoy Being A Girl|SSAA|Jean Kane
 I Enjoy Being A Girl (YWIH)|SSAA|Jean Kane
 I Fall In Love Too Easily|TTBB|Manoj Padki
 I Fall In Love With You Every Day|TTBB|Ray Buntaine
-I Fall To Pieces|SSAA|Kevin Keller
+I Fall to Pieces|SSAA|Kevin Keller
+I Fall to Pieces|TTBB|Kevin Keller
 I Fall To Pieces|SSAA|Tom Gentry
-I Fall To Pieces|TTBB|Kevin Keller
 I Fall To Pieces|TTBB|Tom Gentry
 I Fall To Pieces/Crazy Medley|TTBB|Kevin Keller
 I Feel A Sin Comin' On|SATB|Tamra Perez
@@ -9369,7 +9229,7 @@ I Feel A Song Coming On|SSAA|Jarmela Speta
 I FEEL LOVE (BENJI'S THEME)|SSAA|Jackie Kraft
 I Feel Pretty|SSAA|Carolyn Schmidt
 I Feel the Earth Move|SSAA|Ase Hagerman
-I Feel The Earth Move|SSAA|Deke Sharon
+I Feel the Earth Move|SSAA|Deke Sharon
 I Feel The Earth Move|SSAA|Glenda Lloyd
 I Feel The Earth Move|SSAA|Larry Wright
 I Felt a Funeral in My Brain|SATB|Jay Dougherty
@@ -9388,8 +9248,8 @@ I Found A Million Dollar Baby|TTBB|William Mitchell
 I FOUND A MILLION DOLLAR BABY|SSAA|JoAnne Ingels
 I Found A Rose (in the Devil's Garden)|SSAA|Jay Giallombardo
 I Found A Rose (in the Devil's Garden)|TTBB|Jay Giallombardo
+I Found the End of the Rainbow|TTBB|Ed Waesche
 I Found The End Of The Rainbow|SSAA|Jay Giallombardo
-I Found The End Of The Rainbow|TTBB|Ed Waesche
 I Found The End Of The Rainbow|TTBB|Jay Giallombardo
 I Found You Out When I Found You In|SSAA|June Berg
 I Get A Kick Out Of You|SATB|Deke Sharon
@@ -9415,8 +9275,8 @@ I Get Around|TTBB|Larry Wright
 I Get Around|TTBB|Larry Wright, Doug Anderson
 I Get Around|TTBB|Sam Hubbard
 I Get By With a Little Help From My Friends|SSAA|Rich Hasty
+I Get the Blues When It Rains|SSAA|Anna Maria Parker
 I Get The Blues When It Rains|SSAA|Anita Barzilla
-I Get The Blues When It Rains|SSAA|Anna Maria Parker
 I Get The Blues When It Rains|SSAA|David Harrington
 I Get The Blues When It Rains|SSAA|Unknown
 I Get The Blues When It Rains|TTBB|D. D. McCormick
@@ -9426,14 +9286,13 @@ I Get The Blues When It Rains|TTBB|Unknown
 I Go Back|TTBB|Mark Stevens
 I Go Crazy|TTBB|Michael Webber
 I Go For That|SSAA|Joan D 'Agostino
-I GO FOR THAT|SSAA|Joan D'Agostino
 I Go To Pieces|TTBB|Mark Stevens
 I Go To Rio|SSAA|Rowena Harper
 I Go to the Rock|SSAA|Don Gray
 I Got a Crush On You|SSAA|Marge Bailey
 I Got a Feelin' I'm Fallin'|SSAA|Nancy Bergman
 I Got Better|SATB|Mark Stevens
-I Got Lost In His Arms|SSAA|Jo Lund
+I Got Lost in His Arms|SSAA|Jo Lund
 I Got Lost In His Arms|SSAA|Larry Wright
 I Got Lucky|SSAA|Aaron Dale
 I Got Lucky|TTBB|Aaron Dale
@@ -9465,7 +9324,6 @@ I Got The Music In Me|SSAA|Adam Bock
 I Got The Sun In The Morning|SSAA|Joan D 'Agostino
 I Got The Sun In The Morning|SSAA|Kay Bromert
 I Got The Sun In The Morning|SSAA|Larry Wright
-I GOT THE SUN IN THE MORNING|SSAA|Joan D'Agostino
 I Got You (I Feel Good)|SATB|Deke Sharon
 I Got You (I Feel Good)|SSAA|Erica Kelch-Slesnick
 I Got You (I Feel Good)|SSAA|Mike Menefee
@@ -9485,7 +9343,7 @@ I Guess That's Why They Call It The Blues|TTBB|Mark Stevens
 I Had A Dream, Dear Montage|TTBB|Jay Giallombardo
 I Had Some Help|TTBB|Mark Stevens
 I Had Someone Before I Had You|SSAA|Avis Fellows
-I Had Someone Else Before I Had You|SSAA|Avis Fellows
+I Had Someone Else Before I had You|SSAA|Avis Fellows
 I Had Someone Else Before I Had You|SSAA|David Briner
 I Had Someone Else Before I Had You / Who's Sorry Now Medley|SSAA|Tom Gentry
 I Had Someone Else Before I Had You / Who's Sorry Now Medley|TTBB|David Briner
@@ -9520,12 +9378,12 @@ I Have Seen The Light|TTBB|Jay Giallombardo
 I Have Seen The Light (chorus parts only)|TTBB|Jay Giallombardo
 I Hear Music|TTBB|Dennis Driscoll
 I Hear Music|TTBB|Walter Latzko
+I Heard It Through the Grapevine|SSAA|Dede Nibler
+I Heard It Through the Grapevine|TTBB|Aaron Dale
 I Heard It Through The Grapevine|SATB|Deke Sharon
 I Heard It Through The Grapevine|SSAA|Charlene Yazurlo
-I Heard It Through The Grapevine|SSAA|Dede Nibler
 I Heard It Through The Grapevine|SSAA|Larry Wright
 I Heard It Through The Grapevine|SSAA|Mark Burnip
-I Heard It Through The Grapevine|TTBB|Aaron Dale
 I Heard It Through The Grapevine|TTBB|Larry Wright
 I Heard It Through The Grapevine|TTBB|Mark Burnip
 I Heard The Bells On Christmas Day|SATB|David Wright
@@ -9557,8 +9415,8 @@ I Just Called To Say I Love You|TTBB|Aaron Dale
 I Just Called To Say I Love You|TTBB|Adam Scott
 I Just Called To Say I Love You|TTBB|Gary Thiel
 I Just Can't Make It By Myself|TTBB|Paul Jorg
+I Just Can't Wait to Be King|TTBB|Aaron Dale
 I Just Can't Wait To Be King|SATB|Deke Sharon
-I Just Can't Wait To Be King|TTBB|Aaron Dale
 I Just Decided To Stay|TTBB|Eric Ruthenberg
 I just Fall In Love Again|TTBB|Mark Stevens
 I Just Feel Like Something Good|TTBB|Derric Johnson
@@ -9586,11 +9444,11 @@ I Know Why And So Do You|SSAA|Kevin Keller
 I Know Why And So Do You|TTBB|Joe Mannherz
 I Know Why And So Do You|TTBB|Walter Latzko
 I Left My Heart At The Stage Door Canteen|TTBB|Brent Graham
+I Left My Heart in San Francisco|TTBB|Ted Byrne
 I Left My Heart In San Francisco|SSAA|Larry Wright
 I Left My Heart In San Francisco|TTBB|Jay Wright
 I Left My Heart In San Francisco|TTBB|Larry Wright
 I Left My Heart In San Francisco|TTBB|Scott Kitzmiller
-I Left My Heart In San Francisco|TTBB|Ted Byrne
 I Left My Heart In San Francisco|TTBB|Walter Latzko
 I Left My Heart On A Tree With Mary|TTBB|Gregory Lyne
 I Like Beer|TTBB|Tom Gentry
@@ -9622,12 +9480,12 @@ I Love A Rainy Night|SATB|Deke Sharon
 I Love A Rainy Night|TTBB|Mark Stevens
 I Love A Rainy Night|TTBB|Will Makra
 I Love An Old Fashioned Song|TTBB|Louis Perry
-I Love Being Here With You|SSAA|Aaron Dale
+I Love Being Here with You|SSAA|Aaron Dale
+I Love Being Here with You|TTBB|Aaron Dale
 I Love Being Here With You|SSAA|Joe Mannherz
 I Love Being Here With You|SSAA|Kevin Keller
 I Love Being Here With You|SSAA|Ruby Rhea
 I Love Being Here With You|SSAA|Takako Fuke
-I Love Being Here With You|TTBB|Aaron Dale
 I Love Being Here With You|TTBB|Eric Ruthenberg
 I Love Being Here With You|TTBB|Joe Mannherz
 I Love Being Here With You|TTBB|Ken Potter
@@ -9656,7 +9514,7 @@ I Love That We're Old Fashioned|SSAA|Kevin Keller
 I Love That We're Old Fashioned|TTBB|Kevin Keller
 I Love The Ladies|TTBB|Steve Delehanty
 I Love The Way You're Breaking My Heart|TTBB|Steve Hardy
-I Love The Whole United States|TTBB|Burt Szabo
+I Love the Whole United States|TTBB|Burt Szabo
 I Love The Whole United States|TTBB|George Hulst
 I Love The Whole United States Medley|TTBB|Toban Dvoretsky
 I Love To Go Swimmin' With Wimmen|TTBB|Dennis Driscoll
@@ -9667,7 +9525,7 @@ I Love to Hear That Old Barbershop Style|SSAA|Jo Lund/Val Hicks
 I Love To Hear That Old Barbershop Style|SSAA|Jo Lund
 I Love To Hear That Old Barbershop Style|SSAA|Val Hicks
 I Love To Hear That Old Barbershop Style|TTBB|Val Hicks
-I Love To Laugh|SSAA|Jim Massey
+I Love to Laugh|SSAA|Jim Massey
 I Love To Laugh|TTBB|Val Hicks
 I Love To Laugh (from Walt Disney's MARY POPPINS)|TTBB|Val Hicks
 I Love To See You Smile|TTBB|Jim Emery
@@ -9706,7 +9564,7 @@ I May Never Pass This Way Again|SSAA|Tedda Lippincott
 I May Never Pass This Way Again|TTBB|Joe Mannherz
 I May Wander|SSAA|Joey Minshall
 I Miss Mother Most of All|SSAA|Joe Liles
-I Miss Mother Most Of All|TTBB|Joe Liles
+I Miss Mother Most of All|TTBB|Joe Liles
 I Miss That Mississippi Miss That Misses Me|TTBB|Dennis Driscoll
 I Miss the Good Ol' Days|TTBB|David Naddor
 I Miss You Most Of All|SATB|Larry Triplett
@@ -9751,7 +9609,7 @@ I Never Knew/Get Me To The Church On Time Medley|TTBB|Clay Hine
 I Never Knew/Get Me To The Church On Time Medley(Clay|TTBB|Clay Hine
 I Never Knew/You Were Meant for Me|SSAA|Renee Craig
 I Never Like It When You Leave|TTBB|Dan Wessler
-I Never Meant To Fall In Love|SSAA|Joe Liles
+I Never Meant to Fall in Love|SSAA|Joe Liles
 I Never Meant To Fall In Love|TTBB|Joe Liles
 I Never Miss The Sunshine|SSAA|Tom Gentry
 I Never Miss The Sunshine|TTBB|Tom Gentry
@@ -9967,19 +9825,19 @@ I Want A Girl (Just Like The Girl That Married Dear Old Dad)|TTBB|SPEBSQSA, INC.
 I Want A Girl Medley|SSAA|Avis Fellows
 I Want A Girl Medley|SSAA|Barbara Bianchi
 I Want A Girl Medley|TTBB|Wayne Woodward
+I Want a Hippopotamus for Christmas|SSAA|Kay Bromert
 I Want a Hippopotamus for Christmas|TTBB|Tony Searle
+I Want a Hippopotamus For Christmas|TTBB|Tom Gentry
 I Want A Hippopotamus For Christmas|SATB|Deke Sharon
 I Want A Hippopotamus For Christmas|SATB|Manoj Padki
 I Want A Hippopotamus For Christmas|SSAA|David Wallace
 I Want A Hippopotamus For Christmas|SSAA|Jim Massey
-I Want A Hippopotamus For Christmas|SSAA|Kay Bromert
 I Want A Hippopotamus For Christmas|SSAA|Sam Hubbard
 I Want A Hippopotamus For Christmas|SSAA|Tedda Lippincott
 I Want A Hippopotamus For Christmas|SSAA|Tom Gentry
 I Want A Hippopotamus For Christmas|TTBB|Jon Nicholas
 I Want A Hippopotamus For Christmas|TTBB|Manoj Padki
 I Want A Hippopotamus For Christmas|TTBB|Mark Goodney
-I Want A Hippopotamus For Christmas|TTBB|Tom Gentry
 I Want a Hippopotamus for Christmas (Hippo the Hero)|TTBB|Manoj Padki
 I Want It That Way|SSAA|Sheryl Neal
 I Want It That Way|TTBB|Anders Lindqvist
@@ -10170,8 +10028,8 @@ I Won't Send Roses|TTBB|Theo Hicks
 I Won't Send Roses|TTBB|Theodore Hicks
 I Won't Send Roses (from Mack And Mabel)|TTBB|Theo Hicks
 I Won't Tell A Soul|TTBB|George Hulst
+I Wonder as I Wander|SSAA|Joey Minshall
 I Wonder as I Wander|TTBB|John Wernega
-I Wonder As I Wander|SSAA|Joey Minshall
 I Wonder As I Wander|TTBB|Darin Drown
 I Wonder As I Wander|TTBB|Derric Johnson
 I Wonder As I Wander|TTBB|Jay Giallombardo
@@ -10203,9 +10061,9 @@ I WONDER WHO'S KISSING HIM NOW|SSAA|Carolyn Johnson
 I Wonder Why|TTBB|Walter Latzko
 I Work 8 Hours I Sleep 8 Hours (8 Hours for Love)|SSAA|Jay Giallombardo
 I Work 8 Hours I Sleep 8 Hours (8 Hours for Love)|TTBB|Jay Giallombardo
+I Wouldn't Trade the Silver in My Mother's Hair|TTBB|Jack Baird
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Brent Graham
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Ed Waesche
-I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jack Baird
 I Wouldn't Trade The Silver In My Mother's Hair|TTBB|Jay Giallombardo
 I Write The Songs|SATB|David Wright
 I Write The Songs|SSAA|Jay Giallombardo
@@ -10241,9 +10099,9 @@ I'd Give The World To Hear Alexanders Band Again|TTBB|Unspecified
 I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Emily Moriarty
 I'd Have Baked A Cake (If I Knew You Were Comin')|SSAA|Marsha Zwicker
 I'd Like To Buy The World A Coke|TTBB|Mason Eubank
-I'd Like To Teach The World To Sing|SSAA|Joey Minshall
-I'd Like To Teach The World To Sing|SSAA|Joni Bescos
-I'd Like To Teach The World To Sing|SSAA|Nancy Bergman
+I'd Like to Teach the World to Sing|SSAA|Joey Minshall
+I'd Like to Teach the World to Sing|SSAA|Joni Bescos
+I'd Like to Teach the World to Sing|SSAA|Nancy Bergman
 I'd Like To Teach The World To Sing|TTBB|Dave Stevens
 I'd Like To Teach The World To Sing|TTBB|Ken Bastien
 I'd Like To Teach The World To Sing|TTBB|Rob Hopkins
@@ -10284,9 +10142,9 @@ I'll Be Here|TTBB|Justin Miller
 I'll Be Here (from The Wild Party)|TTBB|Justin Miller
 I'll Be Here With You|SSAA|Brent Graham
 I'll Be Here With You|TTBB|Brent Graham
+I'll Be Home for Christmas|SSAA|Barbershop Harmony Society
 I'll Be Home for Christmas|TTBB|BHS
 I'll Be Home For Christmas|SATB|Joe Mannherz
-I'll Be Home For Christmas|SSAA|Barbershop Harmony Society
 I'll Be Home For Christmas|SSAA|Brent Graham
 I'll Be Home For Christmas|SSAA|Jay Giallombardo
 I'll Be Home For Christmas|SSAA|Kay Bromert
@@ -10353,7 +10211,7 @@ I'll Be There For You|TTBB|Jon Nicholas
 I'll Be There For You|TTBB|Matt Astle
 I'll Be Waiting|SATB|Nicholas Wright
 I'll Be Walkin With My Honey|TTBB|Mo Rector
-I'll Be With You In Apple Blossom Time|SSAA|Nancy Bergman
+I'll Be With You in Apple Blossom Time|SSAA|Nancy Bergman
 I'll Be With You In Apple Blossom Time|SSAA|Walter Latzko
 I'll Be With You In Apple Blossom Time|TTBB|Burt Szabo
 I'll Be With You In Apple Blossom Time|TTBB|Clay Hine
@@ -10385,7 +10243,7 @@ I'll Fly Away|TTBB|Dennis Driscoll
 I'll Fly Away|TTBB|Don Gray
 I'll Fly Away (Keepsake Version)|TTBB|Don Gray
 I'll Fly Away (Society Stock Version)|TTBB|Don Gray
-I'll Follow The Sun|TTBB|Jay Giallombardo
+I'll Follow the Sun|TTBB|Jay Giallombardo
 I'll Forget You|SSAA|Jay Giallombardo
 I'll Forget You|SSAA|Linda Edmondson
 I'll Forget You|TTBB|Burt Szabo
@@ -10396,8 +10254,8 @@ I'll Forget You|TTBB|Louis Perry
 I'll Get By|SSAA|Nancy Bergman
 I'll Get By|TTBB|Joe Mannherz
 I'll Get By|TTBB|Steven Armstrong
+I'll Get By (As Long as I Have You)|TTBB|Steven Armstrong
 I'll Get By (As Long As I Have You)|SSAA|Tedda Lippincott
-I'll Get By (As Long As I Have You)|TTBB|Steven Armstrong
 I'LL GET BY (AS LONG AS I HAVE YOU)|SSAA|Nancy Bergman
 I'll Have To Say I Love You In A Song|SATB|Mark Stevens
 I'll Have To Say I Love You In A Song|TTBB|Mark Stevens
@@ -10431,7 +10289,7 @@ I'll Never Smile Again|TTBB|Wayne Grimmer
 I'll Never Stop Loving You|SSAA|Adam Reimnitz
 I'll Never Stop Loving You|SSAA|Glenda Lloyd
 I'll Never Stop Loving You|TTBB|Brent Graham
-I'll Never Write A Love Song Any More|TTBB|Joe Liles
+I'll Never Write a Love Song Any More|TTBB|Joe Liles
 I'll Never Write A Love Song Anymore|SSAA|Joe Liles
 I'll Say She Does!|TTBB|Dennis Driscoll
 I'll See You In My Dreams|SSAA|Jo Lund
@@ -10474,10 +10332,10 @@ I'm A Ding Dong Daddy from Dumas|TTBB|Dick Stern
 I'm A Ding Dong Daddy from Dumas|TTBB|Walter Latzko
 I'm A Dreamer, Aren't We All|TTBB|Louis Perry
 I'm A Dreamer, Aren't We All|TTBB|Nick Bryant
+I'm a Fool to Want You|TTBB|Larry Triplett
 I'm A Fool To Want You|SATB|Larry Triplett
 I'm A Fool To Want You|SSAA|Larry Triplett
 I'm A Fool To Want You|SSAA|Walter Latzko
-I'm A Fool To Want You|TTBB|Larry Triplett
 I'm A Fool To Want You|TTBB|Walter Latzko
 I'm A Great Big Baby|SSAA|Lynnell Diamond
 I'm A Lonely Little Petunia|TTBB|Ray Buntaine
@@ -10491,7 +10349,7 @@ I'm a Middle-Aged Woman|SSAA|Tom Gentry
 I'm a Middle-Aged Woman|TTBB|Tom Gentry
 I'm A Train|SATB|Peter Knight
 I'm A Train|TTBB|Peter Knight
-I'm A Wild And Wooly Son Of The West|TTBB|Burt Szabo
+I'm A Wild and Wooly Son Of The West|TTBB|Burt Szabo
 I'm A Wild And Wooly Son Of The West|TTBB|Warren 'Buzz' Haeger
 I'm a Woman|SSAA|Lorraine Rochefort
 I'm A Woman|SSAA|Nancy Bergman
@@ -10541,18 +10399,18 @@ I'm An Old Cowhand|TTBB|Don Gray
 I'm An Old Cowhand|TTBB|Rob Campbell
 I'm Back In Love/I'm In Love Again|SSAA|Betty Oliver/Marie Johnson
 I'm Back In Love/I'm In Love Again Medley|SSAA|Betty Oliver
-I'm Beginning To Like It|SSAA|Tom Gentry
+I'm Beginning to Like It|SSAA|Tom Gentry
 I'm Beginning To Like It|TTBB|Tom Gentry
 I'm Beginning to See the Light|SSAA|June Dale
 I'm Beginning to See the Light|SSAA|Linda Masterson
+I'm Beginning to See the Light|SSAA|Nancy Bergman
 I'm Beginning to See the Light|SSAA|Tedda Lippincott
+I'm Beginning to See the Light|SSAA|Walter Latzko
 I'm Beginning to See the Light|TTBB|Marshall Webb
 I'm Beginning To See The Light|SSAA|Jan Meyer
 I'm Beginning To See The Light|SSAA|Kay Bromert
-I'm Beginning To See The Light|SSAA|Nancy Bergman
 I'm Beginning To See The Light|SSAA|Rob Hopkins
 I'm Beginning To See The Light|SSAA|Steve Tramack
-I'm Beginning To See The Light|SSAA|Walter Latzko
 I'm Beginning To See The Light|TTBB|Joe Mannherz
 I'm Beginning To See The Light|TTBB|John Bober
 I'm Beginning To See The Light|TTBB|John Hohl
@@ -10633,11 +10491,11 @@ I'm Gonna Sing|TTBB|Gloria Gaither
 I'm Gonna Sing 'Til The Spirit Moves My Heart|TTBB|Darin Drown
 I'm Gonna Sing Til The Spirit Moves In My Heart|TTBB|Darin Drown
 I'm Gonna Sing Til The Spirit Moves In My Heart(Darin D|TTBB|Darin Drown
+I'm Gonna Sit Right Down and Write Myself a Letter|SSAA|Tom Gentry
+I'm Gonna Sit Right Down and Write Myself a Letter|TTBB|Jimbob Kahlke
 I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Bev Sellers
 I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tedda Lippincott
-I'm Gonna Sit Right Down And Write Myself A Letter|SSAA|Tom Gentry
 I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Jim Kahlke
-I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Jimbob Kahlke
 I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Mo Rector (w/slight changes)
 I'm Gonna Sit Right Down And Write Myself A Letter|TTBB|Tom Gentry
 I'm Gonna Sit Right Down And Write Myself A Letter(Jim Ka|TTBB|Jim Kahlke
@@ -10676,7 +10534,6 @@ I'm Into Something Good|TTBB|John Fortino
 I'm Into Something Good|TTBB|Liz Garnett
 I'm Into Something Good / Happy Together Medley|SSAA|Aaron Dale
 I'm Into Something Good/Happy Together|SSAA|Aaron Dale
-I'm Into Something Good/Happy Together Medley|SSAA|Aaron Dale
 I'm Just A Bill|TTBB|Lance Fisher
 I'm Just A Dancing Sweetheart|SATB|Karen Penketh
 I'm Just a Gigolo/I Ain't Got Nobody|TTBB|Liz Garnett
@@ -10699,7 +10556,6 @@ I'm Knee Deep In Daisies|SSAA|Russ Foris
 I'm Knee Deep In Daisies|TTBB|Roger Cote
 I'm Knee Deep In Daisies|TTBB|Russ Foris
 I'm Knee Deep In Daisies|TTBB|Sherry Brown
-I'M KNEE-DEEP IN DAISIES|SSAA|Jean Kane
 I'm Left On The Corner Alone|TTBB|Einar Pedersen
 I'm Lonesome For You Dear Old Pal|TTBB|Bill Pellant
 I'm Lonesome For You Dear Old Pal|TTBB|Burt Szabo
@@ -10710,14 +10566,13 @@ I'M LOOKIN AT THE WORLD THROUGH ROSE COLORED GLASSES/WHEN YOU WORE A TULIP - Med
 I'm Looking at the World Through Rose Colored Glasses / When You Wore a Tulip|SSAA|Jim Arns
 I'm Looking For A Girl Named Mary|TTBB|Ed Waesche
 I'm Looking Over a 4-Leaf Clover Medley|SSAA|Jim Arns
+I'm Looking Over a Four Leaf Clover|SSAA|Ed Waesche
+I'm Looking Over a Four Leaf Clover|TTBB|Ed Waesche
 I'm Looking Over A Four Leaf Clover|SSAA|Bev Sellers
-I'm Looking Over A Four Leaf Clover|SSAA|Ed Waesche
 I'm Looking Over A Four Leaf Clover|SSAA|Larry Wright
 I'm Looking Over A Four Leaf Clover|SSAA|Lorraine Rochefort
 I'm Looking Over A Four Leaf Clover|TTBB|Barbershop Harmony Society
-I'm Looking Over A Four Leaf Clover|TTBB|Ed Waesche
 I'm Looking Over A Four Leaf Clover|TTBB|Larry Wright
-I'm Looking Over A Four-Leaf Clover|TTBB|Barbershop Harmony Society
 I'm Making A Study Of Beautiful Girls|TTBB|Burt Szabo
 I'm Making A Study Of Beautiful Girls (And I'm Still In My Abc's)|TTBB|Dennis Driscoll
 I'M Making Believe I Don'T Care|SSAA|Joni Bescos
@@ -10743,7 +10598,7 @@ I'm Not In Love|SATB|Deke Sharon
 I'm Not That Girl|SSAA|Sam Hubbard
 I'm Not That Girl|SSAA|Steve Tramack
 I'm Not The Only One|SSAA|Nicholas Wright
-I'm Off To See My Sweetness|TTBB|Dan Wilson
+I'm Off to See my Sweetness|TTBB|Dan Wilson
 I'm Off To See My Sweetness|TTBB|Patrick McAlexander
 I'm Old Fashioned|SSAA|Diane Clark
 I'm Old Fashioned|SSAA|Jo Lund
@@ -10751,8 +10606,6 @@ I'm Old Fashioned|SSAA|Renee Craig
 I'm Old Fashioned|TTBB|Brent Graham
 I'm Old Fashioned|TTBB|Roy Dawson
 I'm Old Fashioned|TTBB|Walter Latzko
-I'm Old-Fashioned|SSAA|Diane Clark
-I'm Old-Fashioned|SSAA|Jo Lund
 I'm On Fire|TTBB|Mark Stevens
 I'm On My Way|TTBB|Jon Nicholas
 I'm Outta Love|SSAA|Staffan Paulson
@@ -10766,7 +10619,7 @@ I'm Putting All My Eggs In One Basket|TTBB|Robert Rund
 I'm Ready|TTBB|Nicholas Wright
 I'm Returning Everything|SSAA|Tom Gentry
 I'm Returning Everything|TTBB|Tom Gentry
-I'm Sending A Letter To Santa Claus|SSAA|Carolyn Schmidt
+I'm Sending A Letter to Santa Claus|SSAA|Carolyn Schmidt
 I'm Sending A Message To Daddy|SSAA|Marie Johnson
 I'm Shooting High|SSAA|Kathy Hanneson
 I'm Shooting High|SSAA|Patrick McAlexander
@@ -10783,18 +10636,18 @@ I'm Sittin' Pretty In A Pretty Little City|TTBB|Don Hewey
 I'm Sitting on Top of the World|SSAA|John Hohl/Dave Stevens
 I'm Sitting On Top of the World|SATB|The Boston Consort
 I'm Sitting On Top of the World|SSAA|Lorraine Rochefort
+I'm Sitting On Top of the World|SSAA|Nancy Bergman
+I'm Sitting On Top of the World|SSAA|Renee Craig
 I'm Sitting On Top of the World|SSAA|The Boston Consort
 I'm Sitting On Top of the World|TTBB|John Hohl & Dave Stevens
-I'm Sitting On Top Of The World|SSAA|Nancy Bergman
-I'm Sitting On Top Of The World|SSAA|Renee Craig
 I'm Sitting On Top Of The World|SSAA|Walter Latzko
 I'm Sitting On Top Of The World|TTBB|Boston Consort
 I'm Sitting On Top Of The World|TTBB|Jay Giallombardo
 I'm Sitting On Top Of The World|TTBB|John Hohl
 I'm Sitting On Top Of The World|TTBB|Rob Hopkins
 I'm Sitting On Top Of The World|TTBB|The Boston Consort
+I'm So Alone with the Crowd|TTBB|Steve Jamison
 I'm So Alone With The Crowd|TTBB|SPEBSQSA
-I'm So Alone With The Crowd|TTBB|Steve Jamison
 I'm So Excited|SSAA|Jim Massey
 I'm So Excited|SSAA|Liz Garnett
 I'm So Glad We Had This Time Together|SSAA|Brent Graham
@@ -10856,7 +10709,6 @@ I'm Waiting For Ships That Never Come In|SSAA|Carolyn Johnson
 I'm Waiting For Ships That Never Come In|TTBB|Burt Szabo
 I'm Walkin'|TTBB|Aaron Dale
 I'm Wild About Horns On Automobiles That Go 'Ta-Ta-Ta-Ta'|TTBB|Don Gray
-I'm Wild About Horns On Automobiles That Go "Ta-Ta-Ta-Ta"|TTBB|Don Gray
 I'm Wishing My Life Away|TTBB|Burt Szabo
 I'm with you|SATB|Joe Mannherz
 I'm with you|SSAA|Deke Sharon
@@ -10915,18 +10767,18 @@ I've Got A Golden Ticket|TTBB|Kevin Keller
 I've Got A Lovely Bunch Of Hot Dogs|TTBB|Bob Brock
 I've Got A Pain In My Sawdust|TTBB|Tom Gentry
 I've Got A Pocketful of Dreams|SSAA|Jon Nicholas
+I've Got My Love to Keep Me Warm|SSAA|Anastasio Rossi
+I've Got My Love to Keep Me Warm|TTBB|Anastasio Rossi
 I've Got My Love To Keep Me Warm|SATB|Deke Sharon
 I've Got My Love To Keep Me Warm|SATB|Joe Mannherz
 I've Got My Love To Keep Me Warm|SATB|Kari Francis
 I've Got My Love To Keep Me Warm|SATB|Kohl Kitzmiller
-I've Got My Love To Keep Me Warm|SSAA|Anastasio Rossi
 I've Got My Love To Keep Me Warm|SSAA|Jon Nicholas
 I've Got My Love To Keep Me Warm|SSAA|June Berg
 I've Got My Love To Keep Me Warm|SSAA|Kohl Kitzmiller
 I've Got My Love To Keep Me Warm|SSAA|Patricia Godfrey
 I've Got My Love To Keep Me Warm|SSAA|Walter Latzko
 I've Got My Love To Keep Me Warm|TTBB|Adam Reimnitz
-I've Got My Love To Keep Me Warm|TTBB|Anastasio Rossi
 I've Got My Love To Keep Me Warm|TTBB|Kohl Kitzmiller
 I've Got My Love To Keep Me Warm|TTBB|Mark Goodney
 I've Got My Love To Keep Me Warm|TTBB|Wayne Grimmer
@@ -10939,14 +10791,14 @@ I've Got The Music In Me|SATB|Deke Sharon
 I've Got The Music In Me|SSAA|Dede Nibler
 I've Got the Time|SSAA|Joe Liles
 I've Got The Time - I've Got The Place|TTBB|Joe Liles
+I've Got the World on a String|SSAA|Larry Wright
 I've Got the World on a String|SSAA|Mac Huff
+I've Got the World on a String|TTBB|Adam Reimnitz
 I've Got the World on a String|TTBB|Unspecified
 I've Got The World On A String|SATB|Joe Mannherz
 I've Got The World On A String|SSAA|Dede Nibler
 I've Got The World On A String|SSAA|Joe Mannherz
-I've Got The World On A String|SSAA|Larry Wright
 I've Got The World On A String|SSAA|Tom Gentry
-I've Got The World On A String|TTBB|Adam Reimnitz
 I've Got The World On A String|TTBB|Dom Finetti
 I've Got The World On A String|TTBB|Kohl Kitzmiller
 I've Got The World On A String|TTBB|Larry Wright
@@ -11099,9 +10951,9 @@ If I Had A Million Dollars|TTBB|Dan Naumann
 If I Had A Voice|SSAA|Dede Nibler
 If I Had My Druthers|TTBB|Mark Goodney
 If I Had My Life to Live Over|SSAA|Joni Bescos
+If I Had My Life to Live Over|SSAA|Nancy Bergman
 If I Had My Life To Live Over|SSAA|June Berg
 If I Had My Life To Live Over|SSAA|Mary K. Coffman Music Fund
-If I Had My Life To Live Over|SSAA|Nancy Bergman
 If I Had My Life To Live Over|SSAA|Tedda Lippincott
 If I Had My Life To Live Over|TTBB|Hal Boehler
 If I Had My Life To Live Over|TTBB|Merrill Miller
@@ -11195,17 +11047,17 @@ If I Only Had A Brain|TTBB|Clay Hine
 If I Only Had A Brain / Heart Medley|TTBB|Lloyd Steinkamp
 If I Only Had A Heart (Brain)|SATB|Deke Sharon
 If I Only Knew Where She's Gone|TTBB|Robert Rund
+If I Ruled the World|SSAA|Nancy Bergman
 If I Ruled the World|SSAA|Renee Craig
+If I Ruled the World|TTBB|Fred King
 If I Ruled The World|SSAA|Don Gray
 If I Ruled The World|SSAA|Ed Waesche
 If I Ruled The World|SSAA|Jay Giallombardo
 If I Ruled The World|SSAA|June Dale
-If I Ruled The World|SSAA|Nancy Bergman
 If I Ruled The World|SSAA|Renee Craig/Nancy Bergman
 If I Ruled The World|SSAA|Robert Rund
 If I Ruled The World|TTBB|Don Gray
 If I Ruled The World|TTBB|Ed Waesche
-If I Ruled The World|TTBB|Fred King
 If I Ruled The World|TTBB|Hal Snyder
 If I Ruled The World|TTBB|Jim Clancy
 If I Ruled The World|TTBB|Joe Mannherz
@@ -11224,7 +11076,7 @@ If I Were A Fish|SATB|Melody Hine
 If I Were A Rich Man|TTBB|Walter Latzko
 If I Were King Of The Forest|TTBB|Lloyd Steinkamp
 If I Were the Only Girl|SSAA|Renee Craig
-If I Were The Only Girl In The World|SSAA|Nancy Bergman
+If I Were the Only Girl in the World|SSAA|Nancy Bergman
 If I Were You|SSAA|LaVeda Redfield
 If I Were You I'd Fall In Love With Me|SSAA|Larry Wright
 If I Were You I'd Fall In Love With Me|TTBB|Larry Wright
@@ -11258,7 +11110,7 @@ If The Lord Be Willin'|TTBB|Mark Smith
 If The Lord Be Willin'|TTBB|SPEBSQSA
 If The Lord Be Willin' (And The Creek Don't Rise)|TTBB|Barbershop Harmony Society
 If the Lord Be Willing|TTBB|Dave Briner
-If The Rest Of The World Don't Want You|TTBB|Louis Perry
+If the Rest of the World Don't Want You|TTBB|Louis Perry
 If The Rest Of The Worlds Don't Want You|TTBB|Lou Perry
 If The World Was Ending|TTBB|Greg Mallett
 If There Never Was An Ireland|SSAA|Nancy Bergman
@@ -11269,7 +11121,7 @@ If There's Anybody Here|SATB|Dave Briner
 If There's Anybody Here|SATB|David Briner
 If There's Anybody Here|SSAA|David Briner
 If There's Anybody Here|TTBB|Ardeth Fullmer
-If There's Anybody Here (From Out Of Town)|TTBB|Ardeth Fullmer
+If There's Anybody Here (From Out of Town)|TTBB|Ardeth Fullmer
 If There's Anybody Here From My Home Town|TTBB|Dennis Driscoll
 If There's Anybody Here From My Hometown|SATB|Dave Briner
 If There's Anybody Here From Out Of Town|SATB|Dave Briner
@@ -11332,7 +11184,6 @@ If You Leave Me Now|TTBB|Anders Lindqvist
 If You Leave Me, I'll Never Cry|TTBB|Dennis Burnett
 If You Love Me|SSAA|Nancy Bergman
 If You Love Me (Really Love Me)|TTBB|Renee Craig
-If You Love Me Really Love Me|SSAA|Nancy Bergman
 If You Love Me, Really Love Me|SSAA|David Wright
 If You Love Me, Really Love Me|SSAA|Nancy Bergman
 If You Love Me, Really Love Me|SSAA|Renee Craig
@@ -11407,7 +11258,7 @@ In A Shanty In Old Shanty Town|TTBB|Walter Latzko
 IN A SHANTY IN OLD SHANTY TOWN|SSAA|Sylvia Asbury
 In a Very Unusual Way|TTBB|Adam Scott
 In A World Like This|TTBB|Simon Arnott
-In An Old Barbershop Chair|TTBB|Joe Liles
+In an Old Barbershop Chair|TTBB|Joe Liles
 In Apple Blossom Time|TTBB|Dick Johnson
 In Between Ox & Donkey Gray|SSAA|Diane Clark
 In Flander's Fields|TTBB|Adam Scott
@@ -11474,9 +11325,7 @@ In The Chapel In the Moonlight|SSAA|Tedda Lippincott
 In The City Of God Knows Where|TTBB|Burt Szabo
 In the City of God-Knows-Where|SSAA|Burt Szabo
 In The City Where Nobody Cares|TTBB|Burt Szabo
-In The Cool Cool Cool Of The Evening|SSAA|Susan Kegley
 In The Cool Cool Cool Of The Evening|TTBB|Jack Schievelbein
-In The Cool Cool Cool Of The Evening|TTBB|Jim Dodge
 In The Cool Cool Cool Of The Evening|TTBB|Jim Shubert
 In The Cool Cool Cool Of The Evening|TTBB|Kohl Kitzmiller
 In the Cool, Cool, Cool of the Evening|TTBB|Jim Dodge
@@ -11488,12 +11337,12 @@ In The Evening By The Moonlight|TTBB|Tom Gentry
 In the First Light|SSAA|Sheryl Neal
 In the First Light|TTBB|Bob Kauflin
 In the First Light|TTBB|Sheryl Neal
+In the Garden|SSAA|Vicki Uhr
 In the Garden|TTBB|Joe Johnson
 In The Garden|SSAA|Diane Clark
 In The Garden|SSAA|Jo Lund
 In The Garden|SSAA|Joe Liles
 In The Garden|SSAA|Tedda Lippincott
-In The Garden|SSAA|Vicki Uhr
 In The Garden|TTBB|Jason Graham
 In The Garden|TTBB|Joe Liles
 In The Garden|TTBB|Roy Keys
@@ -11512,9 +11361,9 @@ In The Good Old Summertime|TTBB|Toban Dvoretsky
 In The Good Old Summertime|TTBB|Walter Latzko
 In The Heart Of A Fool|TTBB|Burt Szabo
 In The Heart Of An Irish Rose|TTBB|Burt Szabo
+In the Heart of the City That Has No Heart|TTBB|Tom Gentry
 In The Heart Of The City That Has No Heart|TTBB|Jack Baird
 In The Heart Of The City That Has No Heart|TTBB|Louis Perry
-In The Heart Of The City That Has No Heart|TTBB|Tom Gentry
 In the Hills of Shiloh|TTBB|Jay Giallombardo
 In the Hollow of Thy Hand|TTBB|Aaron Dale
 In The Land Of Beginning Again|TTBB|Burt Szabo
@@ -11541,13 +11390,13 @@ In The Shade Of The Old Apple Tree|TTBB|Burt Szabo
 In The Shade Of The Old Apple Tree|TTBB|Jack Baird
 In The Shade Of The Old Apple Tree|TTBB|Mo Rector
 In The Shade Of The Old Apple Tree|TTBB|Tom Gentry
+In the Still of the Night|SSAA|Tom Gentry
+In the Still of the Night|TTBB|Tom Gentry
 In The Still Of The Night|SATB|Deke Sharon
 In The Still Of The Night|SATB|Tom Gentry
 In The Still Of The Night|SSAA|Karen McCarville
 In The Still Of The Night|SSAA|Larry Wright
-In The Still Of The Night|SSAA|Tom Gentry
 In The Still Of The Night|TTBB|Larry Wright
-In The Still Of The Night|TTBB|Tom Gentry
 In The Still Of The Night|TTBB|Unspecified
 In the Still of the Nite|SATB|Tom Gentry
 In the Still of the Nite|SSAA|Tom Gentry
@@ -11642,9 +11491,7 @@ Irish Blessing|SATB|Don Gray
 Irish Blessing|SSAA|Don Gray
 Irish Blessing|SSAA|Greg Backwell
 Irish Blessing|SSAA|Jay Giallombardo
-Irish Blessing|SSAA|Jean McFadyen
 Irish Blessing|SSAA|Paul Grimm
-Irish Blessing|SSAA|Sylvia Alsbury
 Irish Blessing|TTBB|Dennis Driscoll
 Irish Blessing|TTBB|Don Gray
 Irish Blessing|TTBB|Mel Knight
@@ -11667,7 +11514,6 @@ Is Somebody Singing|TTBB|Chris Arnold
 Is This Just Another Song|SSAA|Robert Disney
 Is This Just Another Song|TTBB|Robert Disney
 Is This Just Another Song?|TTBB|Bob Disney
-Is You Is Or Is You Ain't (Ma Baby)|SSAA|Jean McFadyen
 Is You Is Or Is You Ain't (Ma Baby)|TTBB|Ian Crane
 Is You Is Or Is You Ain't (Ma Baby)?|TTBB|Greg Volk
 Is You Is Or Is You Ain't My Baby|SSAA|Clay Hine
@@ -11685,7 +11531,6 @@ Isn't It A Pity|TTBB|Joe Mannherz
 Isn't It Romantic|SATB|Sam Hubbard
 Isn't It Romantic|SSAA|Joan D 'Agostino
 Isn't It Romantic|TTBB|Walter Latzko
-ISN'T IT ROMANTIC|SSAA|Joan D'Agostino
 Isn't She Lovely|SATB|Adam Scott
 Isn't She Lovely|TTBB|John Brockman
 Isn't She Lovely|TTBB|Mike Menefee
@@ -11722,11 +11567,11 @@ IT CAME UPON A MIDNIGHT CLEAR, O COME ALL YE FAITHFUL Medley - YW|SSAA|Carolyn E
 It Came Upon A Midnight Clear/Silent Night Medley|TTBB|Jim Clancy
 It Came Upon A Midnight Clear/Silent Night Medley(Jim Cl|TTBB|Jim Clancy
 It Can't Be Wrong|SSAA|Sonny Steffan
-It Could Happen To You|SATB|Gene Cokeroft
+It Could Happen to You|SATB|Gene Cokeroft
+It Could Happen to You|SSAA|Gene Cokeroft
+It Could Happen to You|TTBB|Gene Cokeroft
 It Could Happen To You|SSAA|Dede Nibler
-It Could Happen To You|SSAA|Gene Cokeroft
 It Could Happen To You|TTBB|Dennis Driscoll
-It Could Happen To You|TTBB|Gene Cokeroft
 It Could Happen To You|TTBB|Joe Johnson
 It Could Happen To You|TTBB|Scott Kitzmiller
 It Could Happen To You|TTBB|Steven Armstrong
@@ -11750,14 +11595,14 @@ It Feels Like Christmas|TTBB|Matt Astle
 It Feels Like Home|SSAA|Mark Burnip
 It Feels Like Home|SSAA|Nancy Shumard
 It Feels Like Home|TTBB|Mark Burnip
-It Gets You Right Here|SSAA|Nancy Bergman
 It Gets You Right Here|TTBB|Nancy Bergman
 It Gets You Right Here!|SSAA|Nancy Bergman
+It Had to Be You|SATB|Barbershop Harmony Society
+It Had to Be You|SSAA|Barbershop Harmony Society
 It Had to Be You|SSAA|Nancy Bergman
+It Had to Be You|TTBB|Barbershop Harmony Society
 It Had to Be You|TTBB|Steve Armstrong
-It Had To Be You|SATB|Barbershop Harmony Society
 It Had To Be You|SATB|Steve Tramack
-It Had To Be You|SSAA|Barbershop Harmony Society
 It Had To Be You|SSAA|Carolyn Schmidt
 It Had To Be You|SSAA|Connie Kash
 It Had To Be You|SSAA|Debbie Keretz
@@ -11770,7 +11615,6 @@ It Had To Be You|SSAA|Kevin Keller
 It Had To Be You|SSAA|Suzy Lobaugh
 It Had To Be You|SSAA|Suzy Lobaugh, Greg Williams
 It Had To Be You|SSAA|Tedda Lippincott
-It Had To Be You|TTBB|Barbershop Harmony Society
 It Had To Be You|TTBB|Bruce Evans
 It Had To Be You|TTBB|Dennis Driscoll
 It Had To Be You|TTBB|Don Gray
@@ -11792,6 +11636,7 @@ It Happened In Monterrey|TTBB|John Brockman
 It Hurt So Bad|TTBB|Kyle Snook
 It Is No Secret|TTBB|R. Ellwanger
 It Is No Secret|TTBB|R. J. Margison
+It is Well with My Soul|TTBB|Jim Clancy
 It Is Well With My Soul|SATB|Tamra Perez
 It Is Well With My Soul|SATB|Tom Gentry
 It Is Well With My Soul|SSAA|David Harrington
@@ -11805,7 +11650,6 @@ It Is Well With My Soul|TTBB|Dan Tice
 It Is Well With My Soul|TTBB|David Harrington
 It Is Well With My Soul|TTBB|David Zimmerman
 It Is Well With My Soul|TTBB|Derric Johnson
-It Is Well With My Soul|TTBB|Jim Clancy
 It Is Well With My Soul|TTBB|Joe Liles
 It Is Well With My Soul|TTBB|Larry Wright
 It Is Well With My Soul|TTBB|Paul Jorg
@@ -11823,10 +11667,10 @@ It Never Was You|SSAA|Kevin Keller
 It Never Was You|TTBB|Kevin Keller
 It Only Happens When I Dance With You|SSAA|Sonny Steffan
 It Only Happens When I Dance With You|TTBB|David Longroy
+It Only Takes a Moment|TTBB|David Wright
 It Only Takes A Moment|SATB|Joe Mannherz
 It Only Takes A Moment|SSAA|David Wright
 It Only Takes A Moment|SSAA|Joe Mannherz
-It Only Takes A Moment|TTBB|David Wright
 It Only Takes A Moment|TTBB|Ed Waesche
 It Only Takes A Moment|TTBB|Joe Mannherz
 It Only Takes A Moment (from Hello, Dolly!)|TTBB|David Wright
@@ -11841,8 +11685,8 @@ It Takes Two|TTBB|Dom Finetti
 It Takes Two|TTBB|Joe Grimme
 It Was A Very Good Year|TTBB|Larry Wright
 It Was A Very Good Year|TTBB|Todd Troutman
+It Was Almost Like a Song|SSAA|June Berg
 It Was Almost Like A Song|SSAA|Debbie Keretz
-It Was Almost Like A Song|SSAA|June Berg
 It Was Almost Like A Song|SSAA|Kay Bromert
 It Was Almost Like A Song|SSAA|Tedda Lippincott
 It Was Almost Like A Song|SSAA|Tom Gentry
@@ -11864,34 +11708,34 @@ It's A Beautiful Day|TTBB|Dan Wessler
 It's A Beautiful Day|TTBB|Greg Mallett
 It's A Beautiful Day|TTBB|Hilary Allen
 It's a Beautiful Day for a Bal|TTBB|Dennis Driscoll
+It's a Beautiful Day For a Ball Game|TTBB|Dennis Driscoll
 It's A Beautiful Day For A Ball Game|SSAA|Brent Graham
 It's A Beautiful Day For A Ball Game|SSAA|Jay Giallombardo
 It's A Beautiful Day For A Ball Game|TTBB|Brent Graham
-It's A Beautiful Day For A Ball Game|TTBB|Dennis Driscoll
 It's A Beautiful Day For A Ball Game|TTBB|Jay Giallombardo
 It's A Beautiful Morning|TTBB|Deke Sharon
 It's A Blue World|SSAA|Jean McFadyen
 It's A Blue World|TTBB|Jim West
 It's a Brand New Day|TTBB|Bob Disney
+It's a Brand New Day|TTBB|Robert Disney
 It's A Brand New Day|SSAA|Bob Disney
 It's A Brand New Day|SSAA|Joe Liles
 It's A Brand New Day|SSAA|Robert Disney
 It's A Brand New Day|TTBB|Jim West
-It's A Brand New Day|TTBB|Robert Disney
 It's A Dangerous Game|TTBB|David Wright
+It's a Good Day|SATB|Lloyd Steinkamp
+It's a Good Day|SSAA|Lloyd Steinkamp
+It's a Good Day|TTBB|Lloyd Steinkamp
 It's A Good Day|SATB|Alden Parker
-It's A Good Day|SATB|Lloyd Steinkamp
 It's A Good Day|SSAA|Carolyn Schmidt
 It's A Good Day|SSAA|Chris Arnold
 It's A Good Day|SSAA|Jay Giallombardo
 It's A Good Day|SSAA|Larry Wright
-It's A Good Day|SSAA|Lloyd Steinkamp
 It's A Good Day|TTBB|Bob Dowma
 It's A Good Day|TTBB|Chris Arnold
 It's A Good Day|TTBB|David Wright
 It's A Good Day|TTBB|Jay Giallombardo
 It's A Good Day|TTBB|Larry Wright
-It's A Good Day|TTBB|Lloyd Steinkamp
 It's A Good Day|TTBB|Richard Curtis
 It's A Good Day|TTBB|Val Hicks
 It's a Grand Night for Singing|TTBB|Pete Rupay
@@ -11901,14 +11745,13 @@ It's A Grand Night For Singing|TTBB|Jay Giallombardo
 It's A Grand Night For Singing|TTBB|Rob Hopkins
 It's A Grand Night For Singing|TTBB|Steve Delehanty
 It's A Grand Night For Singing|TTBB|Walter Latzko
+It's a Great Day for the Irish|TTBB|Jack Baird
 It's A Great Day For The Irish|SSAA|Larry Wright
 It's A Great Day For The Irish|SSAA|Nancy Bergman
 It's A Great Day For The Irish|TTBB|Clay Hine
-It's A Great Day For The Irish|TTBB|Jack Baird
 It's A Great Day For The Irish|TTBB|Larry Wright
 It's A Great Day For The Irish|TTBB|Paul Bowman
 It's A Great Day For The Irish / MacNamara's Band|SSAA|Nancy Bergman
-It's a Great Day for the Irish/MacNamara's Band|SSAA|Nancy Bergman
 It's A Hanukkah Song|TTBB|Deke Sharon
 It's a Hanukkah Song (In a Major Key)|TTBB|Larry Triplett
 It's A Jungle Out There|SATB|Kevin Keller
@@ -11925,7 +11768,7 @@ It's A Lovely Day Today (from Call Me Madam)|TTBB|Kohl Kitzmiller
 It's A Lovely Day Today/I Love To Singa Medley|SSAA|Larry Wright
 It's a Man, Every Time, It's a Man|SSAA|Tom Gentry
 It's a Man, Every Time, It's a Man|TTBB|Tom Gentry
-It's A Million To One You're In Love|SSAA|Anna Maria Parker
+It's a Million to One You're in Love|SSAA|Anna Maria Parker
 It's A Million To One You're In Love|SSAA|Joey Minshall
 It's A Million To One You're In Love|SSAA|Kay Bromert
 It's A Million To One You're In Love|SSAA|Marie Johnson
@@ -11952,9 +11795,9 @@ It's A Pity To Say Goodnight|TTBB|Rasmus Krigström
 It's A Pity To Say Goodnight|TTBB|Walter Latzko
 It's A Sign Of Spring|TTBB|Walter Latzko
 It's a Sin to Tell a Lie|SATB|Dave Briner
+It's A Sin to Tell A Lie|SSAA|David Wright
 It's A Sin to Tell A Lie|SSAA|Lorraine Rochefort
 It's A Sin To Tell A Lie|SATB|David Briner
-It's A Sin To Tell A Lie|SSAA|David Wright
 It's A Sin To Tell A Lie|SSAA|Walter Latzko
 It's A Sin To Tell A Lie|TTBB|David Wright
 It's A Sin To Tell A Lie|TTBB|Dennis Driscoll
@@ -11976,7 +11819,6 @@ It's All Over / So Long, Dearie Medley|TTBB|Rob Campbell
 It's All Over Now|TTBB|Burt Szabo
 It's All Over Now / Please Don't Talk About When I'm Gone Medley|TTBB|Ed Waesche
 It's All Over Now / Who's Sorry Now Medley|TTBB|Jim Arns
-It's All Over/So Long, Dearie Medley|TTBB|Rob Campbell
 It's All Right|SSAA|Jeremey Johnson
 It's All Right|TTBB|Adam Scott
 It's All Right|TTBB|Dan Wessler
@@ -12004,10 +11846,10 @@ It's beginning to look a lot like christmas|SSAA|Nancy Bergman
 It's beginning to look a lot like christmas|TTBB|Joe Mannherz
 It's beginning to look a lot like christmas|TTBB|Walter Latzko
 It's Beginning to Look a Lot Like Christmas|SSAA|Louise Hamilton
+It's Beginning To Look a Lot Like Christmas|TTBB|Willis Diekema
 It's Beginning To Look A Lot Like Christmas|SSAA|Jeanne Elmuccio
 It's Beginning To Look A Lot Like Christmas|SSAA|Joan Smith
 It's Beginning To Look A Lot Like Christmas|SSAA|Willis Diekema
-It's Beginning To Look A Lot Like Christmas|TTBB|Willis Diekema
 It'S Beginning To Look A Lot Like Christmas|SSAA|Unspecified
 It's Beginning To Look A Lot Like Christmas / Silver Bells|TTBB|Nancy Bergman
 It's Beginning to Look a Lot Like Xmas/Pine Cones|SSAA|Jean Flinn
@@ -12129,6 +11971,8 @@ It's The Girl|TTBB|Larry Triplett
 It's The Girl|TTBB|Tom Gentry
 It's The Hard-Knock Life|SSAA|Michael Gellert
 It's The Hard-Knock Life|TTBB|Walter Latzko
+It's the Most Wonderful Time of the Year|TTBB|Clay Hine
+It's the Most Wonderful Time of the Year|TTBB|Jay Giallombardo
 It's The Most Wonderful Time of the Year|SSAA|Gwen Schweitzer
 It's The Most Wonderful Time of the Year|SSAA|Nancy Bergman
 It's The Most Wonderful Time Of The Year|SATB|Kay Bromert
@@ -12138,9 +11982,7 @@ It's The Most Wonderful Time Of The Year|SSAA|Larry Wright
 It's The Most Wonderful Time Of The Year|SSAA|Matt Swann
 It's The Most Wonderful Time Of The Year|TTBB|Adam Scott
 It's The Most Wonderful Time Of The Year|TTBB|Brian Hogan
-It's The Most Wonderful Time Of The Year|TTBB|Clay Hine
 It's The Most Wonderful Time Of The Year|TTBB|Derric Johnson
-It's The Most Wonderful Time Of The Year|TTBB|Jay Giallombardo
 It's The Most Wonderful Time Of The Year|TTBB|Larry Wright
 It's The Most Wonderful Time Of The Year|TTBB|Matt Swann
 It's The Most Wonderful Time Of The Year|TTBB|Nancy Bergman
@@ -12153,13 +11995,12 @@ It's the Music that Brings Us Together|TTBB|Clay Hine
 It's The Same Old Dream|SSAA|Joan D 'Agostino
 It's The Same Old Dream|SSAA|Joe Mannherz
 It's The Same Old Dream|TTBB|Joe Mannherz
-IT'S THE SAME OLD DREAM|SSAA|Joan D'Agostino
 It's The Same Old Shillelagh|SSAA|Jay Giallombardo
 It's The Same Old Shillelagh|TTBB|Barbershop Harmony Society
 It's The Same Old Shillelagh|TTBB|Jay Giallombardo
 It's The Same Old Shillelagh|TTBB|Rollie Ransom
 It's The Same Old Shillelagh|TTBB|SPEBSQSA
-It's The Same Old Song|TTBB|Steve Tramack
+It's the Same Old Song|TTBB|Steve Tramack
 It's The Talk Of The Town|SSAA|Dede Nibler
 It's Time|SATB|Deke Sharon
 It's Time|SSAA|David Briner
@@ -12287,7 +12128,6 @@ Jazz Me Blues/Jazzin' in New Orleans Medley|SSAA|Jo Lund
 Jazz Medley|SSAA|Ann Minihane
 Jazz Medley|SSAA|Joe Mannherz
 Jazz Medley|TTBB|Joe Mannherz
-Jazzin In New Orleans|SSAA|Jo Lund
 JAZZIN' IN NEW ORLEANS|SSAA|Jo Lund
 Jazzin' The Blues Away|TTBB|Jon Nicholas
 Jazzman's Serenade|SSAA|Jo Lund
@@ -12300,8 +12140,8 @@ Jealousy|TTBB|Walter Latzko
 Jean|SSAA|Carl Walters
 Jean|TTBB|Carl Walters
 Jean|TTBB|Rob Campbell
+Jeanie With the Light Brown Hair|TTBB|Ed Waesche
 Jeanie With The Light Brown Hair|TTBB|Burt Szabo
-Jeanie With The Light Brown Hair|TTBB|Ed Waesche
 Jeanie With The Light Brown Hair|TTBB|Jon Nicholas
 Jeanie With The Light Brown Hair|TTBB|Nancy Bergman
 Jeannie With The Light Brown Hair|TTBB|Ed Waesche
@@ -12464,11 +12304,13 @@ Journey To The Past|TTBB|Adam Bock
 Joy|SSAA|Kohl Kitzmiller
 Joy|TTBB|Kevin Keller
 Joy Medley|SSAA|Carolyn Johnson
+Joy to the World|SATB|Joe Liles
 Joy to the World|SSAA|David Harrington
+Joy to the World|SSAA|Joe Liles
+Joy to the World|TTBB|Joe Liles
 Joy To The World|SATB|David Harrington
 Joy To The World|SATB|Deke Sharon
 Joy To The World|SATB|Derric Johnson
-Joy To The World|SATB|Joe Liles
 Joy To The World|SATB|John Rutter
 Joy To The World|SATB|Mel Knight
 Joy To The World|SSAA|Brian Beck
@@ -12478,7 +12320,6 @@ Joy To The World|SSAA|Cris Conerty
 Joy To The World|SSAA|Glenda Lloyd
 Joy To The World|SSAA|Jay Giallombardo
 Joy To The World|SSAA|Jeremey Johnson
-Joy To The World|SSAA|Joe Liles
 Joy To The World|TTBB|Brian Beck
 Joy To The World|TTBB|David Harrington
 Joy To The World|TTBB|David Wright
@@ -12486,7 +12327,6 @@ Joy To The World|TTBB|Deke Sharon
 Joy To The World|TTBB|Jay Giallombardo
 Joy To The World|TTBB|Jeremey Johnson
 Joy To The World|TTBB|Joe Johnson
-Joy To The World|TTBB|Joe Liles
 Joy To The World|TTBB|Jon Nicholas
 Joy To The World|TTBB|Nick Bryant
 JOY TO THE WORLD|SSAA|Elaine Gain
@@ -12559,11 +12399,11 @@ Just A Girl That Men Forget|TTBB|Ken Wimbish
 Just A Girl That Men Forget|TTBB|Tom Gentry
 Just A Girl That Men Forget|TTBB|Unknown
 Just A Girl That Men Forget|TTBB|Walter Latzko
+Just a Kid Named Joe|TTBB|Ed Waesche
 Just A Kid Named Joe|SSAA|Betty Grant
 Just A Kid Named Joe|SSAA|Don Wilkenson
 Just A Kid Named Joe|TTBB|David Briner
 Just A Kid Named Joe|TTBB|David Wright
-Just A Kid Named Joe|TTBB|Ed Waesche
 Just A Kid Named Joe|TTBB|Kevin Keller
 Just A Kid Named Joe|TTBB|Rob Campbell
 Just A Letter From Ohio|TTBB|Tom Gentry
@@ -12593,7 +12433,6 @@ Just Because|TTBB|Jim West
 Just Because / How Could You Believe Me (parody) Medley|TTBB|Larry Jackson
 Just Because / Shine|TTBB|Earl Moon
 Just Because / Shine Medley|TTBB|Earl Moon
-Just Because/Shine (Medley)|TTBB|Earl Moon
 Just Between Old Friends|TTBB|Joe Johnson
 Just Bring Tulips Along|TTBB|Brent Graham
 Just For A Girl|TTBB|Toban Dvoretsky
@@ -12619,7 +12458,7 @@ Just Maybe|SATB|Wayne Grimmer
 Just My Imagination|TTBB|Aaron Dale
 Just Once|TTBB|Robert Rund
 Just One More Chance|TTBB|Jerry Bockus
-Just One Of Those Things|SSAA|Joni Bescos
+Just One of Those Things|SSAA|Joni Bescos
 Just One Of Those Things|TTBB|Aaron Dale
 Just One Of Those Things|TTBB|Ed Hinkley
 Just One Of Those Things|TTBB|Joni Bescos
@@ -12661,7 +12500,6 @@ Kansas City|SSAA|Jay Giallombardo
 Kansas City|SSAA|Jo Kraut
 Kansas City|TTBB|Jay Giallombardo
 Kansas City Here I Come|SSAA|Jay Giallombardo
-Kansas City Here I Come|TTBB|Jay Giallombardo
 Kansas City Star|SSAA|Jay Giallombardo
 Kansas City Star|TTBB|Jack Baird
 Kansas City Star|TTBB|Jay Giallombardo
@@ -12698,7 +12536,7 @@ Keep The Whole World Singing|TTBB|Barbershop Harmony Society
 Keep The Whole World Singing|TTBB|Joe Liles
 Keep The Whole World Singing|TTBB|Willis Diekema
 Keep Young and Beautiful|TTBB|Walter Latzko
-Keep Your Eye On The Girlie You Love|TTBB|Barbershop Harmony Society
+Keep Your Eye on the Girlie You Love|TTBB|Barbershop Harmony Society
 Keep Your Eye On The Girlie You Love|TTBB|Jack Baird
 Keep Your Eye On The Girlie You Love|TTBB|Steve Delehanty
 Keep Your Eye On The Girlie You Love / Somebody Stole My Gal|TTBB|Jack Baird, Dick Johnson
@@ -12730,7 +12568,6 @@ Kid's Song/Coney Island Washboard|SSAA|Larry Wright
 Kid's Song/Coney Island Washboard|TTBB|Larry Wright
 Kids In America|SATB|Deke Sharon
 Kids/Coney Island Washboard|TTBB|139th Street Quartet
-Kids/Coney Island Washboard|TTBB|139th Street Quartet,
 Killer Queen|SSAA|Adam Bock
 Killer Queen|TTBB|Adam Bock
 Killer Queen|TTBB|Adam Scott
@@ -12751,6 +12588,8 @@ King of Anything|SSAA|Deke Sharon
 King Of My Heart|SATB|Nicholas Wright
 King Of New York (from Newsies)|TTBB|Josh Ehrlich/Larry Bomback
 King Of Spain|TTBB|Moxy Fruvous
+King of the Road|TTBB|Gene Cokeroft
+King of the Road|TTBB|Scott Kitzmiller
 King Of The Road|SATB|Anders Lindqvist
 King Of The Road|SATB|Joe Mannherz
 King Of The Road|SATB|Kevin Keller
@@ -12758,13 +12597,11 @@ King Of The Road|SSAA|Kevin Keller
 King Of The Road|SSAA|Marilyn Penketh
 King Of The Road|TTBB|Dennis Driscoll
 King Of The Road|TTBB|Fran Wilson
-King Of The Road|TTBB|Gene Cokeroft
 King Of The Road|TTBB|Jay Giallombardo
 King Of The Road|TTBB|Jim Shubert
 King Of The Road|TTBB|Jim West
 King Of The Road|TTBB|Kevin Keller
 King Of The Road|TTBB|Mike Menefee
-King Of The Road|TTBB|Scott Kitzmiller
 King Of The Road|TTBB|Tom Gentry
 King of Wishful Thinking|TTBB|Deke Sharon
 Kings And Queens|TTBB|Nicholas Wright
@@ -12803,9 +12640,9 @@ Kiss To Build A Dream On/Dreams Medley|SSAA|Anthony Sparks
 Kiss, Kiss, Kissin' In The Corn|SSAA|Walter Latzko
 Kisses Sweeter Than Wine|TTBB|David Briner
 Kisses Sweeter Than Wine|TTBB|Walter Latzko
+Kissing a Fool|TTBB|Kyle Kitzmiller
 Kissing A Fool|TTBB|Chris Arnold
 Kissing A Fool|TTBB|Jay Giallombardo
-Kissing A Fool|TTBB|Kyle Kitzmiller
 Kitten On The Keys|TTBB|Walter Latzko
 Knee Deep|TTBB|Kevin Keller
 Knight Quest Medley|TTBB|Tom Gentry
@@ -12841,7 +12678,6 @@ Kwmbayah|TTBB|K.J. Dinham
 Kyrie|TTBB|Mark Stevens, Will Makra
 L-O-V-E|SATB|Larry Triplett
 L-O-V-E|SSAA|Anastasio Rossi
-L-O-V-E|SSAA|Larry Triplett
 L-O-V-E|SSAA|Nancy Bergman
 L-O-V-E|SSAA|Tony Nasto
 L-O-V-E|TTBB|Ben Ferguson
@@ -12890,20 +12726,20 @@ Larger Than Life|TTBB|Deke Sharon
 Last Christmas|SATB|Henrik Rosenberg
 Last Name|SATB|Deke Sharon
 Last night|SATB|Joe Mannherz
-Last Night On The Back Porch|SSAA|Nancy Bergman
+Last Night On the Back Porch|SSAA|Nancy Bergman
 Last Night On The Back Porch|TTBB|Burt Szabo
 Last Night On The Back Porch|TTBB|Dennis Driscoll
 Last Night On The Back Porch|TTBB|Dick Belote
 Last Night On The Back Porch|TTBB|Gay Notes
 Last Night On The Back Porch|TTBB|The Gaynotes
 Last Night On The Back Porch|TTBB|Tom Gentry
+Last Night Was the End of the World|SATB|Barbershop Harmony Society
 Last Night Was the End of the World|SSAA|Jim Clancy
-Last Night Was The End Of The World|SATB|Barbershop Harmony Society
+Last Night Was the End of the World|SSAA|Tedda Lippincott
 Last Night Was The End Of The World|SSAA|Barbershop Harmony Society
 Last Night Was The End Of The World|SSAA|Inc. SPEBSQSA
 Last Night Was The End Of The World|SSAA|Jo Lund
 Last Night Was The End Of The World|SSAA|SPEBSQSA
-Last Night Was The End Of The World|SSAA|Tedda Lippincott
 Last Night Was The End Of The World|TTBB|Barbershop Harmony Society
 Last Night Was The End Of The World|TTBB|Brent Graham
 Last Night Was The End Of The World|TTBB|Buzz Haeger
@@ -12992,6 +12828,7 @@ Leader Of The Pack|SSAA|Dede Nibler
 Leader Of The Pack|SSAA|Deke Sharon
 Leader Of The Pack|SSAA|Larry Wright
 Leader Of The Pack|TTBB|Todd Troutman
+Lean on Me|SSAA|Tedda Lippincott
 Lean On Me|SATB|Cay Outerbridge
 Lean On Me|SATB|Deke Sharon
 Lean On Me|SATB|Tom Gentry
@@ -13000,7 +12837,6 @@ Lean On Me|SSAA|Jan-Ake Westin
 Lean On Me|SSAA|Joey Minshall
 Lean On Me|SSAA|Joey Minshall YWIH
 Lean On Me|SSAA|Nancy Shumard
-Lean On Me|SSAA|Tedda Lippincott
 Lean On Me|TTBB|Adam Anders and Tim Davis
 Lean On Me|TTBB|Alex Kaiserman
 Lean On Me|TTBB|Craig Gibbins
@@ -13136,6 +12972,7 @@ Let The Good Times Roll|TTBB|Wayne Grimmer
 Let The Lower Lights Be Burning|SSAA|Joe Liles
 Let The Lower Lights Be Burning|TTBB|Joe Liles
 Let The Rain|SATB|Nicholas Wright
+Let the Rest of the World Go By|TTBB|Kirk Roose
 Let The Rest Of The World Go By|SSAA|Dianne Goldrick
 Let The Rest Of The World Go By|SSAA|Jo Lund
 Let The Rest Of The World Go By|SSAA|Walter Latzko
@@ -13143,11 +12980,10 @@ Let The Rest Of The World Go By|TTBB|Advanced Arranger's Class, Harmony Educatio
 Let The Rest Of The World Go By|TTBB|Dennis Driscoll
 Let The Rest Of The World Go By|TTBB|Douglas Beck
 Let The Rest Of The World Go By|TTBB|Jack Baird
-Let The Rest Of The World Go By|TTBB|Kirk Roose
 Let The Rest Of The World Go By|TTBB|Mike Menefee
+Let the River Run|SSAA|Sylvia Alsbury
 Let The River Run|SSAA|Eric Ruthenberg
 Let The River Run|SSAA|Liz Garnett
-Let The River Run|SSAA|Sylvia Alsbury
 Let The Sunshine In|SSAA|Carolyn Schmidt
 Let The Sunshine In|SSAA|Emily Moriarty
 Let The Sunshine In|SSAA|Larry Wright
@@ -13208,7 +13044,6 @@ Let Yourself Go|SSAA|Kyle Snook
 Let Yourself Go|SSAA|Larry Wright
 Let Yourself Go|TTBB|David Wright
 Let Yourself Go|TTBB|Larry Wright
-LET YOURSELF GO|SSAA|Joan D'Agostino
 Let Yourself Go / Crazy Rhythm Medley|TTBB|Dave Ebersole
 Let Yourself Go/Crazy Rhythm Medley|TTBB|David Ebersole
 Let Yourself Go/Doin' the New Low Down|SSAA|Dave Briner
@@ -13222,8 +13057,8 @@ Let's Be Buddies|TTBB|David Briner
 Let's Burn Up the Town|SSAA|Anthony Nasto
 Let's Burn Up The Town|TTBB|Adam Reimnitz
 Let's Burn Up The Town|TTBB|Tony Nasto
+Let's Call the Whole Thing Off|SSAA|Carolyn Schmidt
 Let's Call The Whole Thing Off|SATB|Gene Cokeroft
-Let's Call The Whole Thing Off|SSAA|Carolyn Schmidt
 Let's Call The Whole Thing Off|SSAA|Joe Mannherz
 Let's Call The Whole Thing Off|TTBB|Hal Maples
 Let's Call The Whole Thing Off|TTBB|Joe Mannherz
@@ -13239,7 +13074,6 @@ Let's Do It (Let's Fall In Love)|TTBB|John Brockman
 Let's Do It (Let's Fall In Love) / Let's Misbehave Medley|TTBB|Matthew Gallagher
 Let's Do It Again|TTBB|Tom Gentry
 Let's Do It, Let's Fall in Love|SSAA|Lynnell Diamond
-Let's Do It, Let's Fall In Love|SSAA|John Brockman
 Let's Do It/Let's Misbehave (Medley)|TTBB|Matt Gallagher
 Let's Elope|SSAA|Carolyn Schmidt
 Let's Face The Music And Dance|SSAA|David Wright
@@ -13368,7 +13202,7 @@ Life In Technicolor II|TTBB|Nicholas Wright
 Life Is A Highway|SSAA|Brent Graham
 Life Is A Highway|SSAA|Joey Minshall
 Life Is A Highway|TTBB|Nicholas Wright
-Life Is Just A Bowl of Cherries|SATB|Gene Cokeroft
+Life Is Just a Bowl of Cherries|SATB|Gene Cokeroft
 Life Is Just A Bowl of Cherries|TTBB|Dennis Driscoll
 Life On Mars|TTBB|Anders Lindqvist
 LIFE UPON THE WICKED STAGE|SSAA|Tedda Lippincott
@@ -13387,7 +13221,7 @@ Light One Candle|SSAA|Jay Giallombardo
 Light One Candle|SSAA|Muriel Berg
 Light One Candle|TTBB|Carole Prietto
 Light One Candle|TTBB|Jay Giallombardo
-Light The Candles|SSAA|Tedda Lippincott
+Light the Candles|SSAA|Tedda Lippincott
 Light The Legend|SSAA|Jay Giallombardo
 Light The Legend|TTBB|Jay Giallombardo
 Light Up Your Life With Harmony|TTBB|Gene Cokeroft
@@ -13432,14 +13266,9 @@ Linger Awhile|TTBB|Walter Latzko
 Linin Track|SATB|Deke Sharon
 Linus and Lucy|SSAA|Larry Wright
 Lion Sleeps Tonight|SATB|Deke Sharon
-Lion Sleeps Tonight|SATB|Scott Turnbull
 Lion Sleeps Tonight|SSAA|Charlene Yazurlo
 Lion Sleeps Tonight|SSAA|Joey Minshall
 Lion Sleeps Tonight|SSAA|Lorraine Rochefort
-Lion Sleeps Tonight|SSAA|Molly Clark
-Lion Sleeps Tonight|SSAA|Scott Turnbull
-Lion Sleeps Tonight|SSAA|Tedda Lippincott
-Lion Sleeps Tonight|TTBB|Scott Turnbull
 Lion Sleeps Tonight|TTBB|Thomas Degan
 Lion Sleeps Tonight (The) SATB|SATB|Anne Raugh and Seke Sharon
 Lion Sleeps Tonight, The (Wimoweh)|TTBB|Ron Smail
@@ -13496,19 +13325,15 @@ Little Drummer Boy|SSAA|Joey Minshall
 Little Drummer Boy|SSAA|Tedda Lippincott
 Little Drummer Boy|TTBB|Adam Scott
 Little Drummer Boy|TTBB|Bruce Early
-Little Drummer Boy|TTBB|David Wright
 Little Drummer Boy|TTBB|Derric Johnson
 Little Drummer Boy|TTBB|Jim Raycroft
-Little Drummer Boy|TTBB|Jon Nicholas
 Little Drummer Boy|TTBB|M. Gill
 Little Drummer Boy|TTBB|Todd Troutman
-Little Drummer Boy|TTBB|Tracy Shirk
 Little Drummer Boy / Peace On Earth|TTBB|Jay Giallombardo
 Little Drummer Boy & Silent Night Medley|SSAA|Rosey Frerking
 Little Drummer Boy/Peace on Earth|SSAA|Joey Minshall
 Little Girl|SSAA|David Wallace
 Little Girl|SSAA|Mac Huff
-Little Girl|SSAA|Tom Gentry
 Little Girl|TTBB|Lou Perry
 Little Girl|TTBB|Mac Huff
 Little Girl|TTBB|Todd Troutman
@@ -13569,9 +13394,7 @@ Little Pal|TTBB|Louis Perry
 Little Pal|TTBB|Tom Gentry
 Little Pal (Parody)|TTBB|Clay Hine
 Little Pal (TTBB) (arr. Perry) - as sung by The Four Rascals|TTBB|Louis Perry
-Little Patch Of Heaven|SSAA|Aaron Dale
 Little Patch Of Heaven|SSAA|Michael Gellert
-Little Patch Of Heaven|TTBB|Aaron Dale
 Little Patch Of Heaven|TTBB|Dennis Driscoll
 Little Patch Of Heaven|TTBB|Mark Goodney
 Little Rascals Medley|TTBB|Greg Volk
@@ -13598,10 +13421,8 @@ Little Shop Of Horrors|SSAA|Ken Potter
 Little Skipper|TTBB|Robert Strand
 Little Snow Girl|TTBB|Jim Clancy
 Little St Nick|TTBB|Steve Jamison
-Little Street Where Old Friends Meet|TTBB|Burt Szabo
 Little Street Where Old Friends Meet|TTBB|Jay Giallombardo
-Little Street Where Old Friends Meet|TTBB|Sam Breedon
-Little Things Mean A Lot|SSAA|June Dale
+Little Things Mean a Lot|SSAA|June Dale
 Little Things Mean A Lot|TTBB|Bob Biallas
 Little Things Mean A Lot|TTBB|Dennis Driscoll
 Little Things Mean A Lot|TTBB|Michael Webber
@@ -13682,7 +13503,6 @@ Lonesome Looser|SATB|Joe Mannherz
 Lonesome Road|TTBB|Mike Menefee
 Lonesome Suzie|TTBB|Joe Mannherz
 Lonesomest Girl In Town|SSAA|Jay Giallombardo
-Lonesomest Girl In Town|SSAA|Joni Bescos
 Lonesomest Girl In Town|TTBB|Brent Graham
 Lonesomest Girl In Town|TTBB|Clay Hine
 Lonesomest Girl In Town|TTBB|David Harrington
@@ -13712,7 +13532,6 @@ Longest Time (The)|SATB|Tom Gentry
 LONGEST TIME, THE (bass solo + 4 parts)|SSAA|Carolyn Schmidt
 Look At That Face|SSAA|Tedda Lippincott
 Look At Us|SSAA|Tedda Lippincott
-Look For Me At Jesus Feet|SSAA|Janice Wheeler
 LOOK FOR ME AT JESUS' FEET|SSAA|Janice Wheeler
 Look For Me Honey|TTBB|Dan Wilson
 Look For The Light|SATB|Justin Miller
@@ -13742,6 +13561,7 @@ Lookin' At The World Through Rose Colored Glasses|TTBB|Greg Lyne
 Lookin' At The World Through Rose Colored Glasses(Greg|TTBB|Greg Lyne
 Lookin' At The World Thru Rose Colored Glasses|TTBB|David Wright
 Looking At The Rain And Missing You|SSAA|Marie Johnson
+Looking at the World Through Rose Colored Glasses|TTBB|Sherry Brown
 Looking At The World Through Rose Colored Glasses|SSAA|David Wright
 Looking At The World Through Rose Colored Glasses|TTBB|Chuck Williams
 Looking At The World Through Rose Colored Glasses|TTBB|David Wright
@@ -13751,7 +13571,6 @@ Looking At The World Through Rose Colored Glasses|TTBB|Gregory Lyne
 Looking At The World Through Rose Colored Glasses|TTBB|James Moore
 Looking At The World Through Rose Colored Glasses|TTBB|Johann Stoessel
 Looking At The World Through Rose Colored Glasses|TTBB|Mark Freedkin
-Looking At The World Through Rose Colored Glasses|TTBB|Sherry Brown
 Looking At The World Through Rose Colored Glasses|TTBB|Ted Cobb
 Looking At The World Through Rose Colored Glasses(David Wr|TTBB|David Wright
 Looking at the World through Rose Coloured Glasses|TTBB|Ed Waesche
@@ -13773,9 +13592,7 @@ Lora-Belle Lee (aka "Lorabelle Lee")|TTBB|Dave Briner
 Lorabelle Lee|TTBB|Dave Calland
 Lorabelle Lee|TTBB|Jack Baird
 Lorabelle Lee|TTBB|Steve Jamison
-Lord Bless You And Keep You|SSAA|Avis Fellows
 Lord Bless You And Keep You|SSAA|Jay Giallombardo
-Lord Bless You And Keep You|SSAA|Marge Bailey
 Lord Bless You And Keep You|SSAA|Patricia Godfrey
 Lord Bless You And Keep You|TTBB|Jay Giallombardo
 Lord Bless You And Keep You|TTBB|Paul Jorg
@@ -13787,9 +13604,9 @@ Lord's My Shepherd|TTBB|Hugh Calhoun
 Lord's My Shepherd|TTBB|Walter Latzko
 LORD'S PRAYER (SISTER MEAD'S)|SSAA|Kay Bromert
 Lose My Breath|SSAA|Emily Moriarty
+Lose that Long Face|TTBB|Kevin Keller
 Lose That Long Face|SATB|Kevin Keller
 Lose That Long Face|SSAA|Kevin Keller
-Lose That Long Face|TTBB|Kevin Keller
 Losing My Mind|SSAA|Joe Mannherz
 Losing My Mind|TTBB|Adam Bock
 Losing My Mind|TTBB|Greg Mallett
@@ -13804,7 +13621,7 @@ Lost (A Wonderful Girl)|TTBB|Robert Rund
 Lost Boy|SATB|Nicholas Wright
 Lost Boy|TTBB|Nicholas Wright
 Lost In Loveliness|TTBB|Walter Latzko
-Lost In My Dreams|SSAA|Linda Edmondson
+Lost in My Dreams|SSAA|Linda Edmondson
 Lost In the Fifties Tonight|SSAA|Joe Liles
 Lost In The Fifties Tonight (In The Still Of The Nite)|SSAA|Joe Liles
 Lost In The Heart Of My Own Home Town|TTBB|James Moore
@@ -13840,7 +13657,7 @@ Love and Marriage|TTBB|Jim Shubert
 Love At Home|TTBB|Brent Graham
 Love Boat|TTBB|Todd Troutman
 Love Came Down At Christmas/Away In A Manger Medley|TTBB|Donn Updegrove
-Love Can Build A Bridge|SSAA|Tedda Lippincott
+Love Can Build a Bridge|SSAA|Tedda Lippincott
 Love Can Build A Bridge|SSAA|Yvonne Connolly
 Love Can Turn The World|SSAA|Steve Tramack
 Love Changes Everything|SSAA|Tom Gentry
@@ -13860,10 +13677,10 @@ Love In Any Language|TTBB|Derric Johnson
 Love in Any Language (solo and chorus)|SSAA|Dave Briner
 Love In Bloom|TTBB|Walter Latzko
 Love is a Many Splendored Thing|SSAA|Dave Briner
+Love Is a Many Splendored Thing|TTBB|Brent Graham
 Love Is A Many Splendored Thing|SSAA|Brent Graham
 Love Is A Many Splendored Thing|SSAA|David Briner
 Love Is A Many Splendored Thing|SSAA|Jay Giallombardo
-Love Is A Many Splendored Thing|TTBB|Brent Graham
 Love Is A Many Splendored Thing|TTBB|C. J. Sams Jr.
 Love Is A Many Splendored Thing|TTBB|David Briner
 Love Is A Many Splendored Thing|TTBB|Jay Giallombardo
@@ -13915,17 +13732,14 @@ Love Like This|TTBB|David Wright
 Love looks so well on you|TTBB|Joe Mannherz
 Love Me|SSAA|Aaron Dale
 Love Me|SSAA|Larry Triplett
-Love Me|SSAA|Tedda Lippincott
 Love Me|TTBB|Aaron Dale
 Love Me|TTBB|Gary Thiel
 Love Me|TTBB|Larry Triplett
 Love Me|TTBB|Robert Rund
-Love Me And The World Is Mine|SSAA|David Wright
+Love Me and the World is Mine|TTBB|Roger Payne
 Love Me And The World Is Mine|SSAA|Jay Giallombardo
-Love Me And The World Is Mine|TTBB|David Wright
 Love Me And The World Is Mine|TTBB|Jack Baird
 Love Me And The World Is Mine|TTBB|Jay Giallombardo
-Love Me And The World Is Mine|TTBB|Roger Payne
 Love Me And The World Is Mine|TTBB|SPEBSQSA
 Love Me And The World Is Mine|TTBB|the Barbershop Harmony Society
 Love Me as Though There Were No Tomorrow|SSAA|Lorraine Rochefort
@@ -13959,11 +13773,11 @@ Love Medley|SSAA|Marsha Zwicker
 Love Medley|TTBB|Robert Rund
 Love Medley (I Have A Love/One Hand, One Heart)|TTBB|Kirk Young
 Love Never Fails|TTBB|Deke Sharon
+Love of my Life|SSAA|David Wright
 Love of My Life|TTBB|Dale Kynaston
 Love Of My Life|SATB|Anders Lindqvist
 Love Of My Life|SSAA|Alex Kaiserman
 Love Of My Life|SSAA|Anders Lindqvist
-Love Of My Life|SSAA|David Wright
 Love Of My Life|SSAA|Jay Giallombardo
 Love Of My Life|TTBB|Anders Lindqvist
 Love Of My Life|TTBB|Jay Giallombardo
@@ -14060,15 +13874,13 @@ Lovely Way To Spend An Evening|TTBB|Larry Wright
 Lover|TTBB|Ed Waesche
 Lover Come Back|SSAA|Ed Waesche
 Lover Come Back|TTBB|Ed Waesche
-Lover Come Back To Me|SSAA|Ed Waesche
+Lover Come Back to Me|SSAA|Nancy Bergman
 Lover Come Back To Me|SSAA|Jay Giallombardo
-Lover Come Back To Me|SSAA|Nancy Bergman
 Lover Come Back To Me|SSAA|Rebecca J. Wood
-Lover Come Back To Me|TTBB|Ed Waesche
 Lover Come Back To Me|TTBB|Frank De Wolfe
 Lover Come Back To Me|TTBB|Jay Giallombardo
 Lover, Come Back to Me|SSAA|Ed Waesche
-Lover, Come Back To Me|TTBB|Ed Waesche
+Lover, Come Back to Me|TTBB|Ed Waesche
 Lover's Lane Is Crowded Again|SSAA|Larry Wright
 Lover's Lane Is Crowded Again|TTBB|Larry Wright
 Lovers In A Dangers Time|TTBB|Mark Stevens
@@ -14090,6 +13902,7 @@ Lower Case Love|TTBB|Joe Mannherz
 Lu Lu's Back In Town|TTBB|Ed Waesche
 Lucille|SSAA|Dan Wessler
 Lucille|TTBB|Eric Ruthenberg
+Luck Be a Lady|TTBB|David Harrington
 Luck Be a Lady|TTBB|Walter Latzko ed. Mark Hale
 Luck Be A Lady|SSAA|Avis Fellows
 Luck Be A Lady|SSAA|Carolyn Schmidt
@@ -14101,7 +13914,6 @@ Luck Be A Lady|SSAA|Walter Latzko
 Luck Be A Lady|TTBB|Brent Graham
 Luck Be A Lady|TTBB|Chris Arnold
 Luck Be A Lady|TTBB|Dan Naumann
-Luck Be A Lady|TTBB|David Harrington
 Luck Be A Lady|TTBB|Joe Mannherz
 Luck Be A Lady|TTBB|Kohl Kitzmiller
 Luck Be A Lady|TTBB|Steve Jamison
@@ -14148,7 +13960,7 @@ Lullaby of Birdland|SSAA|Larry Wright
 Lullaby of Birdland|TTBB|Joe Mannherz
 Lullaby of Birdland|TTBB|Larry Wright
 Lullaby of Birdland|TTBB|Steve Tramack
-Lullaby Of Broadway|SSAA|Joni Bescos
+Lullaby of Broadway|SSAA|Joni Bescos
 Lullaby Of Broadway|TTBB|Bob Crist
 Lullaby Of Broadway|TTBB|Craig Ewing
 Lullaby Of Broadway|TTBB|Steve Jamison
@@ -14185,7 +13997,6 @@ Lux Aurumque|SATB|Eric Whitacre
 Lux Aurumque|TTBB|Eric Whitacre
 Lydia (The Tattooed Lady)|TTBB|Duane Enders
 Lydia (The Tattooed Lady)|TTBB|Lloyd Steinkamp
-Lydia the Tattooed Lady|TTBB|Lloyd Steinkamp
 Lyin' Eyes|SATB|Tom Gentry
 Lyin' Eyes|TTBB|Thomas Degan
 M-O-T-H-E-R|SSAA|Lauree Cogley
@@ -14210,7 +14021,6 @@ Ma! (She's Makin' Eyes At Me)|TTBB|Harry Swenson
 Ma! (She's Makin' Eyes At Me)|TTBB|Jeff Taylor
 Ma! (She's Makin' Eyes At Me)|TTBB|Mo Rector
 Ma! (She's Making Eyes at Me)|TTBB|Mo Rector
-Ma! She's Makin' Eyes At Me|TTBB|Mo Rector
 MACAVITY, THE MYSTERY CAT|SSAA|Joey Minshall
 Mack the Knife|SSAA|Jim Arns
 Mack The Knife|SATB|Jay Dougherty
@@ -14269,7 +14079,7 @@ Make Believe|SSAA|Rebecca J. Wood
 Make Believe|TTBB|Ed Waesche
 Make Believe|TTBB|Jarmela Speta
 Make Believe|TTBB|Walter Latzko
-Make Love To Me|SSAA|Barbara McNeill
+Make Love to Me|SSAA|Barbara McNeill
 Make Love To Me|SSAA|Jean McFadyen
 Make Mine Barbershop|SSAA|Kay Bromert
 Make Our Garden Grow|TTBB|Jay Giallombardo
@@ -14343,11 +14153,8 @@ Mamma's Gone/I Used to Love You Medley|SSAA|Jo Lund
 Mammas & Papas Medley|TTBB|Peter Mumford
 Mammas, Don't Let Your Babies Grow Up to Be Cowboys|TTBB|Tom Gentry
 Mammy O' Mine|TTBB|Tom Gentry
-Man I Love|SSAA|David Briner
 Man I Love|SSAA|David Wright
-Man I Love|SSAA|Dorothy Herivel
 Man I Love|SSAA|Jo Lund
-Man I Love|SSAA|Nancy Bergman
 Man I Need|SATB|Mark Stevens
 Man I Need|TTBB|Mark Stevens
 Man In The Mirror|SATB|Deke Sharon
@@ -14361,7 +14168,6 @@ Man of Constant Sorrow|TTBB|Deke Sharon
 Man of La Mancha|SSAA|David Wright
 Man of La Mancha|TTBB|David Wright
 Man Of La Mancha|TTBB|Roger Payne
-Man On The Flying Trapeze|SSAA|Jean Shook
 Man On The Flying Trapeze|TTBB|Dennis Driscoll
 Man On The Flying Trapeze|TTBB|Ed Waesche
 Man On The Flying Trapeze|TTBB|Jack Baird
@@ -14373,14 +14179,12 @@ Man With The Bag|SATB|Tom Gentry
 Man With The Bag|SSAA|Deke Sharon
 Man With The Bag|SSAA|Joan D 'Agostino
 Man With The Bag|SSAA|June Berg
-Man With The Bag|SSAA|Marge Bailey
 Man With The Bag|SSAA|Patrick McAlexander
 Man With The Bag|SSAA|Tom Gentry
 Man With The Bag|TTBB|Brian Mastrull
 Man With The Bag|TTBB|David Briner
 Man With The Bag|TTBB|Deke Sharon
 Man With The Bag|TTBB|Jay Giallombardo
-Man With The Bag|TTBB|Jon Nicholas
 Man With The Bag|TTBB|Mark Goodney
 Man With The Bag|TTBB|Theodore Hicks
 Man With The Bag|TTBB|Tom Gentry
@@ -14404,10 +14208,8 @@ Mandy Lee|TTBB|Jay Giallombardo
 Mandy Lee|TTBB|Tom Gentry
 Mandy Make Up Your Mind|TTBB|Val Hicks
 Mandy Make Up Your Name|TTBB|Val Hicks
-Mandy N' Me|TTBB|Dave Stevens
 Maneater|TTBB|Joe Grimme
 Maneater|TTBB|Kohl Kitzmiller
-Manger in Bethlehem Medley|SSAA|Carolyn Johnson
 MANGER MEDLEY|SSAA|Carolyn Johnson
 Mango Tree|SATB|Kohl Kitzmiller
 Mango Tree|TTBB|Adam Bock
@@ -14426,7 +14228,6 @@ Manilow Medley|SSAA|Jay Giallombardo
 Manilow Medley|TTBB|Jay Giallombardo
 Mansions Of The Lord|SATB|Rob Hopkins
 Mansions Of The Lord|TTBB|Bob Shami
-Mansions Of The Lord|TTBB|Jon Nicholas
 Mansions Of The Lord|TTBB|Mike Menefee
 Many Happy Returns Of The Day|TTBB|Louis Perry
 Many Happy Returns Of The Day|TTBB|Roger Cote
@@ -14439,12 +14240,9 @@ Marching Along Together|TTBB|Don Gray
 Marching Along Together|TTBB|Robert Meyer
 Marching Along With Time|TTBB|David Wright
 Marching Along/Stout Hearted Men Medley|TTBB|Unspecified
-Mardi Gras March|SATB|Aaron Dale
-Mardi Gras March|SSAA|Aaron Dale
 Mardi Gras March|SSAA|David Briner
 Mardi Gras March|SSAA|Nancy Bergman
 Mardi Gras March|SSAA|Renee Craig
-Mardi Gras March|TTBB|Aaron Dale
 Mardi Gras March|TTBB|David Briner
 Mardi Gras March|TTBB|Howard Mesecher
 Mardi Gras March|TTBB|Russ Foris
@@ -14476,15 +14274,12 @@ Marry Me|TTBB|Nicholas Wright
 Marry You|TTBB|Alex Kaiserman
 Marry You|TTBB|Deke Sharon
 Marry You|TTBB|Michael Webber
-Marshmallow World|SSAA|Joni Bescos
 Martha, My Dear|TTBB|Todd Troutman
-Marvelous Toy|SSAA|Doris Twardosky
 Marvelous Toy|TTBB|Jay Giallombardo
 Marvin Gaye|TTBB|Thomas Degan
 Mary Did You Know|SATB|Jay Dougherty
 Mary Did You Know|SATB|Joe Mannherz
 Mary Did You Know|SATB|Tom Gentry
-Mary Did You Know|SSAA|Jan Meyer
 Mary Did You Know|SSAA|Joan Melling
 Mary Did You Know|SSAA|Joe Liles
 Mary Did You Know|SSAA|Jon Nicholas
@@ -14495,10 +14290,7 @@ Mary Did You Know|SSAA|Tedda Lippincott
 Mary Did You Know|SSAA|Theodore Hicks
 Mary Did You Know|SSAA|Tom Gentry
 Mary Did You Know|TTBB|Bryan W. Pulver
-Mary Did You Know|TTBB|David Wright
 Mary Did You Know|TTBB|Deke Sharon
-Mary Did You Know|TTBB|Joe Liles
-Mary Did You Know|TTBB|Jon Nicholas
 Mary Did You Know|TTBB|Theodore Hicks
 Mary Did You Know|TTBB|Walter Latzko
 Mary Did You Know?|SSAA|David Wright
@@ -14506,8 +14298,8 @@ Mary Did You Know?|SSAA|Jan Meyer
 Mary Did You Know?|TTBB|David Wright
 Mary Did You Know?|TTBB|Joe Liles
 Mary Did You Know?|TTBB|Tom Gentry
-Mary Had A Baby|SSAA|David Wright
-Mary Had A Baby|TTBB|David Wright
+Mary Had a Baby|SSAA|David Wright
+Mary Had a Baby|TTBB|David Wright
 Mary In The Morning|TTBB|Tom Gentry
 Mary Poppins Medley|SSAA|Tom Gentry
 Mary Poppins Medley|TTBB|Joe Mannherz
@@ -14623,12 +14415,12 @@ Me And Julio Down By The Schoolyard|TTBB|Tony Nasto
 Me And Marie|TTBB|Burt Szabo
 Me And Mrs. Jones|SATB|Deke Sharon
 Me And My Baby|SSAA|Jo Lund
+Me and My Shadow|TTBB|Dennis Driscoll
 Me And My Shadow|SATB|Richard Curtis
 Me And My Shadow|SSAA|Joni Bescos
 Me And My Shadow|SSAA|Nancy Bergman
 Me And My Shadow|TTBB|Dan Wessler
 Me And My Shadow|TTBB|Deke Sharon
-Me And My Shadow|TTBB|Dennis Driscoll
 Me And The Boy Friend|SSAA|Joan D 'Agostino
 ME AND THE BOYFRIEND|SSAA|Joan D 'Agostino
 Me and the Man in the Moon|SSAA|Anna Maria Parker
@@ -14638,10 +14430,10 @@ Meadowlark|TTBB|Greg Mallett
 Mean|SSAA|Glenda Lloyd
 Mean Ol' Moon|SSAA|Carole Prietto
 Mean Ol' Moon|TTBB|Kevin Koehl
+Mean to Me|SSAA|Sylvia Alsbury
 Mean To Me|SSAA|David Wright
 Mean To Me|SSAA|Jo Lund
 Mean To Me|SSAA|Kevin Keller
-Mean To Me|SSAA|Sylvia Alsbury
 Mean To Me|TTBB|David Wright
 Mean To Me|TTBB|Dennis Driscoll
 Mean To Me|TTBB|Kevin Keller
@@ -14930,13 +14722,12 @@ Memories|TTBB|Joe Liles
 Memories|TTBB|Mark Stevens
 Memories|TTBB|Rob Hopkins
 Memories|TTBB|Sheryl Neal
-Memories|TTBB|SPEBSQSA
 Memories|TTBB|Val Hicks
 Memories|TTBB|Walter Latzko
 Memories -|TTBB|SPEBSQSA
 Memories / Will You Remember|TTBB|Frank Leitnaker
 Memories Of A Song In My Heart|TTBB|Bob Disney
-Memories Of You|TTBB|Fred King
+Memories of You|TTBB|Fred King
 Memories Of You|TTBB|Joe Liles
 Memories Only Now|SSAA|Nancy Bergman
 Memory|SSAA|Carolyn Schmidt
@@ -14974,7 +14765,6 @@ Merry Christmas Darling|SATB|Joe Mannherz
 Merry Christmas Darling|SATB|Tom Gentry
 Merry Christmas Darling|SSAA|Debbie Keretz
 Merry Christmas Darling|SSAA|Dianne Goldrick
-Merry Christmas Darling|SSAA|Joan D 'Agostino
 Merry Christmas Darling|SSAA|June Berg
 Merry Christmas Darling|SSAA|Susan Kegley
 Merry Christmas Darling|SSAA|Tom Gentry
@@ -14987,7 +14777,7 @@ MERRY CHRISTMAS EVERYONE|SSAA|Tedda Lippincott
 Merry Christmas Happy New Year|SATB|Deke Sharon
 Merry Christmas, Darling|SSAA|Thomas Gentry
 Merry Christmas, Darling|TTBB|Thomas Gentry
-MERRY CHRISTMAS, DARLING|SSAA|Joan D'Agostino
+MERRY CHRISTMAS, DARLING|SSAA|Joan D 'Agostino
 Merry Christmas, Happy Holidays|SSAA|Cay Outerbridge
 MERRY CHRISTMAS, WASSAILING Medley|SSAA|Carolyn E. Johnson
 MERRY CHRISTMAS, WASSAILING Medley - YW|SSAA|Carolyn E. Johnson
@@ -15049,9 +14839,9 @@ Minneapolis/St. Paul Theme|SSAA|Avis Fellows
 Minnie The Mermaid|SSAA|Carolyn Schmidt
 Minnie The Mermaid|TTBB|Dennis Driscoll
 Minnie the Mermaid Medley|SSAA|Carolyn Schmidt
+Minnie the Moocher|TTBB|Walter Latzko
 Minnie The Moocher|SATB|Deke Sharon
 Minnie The Moocher|SSAA|Walter Latzko
-Minnie The Moocher|TTBB|Walter Latzko
 Minstrel Medley|TTBB|Dave Stevens
 Minstrel Montage|TTBB|Barbershop Harmony Society
 Minstrel Montage|TTBB|BHS
@@ -15083,8 +14873,6 @@ Miss You|TTBB|Walter Latzko
 Miss You Most at Christmas|SATB|Joe Mannherz
 Miss You Most at Christmas|SSAA|Joe Mannherz
 Miss You Most at Christmas|TTBB|Joe Mannherz
-Mission Impossible Theme|SSAA|Steve Tramack
-Mission Impossible Theme|TTBB|Steve Tramack
 Mission: Impossible Theme|SSAA|Glenda Lloyd
 Mission: Impossible Theme|SSAA|Steve Tramack
 Mission: Impossible Theme|TTBB|Simon Arnott
@@ -15168,11 +14956,11 @@ Moment By Moment|TTBB|Derric Johnson
 Moment I Saw Your Eyes The|TTBB|Joe Liles
 Moment of Silence|TTBB|Robert Rund
 Moments Like This|TTBB|Walter Latzko
+Moments to Remember|SSAA|Lyle Pilcher
+Moments to Remember|SSAA|Marge Bailey
+Moments to Remember|TTBB|Ed Waesche
 Moments To Remember|SSAA|Dorothy Short
-Moments To Remember|SSAA|Lyle Pilcher
-Moments To Remember|SSAA|Marge Bailey
 Moments To Remember|SSAA|Tedda Lippincott
-Moments To Remember|TTBB|Ed Waesche
 Moments To Remember|TTBB|Jim West
 Moments To Remember|TTBB|Val Hicks
 Mona Lisa|SSAA|Larry Wright
@@ -15364,7 +15152,6 @@ Most Wonderful Time Of The Year|SATB|Joe Mannherz
 Most Wonderful Time Of The Year|SSAA|Debbie Keretz
 Most Wonderful Time Of The Year|SSAA|Larry Wright
 Most Wonderful Time Of The Year|TTBB|Clay Hine
-Most Wonderful Time Of The Year|TTBB|Dave Plette
 Most Wonderful Time Of The Year|TTBB|Kevin Keller
 Most Wonderful Time Of The Year|TTBB|Larry Wright
 Most Wonderful Time Of The Year|TTBB|Richard Floersheimer
@@ -15373,7 +15160,6 @@ Most Wonderful Time/We Need A Little Christmas (Medley)|TTBB|Don Gray
 Mother|SATB|Kevin Koehl
 Mother|TTBB|Lloyd Steinkamp
 Mother Goose Suite|SSAA|Joan D 'Agostino
-MOTHER GOOSE SUITE|SSAA|Joan D'Agostino
 Mother In Ireland|TTBB|Walter Latzko
 Mother Knows Best|SSAA|Adam Scott
 Mother Machree|TTBB|Paul Bowman
@@ -15453,7 +15239,6 @@ Munchkinland|SSAA|Kevin Keller
 Munchkinland|TTBB|Kevin Keller
 Muppet Show|SSAA|Kirk Young
 Muppet Show|TTBB|Kirk Young
-MUPPET SHOW THEME|SSAA|Carolyn Johnson
 Murder, He Says|SSAA|Carolyn Schmidt
 Music|SSAA|Marie Johnson
 Music & The Mirror ('A Chorus Line')|SSAA|Mary Ann Wydra
@@ -15473,20 +15258,15 @@ Music Man Medley|TTBB|Kevin Keller
 Music Man Medley|TTBB|Rob Hopkins
 Music Man Medley #1|TTBB|Ed Waesche
 Music Man Medley #2|TTBB|Ed Waesche
-Music Man Medley 1|TTBB|Ed Waesche
 Music Man Medley I|TTBB|Steve Delehanty
 Music Man Mini-Show|TTBB|Jay Giallombardo
 Music Moves Me|SSAA|Kay Bromert
 Music Moves Me|SSAA|Tedda Lippincott
-Music Music Music|TTBB|Mo Rector
 Music Music Music|TTBB|Tom Gentry
 Music Of My Heart|SSAA|Aaron Dale
 Music Of My Heart|SSAA|Carole Prietto
 Music Of My Heart|TTBB|Kevin Keller
 Music of the Night|SSAA|Lorraine Rochefort
-Music Of The Night|SSAA|David Wright
-Music Of The Night|SSAA|Tedda Lippincott
-Music Of The Night|TTBB|David Wright
 Music Of The Night|TTBB|Gordon Haines
 Music Of The Night|TTBB|Jay Giallombardo
 Music Speaks Louder Than Words|SSAA|Carole Prietto
@@ -15513,8 +15293,8 @@ My 'Wild' Irish Rose|TTBB|Burt Szabo
 My Alabama|SSAA|Larry Wright
 My Alabama|TTBB|Larry Wright
 My Baby Just Cares for Me|SSAA|Anna Maria Parker
+My Baby Just Cares for Me|SSAA|Elaine Gain
 My Baby Just Cares For Me|SSAA|David Wright
-My Baby Just Cares For Me|SSAA|Elaine Gain
 My Baby Just Cares For Me|SSAA|Jo Lund
 My Baby Just Cares For Me|SSAA|Larry Wright
 My Baby Just Cares For Me|SSAA|Nancy Bergman
@@ -15679,7 +15459,7 @@ My Guy (YWIH)|SSAA|Tedda Lippincott
 My Guy/I Will Follow Him|SSAA|Larry Wright
 My Happy Ending|SATB|Deke Sharon
 My Heart Has Learned To Love You|TTBB|Jack Baird
-My Heart Is Aching For You|TTBB|Joe Liles
+My Heart Is Aching for You|TTBB|Joe Liles
 My Heart Is Open|SATB|Nicholas Wright
 My Heart Stood Still|SSAA|Anna Maria Parker
 My Heart Stood Still|SSAA|Walter Latzko
@@ -15797,7 +15577,6 @@ My Mother's Eyes|TTBB|Unspecified
 My Mother's Pearls|TTBB|Burt Szabo
 My Mother's Rosary|TTBB|Dennis Driscoll
 My Mother's Rosary|TTBB|Unknown
-My Name Is America|TTBB|John Hohl
 My Name Is America|TTBB|Larry Wright
 My Name Is America!|TTBB|John Hohl
 My Neighbor Totoro|SSAA|Sam Hubbard
@@ -15859,7 +15638,7 @@ My Romance|TTBB|Rob Campbell
 My Romance|TTBB|Tom Gentry
 My Romance|TTBB|Walter Latzko
 My Sally|TTBB|Tom Gentry
-My Sally, Just The Same|TTBB|Barbershop Harmony Society
+My Sally, Just the Same|TTBB|Barbershop Harmony Society
 My Sally, Just The Same|TTBB|Harold Ulring
 My Shiny Teeth And Me|TTBB|Ben Lewin
 My Sin|TTBB|Brent Graham
@@ -15966,7 +15745,7 @@ Near You|TTBB|Todd Troutman
 Nearer My God Medley|TTBB|Joe Johnson
 Nearer My God To Thee|TTBB|James Stevens
 Nearer My God To Thee|TTBB|Rudy Hart
-Nearer, My God, To Thee|SSAA|Leola Wright
+Nearer, My God, to Thee|SSAA|Leola Wright
 Nearer, My God, To Thee|SSAA|Nancy Bergman
 Nearer, My God, To Thee|SSAA|Walter Latzko
 Nearer, My God, To Thee|TTBB|David Harrington
@@ -16064,7 +15843,6 @@ New Orleans Post Parade|SSAA|Ardeth Fullmer
 New Orleans Post Parade|TTBB|Bob Jones
 New Orleans/Sweet Georgia Brown|SSAA|Kay Bromert
 New Romantics|SSAA|Lauren Kahn
-New Way to Walk|SSAA|Carolyn Johnson
 NEW WAY TO WALK, A (Adult Women)|SSAA|Carolyn Johnson
 New Words|SSAA|Michael Gellert
 New Words|TTBB|Craig Minor
@@ -16123,12 +15901,9 @@ Next Door Angel Medley|SSAA|Jan-Ake Westin
 Next Door To An Angel|TTBB|Brian Mastrull
 Next Time I Love|SSAA|Larry Wright
 Next Time I Love|TTBB|Larry Wright
-Next To Lovin (I Like Fightin Best)|SSAA|Marge Bailey
 NEXT TO LOVIN' (I LIKE FIGHTIN' BEST)|SSAA|Marge Bailey
-Nice 'n Easy|SSAA|Doris Twardosky
 Nice 'n Easy|TTBB|Ig Jakovac
 NICE 'N' EASY|SSAA|Doris Twardosky
-Nice N' Easy|TTBB|Ig Jakovac
 Nice People|TTBB|Jay Giallombardo
 Nice Work If You Can Get It|SATB|Joe Mannherz
 Nice Work If You Can Get It|SSAA|Carolyn Schmidt
@@ -16139,7 +15914,6 @@ Nice Work If You Can Get It|SSAA|Marsha Zwicker
 Nice Work If You Can Get It|TTBB|Ed Waesche
 Nice Work If You Can Get It|TTBB|Jim Shubert
 Nice Work If You Can Get It|TTBB|Joe Mannherz
-Nice Work If You Can Get It|TTBB|Rob Campbell
 Nice Work If You Can Get It|TTBB|Simon Arnott
 Nice Work, If You Can Get It|TTBB|Rob Campbell
 Nickelodeon Medley|SATB|Deke Sharon
@@ -16157,6 +15931,7 @@ Nine Million Bicycles|TTBB|Hilary Allen
 Nine People's Favorite Thing|TTBB|Kohl Kitzmiller
 Nine People's Favorite Thing (Parody)|TTBB|Kohl Kitzmiller
 Nine to Five|SSAA|Ann Minihane
+Nine to Five|SSAA|Steve Jamison
 Nine To Five|SATB|Kohl Kitzmiller
 Nine To Five|SATB|Matthew Spinner
 Nine To Five|SSAA|Jo Lund
@@ -16164,7 +15939,6 @@ Nine To Five|SSAA|Jon Nicholas
 Nine To Five|SSAA|Kohl Kitzmiller
 Nine To Five|SSAA|Liz Garnett
 Nine To Five|SSAA|Sam Hubbard
-Nine To Five|SSAA|Steve Jamison
 Nine To Five|TTBB|David Wright
 Nine To Five|TTBB|Sam Hubbard
 Nine To Five|TTBB|Steve Jamison
@@ -16281,7 +16055,7 @@ Nobody's Sweetheart Now/Nobody's Baby Medley|SSAA|Larry Wright
 Noel Canon|TTBB|Steven Sametz
 Nonsense Medley|SSAA|Jo Lund
 Noone in the World|SSAA|David Sangster
-North To Alaska|TTBB|John Hohl
+North to Alaska|TTBB|John Hohl
 Northwoods Woman|SSAA|Joe Liles
 Norwegian Wood|TTBB|Jay Giallombardo
 Nostalgia Medley|SSAA|Nancy Bergman
@@ -16366,7 +16140,6 @@ Nuttin' For Christmas|TTBB|Jon Nicholas
 O|SATB|Jon Nicholas
 O|SATB|Nicholas Wright
 O Breath Of Early Spring (Pourquoi Me Reveiller)|TTBB|Jay Giallombardo
-O Canada|SSAA|Joe Liles
 O Canada!|SATB|Deke Sharon
 O Canada!|SATB|Joe Liles
 O Canada!|SSAA|Deke Sharon
@@ -16393,13 +16166,11 @@ O Come All Ye Faithful|TTBB|Unspecified
 O Come All Ye Faithful / Joy To The World Medley|TTBB|Earl Moon
 O Come Emanuel|TTBB|Kevin Keller
 O Come O Come Emmanuel|SATB|Simon Lubkowski
-O Come O Come Emmanuel|SSAA|Kevin Keller
 O Come O Come Emmanuel|SSAA|Mark Rusch
 O Come O Come Emmanuel|TTBB|Deke Sharon
 O Come O Come Emmanuel|TTBB|Gabriel Lawson
 O Come O Come Emmanuel|TTBB|Jim Clancy
 O Come O Come Emmanuel|TTBB|Jon Nicholas
-O Come O Come Emmanuel|TTBB|Kevin Keller
 O Come O Come Emmanuel|TTBB|Mark Rusch
 O Come O Come Emmanuel|TTBB|Nicholas Wright
 O Come O Come Emmanuel (Veni, Veni)|SSAA|Kevin Keller
@@ -16439,7 +16210,6 @@ O Holy Night|TTBB|Ed Lojeski
 O Holy Night|TTBB|Jay Giallombardo
 O Holy Night|TTBB|Jim Clancy
 O Holy Night|TTBB|Joe Mannherz
-O Holy Night|TTBB|Jon Nicholas
 O Holy Night|TTBB|Mark Rusch
 O Holy Night|TTBB|Nick Bryant
 O Holy Night|TTBB|Soren Detlefsen
@@ -16474,7 +16244,6 @@ O Waly Waly|SSAA|Liz Garnett
 O Worship The King|TTBB|Derric Johnson
 O, America|SSAA|Tom Gentry
 O, America|TTBB|Tom Gentry
-O, Canada|SSAA|Norma Andersen
 O, Holy Night|TTBB|Jon Nicholas
 O'Brien Is Tryin' To Learn To Talk Hawaiian|TTBB|Burt Szabo
 O'Brien To Ryan To Goldberg|TTBB|J Rae Jamieson
@@ -16482,10 +16251,9 @@ O'Brien To Ryan To Goldberg|TTBB|Steve Tramack
 Ob La Di, Ob La Da|TTBB|Mark Hale
 Ob La Di, Ob La Da, Life Goes On|TTBB|Mark Hale
 Ob-La-Di|SSAA|Mark Hale
-Ob-La-Di, Ob-La-Da|SSAA|Carolyn Schmidt
+Ob-la-di, Ob-la-da|SSAA|Carolyn Schmidt
 Ob-La-Di, Ob-La-Da|SSAA|Karen McCarville
 Ob-La-Di, Ob-La-Da|TTBB|Jim Shubert
-Ob-La-Di, Ob-La-Da|TTBB|Mark Hale
 Occapella|SSAA|Marie Hampton
 Ocean Eyes|SATB|Nicholas Wright
 Octopus' Garden|SSAA|Carolyn Schmidt
@@ -16496,7 +16264,7 @@ Octopus's Garden|SSAA|Tedda Lippincott
 Octopus's Garden|TTBB|Larry Wright
 Ode To America|SSAA|Nancy Bergman
 Ode To Joy|SATB|David Wright
-Ode To Joy (Joyful, Joyful)|SSAA|Barbara McNeill
+Ode to Joy (Joyful, Joyful)|SSAA|Barbara McNeill
 Ode To Joy (Joyful, Joyful)|SSAA|Carolyn Johnson
 Ode To Joy (Joyful, Joyful)|SSAA|Larry Wright
 Ode To Joy (Joyful, Joyful)|TTBB|Larry Wright
@@ -16515,7 +16283,6 @@ Oh By Jingo!|TTBB|Bud Arberg
 Oh Come All Ye Faithful|TTBB|Barbershop Harmony Society
 Oh Daddy Blues|SSAA|Mark Jennings
 Oh Daddy Blues (You Won't Have No Mama At All)|SSAA|Mark Jennings
-Oh Darling|SSAA|David Harrington
 Oh Happy Day|SATB|Deke Sharon
 Oh Happy Day|SSAA|David Wright
 Oh Happy Day|SSAA|Larry Wright
@@ -16531,7 +16298,6 @@ Oh How We Roared In The Twenties|TTBB|Toban Dvoretzky
 Oh Johnny|SSAA|Jay Giallombardo
 Oh Johnny, Oh Johnny, Oh!|SSAA|Carolyn Johnson
 Oh Little Town Of Bethlehem|SSAA|Nancy Bergman
-Oh Look at Me Now|TTBB|Aaron Dale
 Oh Look At Me Now|SSAA|Aaron Dale
 Oh Mabel|TTBB|Steve Hardy
 Oh My Father|TTBB|Aaron Dale
@@ -16544,7 +16310,6 @@ OH SUSANNA, DUST OFF THAT OLD PIANNA|SSAA|Carolyn Schmidt
 Oh Susannah|TTBB|Aaron Dale
 Oh Susannah, Dust Off That Old Pianna|SSAA|Avis Fellows and Randine Hartlestad
 Oh Suzanna, Dust Off That Old Pianna|TTBB|Brian Mastrull
-Oh What a Beautiful Morning|SSAA|Anna Maria Parker
 Oh What A Beautiful Morning!|SATB|Deke Sharon
 Oh What A Beautiful Morning!|SSAA|Nancy Bergman
 Oh What A Beautiful Morning!|TTBB|Nancy Bergman
@@ -16582,7 +16347,6 @@ Oh, The Thinks You Can Think|TTBB|David Wright
 Oh, What A Beautiful Mornin'|SSAA|Anna Maria Parker
 Oh, What A Beautiful Mornin'|TTBB|David Wright
 Oh, What A Beautiful Mornin'|TTBB|Walter Latzko
-Oh, What A Beautiful Morning|SSAA|Nancy Bergman
 OH, WHAT A BEAUTIFUL MORNING|SSAA|Anna Maria Parker
 Oh, What A Merry Christmas Day|SSAA|Connie Nickel
 Oh, What A Pal Was Whoozis|TTBB|Steve Jamison
@@ -16603,7 +16367,6 @@ Oh! Darling|TTBB|David Harrington
 OH! FRENCHY (HONEY)|SSAA|Carolyn Johnson
 OH! FRENCHY (HONEY) - YW|SSAA|Carolyn Johnson
 Oh! Honey (Frenchy)|SSAA|Carolyn Johnson
-Oh! How I Hate to Get Up in the Morning|SSAA|Nancy Bergman
 Oh! How I Laugh When I Think How I Cried About You|SSAA|Marie Johnson
 Oh! Look At Me Now|TTBB|Aaron Dale
 Oh! Look At Me Now|TTBB|Jim Shubert
@@ -16618,8 +16381,6 @@ Oh! What A Pal Was Mary|TTBB|Jack Baird
 Oh! What A Pal Was Mary|TTBB|Tom Gentry
 Oh! What It Seemed To Be|TTBB|Jim Shubert
 Oh! What It Seemed To Be|TTBB|Mark Goodney
-Oh! You Beautiful Doll|TTBB|Kirk Roose
-Oh! You Beautiful Doll|TTBB|Rob Campbell
 Ohio State University Alma Mater|TTBB|Tom Gentry
 OK, It's Alright With Me|TTBB|Deke Sharon
 Oklahoma|SSAA|Mark Burnip
@@ -16683,7 +16444,6 @@ Old Folks|TTBB|Jim West
 Old Folks|TTBB|Robert Rund
 Old Folks|TTBB|Tom Gentry
 Old Folks|TTBB|Warren 'Buzz' Haeger
-Old Folks|TTBB|Warren Buzz Haeger
 Old Folks At Home|TTBB|Clay Hine
 Old Folks At Home|TTBB|David Wright
 Old Folks Boogie|TTBB|Deke Sharon
@@ -16710,14 +16470,10 @@ Old Man Time|TTBB|Dennis Malone, John Hohl
 Old Man Time|TTBB|John Hohl
 Old Me Better|TTBB|Clay Hine
 Old Mother Hubbard|TTBB|Dan Wessler
-Old Pals Are The Best Pals After All|TTBB|Louis Perry
+Old Pals Are the Best Pals After All|TTBB|Louis Perry
 Old Piano Roll Blues|SSAA|David Wright
-Old Piano Roll Blues|SSAA|Tedda Lippincott
-Old Piano Roll Blues|TTBB|David Wright
-Old Piano Roll Blues|TTBB|Mo Rector
 Old Rocking Chair|TTBB|Rob Campbell
 Old Roses|TTBB|Louis Perry
-Old Rugged Cross|SSAA|Kay Bromert
 Old Rugged Cross|SSAA|Tedda Lippincott
 Old Rugged Cross|TTBB|Dennis Morrissey
 Old Rugged Cross|TTBB|Joe Liles
@@ -16787,12 +16543,12 @@ On A Clear Day|SSAA|Sylvia Alsbury
 On A Cruise|SSAA|Nancy Bergman
 On A Mission|SSAA|Jen Squires
 On A Rainy Day Medley|TTBB|Dan Wilson
+On a Slow Boat to China|TTBB|Greg Hollander
 On a Slow Boat to China|TTBB|Stephen Delehanty
+On A Slow Boat to China|SSAA|Jo Lund
 On A Slow Boat To China|SSAA|Dan Wessler
-On A Slow Boat To China|SSAA|Jo Lund
 On A Slow Boat To China|SSAA|Marsha Zwicker
 On A Slow Boat To China|TTBB|George Peters
-On A Slow Boat To China|TTBB|Greg Hollander
 On A Slow Boat To China|TTBB|Jack McCabe
 On A Slow Boat To China|TTBB|John Bober
 On A Slow Boat To China|TTBB|Jon Nicholas
@@ -16851,7 +16607,6 @@ On The Alamo|TTBB|Walter Latzko
 On the Arms of the Old Armchair|TTBB|Jay Giallombardo
 On The Atchison, Topeka And The Santa Fe|SSAA|Adam Bock
 On The Atchison, Topeka And The Santa Fe|SSAA|Walter Latzko
-On The Atchison, Topeka And The Santa Fe|TTBB|Dick Rode
 On The Atchison, Topeka And The Santa Fe|TTBB|Jay Giallombardo
 On The Atchison, Topeka And The Santa Fe|TTBB|Walter Latzko
 On The Atchison, Topeka, And The Santa Fe|TTBB|Dick Rode
@@ -16874,31 +16629,31 @@ On The Mississippi Queen|TTBB|Dennis Driscoll
 On The Old Dominion Line|TTBB|Burt Szabo
 On The Old Front Porch|TTBB|Burt Szabo
 On The Other End Of A Kiss|TTBB|Steve Hardy
+On the Road Again|TTBB|Jon Nicholas
 On The Road Again|SATB|Kyle Snook
 On The Road Again|SSAA|Carolyn Schmidt
 On The Road Again|SSAA|Dot Calvin
 On The Road Again|SSAA|June Berg
 On The Road Again|TTBB|Aaron Dale
-On The Road Again|TTBB|Jon Nicholas
 On The South Side Of Chicago|SSAA|Larry Wright
+On the Street Where You Live|SSAA|Brent Graham
 On the Street Where You Live|SSAA|June Berg
-On The Street Where You Live|SSAA|Brent Graham
+On the Street Where You Live|TTBB|Ron Middlestaedt
 On The Street Where You Live|SSAA|Jay Giallombardo
 On The Street Where You Live|SSAA|Liz Garnett
 On The Street Where You Live|SSAA|Steve Tramack
 On The Street Where You Live|TTBB|David Wright
 On The Street Where You Live|TTBB|Jay Giallombardo
 On The Street Where You Live|TTBB|Ron Middlestadt
-On The Street Where You Live|TTBB|Ron Middlestaedt
 On The Street Where You Live|TTBB|Steve Tramack
 On The Street Where You Live|TTBB|Walter Latzko
+On the Sunny Side of the Street|SSAA|Ann Minihane
+On the Sunny Side of the Street|TTBB|Don Reckenbeil
+On the Sunny Side of the Street|TTBB|John Muir
 On the Sunny Side of the Street|TTBB|Melvin Knight
-On The Sunny Side Of The Street|SSAA|Ann Minihane
 On The Sunny Side Of The Street|SSAA|Larry Wright
 On The Sunny Side Of The Street|SSAA|Nancy Bergman
 On The Sunny Side Of The Street|TTBB|Clay Hine
-On The Sunny Side Of The Street|TTBB|Don Reckenbeil
-On The Sunny Side Of The Street|TTBB|John Muir
 On The Sunny Side Of The Street|TTBB|Larry Wright
 On The Sunny Side Of The Street|TTBB|Mel Knight
 On The Sunny Side Of The Street|TTBB|Walter Latzko
@@ -16946,13 +16701,13 @@ Once Upon A Dream|SSAA|Sheryl Neal
 Once Upon A Dream|TTBB|Jay Dougherty
 Once Upon A Dream|TTBB|Steve Tramack
 Once Upon A Summertime|TTBB|Walter Latzko
+Once Upon a Time|SSAA|Tom Gentry
 Once Upon A Time|SSAA|Frank Marzocco
 Once Upon A Time|SSAA|Jo Lund
 Once Upon A Time|SSAA|June Dale
 Once Upon A Time|SSAA|Larry Wright
 Once Upon A Time|SSAA|Rob Campbell
 Once Upon A Time|SSAA|Stephanie G. Gentry
-Once Upon A Time|SSAA|Tom Gentry
 Once Upon A Time|TTBB|Larry Wright
 Once Upon A Time|TTBB|Rob Campbell
 Once Upon A Time|TTBB|Tom Gentry
@@ -16998,10 +16753,10 @@ One Fine Day|TTBB|Jeremey Johnson
 One Fine Day|TTBB|Joe Mannherz
 One For My Baby|TTBB|Nathan Peplinski
 One For My Baby|TTBB|Roger Payne
+One for My Baby (And One More for the Road)|TTBB|Roger Payne
 One For My Baby (And One More For The Road)|SSAA|Larry Wright
 One For My Baby (And One More For The Road)|TTBB|Larry Wright
 One For My Baby (And One More For The Road)|TTBB|Mark Goodney
-One For My Baby (And One More For The Road)|TTBB|Roger Payne
 One for the road|SATB|Joe Mannherz
 One God|SSAA|Anita Barzilla
 One God|SSAA|Anna Maria Parker
@@ -17072,7 +16827,7 @@ One Size Fits All|SSAA|Charlene Yazurlo
 One Small Child|SSAA|Kay Bromert
 One Solitary Life|TTBB|Derric Johnson
 One Song|TTBB|Derric Johnson
-One Song At A Time|SSAA|Joe Liles
+One Song at a Time|SSAA|Joe Liles
 One Song At A Time|TTBB|Joe Liles
 One Spring Day In Kentucky|TTBB|Walter Latzko
 One Tin Soldier|SSAA|June Dale
@@ -17171,7 +16926,7 @@ Open Your Eyes|TTBB|Nicholas Wright
 Open Your Heart|SATB|Anders Lindqvist
 Opener Medley|TTBB|Mark Hale
 Opening Night|SSAA|Michael Gellert
-Opening Night On Broadway|SSAA|Nancy Bergman
+Opening Night on Broadway|SSAA|Nancy Bergman
 Opening Night On Broadway|TTBB|Nancy Bergman
 Opening Up|SATB|Melody Hine
 Opening Up|TTBB|Melody Hine
@@ -17228,7 +16983,6 @@ Original Dixieland One Step|SSAA|Bev Sellers
 Original Dixieland One Step|SSAA|Unspecified
 Original Dixieland One Step|TTBB|David Wright
 Original Dixieland One Step|TTBB|Greg Volk
-Original Dixieland One Step|TTBB|Renee Craig
 Original Dixieland One Step|TTBB|Renee Craig, David Harrington
 Original Dixieland One-Step|SSAA|David Wright
 Original Dixieland One-Step|SSAA|Greg Volk
@@ -17262,17 +17016,17 @@ Out There|TTBB|Brent Graham
 Out There|TTBB|Steve Tramack
 Out There (from The Hunchback Of Notre Dame)|TTBB|Steve Tramack
 Over The Hill|SSAA|Marge Bailey
+Over the Rainbow|SATB|Ed Waesche
+Over the Rainbow|SSAA|Anna Maria Parker
+Over the Rainbow|SSAA|Clay Hine
+Over the Rainbow|SSAA|Ed Waesche
+Over the Rainbow|SSAA|Jay Giallombardo
+Over the Rainbow|SSAA|Joni Bescos
 Over the Rainbow|SSAA|Nancy Bergman
-Over The Rainbow|SATB|Ed Waesche
 Over The Rainbow|SATB|Melody Hine
-Over The Rainbow|SSAA|Anna Maria Parker
 Over The Rainbow|SSAA|Brent Graham
 Over The Rainbow|SSAA|Carole Prietto
-Over The Rainbow|SSAA|Clay Hine
-Over The Rainbow|SSAA|Ed Waesche
-Over The Rainbow|SSAA|Jay Giallombardo
 Over The Rainbow|SSAA|Joe Mannherz
-Over The Rainbow|SSAA|Joni Bescos
 Over The Rainbow|SSAA|Michael Gellert
 Over The Rainbow|SSAA|Sam Hubbard
 Over The Rainbow|TTBB|Bob Graham
@@ -17329,7 +17083,6 @@ Pack Up|SSAA|Liz Garnett
 Pack Up Your Sins And Go To The Devil|TTBB|Ed Waesche
 Pack Up Your Troubles / Long Way To Tipperary Medley|TTBB|Jack Baird
 Pack Up Your Troubles in Your Old Kit Bag|TTBB|Clay Hine
-Pack Up Your Troubles/Long Way To Tipperary Medley|TTBB|Jack Baird
 Paddlin' Madelin' Home|SSAA|Nancy Bergman
 Paddlin' Madelin' Home|TTBB|Benjamin Miller
 Paddlin' Madelin' Home|TTBB|Don Gray
@@ -17380,8 +17133,8 @@ Paperback Writer|TTBB|James Henry
 Paperback Writer|TTBB|Jay Giallombardo
 Parade Medley|TTBB|Jay Giallombardo
 Parade of the Wooden Soldiers|SSAA|Teresa Reed
+Parade of the Wooden Soldiers|TTBB|Marty Israel
 Parade Of The Wooden Soldiers|SSAA|Penny Hartmann
-Parade Of The Wooden Soldiers|TTBB|Marty Israel
 Paradise|SATB|Deke Sharon
 Paradise|SATB|Jon Nicholas
 Paradise|SATB|Nicholas Wright
@@ -17538,8 +17291,6 @@ Peter Pan Medley|TTBB|Steve Tramack
 Peter Pan Medley|TTBB|Tom Gentry
 Phantom / Music Of The Night|TTBB|Joe Spiecker
 Phantom Medley|SSAA|David Wright
-Phantom Of The Opera|SSAA|Tedda Lippincott
-Phfft! You Were Gone Parody|SSAA|Cris Conerty
 Phfft! You Were Gone Parody|SSAA|Susan Heimburger
 PHFFT! YOU WERE GONE! Parody|SSAA|Cris Conerty
 Philadelphia Freedom|SSAA|Joe Mannherz
@@ -17593,7 +17344,6 @@ Pity Party|SSAA|Patrick McAlexander
 Pity Party|SSAA|Sharon Holmes
 Place in the Choir|SSAA|Dianne Goldrick
 Place in the Choir|SSAA|Kay Bromert
-Place in the Choir|SSAA|Tom Gentry
 Place in the Choir|TTBB|Liz Garnett
 Place in the Choir|TTBB|Michael Webber
 Place in the Choir|TTBB|Tom Gentry
@@ -17622,13 +17372,13 @@ Playground Life|TTBB|Dick Stuart
 Playing Right Field|TTBB|Tom Gentry
 Playing the Clown|SSAA|Joey Minshall
 Playing The Clown|TTBB|Einar Pedersen
-Please Come Home For Christmas|SATB|Jay Dougherty
+Please Come Home for Christmas|SATB|Jay Dougherty
+Please Come Home for Christmas|SSAA|Jay Dougherty
+Please Come Home for Christmas|TTBB|Jay Dougherty
 Please Come Home For Christmas|SATB|Kohl Kitzmiller
-Please Come Home For Christmas|SSAA|Jay Dougherty
 Please Come Home For Christmas|SSAA|Kohl Kitzmiller
 Please Come Home For Christmas|SSAA|Sharon Holmes
 Please Come Home For Christmas|TTBB|Dom Finetti
-Please Come Home For Christmas|TTBB|Jay Dougherty
 Please Come Home For Christmas|TTBB|Jon Nicholas
 Please Come Home For Christmas|TTBB|Kohl Kitzmiller
 Please Come Home For Christmas|TTBB|Kyle Snook
@@ -17769,7 +17519,6 @@ Precious Friends|SSAA|Tom Gentry
 Precious Friends|TTBB|Tom Gentry
 Precious Lord Take My Hand|SATB|Tom Gentry
 Precious Lord Take My Hand|SSAA|Tom Gentry
-Precious Lord Take My Hand|TTBB|Jon Nicholas
 Precious Lord Take My Hand|TTBB|Tom Gentry
 Precious Lord, Take My Hand|TTBB|Buzz Haeger
 Precious Lord, Take My Hand|TTBB|Dan Tice
@@ -17872,11 +17621,11 @@ Put Another Chair At The Table|TTBB|Mark Goodney
 Put Me To Sleep With An Old Fashioned Melody|TTBB|Burt Szabo
 Put Me To Sleep With An Old Fashioned Melody|TTBB|Clay Hine
 Put Me To Sleep With An Old Fashioned Melody|TTBB|Ed Waesche
+Put on a Happy Face|TTBB|Kevin Keller
 Put On A Happy Face|SATB|Deke Sharon
 Put On A Happy Face|SSAA|Tedda Lippincott
 Put On A Happy Face|TTBB|Howard Dale
 Put On A Happy Face|TTBB|Jay Giallombardo
-Put On A Happy Face|TTBB|Kevin Keller
 Put On A Happy Face|TTBB|Walter Latzko
 Put On A Happy Face/Let A Smile Be Your Umbrella Medley|TTBB|Adam Reimnitz
 Put On A Happy Face/Let A Smile Be Your Umbrella Medley(Adam Reim|TTBB|Adam Reimnitz
@@ -17891,12 +17640,9 @@ Put On Your Old Grey Bonnet|TTBB|Russ Foris
 Put On Your Sunday Clothes|TTBB|Adam Reimnitz
 Put On Your Sunday Clothes|TTBB|Ed Waesche
 Put One Foot In Front of the Other|TTBB|Steve Tramack
-Put Your Arms Around Me Honey|SSAA|Aaron Dale
 Put Your Arms Around Me Honey|SSAA|Nancy Bergman
-Put Your Arms Around Me Honey|TTBB|Aaron Dale
 Put Your Arms Around Me Honey|TTBB|Burt Szabo
 Put Your Arms Around Me Honey|TTBB|Lloyd Steinkamp
-Put Your Arms Around Me Honey|TTBB|Rob Hopkins
 Put Your Arms Around Me, Honey|SSAA|Aaron Dale
 Put Your Arms Around Me, Honey|TTBB|Aaron Dale
 Put Your Arms Around Me, Honey|TTBB|Rob Hopkins
@@ -17912,7 +17658,7 @@ Put Your Head On My Shoulder|TTBB|Jim Shubert
 Put Your Records On|SATB|Deke Sharon
 Put Your Records On|SSAA|Sofia De Rama
 Puttin' on the Ritz|SSAA|Bev Sellers/Kay Bromert
-Puttin' On The Ritz|SSAA|Bev Sellers
+Puttin' On the Ritz|SSAA|Bev Sellers
 Puttin' On The Ritz|SSAA|David Wright
 Puttin' On The Ritz|SSAA|Jo Lund
 Puttin' On The Ritz|SSAA|Kay Bromert
@@ -17974,9 +17720,7 @@ Rainbow Connection|SATB|Joe Mannherz
 Rainbow Connection|SATB|Kevin Keller
 Rainbow Connection|SSAA|Jo Lund
 Rainbow Connection|SSAA|Joe Mannherz
-Rainbow Connection|SSAA|Joey Minshall
 Rainbow Connection|SSAA|Kevin Keller
-Rainbow Connection|SSAA|Marge Bailey
 Rainbow Connection|TTBB|Alexander Ronneburg
 Rainbow Connection|TTBB|Gabriel Lawson
 Rainbow Connection|TTBB|Joe Mannherz
@@ -17996,7 +17740,6 @@ Raining In My Heart|TTBB|Paul Davies
 Rainsong|TTBB|Houston Bright
 Rainy Night In Rio|SATB|Kevin Keller
 Rainy Night In Rio|SSAA|Kevin Keller
-Rainy Night In Rio|TTBB|Kevin Keller
 Raise You Up|SSAA|Carole Prietto
 Raise Your Baton, Mister Leaderman|TTBB|Pete Rupay
 Raise Your Glass|SSAA|Melody Hine
@@ -18033,7 +17776,7 @@ Reach|SSAA|Joey Minshall
 Reach|SSAA|Pat LeVezu
 Reach|SSAA|Sharon Carlson
 REACH|SSAA|Pat LeVezu and Joey Minshall
-Reach For The Light|SSAA|June Dale
+Reach for the Light|SSAA|June Dale
 Reach Out And Touch|TTBB|Ed Waesche
 Reach Out And Touch|TTBB|Jim Stahly
 Reach Out Of The Darkness|SSAA|Kathy Barnett
@@ -18072,7 +17815,7 @@ Red Is The Rose|TTBB|Thomas Degan
 Red River Valley|TTBB|Barbershop Harmony Society
 Red River Valley|TTBB|SPEBSQSA
 Red Rose Rag|TTBB|Melvin Knight
-Red Roses For A Blue Lady|TTBB|Chuck Brooks
+Red Roses For a Blue Lady|TTBB|Chuck Brooks
 Red Rubber Ball|SATB|Joe Mannherz
 Red Rubber Ball|TTBB|Jon Nicholas
 Red Sails In The Sunset|SSAA|Susan Heimburger
@@ -18145,8 +17888,8 @@ Restless|TTBB|Mark Stevens
 Retreat|TTBB|Steve Tramack
 Return to Pooh Corner|SSAA|Joey Minshall
 Return to Pooh Corner|TTBB|Manoj Padki
+Return to Sender|TTBB|Duane Enders
 Return To Sender|SSAA|Kohl Kitzmiller
-Return To Sender|TTBB|Duane Enders
 Reuben And Rachel (Parody)|TTBB|Adam Scott
 Reunion|TTBB|Todd Troutman
 Reunite Commercial|SSAA|Jo Lund
@@ -18178,9 +17921,6 @@ Rhythm Medley|TTBB|Larry Wright
 Rhythm Medley|TTBB|Webb Comfort
 Rhythm Medley (I Got Rhythm/Fascinating Rhythm/Crazy Rhythm)|TTBB|Aaron Dale
 Rhythm n' Words|SSAA|Joe Spiecker
-Rhythm Of Life|SSAA|David Wallace
-Rhythm Of Life|SSAA|Jim Massey
-Rhythm Of Life|SSAA|Jo Kraut
 Rhythm of Love|SSAA|Deke Sharon & David Wright
 Rhythm of Love|TTBB|Deke Sharon & David Wright
 Rhythm of Love|TTBB|Deke Sharon and David Wright
@@ -18192,7 +17932,6 @@ Rhythm Of Love|TTBB|Alex Kaiserman
 Rhythm Of Love|TTBB|Brent Graham
 Rhythm Of Love|TTBB|David Wright
 Rhythm Of Love|TTBB|Deke Sharon
-Rhythm Of Love|TTBB|Jeremey Johnson
 Rhythm Of Love|TTBB|Sharon Wright
 Rhythm of the Night|SSAA|Cindy Becker
 Rhythm Of The Night|SSAA|Cynthia Becker
@@ -18209,8 +17948,8 @@ Ride in That Chariot|SSAA|Unspecified
 Ride Like the Wind|SATB|Joe Mannherz
 Ride Red Ride|TTBB|Emi Mills
 Ride Red Ride|TTBB|Ernie Boring
-Ride The Chariot|SATB|Barbershop Harmony Society
-Ride The Chariot|SSAA|Barbershop Harmony Society
+Ride the Chariot|SATB|Barbershop Harmony Society
+Ride the Chariot|SSAA|Barbershop Harmony Society
 Ride The Chariot|SSAA|David Wright
 Ride The Chariot|TTBB|Barbershop Harmony Society
 Ride The Chariot|TTBB|David Wright
@@ -18229,7 +17968,6 @@ Riding With Private Malone|TTBB|Adam Scott
 Right As Rain|SSAA|Deke Sharon
 Right As Rain|SSAA|Lauren Kahn
 Right As The Rain|SSAA|Joan D 'Agostino
-RIGHT AS THE RAIN|SSAA|Joan D'Agostino
 Right From The Start|TTBB|David Wright
 Right From The Start She Had My Heart|TTBB|David Wright
 Right Here In Your Arms|TTBB|Jim Shubert
@@ -18240,12 +17978,12 @@ Right Round|TTBB|Deke Sharon
 Righteous Brothers Medley|TTBB|Todd Troutman
 Ring a Ding Ding|TTBB|Anthony Bartholemew
 Ring de Christmas Bells|TTBB|Dave Briner
+Ring of Fire|TTBB|Kevin Keller
 Ring Of Fire|SATB|Kevin Keller
 Ring Of Fire|SATB|Sam Hubbard
 Ring Of Fire|SSAA|Kevin Keller
 Ring Of Fire|TTBB|David Wright
 Ring Of Fire|TTBB|Deke Sharon
-Ring Of Fire|TTBB|Kevin Keller
 Ring Of Fire|TTBB|Sam Hubbard
 Ring Out The Bells|SATB|Val Hicks
 Ring Out The Bells|SSAA|Val Hicks
@@ -18255,7 +17993,6 @@ Ring Them Bells|SSAA|Marge Bailey
 Ring Those Christmas Bells|TTBB|Kevin Keller
 Ring-A-Ding Ding|SATB|Kevin Keller
 Ring-A-Ding Ding|SSAA|Kevin Keller
-Ring-A-Ding Ding|TTBB|Anthony Bartholomew
 Ring-A-Ding Ding|TTBB|Kevin Keller
 Ring-a-Ding Ding!|TTBB|Anthony Bartholomew
 Ring, Ring the Banjo!|SATB|Thomas Degan
@@ -18271,7 +18008,6 @@ Rise Like A Phoenix|SSAA|Erica Kelch-Slesnick
 Rise Up|SATB|David Zimmerman
 Rise Up Shepherd|TTBB|Steve Armstrong
 Rise Up Shepherd And Follow|TTBB|Derric Johnson
-Rise Up Shepherd And Follow|TTBB|Jon Nicholas
 Rise Up Shepherd And Follow|TTBB|Walter Latzko
 Rise Up, Shepherd, and Follow|TTBB|Jon Nicholas
 Rise Up, Shepherd, And Follow|TTBB|David Maddux
@@ -18284,7 +18020,6 @@ River Deep Mountain High|SSAA|Deke Sharon
 River In Judea|SSAA|Marie Johnson
 River In Judea|SSAA|Marsha Zwicker
 River Jordan|TTBB|Ken Lang
-River of Dreams|SSAA|Becky Wilkins
 RIVER OF DREAMS|SSAA|Jo Lund
 River of Song|SSAA|Tom Gentry
 River of Song|TTBB|Tom Gentry
@@ -18313,21 +18048,21 @@ Rock and Rock Medley|SSAA|Jo Lund
 Rock and Rock Medley|TTBB|Tom Gentry
 Rock and Roll Christmas|SSAA|Jon Nicholas
 Rock and Roll Christmas|TTBB|Jon Nicholas
+Rock and Roll Is Here to Stay|TTBB|Brent Gerber
 Rock And Roll Is Here To Stay|SSAA|Charlene Yazurlo
-Rock And Roll Is Here To Stay|TTBB|Brent Gerber
 Rock And Roll Is Here To Stay|TTBB|Larry Wright
 Rock And Roll Is Here To Stay|TTBB|Tom Gentry
 ROCK AND ROLL IS HERE TO STAY|SSAA|Lori Ludlum
 Rock and Roll Medley|TTBB|Mark Hale
 Rock And Roll Medley|SSAA|Tom Gentry
 Rock And Roll Medley|TTBB|Tom Gentry
-Rock Around The Clock|SATB|Jon Nicholas
-Rock Around The Clock|SSAA|Bev Sellers
+Rock Around the Clock|SATB|Jon Nicholas
+Rock Around the Clock|SSAA|Bev Sellers
+Rock Around the Clock|SSAA|Jon Nicholas
+Rock Around the Clock|TTBB|Jon Nicholas
 Rock Around The Clock|SSAA|Glenda Lloyd
-Rock Around The Clock|SSAA|Jon Nicholas
 Rock Around The Clock|SSAA|Norma Andersen
 Rock Around The Clock|TTBB|James Shubert
-Rock Around The Clock|TTBB|Jon Nicholas
 Rock Around The Clock|TTBB|Tom Gentry
 Rock Around The Clock (YWIH)|SSAA|Norma Andersen
 Rock It For Me|SSAA|Aaron Dale
@@ -18361,12 +18096,12 @@ Rocket Man|SATB|Deke Sharon
 Rockies Medley|TTBB|Dan Paymar
 Rockin Around the Christmas Tree|SSAA|Sandy Sharpe
 Rockin Around The Christmas Tree|TTBB|Aaron Dale
+Rockin' Around the Christmas Tree|SSAA|Tedda Lippincott
 Rockin' Around The Christmas Tree|SATB|Deke Sharon
 Rockin' Around The Christmas Tree|SSAA|Aaron Dale
 Rockin' Around The Christmas Tree|SSAA|Adam Reimnitz
 Rockin' Around The Christmas Tree|SSAA|Carolyn Schmidt
 Rockin' Around The Christmas Tree|SSAA|Marsha Zwicker
-Rockin' Around The Christmas Tree|SSAA|Tedda Lippincott
 Rockin' Around The Christmas Tree|TTBB|Gabriel Lawson
 Rockin' Around The Christmas Tree|TTBB|Jon Nicholas
 Rockin' Around The Christmas Tree|TTBB|Kevin Koehl
@@ -18418,7 +18153,7 @@ Roll On, Mississippi, Roll On|TTBB|Chuck Northrup
 Roll On, Mississippi, Roll On|TTBB|Rob Hopkins
 Roll On, Mississippi, Roll On|TTBB|SPEBSQSA
 Roll On, Missouri|TTBB|Munson Hinman
-Roll Out Of Bed With A Smile|TTBB|Dennis Driscoll
+Roll Out of Bed With a Smile|TTBB|Dennis Driscoll
 Roll Out Of Bed With A Smile|TTBB|Kevin Keller
 Roll Out Of Bed With A Smile|TTBB|Rob Hopkins
 Roll Out the Barrel/Zip-A-Dee-Doo-Dah Medley|TTBB|Jay Giallombardo
@@ -18426,10 +18161,10 @@ Roll, Michigan Roll|TTBB|Jeremey Johnson
 Rollin' Home|TTBB|G. W. Pellant
 Rolling Along on Long Island|SSAA|Jo Lund
 Rolling in the Deep|SSAA|Don Henken
+Rolling in the Deep|SSAA|Michael Gellert
 Rolling In The Deep|SATB|Alex Morris
 Rolling In The Deep|SSAA|Anthony Bartholomew
 Rolling In The Deep|SSAA|Elaine Gain
-Rolling In The Deep|SSAA|Michael Gellert
 Rolling In The Deep|TTBB|Deke Sharon
 Rolling In The Deep|TTBB|Richard Curtis
 Rolling in the Deep (Beck)|SSAA|Brian Beck
@@ -18452,6 +18187,7 @@ Rose Of Washington Square|TTBB|Jack Baird
 Rose Of Washington Square|TTBB|Walter Latzko
 Rosemary|TTBB|Dennis Driscoll
 Roses Bring Dreams of You|TTBB|Tom Gentry
+Roses of Picardy|TTBB|Willis Diekema
 Roses Of Picardy|SSAA|Nancy Bergman
 Roses Of Picardy|SSAA|Walter Latzko
 Roses Of Picardy|TTBB|Earl Moon
@@ -18460,10 +18196,9 @@ Roses Of Picardy|TTBB|Lou Perry
 Roses Of Picardy|TTBB|Louis Perry
 Roses Of Picardy|TTBB|Roy Keys
 Roses Of Picardy|TTBB|Tom Gentry
-Roses Of Picardy|TTBB|Willis Diekema
 Roses Of Success|TTBB|Don Gray
 Roses Of Success|TTBB|Mark Goodney
-Roses Of Yesterday|SSAA|Nancy Bergman
+Roses of Yesterday|SSAA|Nancy Bergman
 Roses Of Yesterday|TTBB|Elling Sagen
 Rosetta|TTBB|Jon Nicholas
 Rosie|SSAA|Nancy Bergman
@@ -18496,9 +18231,7 @@ ROUTE SIXTY SIX|SSAA|Ardeth Fullmer
 ROUTE SIXTY SIX|SSAA|Dorothy Herivel
 ROUTE SIXTY SIX|SSAA|Jim Arns
 ROUTE SIXTY SIX|SSAA|Marge Bailey
-Route Sixty-Six|SSAA|Jim Arns
 Route Sixty-Six|SSAA|Lorraine Rochefort
-Route Sixty-Six|SSAA|Marge Bailey
 Row Your Boat|SSAA|Jon Nicholas
 Row Your Boat|TTBB|Jon Nicholas
 Row Your Boat|TTBB|Melody Hine
@@ -18560,9 +18293,7 @@ Rudolph The Red Nosed Reindeer|TTBB|Mike Menefee
 RUDOLPH THE RED NOSED REINDEER|SSAA|La Veda Redfield
 RUDOLPH THE RED NOSED REINDEER La|SSAA|Veda Redfield
 Rudolph the Red-Nosed Reindeer|SSAA|Burt Szabo
-Rudolph the Red-Nosed Reindeer|SSAA|Nancy Bergman
 Rudolph the Red-Nosed Reindeer|TTBB|Burt Szabo
-RUDOLPH THE RED-NOSED REINDEER|SSAA|Carolyn Schmidt
 Rule the World|SSAA|Liz Garnett
 Rule The World|SATB|Unspecified
 Rum And Coca Cola|SSAA|Walter Latzko
@@ -18599,7 +18330,6 @@ Runnin' Wild|SSAA|Jan Meyer
 Runnin' Wild|SSAA|Mark Rusch
 Runnin' Wild|SSAA|Nancy Bergman
 Runnin' Wild|SSAA|Walter Latzko
-Runnin' Wild|TTBB|David Wright
 Runnin' Wild|TTBB|Ed Waesche
 Runnin' Wild|TTBB|Mark Rusch
 Runnin' Wild|TTBB|Walter Latzko
@@ -18621,11 +18351,9 @@ S.O.S.|SSAA|Lynnell Diamond
 S'POSIN|SSAA|Diana Franceschi
 S'vivon|TTBB|Gary A. Lewis
 S'Vivon|TTBB|Gary Lewis
-S'Wonderful|TTBB|David Wright
 Sabbath Prayer|TTBB|Manoj Padki
 Sabre Dance|SSAA|Joey Minshall
 Sad Songs (Say So Much)|TTBB|Mark Stevens
-Sadder But Wiser Girl|TTBB|Walter Latzko
 Sadie, Sadie, Married Lady|SSAA|Kay Bromert
 Safe and Sound|SSAA|Adam Bock
 Safe and Sound|SSAA|Lauren Kahn
@@ -18661,7 +18389,6 @@ Salvation Is Created (Spasineye Sodelal)|TTBB|Pavel Chesnokov
 Salvation Is Created (Spasineye Sodelal) (Pavel Chesn|TTBB|Pavel Chesnokov
 Sam Cooke Medley|TTBB|Rob Campbell
 Sam the Old Accordian Man|TTBB|Earl Moon
-Sam You Made the Pants Too Long|SSAA|Tedda Lippincott
 SAM, THE OLD ACCORDIAN MAN|SSAA|Tedda Lippincott
 Sam, The Old Accordion Man|SSAA|Kevin Keller
 Sam, The Old Accordion Man|SSAA|Tedda Lippincott
@@ -18780,14 +18507,12 @@ Save The Last Dance For Me|SSAA|Takako Fuke
 Save The Last Dance For Me|TTBB|Aaron Dale
 Save The Last Dance For Me|TTBB|Kohl Kitzmiller
 Save The Last Dance/Sway Medley|SSAA|Aaron Dale
-Save The Last Dance/Sway Medley|TTBB|Aaron Dale
 Save Tonight|SATB|Nicholas Wright
 Save Tonight|TTBB|Deke Sharon
 Save Your Love for Me|TTBB|Kevin Keller
 Save Your Sorrow|SSAA|Joan D 'Agostino
 Save Your Sorrow|TTBB|Patrick McAlexander
 Save Your Sorrow|TTBB|Walter Latzko
-SAVE YOUR SORROW|SSAA|Joan D'Agostino
 Saved|TTBB|Tom Gentry
 Saving All My Love For You|TTBB|Matthew Gallagher
 Saving All My Love For You|TTBB|Wayne Grimmer
@@ -18799,9 +18524,9 @@ Say Hello to Pittsburgh|TTBB|Tom Gentry
 Say Hello To Sally For Me|TTBB|Walter Latzko
 Say It Isn't So|SSAA|Nancy Bergman
 Say It Isn't So|SSAA|Sharon Holmes
+Say It with Music|SSAA|Linda Edmondson
 Say It With Music|SSAA|Flora Beth Cunningham
 Say It With Music|SSAA|Kay Bromert
-Say It With Music|SSAA|Linda Edmondson
 SAY IT WITH MUSIC Flora|SSAA|Beth Cunningham
 Say Mister / If You Knew Susie Medley|TTBB|Rob Hopkins
 Say Mister, Have You Met Rosie's Sister|TTBB|Adam Scott
@@ -18845,9 +18570,9 @@ School House Medley|TTBB|Jay Giallombardo
 School Song|TTBB|Greg Mallett
 School's Out|TTBB|Jon Nicholas
 Scooby Doo, Where Are You?|TTBB|Dan Wessler
+Scotch and Soda|SSAA|Jo Lund
 Scotch And Soda|SATB|Joe Mannherz
 Scotch And Soda|SSAA|Carolyn Healey
-Scotch And Soda|SSAA|Jo Lund
 Scotch And Soda|SSAA|Mary K. Coffman Music Fund
 Scotch And Soda|SSAA|Scott Kitzmiller
 Scotch And Soda|SSAA|Sylvia Alsbury
@@ -18900,14 +18625,11 @@ Second Hand Rose|SSAA|Walter Latzko
 Second Hand Rose|TTBB|J Rae Jamieson
 Second Hand Rose / She Is More To Be Pitied...|SSAA|Nancy Bergman
 Second Hand Rose/More to Be Pitied|SSAA|Nancy Bergman
-Second Hand Rose/She Is More to Be Pitied|SSAA|Nancy Bergman
 Second Star to the Right|SSAA|Sam Hubbard
 Second Star to the Right|SSAA|Tom Gentry
 Second Star to the Right|TTBB|Sam Hubbard
-Second Star to the Right|TTBB|Tom Gentry
 Second Time Around|SSAA|June Berg
 Second Time Around|TTBB|Jim Emery
-Second Time Around|TTBB|Steve Delehanty
 Secondhand White Baby Grand|SSAA|Larry Wright
 Secondhand White Baby Grand|TTBB|Theo Hicks
 Secondhand White Baby Grand|TTBB|Theodore Hicks
@@ -18943,9 +18665,9 @@ Seize The Day (from Newsies)|TTBB|Theo Hicks
 Seize The Day (From Newsies)|SSAA|Carole Prietto
 Semi Charmed Life|SATB|Deke Sharon
 Semper Paratus|TTBB|Jim West
+Send In the Clowns|SSAA|Kay Bromert
 Send In the Clowns|TTBB|Randy Rogers
 Send In The Clowns|SSAA|Joey Minshall
-Send In The Clowns|SSAA|Kay Bromert
 Send In The Clowns|SSAA|Larry Wright
 Send In The Clowns|SSAA|Tom Gentry
 Send In The Clowns|TTBB|Jay Giallombardo
@@ -18964,7 +18686,7 @@ Senior Citizen Blues|TTBB|Val Hicks
 Senior Moments|TTBB|Tom Gentry
 Sensation Rag|TTBB|Jack Baird
 Sentimental Baby|TTBB|Walter Latzko
-Sentimental Gentleman From Georgia|SSAA|Ed Waesche
+Sentimental Gentleman from Georgia|SSAA|Ed Waesche
 Sentimental Gentleman From Georgia|TTBB|Ed Waesche
 Sentimental Gentleman From Georgia|TTBB|Roy Keys
 Sentimental Journey|SSAA|Audrey Oakley
@@ -19056,10 +18778,8 @@ SEVENTY SIX TROMBONES|SSAA|Mary Lou Gomez-Leon
 SEVENTY SIX TROMBONES Mary|SSAA|Lou Gomez-Leon
 Seventy-Six Trombones|SATB|Kevin Keller
 Seventy-Six Trombones|SSAA|Jay Giallombardo
-Seventy-Six Trombones|SSAA|Mary Lou Gomez-Leon
 Seventy-Six Trombones|SSAA|Tom Gentry
 Seventy-Six Trombones|TTBB|Alden Parker
-Seventy-Six Trombones|TTBB|David Wright
 Seventy-Six Trombones|TTBB|Jay Giallombardo
 Seventy-Six Trombones|TTBB|Tom Gentry
 Seventy-Six Trombones|TTBB|Walter Latzko
@@ -19076,8 +18796,6 @@ Sh Boom|TTBB|Diane Butler
 Sh Boom|TTBB|John Spence
 Sh Boom|TTBB|Mark Goodney
 Sh Boom (Life Could be A Dream)|SSAA|Unspecified
-Sh-Boom|SSAA|Marsha Zwicker
-Sh-Boom|SSAA|Tedda Lippincott
 Sh-Boom|TTBB|Tedda Lippincott
 Sh-Boom (Life Could Be a Dream)|SATB|Dave Briner
 Sh-Boom (Life Could Be a Dream)|SSAA|Dave Briner
@@ -19176,9 +18894,9 @@ She's Called Nova Scotia|TTBB|Joe Liles
 She's Funny That Way|TTBB|Walter Latzko
 She's Gonna Fly|SSAA|Michael Gellert
 She's Gonna Love That Barbershop Song|TTBB|David Longroy
+She's Got a Way|TTBB|David Wright
 She's Got A Way|SSAA|Michael Gellert
 She's Got A Way|TTBB|Dan Wessler
-She's Got A Way|TTBB|David Wright
 She's Got A Way|TTBB|Theodore Hicks
 She's Got You|SSAA|June Berg
 She's Leaving Home|SATB|Manoj Padki
@@ -19284,14 +19002,14 @@ Show Biz Is|TTBB|Keith Clark
 Show Business Medley|TTBB|Jay Giallombardo
 Show Me The Way|SSAA|Cris Conerty
 Show Me The Way|TTBB|Anders Lindqvist
+Show Me Where the Good Times Are|SATB|Gene Cokeroft
+Show Me Where the Good Times Are|SSAA|Gene Cokeroft
 Show Me Where the Good Times Are|TTBB|Dot Short and Gene Cokeroft
-Show Me Where The Good Times Are|SATB|Gene Cokeroft
-Show Me Where The Good Times Are|SSAA|Gene Cokeroft
+Show Me Where the Good Times Are|TTBB|Gene Cokeroft
 Show Me Where The Good Times Are|TTBB|Bob Dowma
 Show Me Where The Good Times Are|TTBB|C. C. Gerheim
 Show Me Where The Good Times Are|TTBB|Dick Kneeland
 Show Me Where The Good Times Are|TTBB|Don Gray
-Show Me Where The Good Times Are|TTBB|Gene Cokeroft
 Show Me Where The Good Times Are|TTBB|Gene Cokeroft/Dot Short
 Show Opener|SSAA|Jo Lund
 Showbiz Medley|TTBB|Jay Giallombardo
@@ -19580,23 +19298,19 @@ Sisters Are Doin' It for Themselves|SSAA|Patrick McAlexander
 Sisters Are Doing It For Themselves|SSAA|Ã…se Hagerman
 Sisters Are Doing It For Themselves|SSAA|Ase Hagerman
 Sisters Are Doing It For Themselves|SSAA|Patrick McAlexander
-SISTERS ARE DOING IT FOR THEMSELVES|SSAA|Åse Hagerman
 Sisters In Song|TTBB|Jim West
 Sisters/Together Wherever We Go|SSAA|Dede Nibler
 Sit Down You're Rockin' The Boat|SSAA|Bev Sellers
-Sit Down You're Rockin' The Boat|SSAA|David Wright
 Sit Down You're Rockin' The Boat|SSAA|Kevin Keller
 Sit Down You're Rockin' The Boat|SSAA|Liz Garnett
-Sit Down You're Rockin' The Boat|TTBB|David Wright
 Sit Down You're Rockin' The Boat|TTBB|David Wright, Steven Armstrong
-Sit Down You're Rockin' The Boat|TTBB|Kevin Keller
 Sit Down You're Rockin' The Boat|TTBB|Richard Floersheimer
 Sit Down You're Rockin' The Boat|TTBB|Steve Jamison
 Sit Down You're Rockin' The Boat|TTBB|Walter Latzko
 Sit Down You're Rocking The Boat|SSAA|Bev Sellers
 Sit Down, You're Rockin' the Boat|SSAA|David Wright
+Sit Down, You're Rockin' the Boat|TTBB|David Wright
 Sit Down, You're Rockin' the Boat|TTBB|Kevin Keller
-Sit Down, You're Rockin' The Boat|TTBB|David Wright
 Sit Still, Look Pretty|SSAA|Deke Sharon
 Sittin' On Top Of The World|TTBB|Roger Payne
 Sitting on The Dock of the Bay/Under the Boardwalk|TTBB|Deke Sharon
@@ -19643,7 +19357,6 @@ Slap That Bass|TTBB|Rob Campbell
 Slap That Bass|TTBB|Walter Latzko
 Sleep|TTBB|Jim West
 Sleep|TTBB|Joe Liles
-Sleep Little Tiny King|SSAA|Tedda Lippincott
 Sleep Soldier (Sailor) Boy|TTBB|Douglas Smith
 Sleep Warm|TTBB|Chuck Pettis
 Sleep Well Little Children|SATB|Ken Potter
@@ -19774,7 +19487,7 @@ So Far Away|SSAA|Glenda Lloyd
 So Far Away|SSAA|Jan Meyer
 So High, So Low|TTBB|Walter Latzko
 So High, So Low, So Wide|TTBB|Walter Latzko
-So In Love|TTBB|David Wright
+So in Love|TTBB|David Wright
 So In Love|TTBB|Frank Oglesby
 So In Love|TTBB|Harry Swenson
 So Long Dearie|SSAA|Nancy Bergman
@@ -19812,7 +19525,6 @@ So Rare|TTBB|Robert Rund
 So This Is Love|TTBB|Gary Lewis
 So Tired|TTBB|Jesse Turner
 So What|SATB|Deke Sharon
-So What's New|SSAA|Jean Shook
 So What's New|TTBB|Marvin Skupski
 SO WHAT'S NEW?|SSAA|Jean Shook
 So Wrong|TTBB|Robert Rund
@@ -19836,7 +19548,6 @@ Softly As I Leave You|TTBB|Larry Newth
 Softly As I Leave You|TTBB|Larry Triplett
 Softly As I Leave You|TTBB|Terry Phillips
 Sold|SSAA|Aaron Dale
-Sold|TTBB|Aaron Dale
 Sold|TTBB|Deke Sharon
 Sold (At the Grundy County Auction)|TTBB|Aaron Dale
 Sold (The Grundy County Auction Incident)|SSAA|Aaron Dale
@@ -19994,7 +19705,10 @@ Someone Like You|TTBB|Steve Tramack
 Someone Like You (from Jekyll And Hyde)|TTBB|Steve Tramack
 Someone Sorry Medley (I Had Someone Else/Who's Sorry Now)|SSAA|Tom Gentry
 Someone That I Used To Love|SSAA|Jean McFadyen
-Someone To Watch Over Me|SSAA|Carolyn Schmidt
+Someone to Watch Over Me|SSAA|Carolyn Schmidt
+Someone to Watch Over Me|SSAA|Muriel Berg
+Someone to Watch Over Me|SSAA|Tedda Lippincott
+Someone to Watch Over Me|TTBB|Jay Giallombardo
 Someone To Watch Over Me|SSAA|David Briner
 Someone To Watch Over Me|SSAA|Dede Nibler
 Someone To Watch Over Me|SSAA|Jay Giallombardo
@@ -20004,10 +19718,7 @@ Someone To Watch Over Me|SSAA|Larry Wright
 Someone To Watch Over Me|SSAA|Liz Garnett
 Someone To Watch Over Me|SSAA|Marge Bailey
 Someone To Watch Over Me|SSAA|Marsha Zwicker
-Someone To Watch Over Me|SSAA|Muriel Berg
 Someone To Watch Over Me|SSAA|Patrick McAlexander
-Someone To Watch Over Me|SSAA|Tedda Lippincott
-Someone To Watch Over Me|TTBB|Jay Giallombardo
 Someone To Watch Over Me|TTBB|Joe Mannherz
 Someone To Watch Over Me|TTBB|Walter Latzko
 SOMEONE TO WATCH OVER ME|SSAA|Dave Briner
@@ -20161,7 +19872,6 @@ Song For A Russian Child|SSAA|David Briner
 Song for Ireland|SSAA|Liz Garnett
 Song for Irene|SSAA|Joey Minshall
 Song for Late Summer|SATB|David Avshalomov
-Song For Mary|TTBB|Jay Giallombardo
 Song For The Little Guy, A (version 2)|TTBB|David Wright, Steven Armstrong
 Song For the Mira|SSAA|Joey Minshall
 Song For The Mira|TTBB|Roy Keys, Bob Pyper, Doug McLellan
@@ -20172,13 +19882,10 @@ Song Of Blessing|TTBB|Brian Beck
 Song Of Change|SATB|Mike Menefee
 Song Sung Blue|TTBB|Hilary Allen
 Song Without An Ending|TTBB|Louis Perry
-Song's Gotta Come From The Heart|SSAA|Bev Sellers
 Song's Gotta Come From The Heart|SSAA|Carolyn Healey
 Song's Gotta Come From The Heart|SSAA|David Wright
 Song's Gotta Come From The Heart|SSAA|Jay Giallombardo
-Song's Gotta Come From The Heart|SSAA|LaVeda Redfield
 Song's Gotta Come From The Heart|SSAA|Tom Gentry
-Song's Gotta Come From The Heart|TTBB|David Wright
 Song's Gotta Come From The Heart|TTBB|Jay Giallombardo
 Song's Gotta Come From The Heart|TTBB|Tom Gentry
 Songbird|SSAA|Dede Nibler
@@ -20318,7 +20025,6 @@ Splish Splash|SSAA|Tom Gentry
 Splish Splash|TTBB|Cay Outerbridge
 Spongebob Medley|TTBB|Kohl Kitzmiller
 Spooky Scary Skeletons|TTBB|Kyle Hottel
-Spoonful Of Sugar|TTBB|Russ Foris
 Spoonful of Sugar/Jolly Holiday Medley|TTBB|Liz Garnett
 Sposin|SSAA|Diana Franceschi
 Spread A Little Happiness|SSAA|Joan Adler
@@ -20346,6 +20052,7 @@ Stairway to Heaven|SSAA|Lorraine Rochefort
 Stairway To Paradise|TTBB|Dan Wessler
 Stairway To The Stars|TTBB|Walter Latzko
 Stand A Little Rain|TTBB|Mark Stevens
+Stand by Me|TTBB|Steve Delehanty
 Stand By Me|SATB|Deke Sharon
 Stand By Me|SATB|Joe Mannherz
 Stand By Me|SATB|Steve Delehanty
@@ -20356,7 +20063,6 @@ Stand By Me|SSAA|Steve Delehanty
 Stand By Me|TTBB|David Wright
 Stand By Me|TTBB|Deke Sharon
 Stand By Me|TTBB|Dianne Goldrick
-Stand By Me|TTBB|Steve Delehanty
 Stand By Your Man|SSAA|Tedda Lippincott
 STAND IN THE LIGHT|SSAA|June Dale
 Stand Out|TTBB|Aaron Dale
@@ -20368,7 +20074,7 @@ Standing On The Corner|TTBB|Burt Szabo
 Standing On The Corner|TTBB|Kevin Keller
 Standing On The Corner|TTBB|Mark Goodney
 Standing On The Corner|TTBB|Walter Latzko
-Standing Outside The Fire|SSAA|Joey Minshall
+Standing Outside the Fire|SSAA|Joey Minshall
 Standing/Leaning Medley|TTBB|Tom Gentry
 Star|SSAA|Steve Delehanty
 Star Medley|TTBB|Steve Delehanty
@@ -20388,7 +20094,6 @@ Star Spangled Banner|SSAA|Joni Bescos
 Star Spangled Banner|SSAA|Nancy Bergman
 Star Spangled Banner|SSAA|Unspecified
 Star Spangled Banner|SSAA|Val Hicks
-Star Spangled Banner|TTBB|Aaron Dale
 Star Spangled Banner|TTBB|Brent Graham
 Star Spangled Banner|TTBB|David Avshalomov
 Star Spangled Banner|TTBB|David Harrington
@@ -20403,7 +20108,6 @@ Star Spangled Banner|TTBB|Kevin Keller
 Star Spangled Banner|TTBB|Nancy Bergman
 Star Spangled Banner|TTBB|Steve Jamison
 Star Spangled Banner|TTBB|Tom Campbell
-Star Spangled Banner|TTBB|Val Hicks
 STAR SPANGLED BANNER|SSAA|Joni Besco
 Star Spangled Banner Medley|TTBB|Clay Hine
 Star Trek: The Next Generation - Main Title|SATB|Joey Minshall
@@ -20416,9 +20120,6 @@ Stardust|TTBB|Walter Latzko
 Starlight|SATB|Nicholas Wright
 Starry, Starry Night|TTBB|Todd Troutman
 Stars|TTBB|Deke Sharon
-Stars And Stripes Forever|SATB|David Wright
-Stars And Stripes Forever|SSAA|David Wright
-Stars And Stripes Forever|TTBB|David Wright
 Stars And Stripes Forever|TTBB|Deke Sharon
 Stars Are The Windows Of Heaven|SSAA|Marie Johnson
 Stars Are The Windows Of Heaven|TTBB|Jim Hickman
@@ -20471,13 +20172,13 @@ Steam Heat|TTBB|Craig Minor
 Steam Heat|TTBB|Tom Gentry
 STEAM HEAT from The Pajama Game|SSAA|Tedda Lippincott
 Steamin' Down The River|TTBB|Val Hicks
-Stella By Starlight|TTBB|Jeremey Johnson
+Stella by Starlight|TTBB|Jeremey Johnson
 Stella By Starlight (from The Uninvited)|TTBB|Jeremey Johnson
+Step in Time|TTBB|Kevin Keller
 Step In Time|SSAA|David Wright
 Step In Time|SSAA|Deke Sharon
 Step In Time|SSAA|June Dale
 Step In Time|TTBB|David Wright
-Step In Time|TTBB|Kevin Keller
 Step Inside Love|TTBB|Steve Jamison
 Step Into Christmas|SSAA|Erica Kelch-Slesnick
 Step Into Christmas|SSAA|Lauren Kahn
@@ -20586,7 +20287,6 @@ Story Of The Rose|SSAA|Brent Graham
 Story Of The Rose|SSAA|Jon Nicholas
 Story Of The Rose|TTBB|Barbershop Harmony Society
 Story Of The Rose|TTBB|Brent Graham
-Story Of The Rose|TTBB|Jon Nicholas
 Story of the Rose (Heart of My Heart)|TTBB|Brent Graham
 Storybook|SATB|Robert Rund
 Stout-Hearted Men|TTBB|Dick Stuart
@@ -20598,11 +20298,11 @@ Stouthearted Men|TTBB|Ray Buntaine
 Stouthearted Men|TTBB|Walter Latzko
 Straight Street|TTBB|Jeremey Johnson
 Straighten Up and Fly Right|SSAA|Brian Beck
+Straighten Up and Fly Right|SSAA|Liz Garnett
 Straighten Up and Fly Right|SSAA|Mary Coffman
 Straighten Up And Fly Right|SATB|Andrew Carolan
 Straighten Up And Fly Right|SATB|Joe Mannherz
 Straighten Up And Fly Right|SSAA|Andrew Carolan
-Straighten Up And Fly Right|SSAA|Liz Garnett
 Straighten Up And Fly Right|SSAA|Mary K. Coffman Music Fund
 Straighten Up And Fly Right|TTBB|Greg Volk
 Straighten Up And Fly Right|TTBB|Jim Shubert
@@ -20650,7 +20350,6 @@ Strike Up The Band / Everybody Step Medley|TTBB|Aaron Dale
 Strike Up The Band / I Love A Parade Medley|TTBB|Hal Snyder
 Strike Up The Band / Mardi Gras March/Drummer's Beat Medley|TTBB|Terry Shannon
 Strike Up the Band Medley|TTBB|David Harrington
-Strike Up the Band/Alexander's Ragtime Band Medley|TTBB|David Harrington
 Strip Polka|TTBB|Dennis Driscoll
 Strollin' Down Harmony Lane|TTBB|Mac Huff
 Strolling Home With Jennie|TTBB|Dave Stevens
@@ -20765,9 +20464,7 @@ Sunday|TTBB|Brent Graham
 Sunday|TTBB|John Hohl
 Sunday|TTBB|Robert Martin
 Sunday Candy|SSAA|Nicholas Wright
-Sunday Kind Of Love|SSAA|Janice Wheeler
 Sunday Kind Of Love|SSAA|Lyndal Thorburn
-Sunday Kind Of Love|TTBB|Adam Reimnitz
 Sunday Kind Of Love|TTBB|Patrick McAlexander
 Sunday Morning|TTBB|Deke Sharon
 Sunday Morning|TTBB|Kevin Keller
@@ -20891,8 +20588,8 @@ Sweet Adeline [Doo-Wop]|TTBB|Will Hamblet
 Sweet Adelines Tapestry|SSAA|Jeanette Hawkenson
 Sweet and Lovely|SSAA|Mac Huff
 Sweet and Lovely|SSAA|Mack Huff
+Sweet and Lovely|TTBB|Mac Huff
 Sweet and Lovely|TTBB|Mack Huff
-Sweet And Lovely|TTBB|Mac Huff
 Sweet And Low|SSAA|Carolyn Johnson
 Sweet And Low|SSAA|Walter Latzko
 Sweet And Low|TTBB|Don Webster
@@ -20945,10 +20642,10 @@ Sweet Georgia Brown|TTBB|Vern Knapp
 Sweet Heaven Medley|TTBB|Adam Reimnitz
 Sweet Heaven Medley (Sweet Heaven/When My Baby Smiles at Me)|TTBB|Adam Reimnitz
 Sweet Home Chicago|TTBB|Deke Sharon
-Sweet Hour Of Prayer|SSAA|Jim Clancy
+Sweet Hour of Prayer|SSAA|Jim Clancy
+Sweet Hour of Prayer|TTBB|Jim Clancy
 Sweet Hour Of Prayer|SSAA|Tedda Lippincott
 Sweet Hour Of Prayer|TTBB|Derric Johnson
-Sweet Hour Of Prayer|TTBB|Jim Clancy
 Sweet Hour Of Prayer|TTBB|Joe Johnson
 Sweet Little Alice Blue Gown|SSAA|Bev Sellers
 Sweet Little Girl|TTBB|Kyle and Kohl Kitzmiller
@@ -21018,7 +20715,6 @@ Swing Down Chariot|TTBB|Barbershop Harmony Society
 Swing Down Chariot|TTBB|The Vagabonds
 Swing Down Chariot|TTBB|Unspecified
 Swing Down Chariot|TTBB|Vagabonds
-Swing Down Chariot|TTBB|Vagabonds,
 SWING DOWN SWEET CHARIOT|SSAA|Karen McCarville
 Swing Low|TTBB|Jim West
 Swing Low, Sweet Chariot|TTBB|Maurice Reagan
@@ -21066,8 +20762,8 @@ Taint No Sin|SSAA|Penketh
 Tainted Love|SATB|Deke Sharon
 Take A Bow|TTBB|Wayne Grimmer
 Take A Chance|SSAA|Joey Minshall
+Take A Chance on Me|SSAA|Joey Minshall
 Take A Chance On Me|SATB|Joey Minshall
-Take A Chance On Me|SSAA|Joey Minshall
 Take a Chance on Me (4 part)|SSAA|Joey Minshall
 Take A Chance on Me (7 part)|SSAA|Joey Minshall
 Take A Little Time|TTBB|Greg Lyne
@@ -21098,7 +20794,7 @@ Take Me Along|SSAA|Becky Cartine
 Take Me As I Am|TTBB|Theo Hicks
 Take Me As I Am|TTBB|Theodore Hicks
 Take Me Back to the 1920's|SSAA|Gwen Schweitzer
-Take Me Back To Toyland|SSAA|DeDe Crow
+Take Me Back to Toyland|SSAA|DeDe Crow
 Take Me Home|TTBB|Mark Stevens
 Take Me Home|TTBB|Nicholas Wright
 Take Me Home Tonight|TTBB|Deke Sharon
@@ -21113,11 +20809,11 @@ Take Me Home, Country Roads|TTBB|Renee Craig
 Take Me Or Leave Me|SATB|Kohl Kitzmiller
 Take Me Or Leave Me|SSAA|Simon Arnott
 Take Me Out|SATB|Deke Sharon
+Take Me Out to the Ball Game|SSAA|Anna Maria Parker
 Take Me Out to the Ball Game|TTBB|Unspecified
 Take Me Out To The Ball Game|SATB|Deke Sharon
 Take Me Out To The Ball Game|SATB|Marshall Webb
 Take Me Out To The Ball Game|SATB|Thomas Degan
-Take Me Out To The Ball Game|SSAA|Anna Maria Parker
 Take Me Out To The Ball Game|SSAA|Avis Fellows
 Take Me Out To The Ball Game|SSAA|Dot Calvin
 Take Me Out To The Ball Game|SSAA|Jay Giallombardo
@@ -21145,9 +20841,9 @@ TAKE ME TO THE BALLGAME|SSAA|Marie Johnson
 Take Me to the Land of Jazz|SSAA|Pete Wendling
 Take Me To The Land of Jazz|SSAA|Ann Minihane
 Take Me To The Land of Jazz|SSAA|Mary Coffman
+Take Me To The Land of Jazz|SSAA|Molly Rowland
 Take Me To The Land Of Jazz|SSAA|Ed Waesche
 Take Me To The Land Of Jazz|SSAA|Mary K. Coffman Music Fund
-Take Me To The Land Of Jazz|SSAA|Molly Rowland
 Take Me To The Land Of Jazz|SSAA|Tedda Lippincott
 Take Me To The Land Of Jazz|TTBB|Ed Waesche
 Take Me To The Land Of Jazz|TTBB|Jack Baird
@@ -21165,26 +20861,25 @@ Take On Me|TTBB|Nicholas Wright
 Take The 'A' Train|TTBB|Joe Johnson
 Take The Moon|SATB|Jay Dougherty
 Take These Wings|SSAA|Vicki Uhr
-Take Your Girlie To The Movies|SSAA|Nancy Bergman
 Take Your Girlie To The Movies|TTBB|Burt Szabo
 Take Your Girlie to the Movies!|SSAA|Nancy Bergman
 Takin' A Chance|SSAA|Dot Calvin
 Takin' a Chance on Love|TTBB|Jay Giallombardo
 Takin' Care of Business|SSAA|Corinna Garriock
 Takin' It To The Streets|TTBB|Patrick McAlexander
+Taking a Chance on Love|SSAA|Ed Waesche
+Taking a Chance on Love|TTBB|Jay Giallombardo
+Taking A Chance on Love|SSAA|Avis Fellows
+Taking A Chance on Love|SSAA|Jay Giallombardo
 Taking A Chance on Love|SSAA|Ruby Rhea
 Taking A Chance On Love|SATB|Steve Jamison
 Taking A Chance On Love|SATB|Tom Gentry
 Taking A Chance On Love|SSAA|Ann Minihane
-Taking A Chance On Love|SSAA|Avis Fellows
-Taking A Chance On Love|SSAA|Ed Waesche
-Taking A Chance On Love|SSAA|Jay Giallombardo
 Taking A Chance On Love|SSAA|Steve Jamison
 Taking A Chance On Love|SSAA|Susan Kegley
 Taking A Chance On Love|SSAA|Tom Gentry
 Taking A Chance On Love|TTBB|Brent Graham
 Taking A Chance On Love|TTBB|Ed Waesche
-Taking A Chance On Love|TTBB|Jay Giallombardo
 Taking A Chance On Love|TTBB|Jim Emery
 Taking A Chance On Love|TTBB|Jim Shubert
 Taking A Chance On Love|TTBB|John Hohl
@@ -21285,8 +20980,8 @@ Telling It To The Daisies|SSAA|Walter Latzko
 Temptation|SATB|Vince Peterson
 Temptation (parody)|TTBB|Richard Lengel
 Tempted|TTBB|Deke Sharon
+Ten Feet Off the Ground|SSAA|Barbara Bianchi
 Ten Feet Off the Ground|SSAA|Vicki Uhr
-Ten Feet Off The Ground|SSAA|Barbara Bianchi
 Ten Feet Off The Ground|SSAA|Marsha Zwicker
 Ten Feet Off The Ground|SSAA|Molly Clark
 Ten Feet Off The Ground|SSAA|Val Hicks
@@ -21356,17 +21051,17 @@ Thank You for being a Friend|TTBB|Patrick McAlexander
 Thank You For Being A Friend (8 parts, chorus and quartet solo)|TTBB|Zac Booles
 Thank You For Being My Dad|TTBB|Theodore Hicks
 Thank You For Letting Us Entertain You|TTBB|Walter Latzko
+Thank You for the Music|SSAA|Larry Wright
 Thank You For the Music|SSAA|Barbara McNeill
 Thank You For the Music|SSAA|Carolyn Healey
 Thank You For the Music|SSAA|Tedda Lippincott
+Thank You For the Music|SSAA|Tom Gentry
 Thank You For the Music|SSAA|Unspecified
 Thank You For The Music|SATB|Karen Penketh
 Thank You For The Music|SSAA|David Wright
 Thank You For The Music|SSAA|Deke Sharon
-Thank You For The Music|SSAA|Larry Wright
 Thank You For The Music|SSAA|Nathan Peplinski
 Thank You For The Music|SSAA|Takako Fuke
-Thank You For The Music|SSAA|Tom Gentry
 Thank You For The Music|TTBB|Kirk Young
 Thank You For The Music|TTBB|Larry Wright
 Thank You For The Music|TTBB|Tom Gentry
@@ -21394,7 +21089,6 @@ Thank You, Lord|TTBB|Fred King
 Thankful|SATB|Gary Lewis
 Thankful|SSAA|Joan D 'Agostino
 Thankful|TTBB|Kohl Kitzmiller
-THANKFUL|SSAA|Joan D'Agostino
 Thankful Heart|TTBB|Brian Mastrull
 Thanks Again|SSAA|David Wright
 Thanks For The Buggy Ride|TTBB|Val Hicks
@@ -21423,7 +21117,7 @@ That Don't Impress Me Much|SSAA|Liz Garnett
 That Feeling In The Moonlight|TTBB|Howard Dale
 That Girl Could Kiss!|TTBB|Jon Nicholas
 That Golden Stair|TTBB|Derric Johnson
-That Great Come And Get It Day|SSAA|Jarmela Speta
+That Great Come and Get It Day|SSAA|Jarmela Speta
 THAT LITTLE BOY OF|SSAA|MINE D. Wilkenson
 That Little Boy Of Mine|SSAA|Dave Wilkinson
 That Little Boy Of Mine|TTBB|Joe Mannherz
@@ -21478,11 +21172,11 @@ That Old Feeling|TTBB|John Hohl
 That Old Feeling|TTBB|Kevin Keller
 That Old Feeling|TTBB|Kirk Roose
 That Old Feeling|TTBB|Walter Latzko
+That Old Gang of Mine|SSAA|Nancy Bergman
+That Old Gang of Mine|TTBB|Jack Baird
 That Old Gang Of Mine|SSAA|Ann Minihane
-That Old Gang Of Mine|SSAA|Nancy Bergman
 That Old Gang Of Mine|SSAA|Val Robin Ladouceur
 That Old Gang Of Mine|SSAA|Walter Latzko
-That Old Gang Of Mine|TTBB|Jack Baird
 THAT OLD GANG OF MINE (PARODY)|SSAA|Val Ladouceur
 That Old Home Town Of Mine|TTBB|Loton Willson
 That Old Irish Mother Of Mine|SSAA|Larry Wright
@@ -21493,7 +21187,7 @@ That Old Irish Mother Of Mine|TTBB|Rob Hopkins
 That Old Quartet of Mine|SSAA|Joni Bescos
 That Old Quartet of Mine|SSAA|Lou Perry
 That Old Quartet of Mine|TTBB|Lou Perry
-That Old Quartet Of Mine|TTBB|Louis Perry
+That Old Quartet of Mine|TTBB|Louis Perry
 That Railroad Rag|TTBB|Kirk Roose
 That Rhythm Man|TTBB|Ed Waesche
 That Silver Haired Daddy Of Mine|TTBB|Joe Liles
@@ -21522,9 +21216,8 @@ That Tumble Down Shack In Athlone|TTBB|SPEBSQSA
 That Tumble-down Shack in Athlone|SSAA|Joni Bescos
 That Tumble-down Shack in Athlone|SSAA|Renee Craig
 That Tumble-Down Shack in Athlone|TTBB|SPEBSQSA (Barbershop Harmony Society)
-That Tumble-Down Shack In Athlone|SSAA|Joe Liles
+That Wonderful Mother of Mine|SSAA|Nancy Bergman
 That Wonderful Mother Of Mine|SSAA|Ann Minihane
-That Wonderful Mother Of Mine|SSAA|Nancy Bergman
 That Wonderful Mother Of Mine|TTBB|Bob Graham
 That Wonderful Mother Of Mine|TTBB|Burt Szabo
 That Wonderful Mother Of Mine|TTBB|Jim Clancy
@@ -21561,8 +21254,8 @@ That's An Irish Lullaby|TTBB|Ed Waesche
 That's An Irish Lullaby|TTBB|Paul Bowman
 THAT'S AN IRISH LULLABY|SSAA|Carolyn E Johnson
 That's An Irish Lullabye|SSAA|Nancy Bergman
+That's Christmas to Me|SSAA|Dawn Haggerty
 That's Christmas To Me|SATB|Kohl Kitzmiller
-That's Christmas To Me|SSAA|Dawn Haggerty
 That's Christmas To Me|SSAA|Kay Bromert
 That's Christmas To Me|SSAA|Kohl Kitzmiller
 That's Christmas To Me|TTBB|Jon Nicholas
@@ -21637,12 +21330,9 @@ THE 123 MEDLEY - CIRCLE OF LIFE|SSAA|Penny Hock
 The 20s Dance Medley|TTBB|Ray Danley
 THE 270 MEDLEY - INCHWORM|SSAA|Patsee Parker
 The 59th Street Bridge Song (Feelin' Groovy)|SATB|Tamra Perez
-The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Bev Sellers
-The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Julie Gaulke
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Marge Bailey
 The 59th Street Bridge Song (Feelin' Groovy)|SSAA|Patsee Parker
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Deke Sharon
-The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Don Gray
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Jon Nicholas
 The 59th Street Bridge Song (Feelin' Groovy)|TTBB|Mark Goodney
 The Ace In The Hole|TTBB|Kohl Kitzmiller
@@ -21664,7 +21354,6 @@ The Ballad Of Springhill|TTBB|Steve Tramack
 The Banana Boat Song|TTBB|Don Gray
 The Band Played On|SSAA|Nancy Bergman
 The Band Played On|SSAA|Renee Craig
-The Band Played On|TTBB|Rob Hopkins
 The Band Played On|TTBB|Yesteryear
 THE BARBERSHOP LIMERICK SONG|SSAA|Joan Adler
 The Barbershop Strut|SSAA|Earl Moon
@@ -21690,7 +21379,6 @@ The Best Is Yet To Come|TTBB|Joe Grimme
 The Best Man|TTBB|Matt Astle
 The Best of Days|SSAA|Joey Minshall
 The Best Of Doo Wop|TTBB|Unspecified
-The Best Of Me|TTBB|Rasmus Krigström
 THE BEST OF TIMES|SSAA|Tedda Lippincott
 The Best Thing For You|SSAA|Kohl Kitzmiller
 The Best Thing For You|TTBB|Kohl Kitzmiller
@@ -21710,10 +21398,9 @@ The Big Brass Band From Brazil|TTBB|Dick Floersheimer
 The Big Parade|SSAA|Michael Gellert
 The Biggest Parakeets in Town|TTBB|Tom Gentry
 The Birds And The Bees|TTBB|TJ Barranger
-The Birth of the Blues|SSAA|Carolyn Schmidt
+The Birth of the Blues|TTBB|David Wright
 The Birth of the Blues|TTBB|Tony Searle
 The Birth Of The Blues|TTBB|Buzz Haeger
-The Birth Of The Blues|TTBB|David Wright
 The Birth Of The Blues|TTBB|Don Gray
 The Birth Of The Blues|TTBB|Steve Jamison
 The Birthday Of A King|SSAA|Jay Giallombardo
@@ -21746,30 +21433,23 @@ The Brooklyn Bridge|SSAA|Sonny Steffan
 The Brotherhood Of Man (Parody)|TTBB|Jay Giallombardo
 The Bunny Hug|TTBB|Jim Shubert
 The Candy Man|TTBB|Joe Johnson
-The Candy Man|TTBB|Kevin Keller
 The Captain Of The Toy Brigade|SSAA|Jay Giallombardo
 The Captain Of The Toy Brigade|TTBB|Burt Szabo
-The Captain Of The Toy Brigade|TTBB|Jay Giallombardo
 The Cat Is High|SSAA|David Wright
 The Cave|SATB|Nicholas Wright
 The Chain|SSAA|Deke Sharon
 The Chain|TTBB|Aaron Dale
 The Chandler's Wife|TTBB|Thomas Degan
 The Chapters Of Life|TTBB|Ed Waesche
-The Chapters Of Life|TTBB|Walter Latzko
 The Chicken Dance|SSAA|Asuka Ichikawa
 The Chipmunk Song|SSAA|Carole Prietto
 The Chipmunk Song|SSAA|Debbie Keretz
 The Chipmunks Christmas Song|TTBB|The Grand Tradition/Reveille
 The Chocolate Carol|SATB|David Avshalomov
 The Chordbuster March|SATB|W. A. Wyatt
-The Chordbuster March|SATB|W.A. Wyatt
 The Chordbuster March|SSAA|Becky Wilkins
-The Chordbuster March|SSAA|Joe Liles
 The Chordbuster March|SSAA|W. A. Wyatt
-The Chordbuster March|SSAA|W.A. Wyatt
 The Chordbuster March|TTBB|W. A. Wyatt
-The Chordbuster March|TTBB|W.A. Wyatt
 The Chordbuster March|TTBB|WA Wyatt
 THE CHORDBUSTER MARCH|SSAA|Becky L Wilkins
 The Chordbuster's March|SSAA|Joe Liles
@@ -21817,9 +21497,9 @@ The Christmas Song (Chestnuts Roasting on an Open Fire)|TTBB|Aaron Dale
 The Christmas Waltz|SSAA|Anastasio Rossi
 The Christmas Waltz|SSAA|Jo Lund
 The Christmas Waltz|TTBB|Joe Johnson
-The Church Bells Are Ringing For Mary|SSAA|Barbara Bianchi
 The Church Bells Are Ringing For Mary|TTBB|Ed Waesche
 The Church Bells Are Ringing For Mary|TTBB|Greg Lapp
+THE CHURCH BELLS ARE RINGING FOR MARY|SSAA|Barbara Bianchi
 The Church Bells' Song|SSAA|Tom Gentry
 The Church Bells' Song|TTBB|Tom Gentry
 The Church In The Wildwood|TTBB|Burt Szabo
@@ -21829,8 +21509,6 @@ The Circle Of Life|SATB|Kohl Kitzmiller
 The Circle Of Life|SATB|Patrick McAlexander
 The Circle Of Life|SSAA|Jim Massey
 The Circle Of Life|SSAA|Penny Hock
-The Circle Of Life|TTBB|Jake Jacobson
-The Circle Of Life|TTBB|Jay Giallombardo
 The Circle Of Life|TTBB|Mark Burnip
 The Circle Of Life|TTBB|Patrick McAlexander
 The Climb|SSAA|Carole Prietto
@@ -21851,7 +21529,6 @@ The Colors of My Life|TTBB|Simon Arnott
 The Colour of My Love|SSAA|Jo Lund
 The Colour of My Love|SSAA|Joe Mannherz
 The Colour of My Love|TTBB|Joe Mannherz
-The County Fair|TTBB|Russ Foris
 The Cranky Old Yank|TTBB|Jim West
 The Crimond|TTBB|Richard Curtis
 The Croquet Song|TTBB|Walter Latzko
@@ -21871,7 +21548,6 @@ The Day After Thanksgiving|TTBB|Eric Ruthenberg
 The Day that the Circus Left Town|TTBB|Fred King
 The Days Back When|TTBB|Theodore Hicks
 The Days Back When|TTBB|Val Hicks
-The Desert Song|TTBB|Jon Nicholas
 The Devil Ain't Lazy|TTBB|Aaron Dale
 The Devil Went Down to Georgia|SSAA|Carole Prietto
 The Dinosaur Strut|TTBB|Unspecified
@@ -21910,7 +21586,6 @@ The First Noel|SATB|David Harrington
 The First Noel|SATB|Deke Sharon
 The First Noel|SATB|Derric Johnson
 The First Noel|SATB|Wayne Grimmer
-The First Noel|SSAA|Carolyn Johnson
 The First Noel|SSAA|David Harrington
 The First Noel|SSAA|Nancy Bergman
 The First Noel|SSAA|Wayne Grimmer
@@ -21933,10 +21608,8 @@ The Fool On The Hill|TTBB|Jon Nicholas
 The Fourth of July Parade|TTBB|Dan Naumann
 The Fox|TTBB|Kevin Koehl
 The Friendly Beasts|SATB|Kay Bromert
-The Frim Fram Sauce|SSAA|Betty Grant
 The Frim Fram Sauce|SSAA|Joe Mannherz
 The Frim Fram Sauce|SSAA|Mike Menefee
-The Frim Fram Sauce|TTBB|Aaron Dale
 The Frim Fram Sauce|TTBB|Joe Mannherz
 THE FRIM FRAM SAUCE|SSAA|Becky V. Grant
 The Fruit Cake|TTBB|Jim West
@@ -21965,7 +21638,7 @@ The Girl in 14G|SSAA|Michael Gellert
 The Girl in 14G|SSAA|Simon Arnott
 The Girl in 14G|SSAA|Tom Gentry
 The Girl in 14G|TTBB|Tom Gentry
-The Girl In My Fantasy|TTBB|Joe Liles
+The Girl in My Fantasy|TTBB|Joe Liles
 The Girl In My Memory|TTBB|Dave Stevens
 The Girl In Noman's Land|SSAA|Joe Mannherz
 The Girl on the Magazine Cover|TTBB|Burt Szabo
@@ -22005,9 +21678,9 @@ The Greatest Gift of All|SSAA|Carole Prietto
 The Greatest Gift of All|SSAA|Tom Gentry
 The Greatest Gift of All|TTBB|Matthew Gallagher
 The Greatest Gift of All|TTBB|Tom Gentry
-The Greatest Love Of All|SSAA|Jo Lund
 The Greatest Love Of All|SSAA|Joey Minshall
 The Greatest Love Of All|TTBB|Todd Troutman
+THE GREATEST LOVE OF ALL|SSAA|Jo Lund
 The Greatest Show|SATB|Theodore Hicks
 The Greatest Show|SSAA|Adam Bock
 The Greatest Show|SSAA|Kohl Kitzmiller
@@ -22022,7 +21695,6 @@ The Hand That Rocked My Cradle Rules My Heart|TTBB|Burt Szabo
 The Hands of Time|SSAA|Joe Mannherz
 The Hands of Time|TTBB|Joe Mannherz
 The Headless Horseman|SATB|Kohl Kitzmiller
-The Headless Horseman|TTBB|Aaron Dale
 The Headless Horseman|TTBB|David Wright
 The Headless Horseman|TTBB|Larry Triplett
 The Heart of a Girl|SSAA|Tom Gentry
@@ -22049,7 +21721,6 @@ The Human Abstract|SATB|David Avshalomov
 The Hut-Sut Song|TTBB|Rasmus Krigström
 The Impossible Dream|SATB|Manoj Padki
 The Impossible Dream|SSAA|Clay Hine
-The Impossible Dream|SSAA|Jay Giallombardo
 The Impossible Dream|SSAA|Larry Wright
 The Impossible Dream|TTBB|Bob Bohn
 The Impossible Dream|TTBB|David Wright
@@ -22082,7 +21753,6 @@ The Joy of Life|SSAA|Joe Mannherz
 The Joy of Life|TTBB|Joe Mannherz
 The Jumpin' Jive|TTBB|Aaron Dale
 The Kazoo Concerto|TTBB|Tom Gentry
-The Key To Success With The Beautiful Girls|TTBB|John Hohl
 The King Is Coming|TTBB|Derric Johnson
 The King Medley|TTBB|Webb Comfort
 The Kingdom of Shy|SATB|Joe Mannherz
@@ -22090,7 +21760,6 @@ The Lady Down the Hall|SSAA|Michael Gellert
 The Lady From 29 Palms|SSAA|Marie Johnson
 The Lady In Red|SSAA|Kohl Kitzmiller
 The Lady Is A Tramp|TTBB|Wayne Grimmer
-The Lady Takes The Cowboy Every Time|SSAA|Nancy Bergman
 The Lady's In Love With You|TTBB|Wayne Grimmer
 The Lamb|SATB|David Avshalomov
 The Last Dance|TTBB|Dennis Driscoll
@@ -22116,17 +21785,16 @@ The Lighthouse Keeper|SSAA|Joey Minshall
 The Lilly|SATB|David Avshalomov
 The Lion Sleeps Tonight|SATB|Scott Turnbull
 The Lion Sleeps Tonight|SSAA|Scott Turnbull
-The Lion Sleeps Tonight|SSAA|Tedda Lippincott
 The Lion Sleeps Tonight|TTBB|Jon Nicholas
 The Lion Sleeps Tonight|TTBB|Scott Turnbull
 The Lion Sleeps Tonight|TTBB|Unspecified
 THE LION SLEEPS TONIGHT|SSAA|Molly Clark
+THE LION SLEEPS TONIGHT|SSAA|Tedda Lippincott
 The Little Bitty Baby|TTBB|Derric Johnson
 The Little Boy|SSAA|Tom Gentry
 The Little Boy|TTBB|Thomas Gentry
 The Little Boy|TTBB|Tom Gentry
 The Little Child|SSAA|Nancy Bergman
-The Little Drummer Boy|SSAA|Tedda Lippincott
 The Little Drummer Boy|TTBB|David Wright
 The Little Drummer Boy|TTBB|Jon Nicholas
 The Little Drummer Boy|TTBB|Tracy Shirk
@@ -22224,7 +21892,6 @@ The Man That Got Away|TTBB|Greg Mallett
 The Man Who Can't Be Moved|SATB|Nicholas Wright
 The Man With the Bag|SSAA|Marge Bailey
 The Man With the Bag|SSAA|Nancy Bergman
-The Man With The Bag|SSAA|Lorraine Rochefort
 The Man With The Bag|TTBB|Jon Nicholas
 The Man With The Bag|TTBB|Tom Gentry and Lorraine Rochefort
 The Mansions Of The Lord|TTBB|Jon Nicholas
@@ -22294,13 +21961,15 @@ The Musics Always There With You|SSAA|Kay Bromert
 The Naughty Lady Of Shady Lane|TTBB|Joe Johnson
 The Naughty Lady Of Shady Lane|TTBB|Unspecified
 THE NAUGHTY LADY OF SHADY LANE|SSAA|Kay Bromert
+The Nearness of You|SSAA|Carolyn Healey
 The Nearness of You|SSAA|John Brockman
 The Nearness of You|SSAA|Rob Hopkins
 The Nearness of You|SSAA|Susan Lamb Kegley
+The Nearness of You|TTBB|John Brockman
 The Nearness of You|TTBB|Kirby Shaw
+The Nearness of You|TTBB|Rob Hopkins
 The Nearness Of You|SATB|Kevin Keller
 The Nearness Of You|SSAA|Adam Reimnitz
-The Nearness Of You|SSAA|Carolyn Healey
 The Nearness Of You|SSAA|Susan Kegley
 The Nearness Of You|SSAA|Walter Latzko
 The Nearness Of You|TTBB|Andrew Harris
@@ -22308,9 +21977,7 @@ The Nearness Of You|TTBB|Bill Pellant
 The Nearness Of You|TTBB|J Rae Jamieson
 The Nearness Of You|TTBB|Jay Dougherty
 The Nearness Of You|TTBB|Jim Shubert
-The Nearness Of You|TTBB|John Brockman
 The Nearness Of You|TTBB|Kevin Keller
-The Nearness Of You|TTBB|Rob Hopkins
 The Nearness Of You|TTBB|Ron Rank
 The Nearness Of You|TTBB|Walter Latzko
 THE NEARNESS OF YOU|SSAA|Joan Adler
@@ -22348,8 +22015,8 @@ The Old Maids Ball|SSAA|Barbara McNeill
 The Old Maids Ball|SSAA|Carolyn Schmidt
 The Old Man|TTBB|Jay Giallombardo
 The Old Man|TTBB|Larry Wright
+The Old Man's Back in Town|SSAA|Joe Liles
 The Old Man's Back In Town|SSAA|Brian Beck
-The Old Man's Back In Town|SSAA|Joe Liles
 The Old North State|TTBB|Jeremey Johnson
 The Old Piano Roll Blues|SSAA|Joni Bescos
 The Old Piano Roll Blues|TTBB|David Wright
@@ -22365,7 +22032,6 @@ The Old Spinning Wheel|TTBB|Tom Gentry
 The Older I Get|SSAA|Sheryl Neal
 The Oldest Established|TTBB|Don Gray
 The One I Love (Belongs To Somebody Else)|TTBB|Clay Hine
-The One I Love Belongs to Somebody Else|TTBB|Clay Hine
 The One I Love Belongs to Somebody Else|TTBB|Jim Shubert
 The One I Love Belongs To Somebody Else|SATB|Joe Mannherz
 The One I Love Belongs To Somebody Else|SSAA|Joe Mannherz
@@ -22373,8 +22039,6 @@ The One on the Right is On the Left|SSAA|Kay Bromert
 The One That You Love|TTBB|Gary Thiel
 The Only Guy Can Make Me Cry|SSAA|Carolyn Johnson
 The Only Thing I Want for Christmas|SSAA|Joan Adler
-The Original Dixieland One Step|SSAA|Greg Volk
-The Original Dixieland One Step|SSAA|Renee Craig
 The Original Dixieland One-Step|TTBB|Renee Craig
 The Out of Tune Song|TTBB|Michael Webber
 The Over 40 Waltz|TTBB|Chuck Brooks
@@ -22429,13 +22093,12 @@ The Power of the Dream|SSAA|Tedda Lippincott
 The Prayer|SATB|Deke Sharon
 The Prayer|SSAA|Jay Giallombardo
 The Prayer|SSAA|Joan D 'Agostino
-The Prayer|SSAA|Joan D'Agostino
 The Prayer|SSAA|Joe Liles
 The Prayer|TTBB|Jay Giallombardo
 The Prayer|TTBB|Kenny Ray Hatton
 The Prayer|TTBB|Steven Armstrong
+The Preacher and the Bear|TTBB|Bud Leabo
 The Preacher And The Bear|SSAA|Walter Latzko
-The Preacher And The Bear|TTBB|Bud Leabo
 The Preacher And The Bear|TTBB|Walter Latzko
 The Proposal Song|TTBB|Jeremey Johnson
 The Quest (Impossible Dream)|SSAA|Ed Waesche
@@ -22450,10 +22113,10 @@ The Red Rose Rag|TTBB|Mel Knight
 The Red, White And Blue|TTBB|Derric Johnson
 The Rest of Your Life|TTBB|Aaron Dale
 The Restroom song|SATB|Joe Mannherz
-The Rhythm Of Life|SSAA|David Wallace
-The Rhythm Of Life|SSAA|Jim Massey
-The Rhythm Of Life|SSAA|Jo Kraut
 The Rhythm Of Life|TTBB|Greg Volk
+THE RHYTHM OF LIFE|SSAA|David Wallace
+THE RHYTHM OF LIFE|SSAA|Jim Massey
+THE RHYTHM OF LIFE|SSAA|Jo Kraut
 The Rhythm of Life (SATB)|SATB|Roger Emerson
 The Rhythm of Love|TTBB|Jeremey Johnson
 The Riff Song|TTBB|Jon Nicholas
@@ -22464,11 +22127,10 @@ The River|SSAA|Joey Minshall
 The River|SSAA|June Berg
 The River|TTBB|Rob Hopkins
 The River Of Dreams|SATB|Deke Sharon
-The River Of Dreams|SSAA|Becky Wilkins
 The River Of Dreams|SSAA|Charlene Yazurlo
-The River Of Dreams|SSAA|Jo Lund
 The River Of Dreams|TTBB|Brian Mastrull
 The River Of Dreams|TTBB|Jay Giallombardo
+THE RIVER OF DREAMS|SSAA|Becky Wilkins
 The River Of No Return|TTBB|Gene Cokeroft
 The River Seine|SSAA|Walter Latzko
 The Roast Beef of Old England|SATB|Matthew Spinner
@@ -22507,6 +22169,7 @@ The Second Time Around|TTBB|Steve Delehanty
 The Secret of Christmas|SATB|Ruby Rhea
 The Secret of Christmas|SSAA|Nancy Bergman
 The Secret of Christmas|TTBB|James Van Heusen
+The Secret of Christmas|TTBB|Russ Foris
 The Secret Of Christmas|SATB|Joe Mannherz
 The Secret Of Christmas|SSAA|Carolyn Schmidt
 The Secret Of Christmas|SSAA|Dianne Goldrick
@@ -22517,7 +22180,6 @@ The Secret Of Christmas|SSAA|Russ Foris
 The Secret Of Christmas|TTBB|Dianne Goldrick
 The Secret Of Christmas|TTBB|Jim Clancy
 The Secret Of Christmas|TTBB|Joe Mannherz
-The Secret Of Christmas|TTBB|Russ Foris
 The Secret of Christmas Medley|TTBB|Jim Clancy
 The Seed|SSAA|Adam Bock
 The Shadow of Your Smile|TTBB|Jeff Taylor
@@ -22543,8 +22205,8 @@ The Sky, The Dawn And The Sun|SSAA|June Dale
 The Skye Boat Song|TTBB|Paul Davies
 The Sleigh|SATB|Deke Sharon
 The Sleigh|TTBB|Derric Johnson
+The Song is Ended|SSAA|Anna Maria Parker
 The Song is Ended|TTBB|Jay Giallombardo
-The Song Is Ended|SSAA|Anna Maria Parker
 The Song Is Ended|SSAA|Joni Bescos
 The Song Is Ended|SSAA|Larry Wright
 The Song Is Ended|TTBB|Ed Waesche
@@ -22570,16 +22232,14 @@ THE SONG'S GOTTA COME FROM THE HEART|SSAA|Sonny Steffan
 The Songs We Sang Together|TTBB|Steve Tramack
 The Sound|TTBB|Nicholas Wright
 The Sound of Music|SSAA|Nancy Bergman
-The Sound Of Music|TTBB|David Wright
-The Sound of Music Medley|SSAA|Nancy Bergman
 The Sound of Music Medley|TTBB|Clay Hine
 The Sound of Music with Climb Every Mountain|TTBB|Joe Liles
+The Sound of Silence|SSAA|Tedda Lippincott
 The Sound Of Silence|SATB|Deke Sharon
 The Sound Of Silence|SATB|Marilyn Penketh
 The Sound Of Silence|SSAA|Diane Butler
 The Sound Of Silence|SSAA|Larry Wright
 The Sound Of Silence|SSAA|Liz Garnett
-The Sound Of Silence|SSAA|Tedda Lippincott
 The Sound Of Silence|TTBB|Erik DeLong
 The Sound Of Silence|TTBB|Jon Nicholas
 The Sound Of Silence|TTBB|Mark Goodney
@@ -22587,8 +22247,6 @@ The Spaniard That Blighted My Life|TTBB|Burt Szabo
 The Spinning Song|TTBB|Jay Giallombardo
 The Spirit Of Adventure|TTBB|Adam Bock
 The Star Spangled Banner|TTBB|Aaron Dale
-The Star Spangled Banner|TTBB|Jim Clancy
-THE STAR SPANGLED BANNER|SSAA|Joni Bescos
 The Star-Spangled Banner|TTBB|Val Hicks
 The Stars and Stripes Forever|SATB|David Wright
 The Stars and Stripes Forever|SSAA|David Wright
@@ -22604,12 +22262,11 @@ The Streets Of New York|TTBB|Burt Szabo
 The Subway|SATB|Mark Stevens
 The Summer Knows|SSAA|Emily Moriarty
 The Summer Knows|SSAA|Joey Minshall
-The Sunshine Of Your Smile|SSAA|Tom Gentry
+The Sunshine of Your Smile|SSAA|Tom Gentry
 The Sunshine Of Your Smile|TTBB|Bill Diekema
 The Sunshine Of Your Smile|TTBB|Ed Gentry
 The Sunshine Of Your Smile|TTBB|Ed Waesche
 The Sunshine Of Your Smile|TTBB|Jay Giallombardo
-The Sunshine Of Your Smile|TTBB|Tom Gentry
 The Super Supper March|SSAA|Dede Nibler
 The Supreme Supremes Medley|SSAA|Kevin Keller
 The Sweet Escape|SATB|Deke Sharon
@@ -22619,11 +22276,10 @@ The Sweetest Song In The World|TTBB|Dennis Driscoll
 The Sweetest Song In The World|TTBB|Louis Perry
 The Sweetest Sounds|SSAA|Dianne Goldrick
 The Sweetest Sounds|SSAA|Patrick McAlexander
-The Sweetest Story Ever Told|TTBB|Burt Szabo
 The Sweetest Story Ever Told|TTBB|Unspecified
-The Sweetheart Of Sigma Chi|TTBB|Barbershop Harmony Society
+The Sweetheart of Sigma Chi|TTBB|Ed Waesche
+The Sweetheart of Sigma Chi|TTBB|Steve Tramack
 The Sweetheart Of Sigma Chi|TTBB|Dave Richards
-The Sweetheart Of Sigma Chi|TTBB|Ed Waesche
 The Sweetheart Of Sigma Chi|TTBB|Ellsworth Morey
 The Sweetheart Of Sigma Chi|TTBB|Inc. SPEBSQSA
 The Sweetheart Of Sigma Chi|TTBB|Jack Baird
@@ -22635,12 +22291,9 @@ The Sweetheart Of Sigma Chi|TTBB|Louis Perry
 The Sweetheart Of Sigma Chi|TTBB|Rob Campbell
 The Sweetheart Of Sigma Chi|TTBB|SPEBSQSA
 The Sweetheart Of Sigma Chi|TTBB|Steve Jamison
-The Sweetheart Of Sigma Chi|TTBB|Steve Tramack
 The Sweetheart Of Sigma Chi|TTBB|Walter Latzko
-The Sweetheart of Sigma Nu|TTBB|Frank Thorne
 The Sweetheart Tree|TTBB|Mancini
 The Swingin' Shepherd Blues|SSAA|Joey Minshall
-The Syncopated Clock|SSAA|Cheryl Suhr
 The Syncopated Walk|TTBB|Walter Latzko
 The Tag|TTBB|Ray Buntaine
 The Tears of a Clown|SATB|Nicholas Wright
@@ -22713,12 +22366,12 @@ The Unicorn|TTBB|Jim West
 The Unicorn|TTBB|Todd Troutman
 The Vatican Rag|SSAA|Dawn Haggerty
 The Very Best Time Of Year|SSAA|Jan Olson
+The Very Thought of You|TTBB|Adam Reimnitz
 The Very Thought Of You|SSAA|Brent Graham
 The Very Thought Of You|SSAA|David Briner
 The Very Thought Of You|SSAA|Jim Arns
 The Very Thought Of You|SSAA|Joanne Dockrell
 The Very Thought Of You|SSAA|Tom Wheeler
-The Very Thought Of You|TTBB|Adam Reimnitz
 The Very Thought Of You|TTBB|Jason Dyer
 The Very Thought Of You|TTBB|Jim Shubert
 The Very Thought Of You|TTBB|Mark Goodney
@@ -22781,7 +22434,6 @@ The Windmills of your Mind|SATB|Dennis Driscoll
 The Windmills of your Mind|SATB|Joe Mannherz
 The Winner Takes It All|SATB|Kyle Snook
 The Winner's Circle|SSAA|Joey Minshall
-The Winners Song|SSAA|Mary Ann Wydra
 THE WINNERS' SONG|SSAA|Mary Ann Wydra
 The Wishing Boot|TTBB|Anthony Bartholomew
 The Wobblin' Goblin With The Broken Broom|TTBB|Michael Webber
@@ -22800,8 +22452,8 @@ The World Is Waiting For The Sunrise|TTBB|Roy Keys
 The World Is Waiting For The Sunrise|TTBB|Steven Armstrong
 The World This Way|SATB|Melody Hine
 The Yankee Doodle Boy|TTBB|Unspecified
+Their Hearts Were Full of Spring|SSAA|Aaron Dale
 Their Hearts Were Full Of Spring|SATB|Joe Mannherz
-Their Hearts Were Full Of Spring|SSAA|Aaron Dale
 Their Hearts Were Full Of Spring|SSAA|Tom Gentry
 Their Hearts Were Full Of Spring|TTBB|Aaron Dale
 Their Hearts Were Full Of Spring|TTBB|Joe Mannherz
@@ -22839,9 +22491,7 @@ There He Goes|TTBB|Walter Latzko
 There I've Said it Again|TTBB|Not Specified
 There I've Said It Again|SATB|Don Gray
 There I've Said It Again|SSAA|Don Gray
-There I've Said It Again|SSAA|Doris Twardosky
 There I've Said It Again|SSAA|Jo Lund
-There I've Said It Again|SSAA|Nancy Bergman
 There I've Said It Again|SSAA|Tom Gentry
 There I've Said It Again|TTBB|Aaron Dale
 There I've Said It Again|TTBB|Don Gray
@@ -22863,10 +22513,10 @@ There Is Nothin' Like A Dame|TTBB|Jarmela Speta
 THERE IS NOTHIN' LIKE A DAME|SSAA|Tedda Lippincott
 There is Nothing Like a Dame|TTBB|Dennis Morrisey
 There is Nothing Like a Dame|TTBB|J. Speta
+There is Nothing Like a Dame|TTBB|Jay Giallombardo
 There is Nothing Like a Dame|TTBB|Unspecified
 There Is Nothing Like A Dame|SSAA|Tedda Lippincott
 There Is Nothing Like A Dame|TTBB|Jarmela Speta
-There Is Nothing Like A Dame|TTBB|Jay Giallombardo
 There Is Nothing Like A Dame|TTBB|Larry Wright
 There Is Nothing Like A Dame|TTBB|Pete Rupay
 There Is Only One of You|TTBB|Tom Gentry
@@ -22883,7 +22533,7 @@ There Used To Be A Ball Park|TTBB|Jay Giallombardo
 There Used To Be A Ball Park|TTBB|Kevin Keller
 There Used to Be a Ballpark|SSAA|Rich Hasty
 There Used to Be a Ballpark|TTBB|Ken Potter
-There Used To Be A Ballpark|TTBB|Roger Payne
+There Used to Be a Ballpark|TTBB|Roger Payne
 There Used To Be A Ballpark|TTBB|Val Hicks
 THERE USED TO BE A BALLPARK|SSAA|Doris Twardosky
 There Used to Be a Ballpark Here|SSAA|Doris Twardosky
@@ -22909,8 +22559,8 @@ There, I've Said It Again|TTBB|Rob Hopkins
 There, I've Said it Again (different tag)|SSAA|Nancy Bergman
 THERE! I'VE SAID IT AGAIN|SSAA|Doris Twardosky
 There'll Be Jubilation Bye And Bye|SSAA|Diana Franceschi
+There'll Be No New Tunes on This Old Piano|TTBB|Gene Cokeroft
 There'll Be No New Tunes On This Old Piano|SSAA|June Berg
-There'll Be No New Tunes On This Old Piano|TTBB|Gene Cokeroft
 There'll Be No New Tunes On This Old Piano|TTBB|Tom Gentry
 There'll Be Now New Tunes On This Old Piano|SSAA|June Berg
 There'll Be Some Changes Made|SSAA|David Wallace
@@ -22926,7 +22576,7 @@ There'll Be Some Changes Made / Who's Sorry Now?|SSAA|Nancy Bergman
 There'll Be Some Changes Made/So Long Dearie Medley|SSAA|Nancy Bergman
 There'll Be Some Changes/Running Wild Medley|SSAA|Jo Lund
 There'll No New Tunes On This Old Piano|TTBB|Rob Hopkins (mod. Larry Lane)
-There's A Beautiful Star|SSAA|Carolyn Johnson
+There's a Beautiful Star|SSAA|Carolyn Johnson
 THERE'S A BEAUTIFUL STAR|SSAA|Carolyn E. Johnson
 There's A Boat Dat's Leavin' Soon for New York|SATB|Kohl Kitzmiller
 There's A Boat Dat's Leavin' Soon for New York|SSAA|Kohl Kitzmiller
@@ -22964,10 +22614,10 @@ There's A New Gang On The Corner|TTBB|Floyd Connett
 There's A New Gang On The Corner|TTBB|Gene Cokeroft
 There's A Place|SSAA|Emily Moriarty
 There's A Place For Us|TTBB|Greg Mallett
+There's a Rainbow 'Round My Shoulder|TTBB|SPEBSQSA
 There's A Rainbow 'Round My Shoulder|TTBB|Barbershop Harmony Society
 There's A Rainbow 'Round My Shoulder|TTBB|Jeff Marks
 There's A Rainbow 'Round My Shoulder|TTBB|Kyle Snook
-There's A Rainbow 'Round My Shoulder|TTBB|SPEBSQSA
 There's a Rose On Your Cheek|TTBB|Hal Staab
 There's a Rose On Your Cheek|TTBB|John Hill
 There's a Rose On Your Cheek|TTBB|Tom Gentry
@@ -23066,6 +22716,7 @@ They Call The Wind Maria|TTBB|Kevin Keller
 They Call The Wind Mariah|TTBB|Don Thomson
 They Call The Wind Mariah|TTBB|Kevin Keller
 They Call The Wind Mariah|TTBB|Steve Jamison
+They Can't Take That Away from Me|TTBB|Aaron Dale
 They Can't Take That Away from Me|TTBB|Mark Hale
 They Can't Take That Away From Me|SATB|Deke Sharon
 They Can't Take That Away From Me|SATB|Larry Triplett
@@ -23073,7 +22724,6 @@ They Can't Take That Away From Me|SSAA|Aaron Dale
 They Can't Take That Away From Me|SSAA|Joe Mannherz
 They Can't Take That Away From Me|SSAA|Larry Triplett
 They Can't Take That Away From Me|SSAA|Melody Hine
-They Can't Take That Away From Me|TTBB|Aaron Dale
 They Can't Take That Away From Me|TTBB|Aaron Dale, Mark Hale
 They Can't Take That Away From Me|TTBB|Joe Mannherz
 They Can't Take That Away From Me|TTBB|Larry Triplett
@@ -23093,14 +22743,12 @@ They Didn't Believe Me / Smoke Gets In Your Eyes Medley|TTBB|David Briner
 They Don't Know (About Us)|TTBB|Mark Stevens
 They Don't Let You In The Opera|SSAA|Melody Hine
 They Go Wild Over Me|SSAA|June Berg
-They Go Wild Simply Wild Over Me|SSAA|June Berg
 They Go Wild, Simply Over Me|TTBB|SPEBSQSA
 They Go Wild, Simply Wild Over Me|SSAA|Jay Giallombardo
 They Go Wild, Simply Wild Over Me|SSAA|Jo Kraut
 They Go Wild, Simply Wild Over Me|SSAA|June Berg/Jo Kraut
 They Go Wild, Simply Wild Over Me|SSAA|Mark Rusch
 They Go Wild, Simply Wild Over Me|SSAA|Tom Gentry
-They Go Wild, Simply Wild Over Me|TTBB|Barbershop Harmony Society
 They Go Wild, Simply Wild Over Me|TTBB|Don Reeves
 They Go Wild, Simply Wild Over Me|TTBB|Jack Baird
 They Go Wild, Simply Wild Over Me|TTBB|John Hohl
@@ -23137,12 +22785,11 @@ They Say It's Wonderful|SSAA|Walter Latzko
 They Say It's Wonderful|TTBB|Dennis Driscoll
 They Say It's Wonderful|TTBB|Ed Waesche
 They Say It's Wonderful|TTBB|Katie Farrell
+They Were All out of Step but Jim|TTBB|Paul Engel
 They Were All Out of Step But Jim|TTBB|Barbershop Harmony Society
 They Were All Out Of Step But Jim|TTBB|Jay Giallombardo
-They Were All Out Of Step But Jim|TTBB|Paul Engel
 They Wrote 'Em in the Good Ol' Days|TTBB|Gene Cokeroft
 They Wrote 'Em In The Good Old Days|TTBB|Gene Cokeroft
-They Wrote Em' in the Good Old Days|TTBB|Gene Cokeroft
 They'll Be Seeing You|TTBB|Unspecified
 They'll Be Seeing You (Hospital Gown)|TTBB|Chordiac Arrest
 They'll Never Believe Me|TTBB|George Davidson
@@ -23206,7 +22853,7 @@ This Could be the Start of Something Big|TTBB|Steve Delehanty
 This Could be the Start of Something Big|TTBB|Walter Latzko
 This Frog|TTBB|Cay Outerbridge
 This Grill Is Not A Home|TTBB|Ben Lewin
-This Guy's In Love With You|TTBB|Dan Wessler
+This Guy's in Love with You|TTBB|Dan Wessler
 This Heart of Mine|SSAA|Anita Barzilla
 This Heart of Mine|SSAA|David Harrington
 This Heart of Mine|SSAA|Kevin Keller
@@ -23253,9 +22900,9 @@ This Is Me|TTBB|Anders Lindqvist
 This Is Me|TTBB|Dianne Goldrick
 This Is Me|TTBB|Liz Garnett
 This Is Me|TTBB|Matt Astle
+This is My Country|SSAA|Sharon Holmes
 This is My Country|TTBB|Barbershop Harmony Society
 This Is My Country|SSAA|Nancy Bergman
-This Is My Country|SSAA|Sharon Holmes
 This Is My Country|TTBB|Al Jacobs
 This Is My Country|TTBB|Derric Johnson
 This Is My Country|TTBB|Gene Cokeroft
@@ -23274,6 +22921,7 @@ This Is The Army, Mr. Jones|TTBB|John Bober
 This Is The Army, Mr. Jones|TTBB|Nancy Bergman
 This Is The Life|SSAA|Jo Lund
 This Is The Life|TTBB|Michael Webber
+This is the Moment|SSAA|Tedda Lippincott
 This is the Moment|TTBB|Jeff Oxley
 This Is The Moment|SATB|Jay Dougherty
 This Is The Moment|SSAA|Brent Graham
@@ -23282,7 +22930,6 @@ This Is The Moment|SSAA|Gene Bender
 This Is The Moment|SSAA|Jay Dougherty
 This Is The Moment|SSAA|Jim Arns
 This Is The Moment|SSAA|Marie Johnson
-This Is The Moment|SSAA|Tedda Lippincott
 This Is The Moment|TTBB|Brent Graham
 This Is The Moment|TTBB|Fred King
 This Is The Moment|TTBB|Jay Dougherty
@@ -23320,8 +22967,6 @@ This Little Light Of Mine|TTBB|Val Hicks
 This Little Light Of Mine / Do Lord Medley|SSAA|Val Hicks
 This Little Light Of Mine / Do Lord Medley|TTBB|Val Hicks
 This Little Light of Mine/Do Lord|TTBB|Val Hicks
-This Little Light Of Mine/Do Lord Medley|SSAA|Val Hicks
-This Little Light Of Mine/Do Lord Medley|TTBB|Val Hicks
 This Little Light Of Mine/Do Lord Medley (Val H|TTBB|Val Hicks
 This Little Piggy|SSAA|George Avener
 This Love|TTBB|Deke Sharon
@@ -23358,7 +23003,6 @@ Those Chords Will Ring Forever|TTBB|Jim Clancy
 Those Days Are Over|TTBB|Joe Johnson
 Those Good Old Fluffy Ruffle Days|TTBB|Gregory Lyne
 Those Lazy Hazy Crazy Days Of Summer|SATB|David Briner
-Those Lazy Hazy Crazy Days Of Summer|SSAA|Marge Bailey
 Those Lazy Hazy Crazy Days Of Summer|TTBB|Jim Shubert
 Those Lazy Hazy Crazy Days Of Summer|TTBB|Mark Goodney
 Those Lazy, Hazy, Crazy Days of Summer|SSAA|Marge Bailey
@@ -23372,7 +23016,6 @@ Those Old-Time Sing-Along Songs|TTBB|Tom Gentry
 Those Riverboat Songs|TTBB|Einar Pedersen
 Those Roarin' Soarin' 20's|TTBB|Earl Moon
 Those Vaudeville Men Medley|TTBB|Renee Craig
-Those Wedding Bells Shall Not Ring Out|TTBB|Burt Szabo
 Those Wedding Bells Shall Not Ring Out!|TTBB|Burt Szabo
 Those Were The Days|SSAA|Margaret Swift
 Those Were The Days|SSAA|Sheryl Neal
@@ -23383,7 +23026,6 @@ Those Were The Days|TTBB|Mark Goodney
 Those Were The Days|TTBB|Walter Latzko
 Thou Art Worthy|TTBB|Joe Browne
 Thoughts Of Home|TTBB|Jim West
-Thousand Thoughts of You|TTBB|Tom Gentry
 Three Bells|SSAA|Valerie Hoy
 THREE BELLS, THE (THE JIMMY BROWN SONG)|SSAA|Louise Hamilton
 THREE BELLS, THE (THE JIMMY BROWN SONG)|SSAA|Valerie Hoy
@@ -23414,8 +23056,8 @@ Throne of Grace|TTBB|Tom Gentry
 Through a Long and Sleepless Night|TTBB|Kevin Keller
 Through the Eyes of Love|TTBB|Jay Giallombardo
 Through The Eyes Of Love|TTBB|John Hohl
+Through the Years|SSAA|Judy Vidal
 Through The Years|SSAA|Diana DeBruycker
-Through The Years|SSAA|Judy Vidal
 Through The Years|SSAA|Tedda Lippincott
 Through The Years|TTBB|Adam Reimnitz
 Through The Years|TTBB|Gene Puerling
@@ -23426,7 +23068,6 @@ Throw Your Arms Around Me|SSAA|Alex Morris
 Throw Your Arms Around Me|TTBB|Alex Morris
 Throw Your Arms Around Me|TTBB|Mark Stevens
 Thunder And Lightning|SSAA|Ã…se Hagerman
-THUNDER AND LIGHTNING|SSAA|Åse Hagerman
 Thunderball|TTBB|Anders Lindqvist
 Thunderball|TTBB|Manoj Padki
 Thursday|SSAA|Fran Carter
@@ -23440,7 +23081,6 @@ Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Douglas Smith
 Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Larry Wright
 Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Mark Goodney
 Tie a Yellow Ribbon 'Round The Ole Oak Tree|TTBB|Todd Troutman
-TIE A YELLOW RIBBON ROUND THE OLE OAK TREE|SSAA|Tedda Lippincott
 Tie Me To Your Apron Strings Again|TTBB|Brent Graham
 Tie Me To Your Apron Strings Again|TTBB|David Briner
 Tie Me To Your Apron Strings Again|TTBB|Dennis Driscoll
@@ -23455,8 +23095,6 @@ Tightrope|SSAA|Sheryl Neal
 Tijuana Jail|TTBB|Donn Updegrove
 Tijuana Taxi|SSAA|Renee Craig
 Til I Hear You Sing|SATB|Theo Hicks
-Til I Hear You Sing|SSAA|June Berg
-Til I Hear You Sing|SSAA|Theo Hicks
 Til I Hear You Sing|TTBB|Theo Hicks
 Til The Season Comes Round Again|SSAA|June Berg
 Til The Season Comes Round Again|SSAA|Sylvia Alsbury
@@ -23588,7 +23226,7 @@ To Have And To Hold|TTBB|R. J. Margison
 To Have, To Hold, To Love|TTBB|Jack Baird
 To Keep My Love Alive|SSAA|David Briner
 To Keep My Love Alive|SSAA|Jo Lund
-To Know Him Is To Love Him|SSAA|Tedda Lippincott
+To Know Him is to Love Him|SSAA|Tedda Lippincott
 To Know Him Is To Love Him|SSAA|Tom Gentry
 To Know Him Is To Love Him|TTBB|Tom Gentry
 To Let A Good Thing Die|TTBB|Gabriel Lawson
@@ -23692,9 +23330,9 @@ Too Many Parties And Too Many Pals|TTBB|Unknown
 Too Many Years Have Gone By|TTBB|David Gillingham
 Too Marvelous|SSAA|Tom Gentry
 Too Marvelous|TTBB|Tom Gentry
+Too Marvelous for Words|TTBB|Mark Hale
 Too Marvelous For Words|SSAA|Suzy Lobaugh
 Too Marvelous For Words|TTBB|Jay Giallombardo
-Too Marvelous For Words|TTBB|Mark Hale
 Too Marvelous For Words|TTBB|Rob Hopkins
 Too Marvelous For Words|TTBB|Walter Latzko
 Too Much Love Will Kill You|TTBB|Kevin Keller
@@ -23730,19 +23368,18 @@ Toot, Toot, Tootsie|TTBB|Joe Mannherz
 Toot, Toot, Tootsie|TTBB|Walter Latzko
 Toot, Toot, Tootsie Goodbye/When the Midnight Choo Choo|TTBB|Pete Rupay
 Tootsie / Lady Love Medley|TTBB|Don Gray
-Tootsie/Lady Love Medley|TTBB|Don Gray
 Top Hat White Tie and Tails|TTBB|Ed Waesche
 Top Hat, White Tie And Tails|TTBB|Chris Arnold
 Top Hat, White Tie And Tails|TTBB|Ed Waesche, Chris Arnold
 Top of the World|SATB|Liz Garnett
 Top of the World|SSAA|Don Gray
+Top of the World|SSAA|Joey Minshall
 Top of the World|SSAA|Joni Bescos
+Top of the World|TTBB|John Hohl
 Top Of The World|SATB|Ken Potter
 Top Of The World|SATB|Vince Peterson
-Top Of The World|SSAA|Joey Minshall
 Top Of The World|SSAA|Susan Kegley
 Top Of The World|TTBB|Jay Giallombardo
-Top Of The World|TTBB|John Hohl
 Top Of The World|TTBB|Liz Garnett
 Top Of The World|TTBB|Mark Goodney
 Top Of The World|TTBB|Mark Stevens
@@ -23819,7 +23456,6 @@ Triangle Love Song|TTBB|Robert Rund
 Tribute|TTBB|Kevin Koehl
 Tribute To The U.S.A.|SSAA|Nancy Bergman
 Tribute to the USA|SSAA|Nancy Bergman
-Tribute To World Peace|TTBB|Jay Giallombardo
 Trick Or Treat|SSAA|Joan D 'Agostino
 Trick Or Treat|TTBB|Dick Floersheimer
 Trickle Trickle|SSAA|Dave Briner
@@ -23831,7 +23467,6 @@ Trim Up The Tree|TTBB|Hal Maples
 Trip A Little Light Fantastic|TTBB|Dan Wessler
 Trip A Little Light Fantastic|TTBB|Simon Arnott
 Triplets|TTBB|Tom Gentry
-Trolley Song|SSAA|Renee Craig
 Troublemaker|SATB|Nicholas Wright
 Truckin'|TTBB|Walter Latzko
 True Colors|SATB|Deke Sharon
@@ -23878,8 +23513,8 @@ Try Everything|TTBB|Hilary Allen
 Try Everything|TTBB|Liz Garnett
 Try It On My Own|SSAA|Tom Gentry
 Try To Remember|SSAA|Nancy Bergman
+Tuck Me to Sleep in My Old 'Tucky Home|TTBB|Lloyd Steinkamp
 Tuck Me To Sleep In My Old 'Tucky Home|TTBB|Kirk Roose
-Tuck Me To Sleep In My Old 'Tucky Home|TTBB|Lloyd Steinkamp
 Tulip Medley|SSAA|Jay Giallombardo
 Tulip Medley|TTBB|Jay Giallombardo
 Tulou Tagaloa|SATB|Aaron Dale
@@ -23945,7 +23580,6 @@ Twas The Night Before Christmas|SSAA|Nancy Bergman
 Twas The Night Before Christmas|SSAA|Patsee Parker
 Twelve Days After Christmas|SSAA|Nancy Bergman
 Twelve Days After Christmas|SSAA|Sylvia Alsbury
-Twelve Days Of Christmas|TTBB|Greg Backwell
 Twelve Days of Christmas Parody|SSAA|Kay Bromert
 Twenties Dance Medley|SSAA|Tom Gentry
 Twenties Dance Medley|TTBB|Tom Gentry
@@ -23967,7 +23601,6 @@ Twilight Zone|TTBB|Walter Latzko
 Twinkle Twinkle Little Me|TTBB|Joe Grimme
 Twinkle Twinkle Little Star|SSAA|Tom Gentry
 Twinkle Twinkle Little Star|TTBB|Tom Gentry
-Twist Medley|SSAA|Carole Prietto
 Twisted|SSAA|Tom Gentry
 Twisted|TTBB|Jeremey Johnson
 Twisted|TTBB|Tom Gentry
@@ -24050,25 +23683,25 @@ Under Pressure|SATB|Deke Sharon
 Under Pressure|SATB|Rowena Harper
 Under Pressure|TTBB|Deke Sharon
 Under The Anheuser Bush|TTBB|Jim Shubert
-Under The Boardwalk|SATB|Barbershop Harmony Society
+Under the Boardwalk|SATB|Barbershop Harmony Society
+Under the Boardwalk|SSAA|Barbershop Harmony Society
+Under the Boardwalk|SSAA|Charlene Yazurlo
+Under the Boardwalk|SSAA|Tom Gentry
+Under the Boardwalk|TTBB|Barbershop Harmony Society
 Under The Boardwalk|SATB|Deke Sharon
 Under The Boardwalk|SATB|SPEBSQSA
-Under The Boardwalk|SSAA|Barbershop Harmony Society
-Under The Boardwalk|SSAA|Charlene Yazurlo
 Under The Boardwalk|SSAA|Deke Sharon
 Under The Boardwalk|SSAA|SPEBSQSA
-Under The Boardwalk|SSAA|Tom Gentry
-Under The Boardwalk|TTBB|Barbershop Harmony Society
 Under The Boardwalk|TTBB|SPEBSQSA
 Under The Boardwalk|TTBB|Tom Gentry
 Under The Bridge|SATB|Deke Sharon
 Under The Bridge|TTBB|Deke Sharon
 Under The Mistletoe|SATB|Scott Anderson
+Under the Sea|SSAA|Joey Minshall
 Under the Sea|TTBB|Scott Turnbull
 Under The Sea|SATB|Deke Sharon
 Under The Sea|SATB|Melody Hine
 Under The Sea|SSAA|Jay Giallombardo
-Under The Sea|SSAA|Joey Minshall
 Under The Sea|SSAA|Larry Wright
 Under The Sea|SSAA|Tedda Lippincott
 Under The Sea|TTBB|Jay Giallombardo
@@ -24133,6 +23766,7 @@ Up On the House Top|TTBB|Jay Giallombardo
 Up On the House Top|TTBB|Jim West
 Up on the Housetop|SSAA|Nancy Bergman
 Up On the Roof|SSAA|Lorraine Rochefort
+Up On the Roof|TTBB|Walter Latzko
 Up On The Roof|SATB|Alex Kaiserman
 Up On The Roof|SATB|Deke Sharon
 Up On The Roof|SATB|Joe Mannherz
@@ -24140,7 +23774,6 @@ Up On The Roof|SSAA|Brent Graham
 Up On The Roof|SSAA|June Berg
 Up On The Roof|TTBB|Brent Graham
 Up On The Roof|TTBB|Deke Sharon
-Up On The Roof|TTBB|Walter Latzko
 UP ON THE ROOF|SSAA|Susan J. Kegley
 Up Over The Hill|TTBB|Rex Jamieson
 Up the Ladder to the Roof|SATB|Kari Francis
@@ -24287,10 +23920,8 @@ Wait Till The Sun Shines, Nellie|TTBB|Larry Wright
 Wait Till The Sun Shines, Nellie|TTBB|Toban Dvoretsky
 Wait Till The Sun Shines, Nellie|TTBB|Walter Latzko
 Wait Till The Sun Shines, Nellie|TTBB|Warren 'Buzz' Haeger
-Wait Till The Sun Shines, Nellie|TTBB|Warren Buzz Haeger
 WAIT TILL THE SUN SHINES, NELLIE|SSAA|Unknown
 Wait till You Get em' Up in the Air Boys|TTBB|John Hohl
-Wait Till You Get Them Up In The Air Boys|TTBB|Don Gray
 Wait Till You Get Them Up In The Air Boys|TTBB|John Hohl
 Wait Till You Get Them Up In The Air Boys|TTBB|Rob Hopkins
 Wait Till You Get Them Up In The Air, Boys|TTBB|Don Gray
@@ -24352,7 +23983,6 @@ Walkin' After Midnight|SSAA|Rick Spencer
 Walkin' After Midnight|SSAA|Tedda Lippincott
 Walkin' After Midnight|TTBB|Manoj Padki
 Walkin' After Midnight|TTBB|Rick Spencer
-WALKIN' AFTER MIDNIGHT|SSAA|Joan D'Agostino
 Walkin' My Baby Back Home|SATB|Deke Sharon
 Walkin' My Baby Back Home|SSAA|Larry Wright
 Walkin' My Baby Back Home|TTBB|Dave Briner, Buzz Haeger, Bob Shami
@@ -24374,12 +24004,12 @@ Walking In The Air|TTBB|Deke Sharon
 Walking In The Air|TTBB|Emily Moriarty
 Walking My Baby Back Home (Boston Common Version)|TTBB|Val Hicks
 Walking My Baby Back Home (Society Stock Version)|TTBB|Val Hicks
+Walking on Sunshine|SSAA|Aaron Dale
+Walking on Sunshine|TTBB|Aaron Dale
 Walking On Sunshine|SATB|Deke Sharon
-Walking On Sunshine|SSAA|Aaron Dale
 Walking On Sunshine|SSAA|Corinna Garriock
 Walking On Sunshine|SSAA|Deke Sharon
 Walking On Sunshine|SSAA|Liz Garnett
-Walking On Sunshine|TTBB|Aaron Dale
 Walking On Sunshine|TTBB|Grant Goulding
 Waltz For Debbie|TTBB|Joe Johnson
 Waltz for Debby|TTBB|Joe Johnson
@@ -24436,26 +24066,19 @@ Waving Through A Window|TTBB|Nicholas Wright
 Waving Through A Window|TTBB|Theodore Hicks
 Way Down in Iowa|SSAA|Kay Bromert
 Way Down On Tampa Bay|TTBB|Jon Nicholas
+Way Down Yonder in New Orleans|SSAA|Nancy Bergman
 Way Down Yonder In New Orleans|SSAA|Bitsy Bacon
 Way Down Yonder In New Orleans|SSAA|Carolyn Schmidt
 Way Down Yonder In New Orleans|SSAA|Jo Lund
 Way Down Yonder In New Orleans|SSAA|Marie Johnson
 Way Down Yonder In New Orleans|SSAA|Muriel Berg
-Way Down Yonder In New Orleans|SSAA|Nancy Bergman
 Way Down Yonder In New Orleans|SSAA|Walter Latzko
 Way Down Yonder In New Orleans|TTBB|Don Gray
 Way Down Yonder In New Orleans|TTBB|Howard Mesecher
 Way Down Yonder In New Orleans|TTBB|Walter Latzko
 Way Down Yonder In New Orleans / When The Saints Go Marching In Medley|TTBB|Ed Waesche
 Way To Your Heart|TTBB|Kevin Koehl
-Way You Look Tonight|SSAA|Joey Minshall
-Way You Look Tonight|SSAA|Larry Wright
-Way You Look Tonight|SSAA|Tom Gentry
-Way You Look Tonight|TTBB|Deke Sharon
 Way You Look Tonight|TTBB|Joe Mannherz
-Way You Look Tonight|TTBB|Larry Wright
-Way You Look Tonight|TTBB|Mark Hale
-Way You Look Tonight|TTBB|Tom Gentry
 Wayfaring Stranger|SATB|Kevin Keller
 Wayfaring Stranger|SSAA|Kevin Keller
 Wayfaring Stranger|TTBB|Dan Tice
@@ -24527,6 +24150,7 @@ We Kiss In A Shadow|TTBB|David Wright
 We Live On Borrowed Time|SSAA|Tedda Lippincott
 We Make A Beautiful Pair|SSAA|Marge Bailey
 We Meet Again|TTBB|Mark Burnip
+We Need a Little Christmas|SSAA|June Berg
 We Need a Little Christmas|TTBB|Anita Kerr
 We Need a Little Christmas|TTBB|Clay Hine
 We Need a Little Christmas|TTBB|Dave Briner
@@ -24536,7 +24160,6 @@ We Need A Little Christmas|SSAA|Connie Nickel
 We Need A Little Christmas|SSAA|Dave Briner
 We Need A Little Christmas|SSAA|Jim Massey
 We Need A Little Christmas|SSAA|Jo Lund
-We Need A Little Christmas|SSAA|June Berg
 We Need A Little Christmas|SSAA|Linda Samuelsson
 We Need A Little Christmas|SSAA|Nancy Bergman
 We Need A Little Christmas|SSAA|Tedda Lippincott
@@ -24574,11 +24197,11 @@ We Three Kings|TTBB|Patrick Rose
 We Three Kings (solo)|TTBB|Jon Nicholas
 We Three Kings / God Rest Ye Merry Medley|TTBB|Paul Jorg
 We Will Rock You|TTBB|Jay Giallombardo
+We Wish You a Merry Christmas|SSAA|Carolyn Johnson
 We Wish You a Merry Christmas|TTBB|Barbershop Harmony Society
 We Wish You A Merry Christmas|SATB|David Harrington
 We Wish You A Merry Christmas|SATB|Deke Sharon
 We Wish You A Merry Christmas|SATB|Joe Mannherz
-We Wish You A Merry Christmas|SSAA|Carolyn Johnson
 We Wish You A Merry Christmas|SSAA|Carolyn Schmidt
 We Wish You A Merry Christmas|SSAA|David Harrington
 We Wish You A Merry Christmas|SSAA|Dianne Goldrick
@@ -24657,8 +24280,8 @@ We're Here For a Good Time (Not a Long Time)|TTBB|Joey Minshall
 We're Number One|SSAA|Tom Gentry
 We're Number One|TTBB|Tom Gentry
 We're off to see the wizard|TTBB|Lloyd Steinkamp
+We're Off to See the Wizard|SSAA|Nancy Bergman
 We're Off To See The Wizard|SSAA|Kevin Keller
-We're Off To See The Wizard|SSAA|Nancy Bergman
 We're Off To See The Wizard|TTBB|Kevin Keller
 We're on Our Way|SSAA|Tom Gentry
 We're on Our Way|TTBB|Tom Gentry
@@ -24737,7 +24360,6 @@ Wellerman|SATB|David Zimmerman
 Wellerman|SSAA|David Zimmerman
 Wellerman|TTBB|Adam Scott
 Wellerman|TTBB|David Zimmerman
-Wells Fargo Wagon|TTBB|Howard Jones
 Wells Fargo Wagon|TTBB|Kyle Snook
 Wells Fargo Wagon|TTBB|Walter Latzko
 Welsh National Anthem|TTBB|Diane Butler
@@ -24753,7 +24375,6 @@ West Virginia's Home to Me|TTBB|Tom Gentry
 Western medley|TTBB|Tom Gentry
 Wet / Dry Medley|TTBB|Ed Waesche
 Wexford Carol|SSAA|Carole Prietto
-Wha Do Ya Do|SSAA|Marie Johnson
 WHA' DO YA' DO|SSAA|Marie Johnson
 What A Country|TTBB|Dave Stevens
 What A Diff'rence a Day Makes|TTBB|Adam Reimnitz
@@ -24770,10 +24391,11 @@ What A Wonderful Daddy You'd Be|SSAA|Lorraine Rochefort
 What A Wonderful Day|TTBB|Mervin Keedy
 What A Wonderful Pal You Are|TTBB|Kirk Roose
 What A Wonderful Wedding That Will Be|TTBB|Joe Liles
+What a Wonderful World|SSAA|Bob Long
 What a Wonderful World|SSAA|Laura Edmondson
+What a Wonderful World|TTBB|Bob Long
 What a Wonderful World|TTBB|Russ Foris
 What A Wonderful World|SATB|Bryan W. Pulver
-What A Wonderful World|SSAA|Bob Long
 What A Wonderful World|SSAA|Cheryl Suhr
 What A Wonderful World|SSAA|Connie Kash
 What A Wonderful World|SSAA|David Briner
@@ -24787,7 +24409,6 @@ What A Wonderful World|SSAA|Michael Gellert
 What A Wonderful World|SSAA|Peg Millard
 What A Wonderful World|SSAA|Tedda Lippincott
 What A Wonderful World|TTBB|Bill Mitchell
-What A Wonderful World|TTBB|Bob Long
 What A Wonderful World|TTBB|Dan Naumann
 What A Wonderful World|TTBB|David Wright
 What A Wonderful World|TTBB|F. J. Catto
@@ -24852,7 +24473,6 @@ What Child Is This Medley|TTBB|Joe Johnson
 What Child is This/A Child of the Poor|SSAA|Kevin Keller
 What Child is This/A Child of the Poor|TTBB|Kevin Keller
 What Christmas Means To Me|TTBB|Kohl Kitzmiller
-What Color Is God's Skin|SSAA|Tedda Lippincott
 WHAT COLOR IS GOD'S SKIN?|SSAA|Tedda Lippincott
 What Did I Have that I Don't Have?|SSAA|Diane Clark
 What Did You Mean When You Said Love|TTBB|Adam Bock
@@ -24908,16 +24528,13 @@ What Is This Feeling?|SSAA|Jay Dougherty
 What Is This Feeling?|SSAA|Simon Arnott
 What Is This Thing Called Love|SSAA|Tom Gentry
 What Is This Thing Called Love|TTBB|Tom Gentry
+What Kind of Fool Am I|SSAA|David Harrington
+What Kind of Fool Am I|SSAA|Kevin Keller
 What Kind Of Fool Am I|SATB|Joe Mannherz
 What Kind Of Fool Am I|SATB|Kevin Keller
 What Kind Of Fool Am I|SATB|Kohl Kitzmiller
-What Kind Of Fool Am I|SSAA|David Harrington
-What Kind Of Fool Am I|SSAA|Kevin Keller
-What Kind Of Fool Am I|TTBB|David Harrington
 What Kind Of Fool Am I|TTBB|Jay Giallombardo
 What Kind Of Fool Am I|TTBB|Joe Mannherz
-What Kind Of Fool Am I|TTBB|Kevin Keller
-What Kind Of Fool Am I|TTBB|Steve Tramack
 What Kind Of Fool Am I|TTBB|Walter Latzko
 What Kind Of Fool Am I?|TTBB|David Harrington
 What Kind Of Fool Am I?|TTBB|Don Gray
@@ -24931,7 +24548,6 @@ What Makes You Beautiful|TTBB|Aaron Dale
 What Makes You Beautiful|TTBB|Dan Wessler
 What Makes You Beautiful|TTBB|Nicholas Wright
 What Makes You Beautiful (One Direction)|SSAA|Shelley Gray
-What More Can A Soldier Give|TTBB|Robert Rund
 What More Can a Soldier Give?|TTBB|Robert Rund
 What More Can a Woman Give|SSAA|Robert Rund
 What No Women Parody|TTBB|Ed Waesche
@@ -24956,17 +24572,14 @@ What Wondrous Love Is This|TTBB|J. Harold Moyer
 What Wondrous Love/O Sacred Head|TTBB|Jay Giallombardo
 What Word Is Sweeter Than Sweetheart|TTBB|William Fisher
 What Would Christmas Be Without A Song|TTBB|Dan Wilson
+What Would I Do Without my Music|SSAA|Tom Gentry
 What Would I Do Without My Music|SSAA|Tedda Lippincott
-What Would I Do Without My Music|SSAA|Tom Gentry
 What Would I Do Without My Music|TTBB|Tom Gentry
 What Would I Do Without You|SATB|Cay Outerbridge
 What Would I Do Without You|SSAA|Takako Fuke
 What You'd Call A Dream|TTBB|Dan Wessler
 What! No Women?|TTBB|Ed Waesche
-What'll I Do|SSAA|Ed Waesche
 What'll I Do|SSAA|Ed Waesche and Renee Craig
-What'll I Do|SSAA|Renee Craig
-What'll I Do|TTBB|Ed Waesche
 What'll I Do|TTBB|Ed Waesche and Renee Craig
 What'll I Do|TTBB|Second Edition
 What'll I Do?|SATB|Deke Sharon
@@ -25043,7 +24656,7 @@ When Christmas Comes To Town|TTBB|Gabriel Lawson
 When Christmas Comes To Town|TTBB|Karen Penketh
 When Christmas Comes To Town|TTBB|Patrick McAlexander
 WHEN CHRISTMAS COMES TO TOWN|SSAA|Doris Twardosky
-When Day Is Done|SSAA|Brent Graham
+When Day is Done|SSAA|Brent Graham
 When Day Is Done|SSAA|Ed Waesche
 When Day Is Done|SSAA|Walter Latzko
 When Day Is Done|TTBB|Ed Waesche
@@ -25059,7 +24672,7 @@ When Francis Dances With Me|TTBB|Walter Latzko
 When Georgia Smiles|TTBB|Burt Szabo
 When God Dips His Love In My Heart|SSAA|Grant Goulding
 When God Dips His Love In My Heart|SSAA|Tedda Lippincott
-When God Fearin' Women Get The Blues|SSAA|Cheryl Suhr
+When God Fearin' Women Get the Blues|SSAA|Cheryl Suhr
 When God Holds You Close In His Arms|TTBB|Joe Liles
 When Grandma Sings The Songs She Loved At The End Of A Perfect Day|TTBB|Jim West
 When He Gave Me You|TTBB|Roy Keys
@@ -25072,6 +24685,7 @@ When I Dream Of My Ould Kerry Home|TTBB|Jerry Koskela
 When I Dream Of Old Erin|SSAA|Jay Giallombardo
 When I Dream Of Old Erin|TTBB|Barbershop Harmony Society
 When I Dream Of Old Erin|TTBB|Don King
+When I Fall in Love|TTBB|David Wright
 When I Fall In Love|SSAA|Ann Minihane
 When I Fall In Love|SSAA|Carolyn Schmidt
 When I Fall In Love|SSAA|David Wright
@@ -25079,7 +24693,6 @@ When I Fall In Love|SSAA|Jay Giallombardo
 When I Fall In Love|SSAA|Jo Lund
 When I Fall In Love|SSAA|Kirby Shaw
 When I Fall In Love|SSAA|Liz Garnett
-When I Fall In Love|TTBB|David Wright
 When I Fall In Love|TTBB|Derric Johnson
 When I Fall In Love|TTBB|Frank Marzocco
 When I Fall In Love|TTBB|Jay Giallombardo
@@ -25095,7 +24708,7 @@ When I Get You Alone Tonight|SSAA|Tom Gentry
 When I Get You Alone Tonight|TTBB|Jay Giallombardo
 When I Get You Alone Tonight/All Alone Medley|TTBB|Rob Campbell
 When I Grow Too Old to Dream|SSAA|Ardeth Fullmer
-When I Grow Too Old To Dream|SSAA|Nancy Bergman
+When I Grow Too Old to Dream|SSAA|Nancy Bergman
 When I Grow Too Old To Dream|TTBB|Brent Graham
 When I Grow Too Old To Dream|TTBB|Don Fraser
 When I Grow Too Old To Dream|TTBB|Don Gray
@@ -25114,7 +24727,7 @@ When I Grow Up|TTBB|Patrick McAlexander
 When I Have Sung My Songs|TTBB|David Zimmerman
 When I Just Wear My Smile|SSAA|Tom Gentry
 When I Just Wear My Smile|TTBB|Tom Gentry
-When I Leave The World Behind|SSAA|Joni Bescos
+When I Leave the World Behind|SSAA|Joni Bescos
 When I Leave The World Behind|SSAA|Nancy Bergman
 When I Leave The World Behind|TTBB|Barbershop Harmony Society
 When I Leave The World Behind|TTBB|SPEBSQSA
@@ -25165,8 +24778,8 @@ When I Sang The Tenor In That Old Quartet|TTBB|Mel Knight
 When I Sang The Tenor In That Old Quartet|TTBB|Toban Dvoretsky
 When I Sang The Tenor In That Old Quartet|TTBB|Unknown
 When I See All The Lovin' They Waste On Babies|TTBB|Larry Wright
+When I See an Elephant Fly|SSAA|Adam Scott
 When I See An Elephant Fly|SSAA|Aaron Dale
-When I See An Elephant Fly|SSAA|Adam Scott
 When I See An Elephant Fly|TTBB|Aaron Dale
 When I See An Elephant Fly|TTBB|Brent Graham
 When I See An Elephant Fly|TTBB|Michael Webber
@@ -25211,13 +24824,6 @@ When I'm Sixty Four|SSAA|Tom Gentry
 When I'm Sixty Four|TTBB|Deke Sharon
 When I'm Sixty Four|TTBB|Jon Nicholas
 When I'm Sixty Four|TTBB|Tom Gentry
-When I'm Sixty-Four|SATB|Tom Gentry
-When I'm Sixty-Four|SSAA|Tom Gentry
-When I'm Sixty-Four|TTBB|Tom Gentry
-WHEN I'M SIXTY-FOUR|SSAA|Carolyn Johnson
-WHEN I'M SIXTY-FOUR|SSAA|Carolyn Schmidt
-WHEN I'M SIXTY-FOUR|SSAA|Charlene Yazurlo
-WHEN I'M SIXTY-FOUR|SSAA|Tedda Lippincott
 When I'm With You|SATB|Mark Stevens
 When Irish Eyes Are Smiling|SSAA|Carolyn Johnson
 When Irish Eyes Are Smiling|SSAA|Nancy Bergman
@@ -25232,7 +24838,6 @@ When is Sometime|SSAA|Robert Rund
 When is Sometime|TTBB|Robert Rund
 When It Comes To Lovin' The Girls / They're All Sweeties Medley|TTBB|Ed Waesche
 When It Comes To Lovin' the Girls/They're All Sweeties Medley|TTBB|Greg Lyne and Ed Wasche
-When It Comes To Lovin' The Girls/They're All Sweeties Medley|TTBB|Ed Waesche
 When It Comes To Lovin' The Girls/They're All Sweeties Medley(Ed Wae|TTBB|Ed Waesche
 When It's Circus Day Back Home|TTBB|Mel Knight
 When It's Night Time Down In Dixieland/Original Dixieland One-Step (Parody)|TTBB|Brent Graham
@@ -25366,7 +24971,6 @@ When The Red Red Robin|SSAA|Dot Calvin
 When The Red Red Robin Comes Bob Bob Bobbin Along|TTBB|Ed Waesche
 When The Red Red Robin Comes Bob Bob Bobbin Along (Ed Wae|TTBB|Ed Waesche
 When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|David Briner
-When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Dot Calvin
 When The Red Red Robin Comes Bob Bob Bobbin' Along|SSAA|Tom Gentry
 When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Blaine Mack
 When The Red Red Robin Comes Bob Bob Bobbin' Along|TTBB|Harry Mays
@@ -25435,7 +25039,6 @@ When Will I Be Loved|TTBB|David Wright
 When Will I Be Loved|TTBB|Marilyn Penketh
 When Will My Life Begin|SSAA|Simon Arnott
 When Winter Comes|TTBB|Brian Mastrull
-When You And I Were Young Maggie|TTBB|Burt Szabo
 When You And I Were Young Maggie|TTBB|David Wright
 When You And I Were Young Maggie|TTBB|Jack Baird
 When You And I Were Young Maggie|TTBB|M. H. Bolds
@@ -25475,8 +25078,8 @@ When You Were Sweet Sixteen|TTBB|Jack Baird
 When You Were The Blossom Of Buttercup Lane And I Was You're Little Boy Blue|TTBB|Burt Szabo
 When You Whispered I Love You|TTBB|Burt Szabo
 When You Wish upon a Star|TTBB|the Barbershop Harmony Society
+When You Wish Upon a Star|SATB|Nancy Bergman
 When You Wish Upon a Star|TTBB|Jay Giallombardo
-When You Wish Upon A Star|SATB|Nancy Bergman
 When You Wish Upon A Star|SSAA|Carolyn Schmidt
 When You Wish Upon A Star|SSAA|Jo Lund
 When You Wish Upon A Star|SSAA|JoAnne Ingles
@@ -25539,13 +25142,12 @@ Where Are The Roses Of Yesterday|TTBB|Rob Campbell
 Where Are the Simple Joys of Maidenhood|SSAA|Lynnell Diamond
 Where Are The Smiles|TTBB|Mo Rector
 Where Are You|TTBB|Walter Latzko
-Where Are You Christmas|SSAA|Joan D'Agostino
 Where Are You Christmas?|SATB|Dan Naumann
 Where Are You Christmas?|SATB|Joe Mannherz
 Where Are You Christmas?|SSAA|Dan Naumann
 Where Are You Christmas?|SSAA|Nancy Bergman
 Where Are You Christmas?|TTBB|Dan Naumann
-WHERE ARE YOU CHRISTMAS?|SSAA|Joan D 'Agostino
+WHERE ARE YOU CHRISTMAS?|SSAA|Joan D'Agostino
 Where Are You Christmas? (from The Polar Express)|TTBB|Dan Naumann
 Where Can I Go Without You|TTBB|Walter Latzko
 Where Did Robinson Crusoe Go With Friday On Saturday Night|SSAA|Jo Lund
@@ -25554,7 +25156,6 @@ Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Gerald Hooper
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|J Rae Jamieson
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Tom Gentry
 Where Did Robinson Crusoe Go With Friday On Saturday Night|TTBB|Walter Latzko
-Where Did the Circus Go|SSAA|Dorothy Herivel
 WHERE DID THE CIRCUS GO?|SSAA|Dorothy Herivel
 Where Did The Good Times Go?|SSAA|Sonny Steffan
 Where Did You Get That Girl?|TTBB|Larry Wright
@@ -25570,7 +25171,6 @@ Where Do You Start?|SSAA|Michael Gellert
 Where Do You Start?|TTBB|Dan Wessler
 Where Do You Start?|TTBB|Dennis Driscoll
 Where Do You Start?|TTBB|Joe Mannherz
-Where Does the Time Go|SSAA|Nancy Bergman
 Where Does The Time Go?|TTBB|Mark Goodney
 WHERE DOES THE TIME GO?|SSAA|Nancy Bergman
 Where Everybody Knows Your Name|SATB|Manoj Padki
@@ -25593,8 +25193,6 @@ Where In The World|SSAA|Jean Flinn
 Where In The World Is Carmen Sandiego?|SSAA|Dianne Goldrick
 Where In The World Is Carmen Sandiego?|TTBB|Dianne Goldrick
 Where Is Love|SATB|Gene Puerling
-Where Is Love|SSAA|June Dale
-Where Is Love|TTBB|Gene Cokeroft
 Where Is Love|TTBB|Tom Gentry
 Where Is Love?|SSAA|Kay Bromert
 Where Is Love?|SSAA|Mary K. Coffman Music Fund
@@ -25623,14 +25221,13 @@ WHERE OR WHEN|SSAA|Diane M. Clark
 Where Southern Roses Grow|TTBB|the Central States District
 Where The Black Eyed Susans Grow|TTBB|Kirk Roose
 Where The Black Eyed Susans Grow|TTBB|Tom Gentil
-Where The Black-Eyed Susans Grow|TTBB|Tom Gentil
 Where The Blue Of The Night Meets The Gold Of The Day|SSAA|Debbie Keretz
 Where The Blue Of The Night Meets The Gold Of The Day|SSAA|Walter Latzko
 Where The Blue Of The Night Meets The Gold Of The Day|TTBB|Dennis Driscoll
 Where The Blue Of The Night Meets The Gold Of The Day|TTBB|Tom Gentry
 Where The Blue Of The Night Meets The Gold Of The Day|TTBB|Walter Latzko
+Where the Boys Are|SSAA|Elaine Gain
 Where The Boys Are|SSAA|Brent Graham
-Where The Boys Are|SSAA|Elaine Gain
 Where The Boys Are|SSAA|Marsha Zwicker
 Where The Boys Are|SSAA|Tedda Lippincott
 Where The Heck Is Dixie?|SSAA|Joey Minshall
@@ -25638,7 +25235,7 @@ Where The Morning Glories Grow|TTBB|Jack Baird
 Where The River Shannon Flows|TTBB|Dennis Driscoll
 Where The River Shannon Flows|TTBB|Kim Brittain
 Where The Sidewalk Ends|TTBB|Adam Bock
-Where The Southern Roses Grow|SSAA|David Wright
+Where the Southern Roses Grow|SSAA|David Wright
 Where The Southern Roses Grow|TTBB|Barbershop Harmony Society
 Where The Southern Roses Grow|TTBB|David Wright
 Where The Sunset Turns The Ocean's Blue To Gold|TTBB|Phil Embury
@@ -25660,7 +25257,6 @@ Whiffenpoof Song|TTBB|Harry Mays
 Whiffenpoof Song|TTBB|Jack Baird
 Whiffenpoof Song|TTBB|Joe Mannherz
 Whiffenpoof Song|TTBB|Lloyd McClure
-Whiffenpoof Song|TTBB|Louis Perry
 Whiffenpoof Song|TTBB|Renee Craig
 Whiffenpoof Song|TTBB|Ron Middlestaedt
 Whiffenpoof Song|TTBB|Steve Shannon
@@ -25713,11 +25309,9 @@ White Cliffs Of Dover|SATB|Larry Triplett
 White Cliffs Of Dover|SSAA|Jay Giallombardo
 White Cliffs Of Dover|SSAA|Larry Triplett
 White Cliffs Of Dover|SSAA|Nancy Bergman
-White Cliffs Of Dover|SSAA|Renee Craig
 White Cliffs Of Dover|SSAA|Sharon Holmes
 White Cliffs Of Dover|TTBB|Brent Graham
 White Cliffs Of Dover|TTBB|Dick Rode
-White Cliffs Of Dover|TTBB|Don Gray
 White Cliffs Of Dover|TTBB|Jay Giallombardo
 White Cliffs Of Dover|TTBB|John Hohl
 White Cliffs Of Dover|TTBB|Larry Triplett
@@ -25746,7 +25340,6 @@ Who Can I Turn To? (When Nobody Needs Me)|TTBB|Liz Garnett
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Robert Rund
 Who Can I Turn To? (When Nobody Needs Me)|TTBB|Simon Arnott
 Who Can Smile|TTBB|Simon Rylander
-Who Cares|SSAA|Avis Fellows
 Who Cares|TTBB|Burt Szabo
 WHO CARES?|SSAA|Avis Fellows
 Who Cares? (from Of Thee I Sing)|TTBB|Johnny Bugarin
@@ -25758,7 +25351,6 @@ Who I Am|SSAA|Jay Giallombardo
 WHO I AM|SSAA|ELAIN GAIN
 Who I'd Be|TTBB|Dan Wessler
 Who I'd Be|TTBB|Soren Detlefsen
-Who Loves You|SSAA|Liz Garnett
 Who Loves You|TTBB|Deke Sharon
 Who Loves You?|SSAA|Liz Garnett
 Who Needs You|TTBB|Sam Hubbard
@@ -25786,7 +25378,6 @@ Who Will Buy|SATB|David Briner
 Who Will Buy|SSAA|David Briner
 Who Will Buy|TTBB|Dave Briner
 Who Will Buy|TTBB|David Briner
-Who Will Buy|TTBB|Kirk Young
 Who Will Buy|TTBB|Mark Burnip
 Who Will Buy|TTBB|Phil Ordaz
 Who Will Buy|TTBB|Walter Latzko
@@ -25821,7 +25412,6 @@ Who'll Take My Place (When I'm Gone)|TTBB|Greg Lyne
 WHO'LL TAKE MY PLACE (WHEN I'M GONE)|SSAA|Barbara Bianchi
 Who'll Take My Place When I'm Gone|SSAA|Marie Johnson
 Who'll Take My Place When I'm Gone|TTBB|Brian Beck
-Who'll Take My Place When I'm Gone|TTBB|Greg Lyne
 Who'll Take My Place When I'm Gone|TTBB|Gregory Lyne
 Who'll Take My Place When I'm Gone|TTBB|Jay Giallombardo
 Who'll Take The Place Of Mary|TTBB|Ed Waesche
@@ -25835,9 +25425,7 @@ Who's In The Strawberry Patch With Sally?|TTBB|Larry Triplett
 Who's In The Strawberry Patch With Sally?|TTBB|Mark Goodney
 Who's In The Strawberry Patch With Sally?|TTBB|Tom Gentry
 Who's Lovin' You|TTBB|Aaron Dale
-Who's Sorry Now|SSAA|Carolyn Johnson
 Who's Sorry Now|SSAA|Dave Briner
-Who's Sorry Now|SSAA|David Briner
 Who's Sorry Now|SSAA|Earl Moon
 Who's Sorry Now|SSAA|Earl Moon/Dave Briner
 Who's Sorry Now|SSAA|Joni Bescos
@@ -25864,7 +25452,6 @@ Whole Lotta Love|SATB|Deke Sharon
 Whose Honey Are You|SSAA|Jean Shook
 Whose Pretty Baby Are You Now|TTBB|Rob Hopkins
 Why Can't We Be Friends?|SATB|Deke Sharon
-Why Did I Choose You|SSAA|Fred King
 Why Did I Choose You|SSAA|Greg Volk
 WHY DID I CHOOSE YOU|SSAA|Dede Nibler
 WHY DID I CHOOSE YOU?|SSAA|Fred King
@@ -25872,8 +25459,8 @@ Why Did It Have To Be Me?|SSAA|Larry Wright
 Why Did It Have To Be Me?|TTBB|Larry Wright
 Why Did You Leave Me, Old Friend|TTBB|Paul Olguin
 Why Did You Make Me Care|TTBB|Jack Baird
+Why Do Fools Fall in Love|SSAA|David Wright
 Why Do Fools Fall In Love|SATB|Deke Sharon
-Why Do Fools Fall In Love|SSAA|David Wright
 Why Do Fools Fall In Love|SSAA|Dianne Goldrick
 Why Do I Love You|TTBB|Mark Hale
 Why Do I Love You|TTBB|Walter Latzko
@@ -25897,15 +25484,13 @@ Why Don't You Fall in Love With Me|SSAA|Nancy Bergman
 Why Don't You Fall In Love With Me?|SSAA|Larry Wright
 Why Don't You Fall In Love With Me?|TTBB|Larry Wright
 Why Don't You Fall In Love With Me?/Undecided (Medley)|TTBB|Clay Hine
-Why Don't You Fall In Love With Me?/Undecided Medley|TTBB|Clay Hine
-Why Don't You Fall In Love With Me/Undecided Medley|TTBB|Clay Hine
 Why Don't You Fall In Love With Me/Undecided Medley(Clay|TTBB|Clay Hine
 Why Georgia|TTBB|Aaron Dale
 Why Haven't I Heard From You|SSAA|Kevin Keller
 Why Haven't I Heard From You|SSAA|Tedda Lippincott
 Why Me|TTBB|Paul Jorg
+Why Not Say Goodbye the Way We Said Hello|SSAA|Mel Knight
 Why Not Say Goodbye the Way We Said Hello|TTBB|Melvin Knight
-Why Not Say Goodbye The Way We Said Hello|SSAA|Mel Knight
 Why Not Say Goodbye The Way We Said Hello|SSAA|Melvin Knight
 Why Not Say Goodbye The Way We Said Hello|TTBB|Mel Knight
 Why Should I Cry Over You|TTBB|Ed Waesche
@@ -25957,14 +25542,12 @@ Will I Ever Tell You|SSAA|Nancy Bergman
 Will I Ever Tell You|TTBB|Howard Jones
 Will I Ever Tell You|TTBB|Mike Sotiriou
 WILL I EVER TELL YOU? (DREAM OF NOW)|SSAA|Marie B Johnson
-Will It Be Me This Time|SSAA|Lynnell Diamond
 Will It Be Me This Time?|SSAA|Nancy Bergman
 WILL IT BE ME THIS TIME?|SSAA|Lynnell Diamond
 Will The Angels Let Me Play|TTBB|Jim West
 Will The Circle Be Unbroken?|TTBB|Jon Nicholas
 Will The Sun Ever Shine Again|SSAA|Fran Carter
 Will The Sun Ever Shine Again|SSAA|Kevin Keller
-Will The Sun Ever Shine Again|TTBB|Kevin Keller
 Will The Sun Ever Shine Again|TTBB|Mark Goodney
 Will The Sun Ever Shine Again?|TTBB|Kevin Keller
 Will Ye Go Lassie Go|TTBB|Ralph Urquhart
@@ -25998,11 +25581,9 @@ Winchester Cathedral|SSAA|Tom Gentry
 Winchester Cathedral|TTBB|Tom Gentry
 Wind Beneath My Wings|SSAA|Hari Birtles
 Wind Beneath My Wings|SSAA|Jay Giallombardo
-Wind Beneath My Wings|SSAA|Julie Starr
 Wind Beneath My Wings|SSAA|R. J. Margison
 Wind Beneath My Wings|SSAA|Tom Gentry
 Wind Beneath My Wings|TTBB|Derric Johnson
-Wind Beneath My Wings|TTBB|Tom Gentry
 Wind Beneath My Wings/You Raise Me Up Medley|TTBB|Jay Giallombardo
 Windmill in old Amsterdam|TTBB|Tony Pelling
 Windy|SSAA|Larry Wright
@@ -26015,7 +25596,6 @@ Wings|SSAA|Hari Birtles
 Wings|SSAA|Lyndal Thorburn
 Wings|SSAA|Michael Gellert
 Wings|TTBB|Simon Arnott
-Wink and a Smile|TTBB|Kim Brittain
 Wink and A Smile|SSAA|Sharon Vitkovsky
 Wink And A Smile|SSAA|Jim Massey
 Winner's Song|SSAA|Mary Ann Wydra
@@ -26058,26 +25638,26 @@ Witchcraft|TTBB|David Briner
 Witchcraft|TTBB|Jim Shubert
 WITCHCRAFT|SSAA|David Briner
 Witchy Woman|SSAA|Liz Garnett
+With a Little Help from My Friends|SSAA|Richard Hasty
+With a Little Help from My Friends|TTBB|Richard Hasty
 With a Little Help From My Friends|SSAA|Rich Hasty
 With A Little Help From My Friends|SATB|Deke Sharon
 With A Little Help From My Friends|SSAA|Joey Minshall
-With A Little Help From My Friends|SSAA|Richard Hasty
 With A Little Help From My Friends|SSAA|Suzy Lobaugh
 With A Little Help From My Friends|SSAA|Unspecified
 With A Little Help From My Friends|TTBB|Patrick McAlexander
 With A Little Help From My Friends|TTBB|Rich Hasty
-With A Little Help From My Friends|TTBB|Richard Hasty
 With A Little Help From My Friends|TTBB|Steve Jamison
 With A Little Help From My Friends|TTBB|Steve Tramack
 With A Little Help From My Friends (YWIH)|SSAA|Suzy Lobaugh
 With A Smile And A Song|TTBB|Russ Foris
 With A Smile And A Song|TTBB|Russ Foris, Dave Stevens
 With a Song and a Smile|TTBB|Russ Foris
+With a Song in My Heart|SSAA|Nancy Bergman
 With A Song In My Heart|SATB|Jim Henry
 With A Song In My Heart|SATB|Renee Craig
 With A Song In My Heart|SSAA|Brent Graham
 With A Song In My Heart|SSAA|Carolyn Schmidt
-With A Song In My Heart|SSAA|Nancy Bergman
 With A Song In My Heart|SSAA|Rebecca J. Wood
 With A Song In My Heart|SSAA|Walter Latzko
 With A Song In My Heart|TTBB|Brent Graham
@@ -26147,7 +25727,6 @@ Wonderful Day like Today|TTBB|Bob Benson
 Wonderful Day like Today|TTBB|Dan Mulligan
 Wonderful Day like Today|TTBB|Mike Wallen
 Wonderful Day like Today|TTBB|Mo Rector
-Wonderful Day like Today|TTBB|Rob Hopkins
 Wonderful Day like Today|TTBB|Walter Latzko
 Wonderful Day Medley|SSAA|David Wright and Marty Griebel
 Wonderful Day Medley|SSAA|David Wright and Mike Griebel
@@ -26250,7 +25829,7 @@ Ya Gotta Be|SATB|Deke Sharon
 Ya Gotta Have Heart|SSAA|Larry Wright
 Ya Gotta Know / I Can't Give You Anything But Love|SSAA|Nancy Bergman
 Ya Gotta Know How To Dance|SSAA|Clay Hine
-Ya Gotta Know How To Love|SSAA|Nancy Bergman
+Ya Gotta Know How to Love|SSAA|Nancy Bergman
 Ya Gotta Know How To Love|TTBB|Nancy Bergman
 Ya Gotta Know How To Love|TTBB|Nancy Bergman, Lloyd Steinkamp and Mike McGee
 Ya Gotta Know How To Love Em'/I Can't Give You Anything But Love Medley|SSAA|Nancy Bergman
@@ -26279,15 +25858,10 @@ Yellow Submarine|TTBB|Jan-Ake Westin
 Yellow Submarine|TTBB|Steve Delehanty
 Yes I Can|TTBB|Steve Tramack
 Yes Indeed|SATB|Earl Moon
-Yes Indeed|SSAA|Earl Moon
-Yes Indeed|SSAA|Karen McCarville
 Yes Indeed|SSAA|Renee Craig
-Yes Indeed|TTBB|David Wright
-Yes Indeed|TTBB|Earl Moon
 Yes Indeed!|TTBB|David Wright
 YES INDEED!|SSAA|Karen McCarville
 Yes Sir That's My Baby|SSAA|David Wright
-Yes Sir That's My Baby|TTBB|Val Hicks
 Yes Sir, That's My Baby|SSAA|W. Donaldson
 Yes Sir, That's My Baby|TTBB|Dan Naumann
 Yes Sir, That's My Baby|TTBB|David Wright
@@ -26307,8 +25881,6 @@ Yes, We Have No Bananas|TTBB|Mort Burt
 Yes, We Have No Bananas|TTBB|Peter Briant
 Yes, We Have No Bananas|TTBB|Sigmund Spaeth
 Yes, We Have No Bananas|TTBB|Unspecified
-YES! WE HAVE NO BANANAS|SSAA|Carolyn Johnson
-YES! WE HAVE NO BANANAS|SSAA|Jo Lund
 Yesterday|SATB|Tom Gentry
 Yesterday|SSAA|Carolyn Johnson
 Yesterday|SSAA|Delyth Knight
@@ -26328,10 +25900,10 @@ Yesterday|TTBB|Tom Gentry
 YESTERDAY|SSAA|Carolyn E. Johnson
 YESTERDAY|SSAA|Diana C DeBruycker
 Yesterday (YWIH)|SSAA|Renee Craig
+Yesterday I Heard the Rain|SSAA|Sharon Carlson
 Yesterday I Heard The Rain|SSAA|Brent Graham
 Yesterday I Heard The Rain|SSAA|Carolyn Johnson
 Yesterday I Heard The Rain|SSAA|G Avener
-Yesterday I Heard The Rain|SSAA|Sharon Carlson
 Yesterday I Heard The Rain|TTBB|Brent Graham
 YESTERDAY I HEARD THE RAIN|SSAA|Carolyn E. Johnson
 YESTERDAY I HEARD THE RAIN - YW|SSAA|Carolyn E. Johnson
@@ -26366,6 +25938,7 @@ You Always Hurt the One You Love|TTBB|Andrew Wittenberg
 You Always Hurt the One You Love|TTBB|Mark Goodney
 You Always Hurt The One You Love|TTBB|Don Gray
 You and I|TTBB|Adam Reimnitz
+You and I|TTBB|Kyle Kitzmiller
 You and I|TTBB|Lou Perry
 You And I|SATB|Deke Sharon
 You And I|SATB|Kyle Kitzmiller
@@ -26376,7 +25949,6 @@ You And I|TTBB|David Harrington
 You And I|TTBB|Jay Giallombardo
 You And I|TTBB|Joey Minshall
 You And I|TTBB|Kevin Keller
-You And I|TTBB|Kyle Kitzmiller
 You And I|TTBB|Louis Perry
 You And I (We Can Conquer The World)|TTBB|David Harrington
 You And Me|SSAA|Tamra Perez
@@ -26423,8 +25995,8 @@ You Are the New Day|TTBB|Gary Thiel
 You Are The New Day|TTBB|Peter Knight
 You are the One I Love|TTBB|Paul Olguin
 You Are The One I Love|TTBB|Paul C. Olguin
-You Are The Sunshine Of My Life|SATB|Clay Hine
-You Are The Sunshine Of My Life|SSAA|Bev Sellers
+You Are the Sunshine of My Life|SSAA|Bev Sellers
+You Are The Sunshine of My Life|SATB|Clay Hine
 You Are The Sunshine Of My Life|SSAA|Carolyn Schmidt
 You Are The Sunshine Of My Life|SSAA|Emily Moriarty
 You Are The Sunshine Of My Life|SSAA|Jean Kane
@@ -26435,9 +26007,9 @@ You Are The Sunshine Of My Life|TTBB|Jim Shubert
 You Are The Sunshine Of My Life|TTBB|Larry Wright
 You Are The Top/Friendship/Anything Goes|TTBB|Jeremey Johnson
 You Are There|TTBB|Michael Webber
+You Belong to Me|SSAA|June Berg
 You Belong To Me|SSAA|Aaron Dale
 You Belong To Me|SSAA|Carolyn Schmidt
-You Belong To Me|SSAA|June Berg
 You Belong To Me|SSAA|Marsha Zwicker
 You Belong To Me|SSAA|Walter Latzko
 You Belong To Me|TTBB|Aaron Dale
@@ -26472,8 +26044,8 @@ You Can Have Every Light On Broadway|TTBB|Ed Waesche
 You Can Have Every Light On Broadway|TTBB|Nancy Bergman
 You Can Make It Happen|TTBB|Kent Borrowdale
 You Can Never Be Too Sure About the Girls/There's a Little B|TTBB|Jay Giallombardo
+You Can't Get a Man With a Gun|SSAA|Tom Gentry
 You Can't Get A Man With A Gun|SSAA|Nancy Bergman
-You Can't Get A Man With A Gun|SSAA|Tom Gentry
 You Can't Go On Forever Breaking My Heart|SSAA|Lois Whitney
 YOU CAN'T GO ON FOREVER BREAKING MY HEART|SSAA|Lois C. Whitney
 You Can't Go Out With Each Tom, Dick, And Harry|TTBB|Norma Andersen
@@ -26484,8 +26056,8 @@ You Can't Hurry Love|SSAA|Liz Garnett
 You Can't Make Me Love You|TTBB|Clay Hine
 You Can't Make Old Friends|SSAA|Adam Bock
 You Can't Make Old Friends|TTBB|Corinna Garriock
+You Can't Stop the Beat|SSAA|Carole Prietto
 You Can't Stop The Beat|SATB|Kohl Kitzmiller
-You Can't Stop The Beat|SSAA|Carole Prietto
 You Can't Stop The Beat|SSAA|Liz Garnett
 You Can't Stop The Beat|TTBB|Carole Prietto
 You Can't Stop The Beat|TTBB|David Wright
@@ -26546,10 +26118,10 @@ You Got a Friend|SSAA|Liz Garnett
 You Gotta Be|SATB|Deke Sharon
 You Gotta Be|SSAA|Deke Sharon
 You Gotta Be|SSAA|Erica Kelch-Slesnick
+You Gotta Be a Football Hero|TTBB|Jay Giallombardo
 You Gotta Be A Football Hero|SSAA|Jay Giallombardo
 You Gotta Be A Football Hero|TTBB|Don Coldren
 You Gotta Be A Football Hero|TTBB|Jack Baird
-You Gotta Be A Football Hero|TTBB|Jay Giallombardo
 You Gotta Be A Football Hero / Betty Coed Medley|TTBB|Steve Jamison
 You Gotta Go South|TTBB|Lee Whitener
 You Gotta Have Charts|TTBB|Roger Payne
@@ -26687,15 +26259,15 @@ You Tell Me Your Dream|TTBB|Clay Hine
 You Tell Me Your Dream|TTBB|Phil Embury
 You There In The Back Row|SSAA|David Wright
 You Think (That You Love Me)|TTBB|Norma Andersen
+You Took Advantage of Me|TTBB|Jay Giallombardo
 You Took Advantage Of Me|SATB|Joe Mannherz
 You Took Advantage Of Me|SSAA|Aaron Dale
 You Took Advantage Of Me|SSAA|Joe Mannherz
 You Took Advantage Of Me|SSAA|Unspecified
 You Took Advantage Of Me|TTBB|Aaron Dale
-You Took Advantage Of Me|TTBB|Jay Giallombardo
 You Took Advantage Of Me|TTBB|Joe Mannherz
 You Took Advantage Of Me (from Present Arms)|TTBB|Aaron Dale
-You Turned The Tables On Me|SSAA|Nancy Bergman
+You Turned the Tables on Me|SSAA|Nancy Bergman
 You Turned The Tables On Me|TTBB|Dan Mulligan
 You Turned The Tables On Me|TTBB|Nancy Bergman
 You Walk With Me|TTBB|Ed Howard
@@ -26783,8 +26355,8 @@ You'll Never Walk Alone|TTBB|Terry Phillips
 YOU'LL NEVER WALK ALONE|SSAA|LaVeda A Redfield
 You're A Dangerous Girl|TTBB|Burt Szabo
 You're A Good Man, Charlie Brown|TTBB|Theodore Hicks
+You're a Grand Old Flag|SSAA|Nancy Bergman
 You're A Grand Old Flag|SSAA|Carolyn Johnson
-You're A Grand Old Flag|SSAA|Nancy Bergman
 You're A Grand Old Flag|SSAA|Patricia Godfrey
 You're A Grand Old Flag|TTBB|Barbershop Harmony Society
 YOU'RE A GRAND OLD FLAG|SSAA|Carolyn E. Johnson
@@ -26801,16 +26373,16 @@ You're A Mean One, Mr. Grinch|TTBB|Greg Volk
 You're A Mean One, Mr. Grinch|TTBB|Jon Nicholas
 You're A Mean One, Mr. Grinch|TTBB|Scott Turnbull, Shaun Agnew
 You're All I Need to Get By|TTBB|Deke Sharon
+You're All I Want for Christmas|TTBB|Richard Bain
 You're All I Want For Christmas|SSAA|Donna Stewart
-You're All I Want For Christmas|TTBB|Richard Bain
 You're All The World To Me|TTBB|Larry Triplett
 You're an Education|TTBB|Bob Rund
 You're an Education (in Yourself)|TTBB|Robert Rund
 You're An Old Smoothie|SSAA|Walter Latzko
 You're An Old Smoothie|TTBB|Walter Latzko
+You're as Welcome as the Flowers in May|TTBB|Floyd Connett
 You're As Welcome as the Flowers In May|SSAA|Traditional
 You're As Welcome As the Flowers In May|TTBB|David Wright
-You're As Welcome As the Flowers In May|TTBB|Floyd Connett
 You're Breaking In A New Heart|SSAA|Dan Naumann
 You're Breaking In A New Heart|SSAA|Joni Bescos
 You're Breaking In A New Heart|SSAA|Rich Hasty
@@ -26889,10 +26461,8 @@ You're Nobody Til' Somebody Loves You|TTBB|Greg Volk
 You're Nobody's Sweetheart Medley|TTBB|Renee Craig
 You're Sixteen|TTBB|Dick Rode
 You're Sixteen (You're Beautiful and You're Mine)|TTBB|Aaron Dale
-You're Sixteen You're Beautiful and You're Mine|TTBB|Aaron Dale
 You're Sixteen You're Beautiful And You're Mine|SSAA|Aaron Dale
 You're Sixteen You're Beautiful And You're Mine|TTBB|Jim Shubert
-You're Sixteen, You're Beautiful And You're Mine|TTBB|Aaron Dale
 You're Sixteen, You're Beautiful And You're Mine(Aaron|TTBB|Aaron Dale
 You're So Vain|SSAA|Mike Taylor
 You're Some Pretty Doll|TTBB|John Hohl
@@ -26910,7 +26480,6 @@ You're The Cream In My Coffee|SSAA|Debbie Porter
 You're The Cream In My Coffee|SSAA|Jeanne Elmuccio
 You're The First, The Last, My Everything|TTBB|Kohl Kitzmiller
 You're The First, The Last, My Everything|TTBB|Nick Bryant
-You're the Flower of My Heart Sweet Adeline|TTBB|Barbershop Harmony Society
 You're The Flower Of My Heart, Sweet Adeline|SSAA|Jay Giallombardo
 You're The Flower Of My Heart, Sweet Adeline|SSAA|Joey Minshall
 You're The Flower Of My Heart, Sweet Adeline|TTBB|Barbershop Harmony Society
@@ -26936,24 +26505,24 @@ You've Been A Good Ol Wagon|SSAA|Joan D 'Agostino
 YOU'VE BEEN A GOOD OL' WAGON|SSAA|Joan Adler
 You've Changed|TTBB|Patrick McAlexander
 You've Changed|TTBB|Walter Latzko
+You've Got a Friend|SSAA|Tom Gentry
 You've Got A Friend|SSAA|Jack Bridges
 You've Got A Friend|SSAA|Lauren Kahn
 You've Got A Friend|SSAA|Sam Hubbard
 You've Got A Friend|SSAA|Tedda Lippincott
-You've Got A Friend|SSAA|Tom Gentry
 You've Got A Friend|TTBB|Brian Mastrull
 You've Got A Friend|TTBB|Cay Outerbridge
 You've Got A Friend|TTBB|Jon Colbath
 You've Got A Friend|TTBB|Mark Stevens
 You've Got A Friend|TTBB|Tom Gentry
-You've Got A Friend In Me|SATB|Dan Wessler
+You've Got a Friend in Me|SATB|Dan Wessler
+You've Got a Friend in Me|SSAA|Dan Wessler
+You've Got a Friend in Me|TTBB|Dan Wessler
 You've Got A Friend In Me|SATB|Deke Sharon
-You've Got A Friend In Me|SSAA|Dan Wessler
 You've Got A Friend In Me|SSAA|David Harrington
 You've Got A Friend In Me|SSAA|Jay Giallombardo
 You've Got A Friend In Me|SSAA|Jo Lund
 You've Got A Friend In Me|SSAA|Larry Wright
-You've Got A Friend In Me|TTBB|Dan Wessler
 You've Got A Friend In Me|TTBB|David Harrington
 You've Got A Friend In Me|TTBB|Gabriel Lawson
 You've Got A Friend In Me|TTBB|Jack Bridges
@@ -27003,10 +26572,10 @@ Your Eyes Have Told Me So|TTBB|Keith Hamilton
 Your Eyes Have Told Me So|TTBB|Walter Latzko
 Your Feet's Too Big|SSAA|Carolyn Schmidt
 Your Feets Too Big|SSAA|Carolyn Schmidt
-Your First Day In Heaven|SSAA|Aaron Dale
+Your First Day in Heaven|SSAA|Aaron Dale
+Your First Day in Heaven|TTBB|Aaron Dale
 Your First Day In Heaven|SSAA|Susan Wells
 Your First Day In Heaven|SSAA|Tedda Lippincott
-Your First Day In Heaven|TTBB|Aaron Dale
 Your Funny Uncle|SATB|Matthew Spinner
 Your Heart Is As Black As Night|SATB|Dan Wessler
 Your Heart Is As Black As Night|SSAA|Dan Wessler
@@ -27032,7 +26601,6 @@ Youth|SATB|Nicholas Wright
 Yuletide Medley|TTBB|Richard Curtis
 Zanzibar|TTBB|Deke Sharon
 Ziegfeld Medley|SSAA|Nancy Bergman
-Zing Went the Strings of My Heart|TTBB|Renee Craig
 Zing Went The Strings Of My Heart|SSAA|Renee Craig
 Zing Went The Strings Of My Heart|TTBB|Barbershop Harmony Society
 ZING WENT THE STRINGS OF MY HEART|SSAA|Carolyn E. Johnson
@@ -27053,7 +26621,6 @@ Zip A Dee Doo Dah|SSAA|Joe Mannherz
 Zip A Dee Doo Dah|TTBB|Larry Wright
 Zip-a-dee Doo-dah|TTBB|Joe Liles
 Zip-A-Dee-Doo-Dah|SSAA|Lorraine Rochefort
-Zip-A-Dee-Doo-Dah|TTBB|Joe Liles
 Zip-A-Dee-Doo-Dah|TTBB|Jon Nicholas
 Zip-Ah-Dee-Doo-Dah|SSAA|Nancy Bergman
 Zombie|SATB|Emily Moriarty

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -20,7 +20,10 @@ Song Title|Voicing|Arranger
 The Supabase import script parses that PSV file, normalizes title and arranger
 text, expands comma-separated supported voicings, deduplicates by
 `normalized_title + voicing + normalized_arranger`, and replaces
-`song_suggestion_catalog` using a server-side service role key:
+`song_suggestion_catalog` using a server-side service role key. The
+`normalized_title` key ignores one leading `A`, `An`, or `The` after applying
+trailing article display normalization, so `Closest Thing To Crazy, The` and
+`The Closest Thing To Crazy` share the same suggestion key.
 
 ```bash
 npm run song-suggestions:import -- --dry-run

--- a/docs/song-sources.md
+++ b/docs/song-sources.md
@@ -25,9 +25,11 @@ Each source PSV uses this header:
 Song Title|Voicing|Arranger
 ```
 
-Rows are deduped by normalized `title + voicing + arranger`. Different voicings
-remain separate rows. Missing arranger remains blank and is not treated as the
-same thing as explicit `Unknown`.
+Rows are deduped by normalized `title + voicing + arranger`. Title keys normalize
+trailing articles for display-style variants, then ignore one leading `A`, `An`,
+or `The` for suggestion grouping. Different voicings remain separate rows.
+Missing arranger remains blank and is not treated as the same thing as explicit
+`Unknown`.
 
 ## Local Environment
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -222,6 +222,9 @@ Code:
   `data/sources/harmony_brigade_song_suggestions.psv`
 - `scripts/merge-song-suggestion-sources.mjs` safely merges committed source
   PSVs into `data/song_suggestion_catalog.psv` with a timestamped local backup
+- Suggestion title keys normalize trailing articles, then ignore one leading
+  `A`, `An`, or `The`; display titles stay human-readable and are not blindly
+  article-stripped.
 - Preserved by `scripts/delete-user.mjs`; catalog rows are global suggestions,
   not user-owned data.
 - Read only through `public.search_repertoire_song_suggestions`
@@ -250,6 +253,8 @@ Required database contract:
 - RLS enabled; no direct browser table access is required
 - Import expands comma-separated source voicings into one row per supported
   voicing and ignores unsupported voicing values
+- Search uses the same article-insensitive title key for catalog rows and query
+  matching while preserving direct title matching for display-title variants.
 - The BHS transform also splits clearly multi-voicing product rows into one row
   per supported voicing and skips ambiguous, unsupported, non-four-part, or
   collection products.

--- a/lib/__tests__/internationalSongsImport.test.mjs
+++ b/lib/__tests__/internationalSongsImport.test.mjs
@@ -42,7 +42,7 @@ describe("International Songs import", () => {
     expect(rows).toEqual([
       {
         title: "A Fool Such As I",
-        normalized_title: "a fool such as i",
+        normalized_title: "fool such as i",
         voicing: "TTBB",
         arranger: "Aaron Dale",
         normalized_arranger: "aaron dale",

--- a/lib/__tests__/songSourcePipeline.test.mjs
+++ b/lib/__tests__/songSourcePipeline.test.mjs
@@ -7,6 +7,7 @@ import {
   normalizeArrangerName,
   normalizeSourceVoicings,
   normalizeTitleArticle,
+  normalizeTitleForSuggestionKey,
 } from "../../scripts/song-sources/source-utils.mjs";
 import {
   formatSourcePsv,
@@ -42,6 +43,27 @@ describe("song source pipeline", () => {
     ]);
   });
 
+  it("builds article-insensitive suggestion title keys", () => {
+    expect(normalizeTitleForSuggestionKey("A Barbershop Time Of Your Life")).toBe(
+      "barbershop time of your life"
+    );
+    expect(normalizeTitleForSuggestionKey("Barbershop Time Of Your Life")).toBe(
+      "barbershop time of your life"
+    );
+    expect(normalizeTitleForSuggestionKey("The Longest Time")).toBe(
+      "longest time"
+    );
+    expect(normalizeTitleForSuggestionKey("Longest Time")).toBe("longest time");
+    expect(normalizeTitleForSuggestionKey("An Old Song")).toBe("old song");
+    expect(normalizeTitleForSuggestionKey("Old Song")).toBe("old song");
+    expect(normalizeTitleForSuggestionKey("Closest Thing To Crazy, The")).toBe(
+      "closest thing to crazy"
+    );
+    expect(normalizeTitleForSuggestionKey("The Closest Thing To Crazy")).toBe(
+      "closest thing to crazy"
+    );
+  });
+
   it("writes and parses PSV rows without losing multi-voicing support", () => {
     const psv = formatSourcePsv([
       {
@@ -64,16 +86,18 @@ describe("song source pipeline", () => {
       ]);
   });
 
-  it("dedupes only matching title, voicing, and arranger rows", () => {
+  it("dedupes article-insensitive matching title, voicing, and arranger rows", () => {
     const deduped = dedupeSourceRows([
       { title: "Song", voicing: "TTBB", arranger: null },
       { title: "Song", voicing: "TTBB", arranger: null },
+      { title: "The Song", voicing: "TTBB", arranger: null },
       { title: "Song", voicing: "SSAA", arranger: null },
       { title: "Song", voicing: "TTBB", arranger: "Someone" },
+      { title: "The Song", voicing: "TTBB", arranger: "Someone Else" },
     ]);
 
-    expect(deduped.duplicateRows).toBe(1);
-    expect(deduped.rows).toHaveLength(3);
+    expect(deduped.duplicateRows).toBe(2);
+    expect(deduped.rows).toHaveLength(4);
   });
 
   it("uses Barbershop Connections Voices as app voicing", () => {
@@ -130,12 +154,22 @@ describe("song source pipeline", () => {
       [
         { title: "Same Song", voicing: "TTBB", arranger: null },
         { title: "Same Song", voicing: "TTBB", arranger: null },
+        { title: "The Same Song", voicing: "TTBB", arranger: "Arranger One" },
       ],
-      [{ title: "Same Song", voicing: "SSAA", arranger: null }],
+      [
+        { title: "The Same Song", voicing: "SSAA", arranger: null },
+        { title: "Same Song", voicing: "TTBB", arranger: "Arranger One" },
+        { title: "Same Song", voicing: "TTBB", arranger: "Arranger Two" },
+      ],
     ]);
 
-    expect(merged.duplicateRows).toBe(1);
-    expect(merged.rows.map((row) => row.voicing)).toEqual(["SSAA", "TTBB"]);
+    expect(merged.duplicateRows).toBe(2);
+    expect(merged.rows).toEqual([
+      { title: "Same Song", voicing: "TTBB", arranger: null },
+      { title: "Same Song", voicing: "TTBB", arranger: "Arranger Two" },
+      { title: "The Same Song", voicing: "SSAA", arranger: null },
+      { title: "The Same Song", voicing: "TTBB", arranger: "Arranger One" },
+    ]);
   });
 
   it("loads local song source env without logging or requiring secrets", async () => {
@@ -150,4 +184,3 @@ describe("song source pipeline", () => {
     expect(process.env.WCWS_TEST_SONG_SOURCE_VALUE).toBe("loaded value");
   });
 });
-

--- a/lib/__tests__/songSuggestionCatalogImport.test.ts
+++ b/lib/__tests__/songSuggestionCatalogImport.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 const {
   normalizeSearchText,
   parseSongSuggestionCatalog,
+  normalizeTitleForSuggestionKey,
 } = await import("../../scripts/import-song-suggestions.mjs");
 
 const catalogSource = readFileSync(
@@ -20,6 +21,16 @@ describe("song suggestion catalog import", () => {
     expect(normalizeSearchText("Mam'selle")).toBe("mam selle");
   });
 
+  it("normalizes catalog title keys without leading articles", () => {
+    expect(normalizeTitleForSuggestionKey("The Longest Time")).toBe(
+      "longest time"
+    );
+    expect(normalizeTitleForSuggestionKey("Longest Time")).toBe("longest time");
+    expect(normalizeTitleForSuggestionKey("Example Song, An")).toBe(
+      "example song"
+    );
+  });
+
   it("parses and deduplicates pipe-delimited catalog rows", () => {
     const rows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
 The End of the World|TTBB|Hilary Allen
@@ -31,7 +42,7 @@ No Arranger Song|TTBB|
     expect(rows).toEqual([
       {
         title: "A Winter's Tale",
-        normalized_title: "a winter s tale",
+        normalized_title: "winter s tale",
         voicing: "SSAA",
         arranger: "Hilary Allen",
         normalized_arranger: "hilary allen",
@@ -47,7 +58,7 @@ No Arranger Song|TTBB|
       },
       {
         title: "The End of the World",
-        normalized_title: "the end of the world",
+        normalized_title: "end of the world",
         voicing: "TTBB",
         arranger: "Hilary Allen",
         normalized_arranger: "hilary allen",
@@ -128,6 +139,52 @@ Mamselle|ttbb|Lou Perry
         voicing: "TTBB",
         arranger: "Lou Perry",
         normalized_arranger: "lou perry",
+        source: "Barbershop Connections",
+      },
+    ]);
+  });
+
+  it("deduplicates article-only title variants without merging arrangers or voicings", () => {
+    const rows = parseSongSuggestionCatalog(`Song Title|Voicing|Arranger
+The Song|TTBB|Arranger One
+Song|TTBB|Arranger One
+An Old Song|TTBB|Arranger Two
+Old Song|TTBB|Arranger Two
+The Song|TTBB|Arranger Three
+Song|SSAA|Arranger One
+`);
+
+    expect(rows).toEqual([
+      {
+        title: "An Old Song",
+        normalized_title: "old song",
+        voicing: "TTBB",
+        arranger: "Arranger Two",
+        normalized_arranger: "arranger two",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "Song",
+        normalized_title: "song",
+        voicing: "SSAA",
+        arranger: "Arranger One",
+        normalized_arranger: "arranger one",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "The Song",
+        normalized_title: "song",
+        voicing: "TTBB",
+        arranger: "Arranger One",
+        normalized_arranger: "arranger one",
+        source: "Barbershop Connections",
+      },
+      {
+        title: "The Song",
+        normalized_title: "song",
+        voicing: "TTBB",
+        arranger: "Arranger Three",
+        normalized_arranger: "arranger three",
         source: "Barbershop Connections",
       },
     ]);

--- a/lib/__tests__/songSuggestions.test.ts
+++ b/lib/__tests__/songSuggestions.test.ts
@@ -129,4 +129,61 @@ describe("getSongSuggestions", () => {
       },
     ]);
   });
+
+  it("groups title suggestions that differ only by leading article", () => {
+    const suggestions = getSongSuggestions(
+      [
+        {
+          song_title: "A Barbershop Time Of Your Life",
+          voicing: "TTBB",
+          arranger_name: "Joe Liles",
+        },
+        {
+          song_title: "Barbershop Time of Your Life",
+          voicing: "SSAA",
+          arranger_name: "Joe Liles",
+        },
+        {
+          song_title: "The Barbershop Time of Your Life",
+          voicing: "TTBB",
+          arranger_name: "Different Arranger",
+        },
+      ],
+      "barbershop time"
+    );
+
+    expect(suggestions).toEqual([
+      {
+        songTitle: "A Barbershop Time Of Your Life",
+        arrangerName: "Joe Liles",
+        voicings: ["TTBB", "SSAA"],
+      },
+      {
+        songTitle: "The Barbershop Time of Your Life",
+        arrangerName: "Different Arranger",
+        voicings: ["TTBB"],
+      },
+    ]);
+  });
+
+  it("matches searches that include an ignored leading article", () => {
+    expect(
+      getSongSuggestions(
+        [
+          {
+            song_title: "Longest Time",
+            voicing: "TTBB",
+            arranger_name: "Test Arranger",
+          },
+        ],
+        "the longest"
+      )
+    ).toEqual([
+      {
+        songTitle: "Longest Time",
+        arrangerName: "Test Arranger",
+        voicings: ["TTBB"],
+      },
+    ]);
+  });
 });

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -65,6 +65,13 @@ const songSuggestionSupportedVoicingMigration = readFileSync(
   ),
   "utf8"
 );
+const songSuggestionArticleTitleMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260505120000_article_insensitive_song_suggestion_titles.sql"
+  ),
+  "utf8"
+);
 const welcomeSeenMigration = readFileSync(
   join(
     repoRoot,
@@ -298,6 +305,17 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain(
       "Import expands comma-separated source voicings"
     );
+    expect(contract).toContain("ignore one leading");
+    expect(songSuggestionArticleTitleMigration).toContain(
+      "duplicate_catalog_rows"
+    );
+    expect(songSuggestionArticleTitleMigration).toContain(
+      "'^(a|an|the)[[:space:]]+'"
+    );
+    expect(songSuggestionArticleTitleMigration).toContain(
+      "search_repertoire_song_suggestions"
+    );
+    expect(songSuggestionArticleTitleMigration).toContain("title_query");
     expect(songSuggestionSupportedVoicingMigration).toContain(
       "song_suggestion_catalog_supported_voicing_chk"
     );

--- a/lib/songSuggestionTitle.ts
+++ b/lib/songSuggestionTitle.ts
@@ -1,0 +1,24 @@
+export function normalizeTitleForDisplay(title: string) {
+  const cleaned = title.replace(/\s+/g, " ").trim();
+  const articleMatch = cleaned.match(/^(.*),\s*(The|A|An)$/i);
+
+  if (!articleMatch) return cleaned;
+
+  return `${articleMatch[2]} ${articleMatch[1]}`.replace(/\s+/g, " ").trim();
+}
+
+export function normalizeSuggestionText(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[’']/g, "'")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function normalizeTitleForSuggestionKey(title: string) {
+  const normalized = normalizeSuggestionText(normalizeTitleForDisplay(title));
+  const withoutArticle = normalized.replace(/^(a|an|the)\s+/, "").trim();
+
+  return withoutArticle || normalized;
+}

--- a/lib/songSuggestions.ts
+++ b/lib/songSuggestions.ts
@@ -1,6 +1,10 @@
 import type { Voicing } from "@/lib/matching";
 import { arrangerDisplayName } from "./arrangerDisplay";
 import { voicingDisplayLabel } from "./partAbbreviations";
+import {
+  normalizeSuggestionText,
+  normalizeTitleForSuggestionKey,
+} from "./songSuggestionTitle";
 
 export type SongSuggestionSource = {
   song_title: string;
@@ -30,16 +34,12 @@ function isVoicing(value: string): value is Voicing {
   return validVoicings.includes(value as Voicing);
 }
 
-function normalizeSearchText(value: string) {
-  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
-}
-
 function suggestionKey(
   suggestion: Pick<SongSuggestion, "songTitle" | "arrangerName">
 ) {
   return [
-    normalizeSearchText(suggestion.songTitle),
-    normalizeSearchText(suggestion.arrangerName),
+    normalizeTitleForSuggestionKey(suggestion.songTitle),
+    normalizeSuggestionText(suggestion.arrangerName),
   ].join(":");
 }
 
@@ -54,7 +54,8 @@ export function getSongSuggestions(
   query: string,
   limit = 6
 ): SongSuggestion[] {
-  const normalizedQuery = normalizeSearchText(query);
+  const normalizedQuery = normalizeSuggestionText(query);
+  const normalizedTitleQuery = normalizeTitleForSuggestionKey(query);
 
   if (normalizedQuery.length < 2) return [];
 
@@ -71,11 +72,15 @@ export function getSongSuggestions(
 
     if (!suggestion.songTitle) continue;
 
-    const normalizedTitle = normalizeSearchText(suggestion.songTitle);
-    const normalizedArranger = normalizeSearchText(suggestion.arrangerName);
+    const normalizedTitle = normalizeSuggestionText(suggestion.songTitle);
+    const normalizedTitleKey = normalizeTitleForSuggestionKey(
+      suggestion.songTitle
+    );
+    const normalizedArranger = normalizeSuggestionText(suggestion.arrangerName);
 
     if (
       !normalizedTitle.includes(normalizedQuery) &&
+      !normalizedTitleKey.includes(normalizedTitleQuery) &&
       !normalizedArranger.includes(normalizedQuery)
     ) {
       continue;

--- a/scripts/barbershoptracks-parser.mjs
+++ b/scripts/barbershoptracks-parser.mjs
@@ -1,3 +1,5 @@
+import { normalizeTitleForSuggestionKey } from "./song-sources/source-utils.mjs";
+
 const supportedVoicings = new Set(["TTBB", "SATB", "SSAA"]);
 
 function cleanText(value) {
@@ -140,7 +142,7 @@ export function parseBarbershopTracksRenderedText(text) {
 
 function sourceKey(row) {
   return [
-    row.title.trim().toLowerCase(),
+    normalizeTitleForSuggestionKey(row.title),
     row.voicing,
     String(row.arranger ?? "").trim().toLowerCase(),
   ].join("|");

--- a/scripts/import-bhs-published-music.mjs
+++ b/scripts/import-bhs-published-music.mjs
@@ -8,6 +8,7 @@ import {
   normalizeSearchText,
   parseSongSuggestionCatalog,
 } from "./import-song-suggestions.mjs";
+import { normalizeTitleForSuggestionKey } from "./song-sources/source-utils.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -243,7 +244,7 @@ function catalogKey(row) {
 }
 
 function toCatalogRow({ title, voicing, arranger, source }) {
-  const normalizedTitle = normalizeSearchText(title);
+  const normalizedTitle = normalizeTitleForSuggestionKey(title);
   const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
 
   return {

--- a/scripts/import-international-songs.mjs
+++ b/scripts/import-international-songs.mjs
@@ -13,6 +13,7 @@ import {
   normalizeSearchText,
   parseSongSuggestionCatalog,
 } from "./import-song-suggestions.mjs";
+import { normalizeTitleForSuggestionKey } from "./song-sources/source-utils.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -41,7 +42,7 @@ function catalogKey(row) {
 }
 
 function toCatalogRow({ title, voicing, arranger }) {
-  const normalizedTitle = normalizeSearchText(title);
+  const normalizedTitle = normalizeTitleForSuggestionKey(title);
   const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
 
   return {

--- a/scripts/import-song-suggestions.mjs
+++ b/scripts/import-song-suggestions.mjs
@@ -6,6 +6,9 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadSongSourcesEnv, requiredEnv } from "./song-sources/env.mjs";
+import { normalizeTitleForSuggestionKey } from "./song-sources/source-utils.mjs";
+
+export { normalizeTitleForSuggestionKey } from "./song-sources/source-utils.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -60,7 +63,7 @@ export function parseSongSuggestionCatalog(contents) {
 
     if (!title || voicings.length === 0) continue;
 
-    const normalizedTitle = normalizeSearchText(title);
+    const normalizedTitle = normalizeTitleForSuggestionKey(title);
     const normalizedArranger = arranger ? normalizeSearchText(arranger) : null;
 
     for (const voicing of voicings) {

--- a/scripts/merge-song-suggestion-sources.mjs
+++ b/scripts/merge-song-suggestion-sources.mjs
@@ -6,6 +6,10 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatSongSuggestionCatalog } from "./import-bhs-published-music.mjs";
 import { parseSongSuggestionCatalog } from "./import-song-suggestions.mjs";
+import {
+  normalizeSuggestionText,
+  normalizeTitleForSuggestionKey,
+} from "./song-sources/source-utils.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
@@ -52,10 +56,16 @@ export function timestamp() {
 
 function catalogKey(row) {
   return [
-    row.title.trim().toLowerCase(),
+    normalizeTitleForSuggestionKey(row.title),
     row.voicing,
-    String(row.arranger ?? "").trim().toLowerCase(),
+    normalizeSuggestionText(row.arranger ?? ""),
   ].join("|");
+}
+
+function preferredCatalogTitle(current, next) {
+  if (next.length > current.length) return next;
+  if (next.length < current.length) return current;
+  return current.localeCompare(next) <= 0 ? current : next;
 }
 
 export function mergeRows(rowSets) {
@@ -67,6 +77,8 @@ export function mergeRows(rowSets) {
       const key = catalogKey(row);
       if (deduped.has(key)) {
         duplicateRows += 1;
+        const existing = deduped.get(key);
+        existing.title = preferredCatalogTitle(existing.title, row.title);
         continue;
       }
       deduped.set(key, row);

--- a/scripts/song-sources/source-utils.mjs
+++ b/scripts/song-sources/source-utils.mjs
@@ -17,6 +17,26 @@ export function normalizeTitleArticle(value) {
   return cleanSourceText(`${articleMatch[2]} ${articleMatch[1]}`);
 }
 
+export function normalizeTitleForDisplay(value) {
+  return normalizeTitleArticle(value);
+}
+
+export function normalizeSuggestionText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[’']/g, "'")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function normalizeTitleForSuggestionKey(value) {
+  const normalized = normalizeSuggestionText(normalizeTitleForDisplay(value) ?? "");
+  const withoutArticle = normalized.replace(/^(a|an|the)\s+/, "").trim();
+
+  return withoutArticle || normalized;
+}
+
 export function normalizeArrangerName(value, { flipCommaName = false } = {}) {
   const arranger = cleanSourceText(value);
   if (!arranger) return null;
@@ -97,10 +117,16 @@ export function normalizeSourceVoicings(value, { noneSpecifiedAsTTBB = false } =
 
 export function sourceRowKey(row) {
   return [
-    cleanSourceText(row.title)?.toLowerCase() ?? "",
+    normalizeTitleForSuggestionKey(row.title),
     row.voicing,
-    cleanSourceText(row.arranger)?.toLowerCase() ?? "",
+    normalizeSuggestionText(row.arranger ?? ""),
   ].join("|");
+}
+
+function preferredSourceTitle(current, next) {
+  if (next.length > current.length) return next;
+  if (next.length < current.length) return current;
+  return current.localeCompare(next) <= 0 ? current : next;
 }
 
 export function sortSourceRows(rows) {
@@ -132,6 +158,8 @@ export function dedupeSourceRows(rows) {
 
     if (deduped.has(key)) {
       duplicateRows += 1;
+      const existing = deduped.get(key);
+      existing.title = preferredSourceTitle(existing.title, normalizedRow.title);
       continue;
     }
 
@@ -143,4 +171,3 @@ export function dedupeSourceRows(rows) {
     duplicateRows,
   };
 }
-

--- a/supabase/migrations/20260505120000_article_insensitive_song_suggestion_titles.sql
+++ b/supabase/migrations/20260505120000_article_insensitive_song_suggestion_titles.sql
@@ -1,0 +1,224 @@
+with normalized_catalog_rows as (
+  select
+    id,
+    coalesce(
+      nullif(
+        regexp_replace(
+          btrim(
+            lower(
+              regexp_replace(
+                regexp_replace(title, '^(.*),\s*(the|a|an)$', '\2 \1', 'i'),
+                '[^[:alnum:]]+',
+                ' ',
+                'g'
+              )
+            )
+          ),
+          '^(a|an|the)[[:space:]]+',
+          '',
+          'i'
+        ),
+        ''
+      ),
+      normalized_title
+    ) as article_insensitive_title
+  from public.song_suggestion_catalog
+),
+duplicate_catalog_rows as (
+  select
+    id,
+    row_number() over (
+      partition by
+        article_insensitive_title,
+        voicing,
+        coalesce(normalized_arranger, '')
+      order by length(title) desc, title, id
+    ) as duplicate_rank
+  from normalized_catalog_rows
+  join public.song_suggestion_catalog using (id)
+)
+delete from public.song_suggestion_catalog
+using duplicate_catalog_rows
+where song_suggestion_catalog.id = duplicate_catalog_rows.id
+  and duplicate_catalog_rows.duplicate_rank > 1;
+
+update public.song_suggestion_catalog
+set normalized_title = coalesce(
+  nullif(
+    regexp_replace(
+      btrim(
+        lower(
+          regexp_replace(
+            regexp_replace(title, '^(.*),\s*(the|a|an)$', '\2 \1', 'i'),
+            '[^[:alnum:]]+',
+            ' ',
+            'g'
+          )
+        )
+      ),
+      '^(a|an|the)[[:space:]]+',
+      '',
+      'i'
+    ),
+    ''
+  ),
+  normalized_title
+);
+
+create or replace function public.search_repertoire_song_suggestions(
+  p_query text,
+  p_limit integer default 10
+)
+returns table (
+  song_title text,
+  voicing text,
+  arranger_name text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with normalized_input as (
+    select
+      raw_query,
+      query,
+      coalesce(
+        nullif(
+          regexp_replace(query, '^(a|an|the)[[:space:]]+', '', 'i'),
+          ''
+        ),
+        query
+      ) as title_query
+    from (
+      select
+        btrim(coalesce(p_query, '')) as raw_query,
+        btrim(
+          lower(
+            regexp_replace(coalesce(p_query, ''), '[^[:alnum:]]+', ' ', 'g')
+          )
+        ) as query
+    ) normalized_query
+  ),
+  user_suggestions as (
+    select distinct
+      btrim(user_repertoire.song_title) as song_title,
+      user_repertoire.voicing,
+      nullif(btrim(coalesce(user_repertoire.arranger_name, '')), '') as arranger_name,
+      coalesce(
+        nullif(
+          regexp_replace(
+            btrim(
+              lower(
+                regexp_replace(
+                  regexp_replace(user_repertoire.song_title, '^(.*),\s*(the|a|an)$', '\2 \1', 'i'),
+                  '[^[:alnum:]]+',
+                  ' ',
+                  'g'
+                )
+              )
+            ),
+            '^(a|an|the)[[:space:]]+',
+            '',
+            'i'
+          ),
+          ''
+        ),
+        lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+      ) as normalized_title,
+      1 as source_rank
+    from public.user_repertoire
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(user_repertoire.song_title) <> ''
+      and user_repertoire.voicing in ('TTBB', 'SATB', 'SSAA')
+      and (
+        coalesce(
+          nullif(
+            regexp_replace(
+              btrim(
+                lower(
+                  regexp_replace(
+                    regexp_replace(user_repertoire.song_title, '^(.*),\s*(the|a|an)$', '\2 \1', 'i'),
+                    '[^[:alnum:]]+',
+                    ' ',
+                    'g'
+                  )
+                )
+              ),
+              '^(a|an|the)[[:space:]]+',
+              '',
+              'i'
+            ),
+            ''
+          ),
+          lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+        ) like '%' || normalized_input.title_query || '%'
+        or lower(regexp_replace(user_repertoire.song_title, '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+        or lower(regexp_replace(coalesce(user_repertoire.arranger_name, ''), '[^[:alnum:]]+', ' ', 'g'))
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  catalog_suggestions as (
+    select distinct
+      btrim(song_suggestion_catalog.title) as song_title,
+      song_suggestion_catalog.voicing,
+      nullif(btrim(coalesce(song_suggestion_catalog.arranger, '')), '') as arranger_name,
+      song_suggestion_catalog.normalized_title,
+      2 as source_rank
+    from public.song_suggestion_catalog
+    cross join normalized_input
+    where auth.role() = 'authenticated'
+      and length(normalized_input.query) >= 2
+      and btrim(song_suggestion_catalog.title) <> ''
+      and song_suggestion_catalog.voicing in ('TTBB', 'SATB', 'SSAA')
+      and (
+        song_suggestion_catalog.normalized_title like normalized_input.title_query || '%'
+        or song_suggestion_catalog.normalized_title like '%' || normalized_input.title_query || '%'
+        or song_suggestion_catalog.title ilike '%' || normalized_input.raw_query || '%'
+        or coalesce(song_suggestion_catalog.normalized_arranger, '')
+          like '%' || normalized_input.query || '%'
+      )
+  ),
+  combined_suggestions as (
+    select * from user_suggestions
+    union all
+    select * from catalog_suggestions
+  ),
+  deduped_suggestions as (
+    select
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title,
+      min(combined_suggestions.source_rank) as source_rank
+    from combined_suggestions
+    group by
+      combined_suggestions.song_title,
+      combined_suggestions.voicing,
+      combined_suggestions.arranger_name,
+      combined_suggestions.normalized_title
+  )
+  select
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name
+  from deduped_suggestions
+  order by
+    case
+      when deduped_suggestions.normalized_title = (select title_query from normalized_input) then 0
+      when deduped_suggestions.normalized_title like (select title_query from normalized_input) || '%' then 1
+      else 2
+    end,
+    deduped_suggestions.source_rank,
+    deduped_suggestions.song_title,
+    deduped_suggestions.voicing,
+    deduped_suggestions.arranger_name nulls first
+  limit least(greatest(coalesce(p_limit, 10), 1), 20);
+$$;
+
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from public;
+revoke all on function public.search_repertoire_song_suggestions(text, integer) from anon;
+grant execute on function public.search_repertoire_song_suggestions(text, integer) to authenticated;


### PR DESCRIPTION
## Summary
- Add shared article-insensitive suggestion title keys that normalize trailing articles and ignore one leading A/An/The for dedupe and UI grouping.
- Apply the key across source dedupe, catalog merge/import, Add Song suggestion grouping, and regenerated `data/song_suggestion_catalog.psv`.
- Add a Supabase migration to dedupe/update existing catalog rows and align `search_repertoire_song_suggestions` query matching with the new title key.

## Docs and tests
- Updated `docs/song-sources.md`, `docs/imports.md`, and `docs/supabase-contract.md` for the article-insensitive title-key contract.
- Added tests for title-key normalization, source/catalog dedupe, Add Song grouping, and Supabase contract coverage.

## Verification
- npm run song-suggestions:import -- --dry-run
- npm run test:run
- npm run build
- npm run lint (fails on pre-existing unrelated lint issues in app/join, components/AppNav, components/RepertoireManager, components/MatchCard, etc.)

## Impact audit
- Navigation/home/onboarding/Help/Privacy/mobile/accessibility/auth/permissions/deployment/admin support: no user-flow or permission changes beyond cleaner Add Song suggestions.
- Analytics/privacy: no event or data-collection changes.
- Data/RLS: migration updates global `song_suggestion_catalog` normalized title keys and the suggestion RPC; no user-owned repertoire data is modified.
- Deployment/manual step: after merge, run the existing Song Suggestion Catalog Import workflow with `dry_run=false` if production catalog rows need to be refreshed from the regenerated PSV. The migration also cleans up existing production rows.

Closes #360