### PR TITLE
Improve shared song import review

### DIFF
--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -18,6 +18,7 @@ import {
   type CopyableSharedSong,
   type SharedRepertoire,
   type SharedRepertoireSong,
+  type SharedSongCopySelection,
 } from "@/lib/repertoireSharing";
 
 const confidenceLevels: Confidence[] = [
@@ -32,8 +33,9 @@ const partsByVoicing: Record<Voicing, Part[]> = {
   SSAA: ["Soprano 1", "Soprano 2", "Alto 1", "Alto 2"],
 };
 
-type SelectionByVoicing = Partial<
-  Record<Voicing, { part: Part | ""; confidence: Confidence | "" }>
+type SongCopySelections = Record<
+  string,
+  { part: Part | ""; confidence: Confidence | "" }
 >;
 
 function duplicateLabel(status: CopyableSharedSong["duplicateStatus"]) {
@@ -48,8 +50,8 @@ export function SharedRepertoireManager({ code }: { code: string }) {
   const [share, setShare] = useState<SharedRepertoire | null>(null);
   const [songs, setSongs] = useState<CopyableSharedSong[]>([]);
   const [selectedSongIds, setSelectedSongIds] = useState<Set<string>>(new Set());
-  const [selectionsByVoicing, setSelectionsByVoicing] =
-    useState<SelectionByVoicing>({});
+  const [songCopySelections, setSongCopySelections] =
+    useState<SongCopySelections>({});
   const [isSignedIn, setIsSignedIn] = useState(false);
   const [message, setMessage] = useState("");
   const [copying, setCopying] = useState(false);
@@ -69,6 +71,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
         if (!sharedRepertoire) {
           setSongs([]);
           setSelectedSongIds(new Set());
+          setSongCopySelections({});
           return;
         }
 
@@ -79,6 +82,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
           );
           setSongs(anonymousSongs);
           setSelectedSongIds(new Set());
+          setSongCopySelections({});
           return;
         }
 
@@ -88,13 +92,8 @@ export function SharedRepertoireManager({ code }: { code: string }) {
           myRepertoire
         );
         setSongs(resolvedSongs);
-        setSelectedSongIds(
-          new Set(
-            resolvedSongs
-              .filter((song) => song.duplicateStatus !== "exact")
-              .map((song) => song.id)
-          )
-        );
+        setSelectedSongIds(new Set());
+        setSongCopySelections({});
       } catch (err) {
         console.error(err);
         setMessage("Could not load songs to copy. Check the link and try again.");
@@ -110,11 +109,13 @@ export function SharedRepertoireManager({ code }: { code: string }) {
     () => songs.filter((song) => selectedSongIds.has(song.id)),
     [selectedSongIds, songs]
   );
-  const selectedVoicings = useMemo(
-    () => Array.from(new Set(selectedSongs.map((song) => song.voicing))).sort(),
-    [selectedSongs]
-  );
   const eligibleSongs = songs.filter((song) => song.duplicateStatus !== "exact");
+  const incompleteSelectedSongs = selectedSongs.filter((song) => {
+    const selection = songCopySelections[song.id];
+    return !selection?.part || !selection?.confidence;
+  });
+  const canCopySelectedSongs =
+    selectedSongs.length > 0 && incompleteSelectedSongs.length === 0;
   const signInPath = `/login?redirect=${encodeURIComponent(
     `/shared-repertoire/${normalizedCode}`
   )}`;
@@ -141,15 +142,15 @@ export function SharedRepertoireManager({ code }: { code: string }) {
     setSelectedSongIds(new Set());
   }
 
-  function updateVoicingSelection(
-    voicing: Voicing,
+  function updateSongSelection(
+    songId: string,
     patch: Partial<{ part: Part | ""; confidence: Confidence | "" }>
   ) {
-    setSelectionsByVoicing((current) => ({
+    setSongCopySelections((current) => ({
       ...current,
-      [voicing]: {
-        part: current[voicing]?.part ?? "",
-        confidence: current[voicing]?.confidence ?? "",
+      [songId]: {
+        part: current[songId]?.part ?? "",
+        confidence: current[songId]?.confidence ?? "",
         ...patch,
       },
     }));
@@ -166,28 +167,23 @@ export function SharedRepertoireManager({ code }: { code: string }) {
       return;
     }
 
-    const missingVoicing = selectedVoicings.find((voicing) => {
-      const selection = selectionsByVoicing[voicing];
-      return !selection?.part || !selection?.confidence;
-    });
-
-    if (missingVoicing) {
-      setMessage(`Choose a part and confidence for ${missingVoicing}.`);
+    if (incompleteSelectedSongs.length > 0) {
+      setMessage(
+        "Choose a part and confidence for each selected song before copying."
+      );
       return;
     }
 
-    const completeSelections = Object.fromEntries(
-      selectedVoicings.map((voicing) => {
-        const selection = selectionsByVoicing[voicing];
-        return [
-          voicing,
-          {
-            part: selection?.part as Part,
-            confidence: selection?.confidence as Confidence,
-          },
-        ];
-      })
-    ) as Record<Voicing, { part: Part; confidence: Confidence }>;
+    const completeSelections: SharedSongCopySelection[] = selectedSongs.map(
+      (song) => {
+        const selection = songCopySelections[song.id];
+        return {
+          songId: song.id,
+          part: selection?.part as Part,
+          confidence: selection?.confidence as Confidence,
+        };
+      }
+    );
 
     try {
       setCopying(true);
@@ -213,6 +209,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
       );
       setSongs(refreshedSongs);
       setSelectedSongIds(new Set());
+      setSongCopySelections({});
     } catch (err) {
       console.error(err);
       setMessage("Could not copy songs. Check your connection and try again.");
@@ -245,15 +242,22 @@ export function SharedRepertoireManager({ code }: { code: string }) {
         ) : (
           <>
             <section className="mt-8 rounded-2xl border border-cyan-300/25 bg-cyan-300/10 p-6">
-              <p className="text-sm font-semibold uppercase tracking-normal text-cyan-200">
+              <a
+                href="/songs"
+                className="inline-flex text-sm font-semibold text-cyan-100 hover:text-white"
+              >
+                &larr; Back to My Songs
+              </a>
+              <p className="mt-4 text-sm font-semibold uppercase tracking-normal text-cyan-200">
                 Copy songs from another singer
               </p>
               <h1 className="mt-3 text-4xl font-bold tracking-tight">
-                {share.ownerDisplayName} shared songs with you
+                {share.ownerDisplayName} shared {songs.length}{" "}
+                {songs.length === 1 ? "song" : "songs"} with you
               </h1>
               <p className="mt-3 max-w-3xl text-slate-200">
                 {isSignedIn
-                  ? "You can copy songs into My Songs. You'll choose your own part and confidence before saving."
+                  ? "Choose the songs you want to copy into My Songs. For each selected song, choose the part you usually sing and your confidence. Songs already in My Songs are shown but can't be copied again."
                   : "Sign in to copy songs into My Songs."}
               </p>
               {!isSignedIn && (
@@ -270,8 +274,8 @@ export function SharedRepertoireManager({ code }: { code: string }) {
               <section className="mt-5 rounded-2xl border border-white/10 bg-white/5 p-5">
                 <h2 className="text-2xl font-semibold">Copy songs</h2>
                 <p className="mt-2 text-sm leading-6 text-slate-300">
-                  For copied songs, choose the part you usually sing and your
-                  confidence. You can edit individual songs later.
+                  Review the shared songs below. Selected songs show their own
+                  part and confidence controls.
                 </p>
 
                 <div className="mt-4 flex flex-wrap gap-2">
@@ -280,7 +284,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                     onClick={selectAllEligible}
                     className="rounded-xl bg-white/10 px-4 py-2 text-sm font-semibold text-cyan-100 hover:bg-white/20"
                   >
-                    Select all eligible
+                    Select songs I don&apos;t already have
                   </button>
                   <button
                     type="button"
@@ -291,75 +295,10 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                   </button>
                 </div>
 
-                {selectedVoicings.length > 0 && (
-                  <div className="mt-4 grid gap-3 md:grid-cols-2">
-                    {selectedVoicings.map((voicing) => (
-                      <div
-                        key={voicing}
-                        className="rounded-xl border border-white/10 bg-slate-950/60 p-3"
-                      >
-                        <p className="text-sm font-semibold text-white">
-                          {voicingDisplayLabel(voicing)} copied songs
-                        </p>
-                        <p className="mt-1 text-xs text-slate-400">
-                          {printedNotationSummary(voicing)}
-                        </p>
-                        <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                          <label className="block">
-                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
-                              Part
-                            </span>
-                            <select
-                              value={selectionsByVoicing[voicing]?.part ?? ""}
-                              onChange={(event) =>
-                                updateVoicingSelection(voicing, {
-                                  part: event.target.value as Part | "",
-                                })
-                              }
-                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                            >
-                              <option value="">Choose part</option>
-                              {partsByVoicing[voicing].map((part) => (
-                                <option key={part} value={part}>
-                                  {partButtonLabel(voicing, part)}
-                                </option>
-                              ))}
-                            </select>
-                          </label>
-                          <label className="block">
-                            <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
-                              Confidence
-                            </span>
-                            <select
-                              value={
-                                selectionsByVoicing[voicing]?.confidence ?? ""
-                              }
-                              onChange={(event) =>
-                                updateVoicingSelection(voicing, {
-                                  confidence: event.target
-                                    .value as Confidence | "",
-                                })
-                              }
-                              className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
-                            >
-                              <option value="">Choose confidence</option>
-                              {confidenceLevels.map((confidence) => (
-                                <option key={confidence} value={confidence}>
-                                  {confidence}
-                                </option>
-                              ))}
-                            </select>
-                          </label>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-
                 <button
                   type="button"
                   onClick={copySelectedSongs}
-                  disabled={copying || selectedSongs.length === 0}
+                  disabled={copying || !canCopySelectedSongs}
                   className="mt-4 rounded-xl bg-cyan-300 px-5 py-3 font-bold text-slate-950 hover:bg-cyan-200 disabled:opacity-40"
                 >
                   {copying
@@ -368,6 +307,13 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                         selectedSongs.length === 1 ? "song" : "songs"
                       }`}
                 </button>
+                {selectedSongs.length > 0 &&
+                  incompleteSelectedSongs.length > 0 && (
+                    <p className="mt-2 text-sm text-slate-300">
+                      Choose a part and confidence for each selected song before
+                      copying.
+                    </p>
+                  )}
               </section>
             )}
 
@@ -392,10 +338,10 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                     const disabled = song.duplicateStatus === "exact";
 
                     return (
-                      <label
+                      <div
                         key={song.id}
                         className={`flex gap-3 p-4 ${
-                          disabled ? "opacity-70" : "cursor-pointer"
+                          disabled ? "bg-slate-950/30 opacity-70" : ""
                         }`}
                       >
                         {isSignedIn && (
@@ -405,9 +351,10 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                             disabled={disabled}
                             onChange={() => toggleSong(song)}
                             className="mt-1 h-4 w-4 rounded border-white/20 bg-slate-900 text-cyan-300"
+                            aria-label={`Select ${song.songTitle}`}
                           />
                         )}
-                        <span className="min-w-0 flex-1">
+                        <div className="min-w-0 flex-1">
                           <span className="block font-semibold text-white">
                             {song.songTitle}
                           </span>
@@ -420,8 +367,69 @@ export function SharedRepertoireManager({ code }: { code: string }) {
                               {label}
                             </span>
                           )}
-                        </span>
-                      </label>
+                          {song.duplicateStatus ===
+                            "possible_arrangement" && (
+                            <span className="mt-2 block text-xs text-slate-400">
+                              Check the arranger before copying.
+                            </span>
+                          )}
+                          {isSignedIn && selectedSongIds.has(song.id) && (
+                            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+                              <label className="block">
+                                <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                                  Part
+                                </span>
+                                <select
+                                  value={songCopySelections[song.id]?.part ?? ""}
+                                  onChange={(event) =>
+                                    updateSongSelection(song.id, {
+                                      part: event.target.value as Part | "",
+                                    })
+                                  }
+                                  className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                >
+                                  <option value="">Choose part</option>
+                                  {partsByVoicing[song.voicing].map((part) => (
+                                    <option key={part} value={part}>
+                                      {partButtonLabel(song.voicing, part)}
+                                    </option>
+                                  ))}
+                                </select>
+                              </label>
+                              <label className="block">
+                                <span className="text-xs font-semibold uppercase tracking-normal text-slate-400">
+                                  Confidence
+                                </span>
+                                <select
+                                  value={
+                                    songCopySelections[song.id]?.confidence ?? ""
+                                  }
+                                  onChange={(event) =>
+                                    updateSongSelection(song.id, {
+                                      confidence: event.target
+                                        .value as Confidence | "",
+                                    })
+                                  }
+                                  className="mt-1 w-full rounded-xl border border-white/10 bg-slate-900 px-3 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                >
+                                  <option value="">Choose confidence</option>
+                                  {confidenceLevels.map((confidence) => (
+                                    <option
+                                      key={confidence}
+                                      value={confidence}
+                                    >
+                                      {confidence}
+                                    </option>
+                                  ))}
+                                </select>
+                              </label>
+                              <span className="text-xs text-slate-400 sm:col-span-2">
+                                {printedNotationSummary(song.voicing)}
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
                     );
                   })}
                 </div>

--- a/lib/__tests__/sharedRepertoireImportUi.test.ts
+++ b/lib/__tests__/sharedRepertoireImportUi.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const sharedRepertoireManager = readFileSync(
+  join(repoRoot, "components/SharedRepertoireManager.tsx"),
+  "utf8"
+);
+const repertoireSharing = readFileSync(
+  join(repoRoot, "lib/repertoireSharing.ts"),
+  "utf8"
+);
+
+describe("shared repertoire import UI", () => {
+  it("uses clear copy-flow labels and a top My Songs exit", () => {
+    expect(sharedRepertoireManager).toContain('href="/songs"');
+    expect(sharedRepertoireManager).toContain("&larr; Back to My Songs");
+    expect(sharedRepertoireManager).toContain(
+      "Select songs I don&apos;t already have"
+    );
+    expect(sharedRepertoireManager).not.toContain("Select all eligible");
+    expect(sharedRepertoireManager).toContain(
+      "Choose the songs you want to copy into My Songs"
+    );
+  });
+
+  it("keeps song cards as the import unit with per-song part and confidence", () => {
+    expect(sharedRepertoireManager).toContain("songCopySelections");
+    expect(sharedRepertoireManager).toContain("updateSongSelection(song.id");
+    expect(sharedRepertoireManager).toContain("partsByVoicing[song.voicing]");
+    expect(sharedRepertoireManager).toContain(
+      "selectedSongIds.has(song.id)"
+    );
+    expect(sharedRepertoireManager).not.toContain("selectionsByVoicing");
+    expect(sharedRepertoireManager).not.toContain("selectedVoicings");
+  });
+
+  it("requires complete per-song choices and shows selected copy count", () => {
+    expect(sharedRepertoireManager).toContain("!canCopySelectedSongs");
+    expect(sharedRepertoireManager).toContain(
+      "Choose a part and confidence for each selected song before copying."
+    );
+    expect(sharedRepertoireManager).toContain(
+      "`Copy ${selectedSongs.length} selected ${"
+    );
+    expect(sharedRepertoireManager).toContain("songId: song.id");
+  });
+
+  it("keeps duplicate and possible-arrangement context visible", () => {
+    expect(sharedRepertoireManager).toContain("Already in My Songs");
+    expect(sharedRepertoireManager).toContain("Possible different arrangement");
+    expect(sharedRepertoireManager).toContain(
+      "Check the arranger before copying."
+    );
+    expect(sharedRepertoireManager).toContain(
+      'song.duplicateStatus === "exact"'
+    );
+  });
+});
+
+describe("shared repertoire import helper", () => {
+  it("copies with per-song selections keyed by shared song id", () => {
+    expect(repertoireSharing).toContain("SharedSongCopySelection");
+    expect(repertoireSharing).toContain("selections: SharedSongCopySelection[]");
+    expect(repertoireSharing).toContain("selectionsBySongId.get(song.id)");
+    expect(repertoireSharing).not.toContain("selectionsByVoicing");
+  });
+});

--- a/lib/repertoireSharing.ts
+++ b/lib/repertoireSharing.ts
@@ -6,7 +6,6 @@ import {
   type RepertoireRow,
 } from "@/lib/repertoireStore";
 import { getCurrentUser } from "@/lib/profileStore";
-import { voicingDisplayLabel } from "@/lib/partAbbreviations";
 
 export type RepertoireShare = {
   id: string;
@@ -43,6 +42,12 @@ export type SharedRepertoire = {
 
 export type CopyableSharedSong = SharedRepertoireSong & {
   duplicateStatus: "eligible" | "exact" | "possible_arrangement";
+};
+
+export type SharedSongCopySelection = {
+  songId: string;
+  part: Part;
+  confidence: Confidence;
 };
 
 export const repertoireCopyRequestMessage =
@@ -242,22 +247,23 @@ export async function getSharedRepertoire(code: string) {
 
 export async function copySharedSongsToMyRepertoire(
   songs: SharedRepertoireSong[],
-  selectionsByVoicing: Record<Voicing, { part: Part; confidence: Confidence }>
+  selections: SharedSongCopySelection[]
 ) {
   const myRepertoire = await getMyRepertoire();
   const copyableSongs = resolveSharedSongCopyability(
     songs,
     myRepertoire
   ).filter((song) => song.duplicateStatus !== "exact");
+  const selectionsBySongId = new Map(
+    selections.map((selection) => [selection.songId, selection])
+  );
   let copiedCount = 0;
   const skippedExactCount = songs.length - copyableSongs.length;
 
   for (const song of copyableSongs) {
-    const selection = selectionsByVoicing[song.voicing];
+    const selection = selectionsBySongId.get(song.id);
     if (!selection) {
-      throw new Error(
-        `Choose a part and confidence for ${voicingDisplayLabel(song.voicing)}.`
-      );
+      throw new Error(`Choose a part and confidence for ${song.songTitle}.`);
     }
 
     await addRepertoireItem({


### PR DESCRIPTION
## Summary
- Rework the shared-repertoire import flow around song-by-song review instead of voicing-level import settings.
- Add a top Back to My Songs link, clearer intro copy, and the `Select songs I don’t already have` bulk action.
- Keep already-owned songs visible/non-copyable, preserve possible-arrangement context, and require part/confidence per selected song before copying.

## Docs and tests
- Added focused shared repertoire import UI/source coverage for the new labels, per-song state, duplicate handling, disabled copy state, and per-song copy helper contract.
- Docs were not updated because this is a focused in-app UX improvement with no setup, deployment, schema, RLS, analytics, or contract changes.

## Verification
- `npm run test:run`
- `npm run build`

## Supabase / manual steps
- No migration required. No Supabase schema, RLS, or data-model changes.
- No manual deployment steps required.

Closes #369