### PR TITLE
Polish My Songs route and acknowledgments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,5 +203,6 @@ Guardrails:
 - `lib/activeQuartetSnapshot.ts`: refreshes active quartet snapshots after repertoire changes
 - `lib/participantEntries.ts`: combines participant rows with profile display names
 - `app/join/[code]/page.tsx`: session join/results
-- `app/repertoire/page.tsx`: repertoire management
+- `app/songs/page.tsx`: canonical My Songs route
+- `app/repertoire/page.tsx`: legacy My Songs redirect
 - `docs/supabase-contract.md`: app/database contract and Supabase guardrails

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -11,8 +11,10 @@ import {
   feedbackHelpCopy,
   helpAcknowledgments,
   helpAcknowledgmentsIntro,
+  helpDevelopmentNote,
   helpGuideSections,
   helpNavItems,
+  helpSongSuggestionSources,
   helpWelcomeCopy,
 } from "@/lib/helpContent";
 import { getCurrentUser } from "@/lib/profileStore";
@@ -229,6 +231,25 @@ export default function HelpPage() {
               </li>
             ))}
           </ul>
+          <p className="mt-5 text-sm font-semibold uppercase text-slate-300">
+            Song suggestion sources
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-base leading-7 text-slate-300">
+            {helpSongSuggestionSources.map((item) => (
+              <li key={item.name}>
+                <span className="font-semibold text-slate-100">
+                  {item.name}
+                </span>
+                , {item.contribution}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-5 text-sm font-semibold uppercase text-slate-300">
+            Development note
+          </p>
+          <p className="mt-3 text-base leading-7 text-slate-300">
+            {helpDevelopmentNote}
+          </p>
         </section>
 
         <section

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -1205,7 +1205,7 @@ export default function JoinSessionPage() {
               {isCurrentParticipant && (
                 <>
                   <a
-                    href="/repertoire"
+                    href="/songs"
                     className="w-fit rounded-lg border border-cyan-300/30 px-3 py-2 text-sm font-semibold text-cyan-200 hover:bg-cyan-300/10"
                   >
                     Edit My Songs
@@ -1637,7 +1637,7 @@ export default function JoinSessionPage() {
                     </div>
                     <div className="mt-4 flex flex-col gap-2 sm:flex-row">
                       <a
-                        href="/repertoire"
+                        href="/songs"
                         className="rounded-xl bg-cyan-300 px-5 py-3 text-center font-semibold text-slate-950 hover:bg-cyan-200"
                       >
                         Review My Songs

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,7 @@ const actions = [
     description: "Enter a code from another singer.",
   },
   {
-    href: "/repertoire",
+    href: "/songs",
     title: "My Songs",
     description: "Add or update songs you know.",
   },
@@ -48,7 +48,7 @@ const setupPrompts: Record<
     message: "Add a few songs before starting or joining a quartet.",
     helper:
       "You can type songs in, copy songs from another singer, or add Harmony Brigade songs from My Songs.",
-    href: "/repertoire",
+    href: "/songs",
     action: "Add songs",
   },
 };

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -24,10 +24,10 @@ export default function PrivacyPage() {
             <ul className="mt-3 list-disc space-y-2 pl-5 text-slate-300">
               <li>Your display name for profile and quartet screens.</li>
               <li>
-                Your My Songs entries, including song title, arrangement
-                voicing, parts known, confidence, arranger if entered, notes if
-                entered, date added or updated, and last-sung information when
-                you mark a song as sung in the app.
+                The songs you add, including song title, arrangement voicing,
+                parts known, confidence, arranger if entered, notes if entered,
+                date added or updated, and last-sung information when you mark a
+                song as sung in the app.
               </li>
               <li>
                 Quartet/session data, including join codes, active membership,
@@ -44,7 +44,7 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">How we use it</h2>
             <p className="mt-2 text-slate-300">
               The app uses your information to sign you in, save your profile,
-              manage My Songs, let you join or leave quartets, refresh
+              manage your songs, let you join or leave quartets, refresh
               quartet snapshots, and show songs the group may be able to sing.
               Song title suggestions are generated from distinct song title,
               arrangement voicing, and arranger values that singers have entered
@@ -60,7 +60,7 @@ export default function PrivacyPage() {
               identity fields such as title, arrangement voicing, and arranger
               from catalog imports or previously saved song identities.
               Suggestions are not authoritative, and adding a song to My Songs
-              does not add it to anyone else&apos;s My Songs. Personal details
+              does not add it to anyone else&apos;s saved songs. Personal details
               such as notes, confidence, last-sung history, user identity, and
               email address are not exposed as suggestions.
             </p>
@@ -73,7 +73,7 @@ export default function PrivacyPage() {
               creates a private code/link. Anyone with an active code/link can
               view safe song identity fields: title, arrangement voicing, and
               arranger. They must sign in before copying songs, and copied songs
-              become their own My Songs entries with their chosen part and
+              become their own saved songs with their chosen part and
               confidence. The shared view does not expose notes, confidence,
               last-sung history, email address, or account details, and you can
               revoke the link.
@@ -84,7 +84,7 @@ export default function PrivacyPage() {
             <h2 className="text-xl font-semibold">Harmony Brigade songs</h2>
             <p className="mt-2 text-slate-300">
               Adding Harmony Brigade songs uses reference data to help you add
-              songs to My Songs. It does not publicly indicate that you attended
+              songs. It does not publicly indicate that you attended
               a Brigade event. Your selected year, brigade, song choices, parts,
               and confidence are not shown to other users by default, except
               through normal quartet matching if you join a quartet.

--- a/app/repertoire/page.tsx
+++ b/app/repertoire/page.tsx
@@ -1,5 +1,5 @@
-import RepertoireManager from "@/components/RepertoireManager";
+import { redirect } from "next/navigation";
 
 export default function RepertoirePage() {
-  return <RepertoireManager />;
+  redirect("/songs");
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -159,7 +159,7 @@ export default function SettingsPage() {
 
           {showRepertoireNextStep && (
             <a
-              href="/repertoire"
+              href="/songs"
               className="mt-4 inline-block rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-cyan-200 hover:bg-white/20"
             >
               Add songs to My Songs

--- a/app/songs/page.tsx
+++ b/app/songs/page.tsx
@@ -1,0 +1,5 @@
+import RepertoireManager from "@/components/RepertoireManager";
+
+export default function SongsPage() {
+  return <RepertoireManager />;
+}

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -7,10 +7,10 @@ import { hasQuartetWorkflowHistory } from "@/lib/activeQuartet";
 import { isSafeAppRedirectPath } from "@/lib/authRedirect";
 
 function getRedirectPath() {
-  if (typeof window === "undefined") return "/repertoire";
+  if (typeof window === "undefined") return "/songs";
 
   const redirect = new URLSearchParams(window.location.search).get("redirect");
-  return isSafeAppRedirectPath(redirect) ? redirect : "/repertoire";
+  return isSafeAppRedirectPath(redirect) ? redirect : "/songs";
 }
 
 export default function WelcomePage() {
@@ -62,7 +62,7 @@ export default function WelcomePage() {
       setSaving(true);
       setMessage("");
       await markWelcomeSeen();
-      window.location.href = hasDisplayName ? "/repertoire" : "/settings";
+      window.location.href = hasDisplayName ? "/songs" : "/settings";
     } catch (err) {
       console.error(err);
       setMessage("Could not save your quick-start progress. Please try again.");

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -16,9 +16,10 @@ const primaryNavItems = [
     isActive: (pathname: string) => pathname.startsWith("/join"),
   },
   {
-    href: "/repertoire",
+    href: "/songs",
     label: "My Songs",
-    isActive: (pathname: string) => pathname === "/repertoire",
+    isActive: (pathname: string) =>
+      pathname === "/songs" || pathname === "/repertoire",
   },
 ];
 

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -36,6 +36,9 @@ blank arranger values to `Unknown`, and do not rewrite `Unknown` to blank.
 Current source refresh commands, local credentials, and the manual GitHub import
 workflow are documented in [docs/song-sources.md](song-sources.md).
 
+When adding a new external source or changing a source's role, check the Help
+page acknowledgments and song suggestion source list in the same PR.
+
 ## BHS Published Music Refresh
 
 The BHS Published Music source file is committed at:

--- a/docs/song-sources.md
+++ b/docs/song-sources.md
@@ -75,6 +75,11 @@ under `data/backups/`, and writes `data/song_suggestion_catalog.psv`.
 
 ## Source Notes
 
+When adding or materially changing an external source, check whether the Help
+page acknowledgments need a matching source entry. Keep the source list limited
+to references that support song suggestions or My Songs-building helpers, and
+do not imply endorsement by the upstream source.
+
 Barbershop Connections:
 
 - Uses the `Voices` field as the app voicing.

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -38,6 +38,7 @@ describe("sanitizeAnalyticsProperties", () => {
 describe("getAnalyticsRoute", () => {
   it("keeps public route names safe for dashboard breakdowns", () => {
     expect(getAnalyticsRoute("/")).toBe("/");
+    expect(getAnalyticsRoute("/songs")).toBe("/songs");
     expect(getAnalyticsRoute("/repertoire")).toBe("/repertoire");
     expect(getAnalyticsRoute("/settings?tab=name")).toBe("/settings");
   });

--- a/lib/__tests__/authRoute.test.ts
+++ b/lib/__tests__/authRoute.test.ts
@@ -22,6 +22,7 @@ describe("isPublicAuthPath", () => {
   });
 
   it("protects app routes", () => {
+    expect(isPublicAuthPath("/songs")).toBe(false);
     expect(isPublicAuthPath("/repertoire")).toBe(false);
     expect(isPublicAuthPath("/join/ABC123")).toBe(false);
     expect(isPublicAuthPath("/auth/callback")).toBe(false);

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   helpAcknowledgments,
   helpAcknowledgmentsIntro,
+  helpDevelopmentNote,
   helpGuideSections,
   helpSections,
   feedbackHelpCopy,
   helpFeedbackInvitationCopy,
   helpNavItems,
+  helpSongSuggestionSources,
   helpWelcomeCopy,
   quickStartSteps,
 } from "../helpContent";
@@ -72,7 +74,7 @@ describe("help content", () => {
     expect(guideText).toContain("Harmony Brigade songs");
     expect(guideText).toContain("Song Title Autocomplete");
     expect(guideText).toContain("Suggestions are optional");
-    expect(guideText).toContain("does not add it to anyone else’s My Songs");
+    expect(guideText).toContain("does not add it to anyone else’s saved songs");
     expect(guideText).toContain("More Ways To Build My Songs");
     expect(guideText).toContain("Treble (SSAA)");
     expect(guideText).toContain("Mixed (SATB)");
@@ -173,5 +175,25 @@ describe("help content", () => {
     expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
       "sweetadelines.com published and arranged music lists"
     );
+  });
+
+  it("lists song suggestion sources and a clear AI development note", () => {
+    expect(helpSongSuggestionSources.map((item) => item.name)).toEqual([
+      "barbershopconnections.com",
+      "barbershoptracks.com",
+      "gud2brabah.com",
+      "Scott Anderson’s International songs list",
+      "shop.barbershop.org",
+      "sweetadelines.com",
+      "timtracks.com",
+    ]);
+    expect(helpSongSuggestionSources.map((item) => item.contribution).join(" ")).toContain(
+      "Ross Wilkins’ Harmony Brigade database"
+    );
+    expect(helpDevelopmentNote).toContain("built by Tim Peterson");
+    expect(helpDevelopmentNote).toContain("OpenAI Codex and ChatGPT");
+    expect(helpDevelopmentNote).toContain("No OpenAI or other AI product runs inside the app");
+    expect(helpDevelopmentNote).not.toContain("Powered by OpenAI");
+    expect(helpDevelopmentNote).not.toContain("Built by OpenAI");
   });
 });

--- a/lib/__tests__/loginContent.test.ts
+++ b/lib/__tests__/loginContent.test.ts
@@ -13,7 +13,7 @@ describe("login intro content", () => {
     expect(copy).toContain("what can we sing together right now");
     expect(copy).toContain("songs they know");
     expect(copy).toContain("parts they can sing");
-    expect(copy).toContain("Sign in to save My Songs");
+    expect(copy).toContain("Sign in to save your songs");
   });
 
   it("links new users to help before they sign in", () => {

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -16,6 +16,7 @@ describe("privacy page copy", () => {
   it("discloses account, My Songs, quartet, feedback, analytics, and providers", () => {
     expect(privacyPage).toContain("email address");
     expect(privacyPage).toContain("We do not show your email address");
+    expect(privacyPage).toContain("The songs you add");
     expect(privacyPage).toContain("song title");
     expect(privacyPage).toContain("parts");
     expect(privacyPage).toContain("confidence");
@@ -29,6 +30,9 @@ describe("privacy page copy", () => {
     expect(privacyPage).toContain("Supabase");
     expect(privacyPage).toContain("Vercel");
     expect(privacyPage).toContain("Resend");
+    expect(privacyPage).not.toContain("Your My Songs entries");
+    expect(privacyPage).not.toContain("manage My Songs");
+    expect(privacyPage).not.toContain("their own My Songs entries");
   });
 
   it("does not overstate analytics or provider privacy", () => {

--- a/lib/__tests__/songsRoute.test.ts
+++ b/lib/__tests__/songsRoute.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const appNav = readFileSync(join(repoRoot, "components/AppNav.tsx"), "utf8");
+const homePage = readFileSync(join(repoRoot, "app/page.tsx"), "utf8");
+const songsPage = readFileSync(join(repoRoot, "app/songs/page.tsx"), "utf8");
+const repertoirePage = readFileSync(
+  join(repoRoot, "app/repertoire/page.tsx"),
+  "utf8"
+);
+
+describe("canonical My Songs route", () => {
+  it("serves My Songs at /songs and redirects the legacy repertoire route", () => {
+    expect(songsPage).toContain("function SongsPage");
+    expect(songsPage).toContain("<RepertoireManager />");
+    expect(repertoirePage).toContain('redirect("/songs")');
+  });
+
+  it("uses /songs for user-facing My Songs navigation", () => {
+    expect(appNav).toContain('href: "/songs"');
+    expect(appNav).toContain('pathname === "/songs"');
+    expect(appNav).toContain('pathname === "/repertoire"');
+    expect(homePage).toContain('href: "/songs"');
+    expect(homePage).not.toContain('href: "/repertoire"');
+  });
+});

--- a/lib/__tests__/welcomePage.test.ts
+++ b/lib/__tests__/welcomePage.test.ts
@@ -20,7 +20,7 @@ describe("first-login welcome page", () => {
 
   it("marks the welcome as seen and routes to the right setup step", () => {
     expect(welcomePage).toContain("markWelcomeSeen");
-    expect(welcomePage).toContain('hasDisplayName ? "/repertoire" : "/settings"');
+    expect(welcomePage).toContain('hasDisplayName ? "/songs" : "/settings"');
   });
 
   it("skips returning users with profile, repertoire, or quartet history", () => {

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -76,7 +76,7 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "How Suggestions Are Shared",
         body: [
-          "When you add a song, the title, arrangement voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s My Songs.",
+          "When you add a song, the title, arrangement voicing, and arranger you enter can help future singers find the same song faster. Adding a song does not add it to anyone else’s saved songs.",
           "Suggestions do not expose private user details such as user IDs, singer names, notes, parts, confidence, timestamps, or your full personal song list.",
         ],
       },
@@ -116,7 +116,7 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "Notes",
         body: [
-          "Notes are for your own memory — for example, version reminders, tags, first words, key, or tricky spots. They help you manage My Songs but are not used to decide whether the quartet can sing a song.",
+          "Notes are for your own memory — for example, version reminders, tags, first words, key, or tricky spots. They help you manage your songs but are not used to decide whether the quartet can sing a song.",
         ],
       },
       {
@@ -147,14 +147,14 @@ export const helpGuideSections: HelpGuideSection[] = [
         title: "What Start Does",
         body: [
           "Start creates a quartet session and gives it a short code. Other singers can enter the code, scan the QR code, or open the shared link to join.",
-          "You are part of the quartet you start. My Songs is used along with the other singers’ saved songs to find matches, so add at least a few songs first.",
+          "You are part of the quartet you start. Your saved songs are used along with the other singers’ saved songs to find matches, so add at least a few songs first.",
         ],
       },
       {
         title: "After Singers Join",
         body: [
           "Once singers join, the app compares the current quartet members’ saved song snapshots. A quartet is full when four singers have joined.",
-          "Starting a quartet does not permanently change anyone else’s My Songs. It only creates a shared place where the group can compare what each singer already has saved.",
+          "Starting a quartet does not permanently change anyone else’s saved songs. It only creates a shared place where the group can compare what each singer already has saved.",
         ],
       },
       {
@@ -175,8 +175,8 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "What Join Uses",
         body: [
-          "When you join, the app uses My Songs to look for songs the group can sing together. Joining does not add songs to My Songs or change the songs you already saved.",
-          "If My Songs is empty or missing common songs, the group may see fewer matches until you add or update entries.",
+          "When you join, the app uses your saved songs to look for songs the group can sing together. Joining does not add songs to My Songs or change the songs you already saved.",
+          "If your song list is empty or missing common songs, the group may see fewer matches until you add or update entries.",
         ],
       },
       {
@@ -236,7 +236,7 @@ export const helpGuideSections: HelpGuideSection[] = [
     eyebrow: "Managing A Quartet",
     title: "Update, Leave, Or Rejoin A Quartet",
     intro:
-      "Quartet membership and match results come from the current quartet data. Use the quartet controls when someone updates My Songs, changes names, leaves, rejoins, or needs to be removed.",
+      "Quartet membership and match results come from the current quartet data. Use the quartet controls when someone updates saved songs, changes names, leaves, rejoins, or needs to be removed.",
     topics: [
       {
         title: "Managing The Quartet",
@@ -303,6 +303,40 @@ export const helpAcknowledgments: HelpAcknowledgment[] = [
       "for maintaining the sweetadelines.com published and arranged music lists used as song suggestion sources",
   },
 ];
+
+export const helpSongSuggestionSources: HelpAcknowledgment[] = [
+  {
+    name: "barbershopconnections.com",
+    contribution: "for song suggestion reference data",
+  },
+  {
+    name: "barbershoptracks.com",
+    contribution: "for song suggestion reference data",
+  },
+  {
+    name: "gud2brabah.com",
+    contribution: "for Ross Wilkins’ Harmony Brigade database",
+  },
+  {
+    name: "Scott Anderson’s International songs list",
+    contribution: "for songs sung at International",
+  },
+  {
+    name: "shop.barbershop.org",
+    contribution: "for BHS published music suggestion data",
+  },
+  {
+    name: "sweetadelines.com",
+    contribution: "for published and arranged music suggestion data",
+  },
+  {
+    name: "timtracks.com",
+    contribution: "for song suggestion reference data",
+  },
+];
+
+export const helpDevelopmentNote =
+  "What Can We Sing was built by Tim Peterson with substantial coding assistance from OpenAI Codex and ChatGPT. No OpenAI or other AI product runs inside the app or processes user quartet or repertoire activity in real time.";
 
 export const helpWelcomeCopy =
   "We really hope you have a great time using What Can We Sing, and that it makes your convention, afterglow, or Brigade experience that much more fun and worthwhile.";

--- a/lib/loginContent.ts
+++ b/lib/loginContent.ts
@@ -4,5 +4,5 @@ export const loginIntro = {
     "What Can We Sing helps a pickup quartet quickly answer the question: what can we sing together right now?",
   details:
     "Each singer adds the songs they know, the arrangement voicing, the barbershop parts they can sing, and how confident they feel. When singers join the same quartet, the app compares everyone's saved songs and shows songs where the required parts are covered by different people.",
-  signInReason: "Sign in to save My Songs and join or start a quartet.",
+  signInReason: "Sign in to save your songs and join or start a quartet.",
 } as const;


### PR DESCRIPTION
## Summary
- Make `/songs` the canonical My Songs route, keep `/repertoire` as a redirect, and update user-facing app navigation/entry links.
- Add Help acknowledgments for song suggestion sources plus a modest AI development note.
- Polish contextual My Songs wording on Help, Privacy, and login copy.

## Docs and tests
- Updated `docs/imports.md`, `docs/song-sources.md`, and `AGENTS.md` for source acknowledgment and route guidance.
- Added route/copy coverage for `/songs`, legacy `/repertoire`, acknowledgments, privacy wording, login wording, and protected route expectations.

## Verification
- `npm run test:run`
- `npm run build`

## Supabase / manual steps
- No migration required. No Supabase schema, RLS, or data-model changes.
- No manual deployment steps required.

Closes #350
Closes #353
Closes #364
Closes #365