### PR TITLE
Fix quartet title grouping, thin-match prompts, and full joins

### DIFF
--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -8,6 +8,10 @@ import { MatchCard } from "@/components/MatchCard";
 import { QuartetActionConfirmation } from "@/components/QuartetActionConfirmation";
 import { noArrangerEnteredLabel } from "@/lib/arrangerDisplay";
 import { trackEvent } from "@/lib/analytics";
+import {
+  conversationStartersIntro,
+  shouldShowConversationStarters,
+} from "@/lib/conversationStarters";
 import { intentionalJoinStorageKey } from "@/lib/joinIntent";
 import { resolveCurrentUserRepertoireForMarkAsSung } from "@/lib/markAsSung";
 import {
@@ -34,6 +38,7 @@ import {
   type DbParticipant,
   getParticipants,
   getSessionByCode,
+  QuartetFullError,
   removeParticipant,
   removeParticipantById,
   subscribeToSessionParticipants,
@@ -72,6 +77,7 @@ import {
   getRecentSungSongs,
   type SungSongEvent,
 } from "@/lib/sungSongStore";
+import { compactTitleKey } from "@/lib/songSuggestionTitle";
 
 const matchSections = [
   {
@@ -92,6 +98,8 @@ const matchSections = [
 ] as const;
 
 const MAX_QUARTET_PARTICIPANTS = 4;
+const quartetFullMessage =
+  "This quartet is already full. Ask the group to start a new quartet.";
 
 type PersonalSongNote = {
   songTitle: string;
@@ -106,7 +114,7 @@ function leftQuartetStorageKey(code: string) {
 }
 
 function normalizeSongTitle(title: string) {
-  return title.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return compactTitleKey(title);
 }
 
 function normalizeOptionalText(value: string | null | undefined) {
@@ -324,7 +332,8 @@ export default function JoinSessionPage() {
           session_id: id,
           participant_count: existingParticipants.length,
         });
-        showStatusMessage("This quartet already has four singers.");
+        setLoadError(quartetFullMessage);
+        showStatusMessage(quartetFullMessage, "error");
         return;
       }
 
@@ -370,6 +379,16 @@ export default function JoinSessionPage() {
       );
     } catch (err) {
       console.error(err);
+      if (err instanceof QuartetFullError) {
+        trackEvent("quartet_join_failed", {
+          session_id: id,
+          reason: "quartet_full",
+        });
+        setLoadError(quartetFullMessage);
+        showStatusMessage(quartetFullMessage, "error");
+        return;
+      }
+
       trackEvent("quartet_join_failed", {
         session_id: id,
         reason: "write_failed",
@@ -933,8 +952,6 @@ export default function JoinSessionPage() {
     profileDisplayNamesByUserId
   );
   const matches = findMatches(allEntries);
-  const conversationStarters =
-    matches.length === 0 ? findConversationStarters(allEntries) : [];
   const groupedMatches = matchSections.map((section) => ({
     ...section,
     matches: matches.filter((match) => match.category === section.category),
@@ -942,6 +959,11 @@ export default function JoinSessionPage() {
   const readyMatchCount = groupedMatches.find(
     (section) => section.category === "ready"
   )?.matches.length ?? 0;
+  const showConversationStartersSection =
+    shouldShowConversationStarters(readyMatchCount);
+  const conversationStarters = showConversationStartersSection
+    ? findConversationStarters(allEntries)
+    : [];
   const possibleMatchCount = groupedMatches.find(
     (section) => section.category === "possible"
   )?.matches.length ?? 0;
@@ -973,6 +995,7 @@ export default function JoinSessionPage() {
     MAX_QUARTET_PARTICIPANTS - participants.length
   );
   const isQuartetFull = participants.length >= MAX_QUARTET_PARTICIPANTS;
+  const shouldShowQuartetResults = isCurrentUserParticipant || !isQuartetFull;
   const showManageButton =
     Boolean(session) &&
     isQuartetFull &&
@@ -1445,7 +1468,31 @@ export default function JoinSessionPage() {
           </div>
         )}
 
-        {!loadError && !quartetExpired && !pendingActiveQuartet && (
+        {!loadError &&
+          !quartetExpired &&
+          !pendingActiveQuartet &&
+          !shouldShowQuartetResults &&
+          isQuartetFull && (
+            <div className="mt-8 rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
+              <p className="font-semibold text-rose-100">
+                {quartetFullMessage}
+              </p>
+              <p className="mt-2 text-sm text-rose-100">
+                A quartet can have up to four singers.
+              </p>
+              <a
+                href="/join"
+                className="mt-4 inline-block rounded-xl bg-rose-100 px-5 py-3 font-semibold text-slate-950 hover:bg-white"
+              >
+                Enter a different code
+              </a>
+            </div>
+          )}
+
+        {!loadError &&
+          !quartetExpired &&
+          !pendingActiveQuartet &&
+          shouldShowQuartetResults && (
           <>
             {showJoinInfo && (
               <section className="mt-6 rounded-2xl border border-cyan-300/30 bg-cyan-300/10 p-5">
@@ -1597,23 +1644,10 @@ export default function JoinSessionPage() {
                       </a>
                     </div>
 
-                    {conversationStarters.length > 0 ? (
-                      <div className="mt-6">
-                        <h3 className="text-lg font-semibold text-cyan-100">
-                          Conversation starters
-                        </h3>
-                        <p className="mt-1 text-sm text-slate-300">
-                          These are not ready matches, but they may help the
-                          quartet find songs to talk through or add.
-                        </p>
-                        <div className="mt-3 space-y-3">
-                          {conversationStarters.map(renderConversationStarter)}
-                        </div>
-                      </div>
-                    ) : (
+                    {conversationStarters.length === 0 && (
                       <p className="mt-4 text-sm text-slate-400">
-                        We also did not find any song titles entered by more
-                        than one singer yet.
+                        The prompts below can still help the group compare
+                        songs and parts.
                       </p>
                     )}
                   </section>
@@ -1667,6 +1701,28 @@ export default function JoinSessionPage() {
                         </div>
                       </section>
                     )
+                )}
+
+                {showConversationStartersSection && (
+                  <section className="rounded-2xl border border-cyan-300/15 bg-cyan-300/5 p-5">
+                    <h3 className="text-lg font-semibold text-cyan-100">
+                      Conversation starters
+                    </h3>
+                    <p className="mt-1 text-sm text-slate-300">
+                      {conversationStartersIntro(readyMatchCount)}
+                    </p>
+                    {conversationStarters.length > 0 ? (
+                      <div className="mt-3 space-y-3">
+                        {conversationStarters.map(renderConversationStarter)}
+                      </div>
+                    ) : (
+                      <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-slate-300">
+                        <li>Ask if anyone knows another part on a shared song.</li>
+                        <li>Compare title, voicing, and arranger for near misses.</li>
+                        <li>Add one or two likely shared songs to My Songs.</li>
+                      </ul>
+                    )}
+                  </section>
                 )}
               </div>
             </div>

--- a/components/MatchCard.test.tsx
+++ b/components/MatchCard.test.tsx
@@ -131,6 +131,55 @@ describe("MatchCard", () => {
     expect(html).toContain("Bass Singer (Arranger: No arranger entered)");
   });
 
+  it("shows exact-match saved title variants without fuzzy guidance", () => {
+    const html = renderMatch({
+      songTitle: "A Barbershop Time Of Your Life",
+      voicing: "TTBB",
+      arrangerNames: ["Joe Liles"],
+      hasMissingArrangerInfo: false,
+      category: "ready",
+      missingParts: [],
+      assignments: {},
+      warnings: [],
+      score: 0,
+      titleVariants: [
+        {
+          title: "A Barbershop Time Of Your Life",
+          normalizedTitle: "barbershop time of your life",
+          singers: [
+            {
+              displayName: "Tim",
+              part: "Tenor",
+              confidence: "Good to Go",
+              arrangerName: "Joe Liles",
+            },
+          ],
+        },
+        {
+          title: "Barbershop Time Of Your Life",
+          normalizedTitle: "barbershop time of your life",
+          singers: [
+            {
+              displayName: "Amber",
+              part: "Baritone",
+              confidence: "Good to Go",
+              arrangerName: "Joe Liles",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(html).toContain("Title variants");
+    expect(html).toContain(
+      "Singers saved this match under different title variants."
+    );
+    expect(html).toContain("A Barbershop Time Of Your Life");
+    expect(html).toContain("Barbershop Time Of Your Life");
+    expect(html).not.toContain("Potential title match");
+    expect(html).not.toContain("If these are the same song");
+  });
+
   it("displays treble and mixed parts as barbershop functional parts", () => {
     const html = renderMatch({
       songTitle: "Treble Song",

--- a/components/MatchCard.tsx
+++ b/components/MatchCard.tsx
@@ -201,20 +201,26 @@ export function MatchCard({
           </p>
         )}
 
-        {match.titleMatchType === "fuzzy" && match.titleVariants?.length ? (
+        {match.titleVariants?.length ? (
           <div className="mt-3 rounded-lg bg-amber-300/10 p-3 text-sm text-amber-50">
             <p className="font-semibold text-amber-100">
-              Potential title match
+              {match.titleMatchType === "fuzzy"
+                ? "Potential title match"
+                : "Title variants"}
             </p>
             <p className="mt-1 text-xs text-amber-50/80">
-              These saved song entries may refer to the same song.
+              {match.titleMatchType === "fuzzy"
+                ? "These saved song entries may refer to the same song."
+                : "Singers saved this match under different title variants."}
             </p>
-            <p className="mt-2 text-xs text-amber-50/70">
-              Comparison key:{" "}
-              {match.titleVariants
-                .map((variant) => variant.normalizedTitle)
-                .join(" / ")}
-            </p>
+            {match.titleMatchType === "fuzzy" && (
+              <p className="mt-2 text-xs text-amber-50/70">
+                Comparison key:{" "}
+                {match.titleVariants
+                  .map((variant) => variant.normalizedTitle)
+                  .join(" / ")}
+              </p>
+            )}
             <div className="mt-3 space-y-3">
               {match.titleVariants.map((variant) => {
                 const arrangerLabels = uniqueArrangerLabels(variant.singers);
@@ -223,7 +229,7 @@ export function MatchCard({
                 return (
                   <div key={variantKey(variant)}>
                     <p className="font-semibold text-white">
-                      "{variant.title}"
+                      &quot;{variant.title}&quot;
                     </p>
                     {showVariantArranger && (
                       <p className="mt-0.5 text-xs text-amber-50/80">
@@ -251,10 +257,12 @@ export function MatchCard({
                 );
               })}
             </div>
-            <p className="mt-3 text-xs text-amber-50/80">
-              If these are the same song, consider updating song titles in My
-              Songs so future matches are clearer.
-            </p>
+            {match.titleMatchType === "fuzzy" && (
+              <p className="mt-3 text-xs text-amber-50/80">
+                If these are the same song, consider updating song titles in My
+                Songs so future matches are clearer.
+              </p>
+            )}
           </div>
         ) : null}
 

--- a/docs/app-flows.md
+++ b/docs/app-flows.md
@@ -32,7 +32,9 @@ Joining by `/join/[code]` reads the session by join code and fetches current
 by `user_id`, not by display name.
 
 New participants can join until the quartet has four singers. The four-singer
-limit is enforced before inserting another `session_participants` row.
+limit is enforced by `join_session_participant`, which locks the session before
+checking active participant count and inserting another `session_participants`
+row.
 
 ### Rejoin Quartet
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -21,6 +21,10 @@ migrations in `supabase/migrations`, and tests or test documentation.
   `/join/[code]`.
 - `/join/[code]` reads fresh session and participant data from Supabase on load.
   Existing participants are recognized by `user_id`, not by display name.
+- Joining or rejoining writes the participant snapshot through
+  `join_session_participant`, which locks the session row, lets existing active
+  participants refresh their snapshot, and rejects new participants when four
+  active participant rows already exist.
 - Local active-quartet state is a shortcut for navigation only. It must not be
   treated as proof that the user still has a current `session_participants` row.
 - My Songs add, edit, delete, and mark-as-sung actions update
@@ -496,8 +500,8 @@ Purpose: source of truth for quartet join codes and session activity.
 Code:
 - Insert new session: `lib/sessionStore.ts#createSession`
 - Read by join code: `lib/sessionStore.ts#getSessionByCode`
-- Update `last_activity_at`: internal helper in `lib/sessionStore.ts`, called
-  after participant snapshot upserts.
+- Update `last_activity_at`: `public.join_session_participant` updates activity
+  after participant snapshot writes.
 - Start quartet flow: `app/session/page.tsx` creates the session before
   inserting the first participant snapshot.
 - Preserved by `scripts/delete-user.mjs`; sessions are shared join-code records.
@@ -526,7 +530,8 @@ from this table, not local-only state.
 
 Code:
 - Read participants: `lib/sessionStore.ts#getParticipants`
-- Insert/update own snapshot: `lib/sessionStore.ts#upsertParticipant`
+- Insert/update own snapshot: `lib/sessionStore.ts#upsertParticipant`, through
+  `public.join_session_participant`
 - Delete own row: `lib/sessionStore.ts#removeParticipant`
 - Remove selected row by id: `lib/sessionStore.ts#removeParticipantById`,
   through `public.remove_session_participant_by_id`
@@ -561,6 +566,12 @@ Required database contract:
 - Authenticated users can select session participants.
 - Authenticated users can insert/update/delete only their own row where
   `user_id = auth.uid()`.
+- `public.join_session_participant(p_session_id uuid, p_display_name text,
+  p_repertoire jsonb, p_last_activity_at timestamptz, p_max_participants integer)`
+  is a security-definer RPC available only to authenticated users. It uses
+  `auth.uid()` for `user_id`, locks the session row before checking capacity,
+  allows an existing active participant to update/rejoin, and rejects a new
+  participant when four active rows already exist.
 - Authenticated users who are current participants in a session can call
   `public.remove_session_participant_by_id(p_session_id, p_participant_id)` to
   remove another participant from that same session.
@@ -570,6 +581,7 @@ Established by migrations:
 - `20260428051000_fix_session_participants_rls.sql`
 - `20260428060000_supabase_contract_alignment.sql`
 - `20260428151000_add_participant_removal_function.sql`
+- `20260505133000_add_safe_session_join_function.sql`
 
 ### `sung_song_events`
 

--- a/lib/__tests__/conversationStarters.test.ts
+++ b/lib/__tests__/conversationStarters.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  conversationStartersIntro,
+  shouldShowConversationStarters,
+} from "../conversationStarters";
+
+describe("conversation starter visibility", () => {
+  it("shows conversation starters for fewer than three ready matches", () => {
+    expect(shouldShowConversationStarters(0)).toBe(true);
+    expect(shouldShowConversationStarters(1)).toBe(true);
+    expect(shouldShowConversationStarters(2)).toBe(true);
+  });
+
+  it("hides conversation starters when ready matches are plentiful", () => {
+    expect(shouldShowConversationStarters(3)).toBe(false);
+    expect(shouldShowConversationStarters(4)).toBe(false);
+  });
+
+  it("uses state-specific intro copy", () => {
+    expect(conversationStartersIntro(0)).toContain("No ready matches yet");
+    expect(conversationStartersIntro(2)).toContain("Only a few ready matches");
+  });
+});

--- a/lib/__tests__/matching.test.ts
+++ b/lib/__tests__/matching.test.ts
@@ -198,6 +198,89 @@ describe("findMatches", () => {
     expect(matches[0].songTitle).toBe("Hello, Mary Lou!");
   });
 
+  it("groups leading-article title variants as ready matches and surfaces variants", () => {
+    const entries: SingerEntry[] = [
+      { userId: "1", displayName: "Tim", songTitle: "A Barbershop Time Of Your Life", voicing: "TTBB", arrangerName: "Joe Liles", partsKnown: ["Tenor"] },
+      { userId: "2", displayName: "Alex", songTitle: "A Barbershop Time Of Your Life", voicing: "TTBB", arrangerName: "Joe Liles", partsKnown: ["Lead"] },
+      { userId: "3", displayName: "Amber", songTitle: "Barbershop Time Of Your Life", voicing: "TTBB", arrangerName: "Joe Liles", partsKnown: ["Baritone"] },
+      { userId: "4", displayName: "Ross", songTitle: "Barbershop Time Of Your Life", voicing: "TTBB", arrangerName: "Joe Liles", partsKnown: ["Bass"] },
+    ];
+
+    const matches = findMatches(entries);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      songTitle: "A Barbershop Time Of Your Life",
+      category: "ready",
+      missingParts: [],
+      arrangerNames: ["Joe Liles"],
+    });
+    expect(matches[0].titleVariants).toEqual([
+      {
+        title: "A Barbershop Time Of Your Life",
+        normalizedTitle: "barbershop time of your life",
+        singers: [
+          {
+            displayName: "Tim",
+            part: "Tenor",
+            confidence: null,
+            arrangerName: "Joe Liles",
+          },
+          {
+            displayName: "Alex",
+            part: "Lead",
+            confidence: null,
+            arrangerName: "Joe Liles",
+          },
+        ],
+      },
+      {
+        title: "Barbershop Time Of Your Life",
+        normalizedTitle: "barbershop time of your life",
+        singers: [
+          {
+            displayName: "Amber",
+            part: "Baritone",
+            confidence: null,
+            arrangerName: "Joe Liles",
+          },
+          {
+            displayName: "Ross",
+            part: "Bass",
+            confidence: null,
+            arrangerName: "Joe Liles",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("uses article-insensitive title keys for common article cases", () => {
+    const cases = [
+      ["The Longest Time", "Longest Time"],
+      ["An Old Song", "Old Song"],
+      [
+        "Closest Thing To Crazy, The",
+        "The Closest Thing To Crazy",
+        "Closest Thing To Crazy",
+      ],
+    ];
+
+    for (const titles of cases) {
+      const entries: SingerEntry[] = [
+        { userId: "1", displayName: "T", songTitle: titles[0], voicing: "TTBB", partsKnown: ["Tenor"] },
+        { userId: "2", displayName: "L", songTitle: titles[1], voicing: "TTBB", partsKnown: ["Lead"] },
+        { userId: "3", displayName: "Bari", songTitle: titles[2] ?? titles[0], voicing: "TTBB", partsKnown: ["Baritone"] },
+        { userId: "4", displayName: "Bass", songTitle: titles[1], voicing: "TTBB", partsKnown: ["Bass"] },
+      ];
+
+      expect(findMatches(entries)[0]).toMatchObject({
+        category: "ready",
+        missingParts: [],
+      });
+    }
+  });
+
   it("suggests a possible match for conservative near-duplicate titles", () => {
     const entries: SingerEntry[] = [
       { userId: "1", displayName: "T", songTitle: "Why Try to Change Me", voicing: "TTBB", partsKnown: ["Tenor"] },
@@ -221,7 +304,7 @@ describe("findMatches", () => {
     expect(matches[0].titleVariants).toEqual([
       {
         title: "Why Try to Change Me",
-        normalizedTitle: "whytrytochangeme",
+        normalizedTitle: "why try to change me",
         singers: [
           {
             displayName: "T",
@@ -245,7 +328,7 @@ describe("findMatches", () => {
       },
       {
         title: "Why Try To Change Me Now",
-        normalizedTitle: "whytrytochangemenow",
+        normalizedTitle: "why try to change me now",
         singers: [
           {
             displayName: "Bass",
@@ -301,7 +384,7 @@ describe("findMatches", () => {
     expect(matches[0].titleVariants).toEqual([
       {
         title: "Why Try To Change Me",
-        normalizedTitle: "whytrytochangeme",
+        normalizedTitle: "why try to change me",
         singers: [
           {
             displayName: "Tenor",
@@ -313,7 +396,7 @@ describe("findMatches", () => {
       },
       {
         title: "Why Try To Change Me Now",
-        normalizedTitle: "whytrytochangemenow",
+        normalizedTitle: "why try to change me now",
         singers: [
           {
             displayName: "Lead",
@@ -331,7 +414,7 @@ describe("findMatches", () => {
       },
       {
         title: "Why Try to Change Me Now",
-        normalizedTitle: "whytrytochangemenow",
+        normalizedTitle: "why try to change me now",
         singers: [
           {
             displayName: "Bass",

--- a/lib/__tests__/quartetManagePanel.test.ts
+++ b/lib/__tests__/quartetManagePanel.test.ts
@@ -36,8 +36,16 @@ describe("quartet manage panel markup", () => {
       "all required parts are covered by different"
     );
     expect(joinPage).toContain("Conversation starters");
-    expect(joinPage).toContain("These are not ready matches");
+    expect(joinPage).toContain("conversationStartersIntro");
+    expect(joinPage).toContain("showConversationStartersSection");
+    expect(joinPage).toContain("Ask if anyone knows another part");
     expect(joinPage).toContain("Review My Songs");
     expect(joinPage).not.toContain("Refresh matches");
+  });
+
+  it("keeps full-quartet failed joiners out of active results", () => {
+    expect(joinPage).toContain("quartetFullMessage");
+    expect(joinPage).toContain("shouldShowQuartetResults");
+    expect(joinPage).toContain("A quartet can have up to four singers.");
   });
 });

--- a/lib/__tests__/sessionParticipantResolution.test.ts
+++ b/lib/__tests__/sessionParticipantResolution.test.ts
@@ -66,4 +66,17 @@ describe("session participant resolution", () => {
       participant: existingParticipant,
     });
   });
+
+  it("rejects a new participant when the quartet is full", () => {
+    const participants = [
+      participant("participant-1", "user-1", "Singer 1"),
+      participant("participant-2", "user-2", "Singer 2"),
+      participant("participant-3", "user-3", "Singer 3"),
+      participant("participant-4", "user-4", "Singer 4"),
+    ];
+
+    expect(resolveParticipantForJoin(participants, "user-5", 4)).toEqual({
+      status: "full",
+    });
+  });
 });

--- a/lib/__tests__/sessionStore.test.ts
+++ b/lib/__tests__/sessionStore.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 import {
+  QuartetFullError,
   removeParticipant,
   removeParticipantById,
   SessionParticipantWriteError,
@@ -77,9 +78,10 @@ describe("sessionStore writes", () => {
       repertoire: [],
       joined_at: "2026-04-28T00:00:00.000Z",
     };
-    const participantQuery = query({ data: savedParticipant });
-    const sessionQuery = query({});
-    supabaseMock.queryQueue.push(participantQuery, sessionQuery);
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: savedParticipant,
+      error: null,
+    });
 
     await expect(
       upsertParticipant(
@@ -91,42 +93,67 @@ describe("sessionStore writes", () => {
       )
     ).resolves.toEqual(savedParticipant);
 
-    expect(supabaseMock.from).toHaveBeenNthCalledWith(
-      1,
-      "session_participants"
-    );
-    expect(participantQuery.upsert).toHaveBeenCalledWith(
-      {
-        session_id: "session-1",
-        user_id: "user-1",
-        display_name: "Tim",
-        repertoire: [],
-      },
-      { onConflict: "session_id,user_id" }
-    );
-    expect(supabaseMock.from).toHaveBeenNthCalledWith(2, "sessions");
-    expect(sessionQuery.update).toHaveBeenCalledWith({
-      last_activity_at: "2026-04-28T19:00:00.000Z",
+    expect(supabaseMock.rpc).toHaveBeenCalledWith("join_session_participant", {
+      p_session_id: "session-1",
+      p_display_name: "Tim",
+      p_repertoire: [],
+      p_last_activity_at: "2026-04-28T19:00:00.000Z",
+      p_max_participants: 4,
     });
-    expect(sessionQuery.eq).toHaveBeenCalledWith("id", "session-1");
+    expect(supabaseMock.from).not.toHaveBeenCalled();
   });
 
   it("rejects unverified participant upserts", async () => {
-    supabaseMock.queryQueue.push(
-      query({
-        data: {
-          id: "participant-1",
-          session_id: "session-2",
-          user_id: "user-1",
-        },
-      })
-    );
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: {
+        id: "participant-1",
+        session_id: "session-2",
+        user_id: "user-1",
+      },
+      error: null,
+    });
 
     await expect(
       upsertParticipant("session-1", "user-1", "Tim", [])
     ).rejects.toBeInstanceOf(SessionParticipantWriteError);
 
-    expect(supabaseMock.from).toHaveBeenCalledTimes(1);
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("maps full quartet RPC failures to a typed error", async () => {
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: null,
+      error: {
+        message: "This quartet is already full.",
+      },
+    });
+
+    await expect(
+      upsertParticipant("session-1", "user-1", "Tim", [])
+    ).rejects.toBeInstanceOf(QuartetFullError);
+
+    expect(supabaseMock.from).not.toHaveBeenCalled();
+  });
+
+  it("accepts array-shaped participant RPC responses", async () => {
+    supabaseMock.rpc.mockResolvedValueOnce({
+      data: [
+        {
+          id: "participant-1",
+          session_id: "session-1",
+          user_id: "user-1",
+        },
+      ],
+      error: null,
+    });
+
+    await expect(
+      upsertParticipant("session-1", "user-1", "Tim", [])
+    ).resolves.toMatchObject({
+      id: "participant-1",
+      session_id: "session-1",
+      user_id: "user-1",
+    });
   });
 
   it("deletes the current user's participant row and verifies it is gone", async () => {

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -44,6 +44,13 @@ const participantRemovalMigration = readFileSync(
   ),
   "utf8"
 );
+const safeSessionJoinMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260505133000_add_safe_session_join_function.sql"
+  ),
+  "utf8"
+);
 const songSuggestionsMigration = readFileSync(
   join(
     repoRoot,
@@ -168,6 +175,7 @@ describe("Supabase contract guardrails", () => {
     expect(migration).toContain("(session_id, user_id)");
     expect(migration).toContain("supabase_realtime");
     expect(contract).toContain("join/rejoin");
+    expect(contract).toContain("join_session_participant");
     expect(contract).toContain("leave");
     expect(contract).toContain("repertoire snapshot");
     expect(contract).toContain("Match calculation source");
@@ -176,6 +184,13 @@ describe("Supabase contract guardrails", () => {
     expect(appFlows).toContain("Source Of Truth");
     expect(appFlows).toContain("Rejoin Quartet");
     expect(appFlows).toContain("Remove Singer");
+    expect(safeSessionJoinMigration).toContain("join_session_participant");
+    expect(safeSessionJoinMigration).toContain("for update");
+    expect(safeSessionJoinMigration).toContain("auth.uid()");
+    expect(safeSessionJoinMigration).toContain(
+      "This quartet is already full."
+    );
+    expect(safeSessionJoinMigration).toContain("to authenticated");
   });
 
   it("documents and migrates the first-login welcome flag", () => {

--- a/lib/conversationStarters.ts
+++ b/lib/conversationStarters.ts
@@ -1,0 +1,11 @@
+export function shouldShowConversationStarters(readyMatchCount: number) {
+  return readyMatchCount < 3;
+}
+
+export function conversationStartersIntro(readyMatchCount: number) {
+  if (readyMatchCount === 0) {
+    return "No ready matches yet. These prompts can help the group find something close.";
+  }
+
+  return "Only a few ready matches. These prompts can help uncover another option.";
+}

--- a/lib/matching.ts
+++ b/lib/matching.ts
@@ -1,6 +1,11 @@
 import { isLikelySameSongTitle } from "./fuzzySongTitles";
 import { areLikelySameArrangerGroup } from "./arrangerDisplay";
 import { functionalPartName } from "./partAbbreviations";
+import {
+  compactTitleKey,
+  normalizeTitleForDisplay,
+  normalizeTitleForSuggestionKey,
+} from "./songSuggestionTitle";
 
 export type Voicing = "TTBB" | "SATB" | "SSAA";
 
@@ -121,7 +126,7 @@ export function normalizeConfidence(confidence?: string | null): Confidence | nu
 }
 
 function normalizeTitle(title: string): string {
-  return title.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return compactTitleKey(title);
 }
 
 function confidenceValue(confidence?: string | null): number {
@@ -327,6 +332,28 @@ function preferredSuggestionTitle(firstTitle: string, secondTitle: string) {
     : secondTitle;
 }
 
+function preferredGroupTitle(entries: SingerEntry[]) {
+  const counts = new Map<string, number>();
+
+  for (const entry of entries) {
+    const title = normalizeTitleForDisplay(entry.songTitle);
+    counts.set(title, (counts.get(title) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort(([firstTitle, firstCount], [secondTitle, secondCount]) => {
+      const countDifference = secondCount - firstCount;
+      if (countDifference !== 0) return countDifference;
+
+      const lengthDifference = secondTitle.length - firstTitle.length;
+      if (lengthDifference !== 0) return lengthDifference;
+
+      return firstTitle.localeCompare(secondTitle, undefined, {
+        sensitivity: "base",
+      });
+    })[0][0];
+}
+
 function buildTitleVariants(
   assignment: Record<Part, SingerEntry>
 ): MatchTitleVariant[] {
@@ -349,7 +376,7 @@ function buildTitleVariants(
 
     variants.set(entry.songTitle, {
       title: entry.songTitle,
-      normalizedTitle: normalizeTitle(entry.songTitle),
+      normalizedTitle: normalizeTitleForSuggestionKey(entry.songTitle),
       singers: [singer],
     });
   }
@@ -357,6 +384,11 @@ function buildTitleVariants(
   return Array.from(variants.values()).sort((a, b) =>
     a.title.localeCompare(b.title, undefined, { sensitivity: "base" })
   );
+}
+
+function titleVariantsForMatch(assignment: Record<Part, SingerEntry>) {
+  const variants = buildTitleVariants(assignment);
+  return variants.length > 1 ? variants : undefined;
 }
 
 export function findMatches(entries: SingerEntry[]): MatchResult[] {
@@ -371,7 +403,8 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
   const fuzzyFullMatchGroupKeys = new Set<string>();
 
   for (const [groupKey, group] of groups) {
-    const { songTitle, voicing } = group[0];
+    const { voicing } = group[0];
+    const songTitle = preferredGroupTitle(group);
     const requiredParts = requiredPartsForVoicing(voicing);
 
     const fullAssignment = findDistinctAssignment(requiredParts, group);
@@ -395,6 +428,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
         assignments: buildAssignments(fullAssignment),
         warnings,
         score: scoreMatch("ready", fullAssignment, group, requiredParts, warnings),
+        titleVariants: titleVariantsForMatch(fullAssignment),
         sourceGroupKeys: [groupKey],
       });
 
@@ -442,6 +476,7 @@ export function findMatches(entries: SingerEntry[]): MatchResult[] {
           requiredParts,
           warnings
         ),
+        titleVariants: titleVariantsForMatch(bestNearMatch.assignment),
         sourceGroupKeys: [groupKey],
       });
     }
@@ -532,7 +567,8 @@ export function findConversationStarters(
   const starters: ConversationStarter[] = [];
 
   for (const group of groups.values()) {
-    const { songTitle, voicing } = group[0];
+    const { voicing } = group[0];
+    const songTitle = preferredGroupTitle(group);
     const requiredParts = requiredPartsForVoicing(voicing);
     const distinctSingerIds = new Set(group.map((entry) => entry.userId));
 

--- a/lib/sessionStore.ts
+++ b/lib/sessionStore.ts
@@ -25,6 +25,24 @@ export class SessionParticipantWriteError extends Error {
   }
 }
 
+export class QuartetFullError extends Error {
+  constructor(message = "This quartet is already full.") {
+    super(message);
+    this.name = "QuartetFullError";
+  }
+}
+
+function isQuartetFullError(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+
+  const message =
+    "message" in error && typeof error.message === "string"
+      ? error.message
+      : "";
+
+  return /quartet is already full/i.test(message);
+}
+
 export async function createSession(joinCode: string) {
   const { data, error } = await supabase
     .from("sessions")
@@ -37,15 +55,6 @@ export async function createSession(joinCode: string) {
 
   if (error) throw error;
   return data as DbSession;
-}
-
-async function updateSessionActivity(sessionId: string, lastActivityAt: string) {
-  const { error } = await supabase
-    .from("sessions")
-    .update({ last_activity_at: lastActivityAt })
-    .eq("id", sessionId);
-
-  if (error) throw error;
 }
 
 export async function getSessionByCode(joinCode: string) {
@@ -66,29 +75,32 @@ export async function upsertParticipant(
   repertoire: SingerEntry[],
   lastActivityAt = new Date().toISOString()
 ) {
-  const { data, error } = await supabase
-    .from("session_participants")
-    .upsert(
-      {
-        session_id: sessionId,
-        user_id: userId,
-        display_name: displayName,
-        repertoire,
-      },
-      { onConflict: "session_id,user_id" }
-    )
-    .select()
-    .single();
+  const { data, error } = await supabase.rpc("join_session_participant", {
+    p_session_id: sessionId,
+    p_display_name: displayName,
+    p_repertoire: repertoire,
+    p_last_activity_at: lastActivityAt,
+    p_max_participants: 4,
+  });
 
-  if (error) throw error;
-  if (!data || data.session_id !== sessionId || data.user_id !== userId) {
+  if (error) {
+    if (isQuartetFullError(error)) throw new QuartetFullError();
+    throw error;
+  }
+
+  const participant = Array.isArray(data) ? data[0] : data;
+
+  if (
+    !participant ||
+    participant.session_id !== sessionId ||
+    participant.user_id !== userId
+  ) {
     throw new SessionParticipantWriteError(
       "Could not verify the quartet participant snapshot was saved."
     );
   }
 
-  await updateSessionActivity(sessionId, lastActivityAt);
-  return data as DbParticipant;
+  return participant as DbParticipant;
 }
 
 export async function getParticipants(sessionId: string) {

--- a/lib/songSuggestionTitle.ts
+++ b/lib/songSuggestionTitle.ts
@@ -22,3 +22,7 @@ export function normalizeTitleForSuggestionKey(title: string) {
 
   return withoutArticle || normalized;
 }
+
+export function compactTitleKey(title: string) {
+  return normalizeTitleForSuggestionKey(title).replace(/[^a-z0-9]/g, "");
+}

--- a/supabase/migrations/20260505133000_add_safe_session_join_function.sql
+++ b/supabase/migrations/20260505133000_add_safe_session_join_function.sql
@@ -1,0 +1,96 @@
+create or replace function public.join_session_participant(
+  p_session_id uuid,
+  p_display_name text,
+  p_repertoire jsonb,
+  p_last_activity_at timestamptz default now(),
+  p_max_participants integer default 4
+)
+returns public.session_participants
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  existing_participant public.session_participants%rowtype;
+  saved_participant public.session_participants%rowtype;
+  active_participant_count integer;
+begin
+  if current_user_id is null then
+    raise exception 'You must be logged in to join a quartet.';
+  end if;
+
+  perform 1
+  from public.sessions
+  where id = p_session_id
+  for update;
+
+  if not found then
+    raise exception 'Could not find that quartet.';
+  end if;
+
+  select *
+  into existing_participant
+  from public.session_participants
+  where session_id = p_session_id
+    and user_id = current_user_id;
+
+  if existing_participant.id is null then
+    select count(*)
+    into active_participant_count
+    from public.session_participants
+    where session_id = p_session_id;
+
+    if active_participant_count >= least(greatest(coalesce(p_max_participants, 4), 1), 4) then
+      raise exception 'This quartet is already full.';
+    end if;
+  end if;
+
+  insert into public.session_participants (
+    session_id,
+    user_id,
+    display_name,
+    repertoire
+  )
+  values (
+    p_session_id,
+    current_user_id,
+    btrim(p_display_name),
+    coalesce(p_repertoire, '[]'::jsonb)
+  )
+  on conflict (session_id, user_id)
+  do update set
+    display_name = excluded.display_name,
+    repertoire = excluded.repertoire
+  returning *
+  into saved_participant;
+
+  update public.sessions
+  set last_activity_at = coalesce(p_last_activity_at, now())
+  where id = p_session_id;
+
+  return saved_participant;
+end;
+$$;
+
+revoke all on function public.join_session_participant(
+  uuid,
+  text,
+  jsonb,
+  timestamptz,
+  integer
+) from public;
+revoke all on function public.join_session_participant(
+  uuid,
+  text,
+  jsonb,
+  timestamptz,
+  integer
+) from anon;
+grant execute on function public.join_session_participant(
+  uuid,
+  text,
+  jsonb,
+  timestamptz,
+  integer
+) to authenticated;


### PR DESCRIPTION
## Summary
- Make quartet match grouping use the article-insensitive title key from song suggestions, while preserving user-entered titles and surfacing grouped title variants in match details.
- Show Conversation Starters whenever there are fewer than 3 ready matches, with state-specific intro copy and fallback prompts when no dynamic near-match cards exist.
- Route participant joins through a new `join_session_participant` Supabase RPC that locks the session, permits existing participants to refresh/rejoin, and rejects new fifth participants atomically.

## Docs and tests
- Updated `docs/app-flows.md` and `docs/supabase-contract.md` for the server-side join contract.
- Added/updated tests for article-insensitive matching/title variants, MatchCard title-variant rendering, Conversation Starter visibility, full-quartet resolution, session-store RPC behavior, and Supabase contract coverage.

## Verification
- npm run test:run
- npm run build

## Impact audit
- Navigation/home/onboarding/Help/Privacy: no copy or route changes required beyond the join-page failed-full state.
- Quartet UI/mobile/accessibility: match cards now show exact title variants; Conversation Starters remain below ready/possible/missing match sections; failed full joins show a recoverable error with a link back to code entry.
- Analytics/privacy: existing join failure/full events are reused; no new event payloads or personal data collection.
- Data/RLS/Supabase: adds `join_session_participant`; no user-owned repertoire titles are changed; `session_participants` remains the active membership source of truth.
- Deployment/admin/support: production deploy should apply the migration before the app relies on the RPC. No manual dashboard change required.

Closes #361
Closes #362
Closes #363