### PR TITLE
Handle service-cap failures gracefully

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  console.error("Application route error", error);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-950 px-6 text-white">
+      <section className="max-w-lg rounded-2xl border border-rose-300/20 bg-rose-400/10 p-6">
+        <p className="text-sm font-semibold uppercase tracking-normal text-rose-100">
+          Something went wrong
+        </p>
+        <h1 className="mt-2 text-3xl font-bold">The app hit a temporary issue.</h1>
+        <p className="mt-3 text-slate-200">
+          Reload this page and try again. If this is happening during a busy
+          event, it may be a temporary service limit.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-5 rounded-xl bg-rose-100 px-5 py-3 font-semibold text-slate-950 hover:bg-white"
+        >
+          Try again
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/app/join/[code]/page.tsx
+++ b/app/join/[code]/page.tsx
@@ -8,6 +8,7 @@ import { MatchCard } from "@/components/MatchCard";
 import { QuartetActionConfirmation } from "@/components/QuartetActionConfirmation";
 import { noArrangerEnteredLabel } from "@/lib/arrangerDisplay";
 import { trackEvent } from "@/lib/analytics";
+import { serviceErrorMessage } from "@/lib/runtimeErrors";
 import {
   conversationStartersIntro,
   shouldShowConversationStarters,
@@ -150,6 +151,7 @@ export default function JoinSessionPage() {
   const [message, setMessage] = useState("");
   const [messageKind, setMessageKind] =
     useState<QuartetStatusMessageKind>("persistent");
+  const [liveUpdatesPaused, setLiveUpdatesPaused] = useState(false);
   const [copyMessage, setCopyMessage] = useState("");
   const [qrUrl, setQrUrl] = useState("");
   const [loadError, setLoadError] = useState("");
@@ -256,7 +258,7 @@ export default function JoinSessionPage() {
     } catch (err) {
       console.error(err);
       if (options.showErrorMessage ?? true) {
-        showStatusMessage("Could not refresh singers. Please try again.", "error");
+        showStatusMessage(serviceErrorMessage(err, "database_read"), "error");
       }
       throw err;
     }
@@ -393,7 +395,7 @@ export default function JoinSessionPage() {
         session_id: id,
         reason: "write_failed",
       });
-      showStatusMessage("Could not join quartet. Please try again.", "error");
+      showStatusMessage(serviceErrorMessage(err, "database_write"), "error");
     } finally {
       setJoiningQuartet(false);
     }
@@ -482,10 +484,7 @@ export default function JoinSessionPage() {
         session_id: sessionId,
         source: "quartet_page",
       });
-      showStatusMessage(
-        "Could not leave quartet. Check your connection and try again.",
-        "error"
-      );
+      showStatusMessage(serviceErrorMessage(err, "database_write"), "error");
       setLeaving(false);
       return false;
     }
@@ -555,10 +554,7 @@ export default function JoinSessionPage() {
       setParticipantToRemove(null);
     } catch (err) {
       console.error(err);
-      showStatusMessage(
-        "Could not remove that singer. Check your connection and try again.",
-        "error"
-      );
+      showStatusMessage(serviceErrorMessage(err, "database_write"), "error");
       setParticipantToRemove(null);
     } finally {
       setRemovingParticipantId("");
@@ -736,7 +732,7 @@ export default function JoinSessionPage() {
         voicing: match.voicing,
       });
       showStatusMessage(
-        "Could not mark that song as sung. Check your connection and try again.",
+        serviceErrorMessage(err, "database_write"),
         "error"
       );
     } finally {
@@ -747,28 +743,35 @@ export default function JoinSessionPage() {
   useEffect(() => {
     if (!sessionId) return;
 
-    return subscribeToSessionParticipants(sessionId, (payload) => {
-      const previousParticipants = participantsRef.current;
-      const updatedParticipants = applyParticipantChange(
-        previousParticipants,
-        payload,
-        sessionId
-      );
-      setTrackedParticipants(updatedParticipants);
-      if (
-        didCurrentParticipantGetRemoved(
+    return subscribeToSessionParticipants(
+      sessionId,
+      (payload) => {
+        setLiveUpdatesPaused(false);
+        const previousParticipants = participantsRef.current;
+        const updatedParticipants = applyParticipantChange(
           previousParticipants,
-          updatedParticipants,
-          currentUserId
-        )
-      ) {
-        markCurrentUserRemovedFromQuartet(sessionId);
+          payload,
+          sessionId
+        );
+        setTrackedParticipants(updatedParticipants);
+        if (
+          didCurrentParticipantGetRemoved(
+            previousParticipants,
+            updatedParticipants,
+            currentUserId
+          )
+        ) {
+          markCurrentUserRemovedFromQuartet(sessionId);
+        }
+        void refreshParticipantProfileNames(updatedParticipants);
+        void refreshParticipants(sessionId, { showErrorMessage: false }).catch(
+          () => undefined
+        );
+      },
+      () => {
+        setLiveUpdatesPaused(true);
       }
-      void refreshParticipantProfileNames(updatedParticipants);
-      void refreshParticipants(sessionId, { showErrorMessage: false }).catch(
-        () => undefined
-      );
-    });
+    );
   }, [currentUserId, sessionId]);
 
   const participantUserIds = Array.from(
@@ -1408,6 +1411,24 @@ export default function JoinSessionPage() {
                 Try again
               </button>
             )}
+          </div>
+        )}
+
+        {!loadError && !quartetExpired && liveUpdatesPaused && (
+          <div className="mt-4 rounded-xl border border-amber-200/20 bg-amber-300/10 p-4 text-sm text-amber-50">
+            <p className="font-semibold">
+              Live updates paused — refresh to get the latest quartet state.
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                if (!sessionId) return;
+                void refreshParticipants(sessionId);
+              }}
+              className="mt-3 rounded-xl bg-amber-100 px-4 py-2 font-semibold text-slate-950 hover:bg-white"
+            >
+              Refresh quartet
+            </button>
           </div>
         )}
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { getPostLoginRedirectPath } from "@/lib/authRedirect";
 import { loginIntro } from "@/lib/loginContent";
+import { serviceErrorMessage } from "@/lib/runtimeErrors";
 import { supabase } from "@/lib/supabase";
 import { useState } from "react";
 
@@ -12,12 +13,26 @@ export default function LoginPage() {
   const [message, setMessage] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
+  const [lastCodeRequest, setLastCodeRequest] = useState<{
+    email: string;
+    sentAt: number;
+  } | null>(null);
 
   async function sendLoginCode() {
     const normalizedEmail = email.trim();
 
     if (!normalizedEmail) {
       setMessage("Enter your email address and we’ll send a login code.");
+      return;
+    }
+
+    if (
+      lastCodeRequest?.email === normalizedEmail &&
+      Date.now() - lastCodeRequest.sentAt < 60_000
+    ) {
+      setMessage(
+        "We just sent a code to that email. Wait a minute before requesting another so email rate limits do not block you."
+      );
       return;
     }
 
@@ -33,16 +48,18 @@ export default function LoginPage() {
       });
 
       if (error) {
-        setMessage(`${error.message} Check the email address and try again.`);
+        console.error("Login email request failed", error);
+        setMessage(serviceErrorMessage(error, "auth_email"));
         return;
       }
 
       setHasSentCode(true);
+      setLastCodeRequest({ email: normalizedEmail, sentAt: Date.now() });
       setCode("");
       setMessage("Enter the code sent to your email.");
     } catch (err) {
       console.error(err);
-      setMessage("Network unavailable. Try again when you have a connection.");
+      setMessage(serviceErrorMessage(err, "auth_email"));
     } finally {
       setIsSending(false);
     }

--- a/app/session/page.tsx
+++ b/app/session/page.tsx
@@ -12,6 +12,7 @@ import {
 import { getCurrentUser, getMyProfile } from "@/lib/profileStore";
 import { buildParticipantEntries } from "@/lib/participantEntries";
 import { getMyRepertoire } from "@/lib/repertoireStore";
+import { serviceErrorMessage } from "@/lib/runtimeErrors";
 import { trackEvent } from "@/lib/analytics";
 import {
   createSession,
@@ -105,9 +106,7 @@ export default function SessionPage() {
       return true;
     } catch (err) {
       console.error("Failed to create session", err);
-      setErrorMessage(
-        "Could not create a quartet code. Check your connection and try again."
-      );
+      setErrorMessage(serviceErrorMessage(err, "database_write"));
       return false;
     } finally {
       if (!didNavigate) {
@@ -153,9 +152,7 @@ export default function SessionPage() {
         session_id: activeQuartet.sessionId,
         source: "start_page_existing_quartet",
       });
-      setErrorMessage(
-        "Could not leave your current quartet. Check your connection and try again."
-      );
+      setErrorMessage(serviceErrorMessage(err, "database_write"));
       setLeavingCurrent(false);
     }
   }

--- a/components/RepertoireManager.tsx
+++ b/components/RepertoireManager.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/repertoireView";
 import { formatLastSungStatus } from "@/lib/lastSung";
 import { trackEvent } from "@/lib/analytics";
+import { serviceErrorMessage } from "@/lib/runtimeErrors";
 import {
   addRepertoireItem,
   deleteRepertoireItem,
@@ -227,9 +228,7 @@ export default function RepertoireManager() {
       setLoadError("");
     } catch (err) {
       console.error(err);
-      setLoadError(
-        "Could not load your songs. Check your connection and try again."
-      );
+      setLoadError(serviceErrorMessage(err, "database_read"));
       throw err;
     }
   }
@@ -266,9 +265,7 @@ export default function RepertoireManager() {
         setRepertoireShare(await getMyActiveRepertoireShare());
       } catch (err) {
         console.error(err);
-        setLoadError(
-          "Could not load your songs. Check your connection and try again."
-        );
+        setLoadError(serviceErrorMessage(err, "database_read"));
       } finally {
         setLoading(false);
       }
@@ -397,7 +394,7 @@ export default function RepertoireManager() {
     } catch (err) {
       console.error(err);
       setHarmonyBrigadeMessage(
-        "Could not load Harmony Brigade songs. Please try again."
+        serviceErrorMessage(err, "database_read")
       );
     } finally {
       setIsHarmonyBrigadeLoading(false);
@@ -425,7 +422,7 @@ export default function RepertoireManager() {
     } catch (err) {
       console.error(err);
       setHarmonyBrigadeMessage(
-        "Could not load Harmony Brigade songs. Please try again."
+        serviceErrorMessage(err, "database_read")
       );
     } finally {
       setIsHarmonyBrigadeLoading(false);
@@ -666,7 +663,7 @@ export default function RepertoireManager() {
       trackEvent("repertoire_update_failed", {
         action: "add",
       });
-      setMessage("Could not add song. Please try again.");
+      setMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setIsAdding(false);
     }
@@ -719,7 +716,7 @@ export default function RepertoireManager() {
       trackEvent("repertoire_update_failed", {
         action: "delete",
       });
-      setMessage("Could not delete song. Please try again.");
+      setMessage(serviceErrorMessage(err, "database_write"));
       setItemToDelete(null);
     } finally {
       setDeletingId(null);
@@ -800,7 +797,7 @@ export default function RepertoireManager() {
       trackEvent("repertoire_update_failed", {
         action: "edit",
       });
-      setMessage("Could not save changes. Please try again.");
+      setMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setSavingEditId(null);
     }
@@ -822,7 +819,7 @@ export default function RepertoireManager() {
       trackEvent("song_mark_sung_failed", {
         source: "my_songs",
       });
-      setMessage("Could not mark song sung. Please try again.");
+      setMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setMarkingSungId(null);
     }
@@ -839,7 +836,7 @@ export default function RepertoireManager() {
       setShareMessage("Copy link/code created.");
     } catch (err) {
       console.error(err);
-      setShareMessage("Could not create copy link/code. Please try again.");
+      setShareMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setIsCreatingShare(false);
     }
@@ -904,7 +901,7 @@ export default function RepertoireManager() {
       setShareMessage("Copy link/code revoked.");
     } catch (err) {
       console.error(err);
-      setShareMessage("Could not revoke copy link/code. Please try again.");
+      setShareMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setIsRevokingShare(false);
     }
@@ -949,11 +946,12 @@ export default function RepertoireManager() {
       return;
     }
 
+    let addedCount = 0;
+
     try {
       setIsAddingHarmonyBrigadeSongs(true);
       setHarmonyBrigadeMessage("");
 
-      let addedCount = 0;
       for (const input of inputs) {
         await addRepertoireItem(input);
         addedCount += 1;
@@ -983,7 +981,16 @@ export default function RepertoireManager() {
       trackEvent("repertoire_update_failed", {
         action: "harmony_brigade_add",
       });
-      setHarmonyBrigadeMessage("Could not add songs. Please try again.");
+      setHarmonyBrigadeMessage(
+        addedCount > 0
+          ? `${addedCount} ${
+              addedCount === 1 ? "song was" : "songs were"
+            } added before saving stopped. ${serviceErrorMessage(
+              err,
+              "database_write"
+            )} Retry the remaining songs.`
+          : serviceErrorMessage(err, "database_write")
+      );
     } finally {
       setIsAddingHarmonyBrigadeSongs(false);
     }

--- a/components/SharedRepertoireManager.tsx
+++ b/components/SharedRepertoireManager.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/partAbbreviations";
 import { getCurrentUser } from "@/lib/profileStore";
 import { getMyRepertoire } from "@/lib/repertoireStore";
+import { serviceErrorMessage } from "@/lib/runtimeErrors";
 import {
   copySharedSongsToMyRepertoire,
   getSharedRepertoire,
@@ -94,9 +95,9 @@ export function SharedRepertoireManager({ code }: { code: string }) {
         setSongs(resolvedSongs);
         setSelectedSongIds(new Set());
         setSongCopySelections({});
-      } catch (err) {
-        console.error(err);
-        setMessage("Could not load songs to copy. Check the link and try again.");
+    } catch (err) {
+      console.error(err);
+      setMessage(serviceErrorMessage(err, "database_read"));
       } finally {
         setLoading(false);
       }
@@ -212,7 +213,7 @@ export function SharedRepertoireManager({ code }: { code: string }) {
       setSongCopySelections({});
     } catch (err) {
       console.error(err);
-      setMessage("Could not copy songs. Check your connection and try again.");
+      setMessage(serviceErrorMessage(err, "database_write"));
     } finally {
       setCopying(false);
     }

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,45 @@
+# Production Readiness
+
+What Can We Sing can run on free-tier services for normal development and
+small-group testing. Before a convention, Brigade weekend, or other high-usage
+event, check the services below so quota or rate-limit failures do not surprise
+singers in the room.
+
+## Services To Monitor
+
+- Vercel hosting, runtime errors, function limits, and deployment health
+- Supabase Auth email/OTP rate limits
+- Supabase database size, egress, PostgREST health, and paused-project status
+- Supabase Realtime connection and message usage
+- Resend daily/monthly email usage if it is in the login email path
+- PostHog usage, ingestion status, and dashboard availability
+
+## In-App Failure Handling
+
+The app classifies common provider failures in `lib/runtimeErrors.ts` and shows
+plain-language messages for email limits, database read failures, database
+write/quota failures, rate limits, and network outages.
+
+Expected user-facing behavior:
+
+- Login email send failures mention temporary email limits or rate limits.
+- My Songs and shared-song load failures do not pretend the user has no songs.
+- Save failures explain that the app may be able to read data but unable to
+  save changes because of a database usage limit or temporary service issue.
+- Harmony Brigade batch adds report if some songs saved before a later failure.
+- Quartet realtime failures show that live updates are paused and offer a
+  manual refresh.
+- Analytics calls are guarded so PostHog failures cannot block core flows.
+
+## Event Preflight
+
+Before a large event:
+
+1. Check Supabase database size, egress, Auth email/rate limits, and Realtime
+   usage.
+2. Check Resend usage if email delivery is routed through Resend.
+3. Check Vercel usage, recent runtime errors, and deployment health.
+4. Consider temporarily upgrading Supabase, Resend, or Vercel for event week if
+   expected use is close to a free-tier limit.
+5. Do a smoke test: sign in, open My Songs, add a song, start a quartet, join
+   from another device, and confirm live updates.

--- a/lib/__tests__/appErrorBoundary.test.ts
+++ b/lib/__tests__/appErrorBoundary.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appError = readFileSync(join(process.cwd(), "app/error.tsx"), "utf8");
+
+describe("app error boundary", () => {
+  it("shows a friendly retry fallback without raw stack text", () => {
+    expect(appError).toContain("The app hit a temporary issue.");
+    expect(appError).toContain("temporary service limit");
+    expect(appError).toContain("Try again");
+    expect(appError).not.toContain("error.message");
+  });
+});

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -161,7 +161,8 @@ describe("help content", () => {
       "Jessica Rodman",
       "Scott Anderson",
       "Marcie Jones and Ann Monaghan McAlexander",
-      "Sweet Adelines",
+      "Sweet Adelines International",
+      "Barbershop Harmony Society",
     ]);
     expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
       "Instant Quartet"
@@ -173,7 +174,10 @@ describe("help content", () => {
       "voicing terminology"
     );
     expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
-      "sweetadelines.com published and arranged music lists"
+      "sweetadelines.com published and arranged music list PDFs"
+    );
+    expect(helpAcknowledgments.map((item) => item.contribution).join(" ")).toContain(
+      "shop.barbershop.org published music Google sheet"
     );
   });
 

--- a/lib/__tests__/productionReadiness.test.ts
+++ b/lib/__tests__/productionReadiness.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const doc = readFileSync(
+  join(process.cwd(), "docs/production-readiness.md"),
+  "utf8"
+);
+
+describe("production readiness docs", () => {
+  it("documents service limits and preflight checks", () => {
+    expect(doc).toContain("Vercel");
+    expect(doc).toContain("Supabase Auth");
+    expect(doc).toContain("Supabase Realtime");
+    expect(doc).toContain("Resend");
+    expect(doc).toContain("PostHog");
+    expect(doc).toContain("Event Preflight");
+  });
+});

--- a/lib/__tests__/quartetManagePanel.test.ts
+++ b/lib/__tests__/quartetManagePanel.test.ts
@@ -27,7 +27,7 @@ describe("quartet manage panel markup", () => {
     expect(joinPage).toContain("Nice — marked as sung.");
     expect(joinPage).toContain("celebratingSungKey");
     expect(joinPage).toContain("isSungCelebrating={celebratingSungKey === id}");
-    expect(joinPage).toContain("Could not mark that song as sung.");
+    expect(joinPage).toContain('serviceErrorMessage(err, "database_write")');
   });
 
   it("renders encouraging full-quartet no-match guidance and conversation starters", () => {

--- a/lib/__tests__/runtimeErrors.test.ts
+++ b/lib/__tests__/runtimeErrors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { classifyRuntimeError, serviceErrorMessage } from "../runtimeErrors";
+
+describe("runtime error classification", () => {
+  it("recognizes auth email rate limits and quota failures", () => {
+    expect(
+      classifyRuntimeError("429 Too Many Requests", "auth_email").category
+    ).toBe("auth_email_rate_limited");
+    expect(classifyRuntimeError("daily email quota exceeded", "auth_email")).toMatchObject({
+      category: "auth_email_quota_exceeded",
+      message: expect.stringContaining("login email"),
+    });
+  });
+
+  it("recognizes database read and write service-cap failures", () => {
+    expect(
+      classifyRuntimeError("Supabase project unavailable", "database_read")
+        .message
+    ).toContain("saved songs are probably still there");
+    expect(
+      classifyRuntimeError("cannot execute INSERT in a read-only transaction", "database_write")
+        .category
+    ).toBe("database_read_only_or_quota");
+    expect(serviceErrorMessage("quota exceeded", "database_write")).toContain(
+      "could not save changes"
+    );
+  });
+
+  it("recognizes network failures without exposing raw provider text", () => {
+    const info = classifyRuntimeError(new Error("Failed to fetch"), "runtime");
+
+    expect(info.category).toBe("network_unavailable");
+    expect(info.message).toBe(
+      "Network unavailable. Try again when you have a connection."
+    );
+  });
+});

--- a/lib/__tests__/serviceFailureUi.test.ts
+++ b/lib/__tests__/serviceFailureUi.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const loginPage = readFileSync(join(repoRoot, "app/login/page.tsx"), "utf8");
+const repertoireManager = readFileSync(
+  join(repoRoot, "components/RepertoireManager.tsx"),
+  "utf8"
+);
+const joinPage = readFileSync(join(repoRoot, "app/join/[code]/page.tsx"), "utf8");
+const sharedRepertoireManager = readFileSync(
+  join(repoRoot, "components/SharedRepertoireManager.tsx"),
+  "utf8"
+);
+const analytics = readFileSync(join(repoRoot, "lib/analytics.ts"), "utf8");
+
+describe("service failure UI", () => {
+  it("uses shared service-limit messaging in login and song flows", () => {
+    expect(loginPage).toContain('serviceErrorMessage(error, "auth_email")');
+    expect(loginPage).toContain("Wait a minute before requesting another");
+    expect(repertoireManager).toContain('serviceErrorMessage(err, "database_read")');
+    expect(repertoireManager).toContain('serviceErrorMessage(err, "database_write")');
+    expect(sharedRepertoireManager).toContain(
+      'serviceErrorMessage(err, "database_write")'
+    );
+  });
+
+  it("reports partial Harmony Brigade saves and realtime pause state", () => {
+    expect(repertoireManager).toContain("added before saving stopped");
+    expect(repertoireManager).toContain("Retry the remaining songs");
+    expect(joinPage).toContain("liveUpdatesPaused");
+    expect(joinPage).toContain("Live updates paused");
+    expect(joinPage).toContain("Refresh quartet");
+  });
+
+  it("keeps analytics guarded from blocking app flows", () => {
+    expect(analytics).toContain("try {");
+    expect(analytics).toContain("posthog.capture");
+    expect(analytics).toContain("Analytics event failed");
+    expect(analytics).toContain("posthog.identify");
+    expect(analytics).toContain("posthog.reset");
+  });
+});

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -298,9 +298,14 @@ export const helpAcknowledgments: HelpAcknowledgment[] = [
     contribution: "for crucial feedback on voicing terminology",
   },
   {
-    name: "Sweet Adelines",
+    name: "Sweet Adelines International",
     contribution:
-      "for maintaining the sweetadelines.com published and arranged music lists used as song suggestion sources",
+      "for maintaining the sweetadelines.com published and arranged music list PDFs used as song suggestion sources",
+  },
+  {
+    name: "Barbershop Harmony Society",
+    contribution:
+      "for maintaining the shop.barbershop.org published music Google sheet used as song suggestion sources",
   },
 ];
 

--- a/lib/runtimeErrors.ts
+++ b/lib/runtimeErrors.ts
@@ -1,0 +1,174 @@
+export type RuntimeErrorCategory =
+  | "auth_email_rate_limited"
+  | "auth_email_quota_exceeded"
+  | "database_unavailable"
+  | "database_read_only_or_quota"
+  | "rate_limited"
+  | "network_unavailable"
+  | "unknown_service_error";
+
+export type RuntimeErrorOperation =
+  | "auth_email"
+  | "database_read"
+  | "database_write"
+  | "realtime"
+  | "runtime";
+
+export type RuntimeErrorInfo = {
+  category: RuntimeErrorCategory;
+  operation: RuntimeErrorOperation;
+  message: string;
+};
+
+const EMAIL_LIMIT_MESSAGE =
+  "We could not send the login email right now. This may be a temporary email limit or rate limit. Wait a minute and try again, or ask the event organizer for help.";
+
+const DATABASE_READ_MESSAGE =
+  "Could not load songs right now. Your saved songs are probably still there; the app just could not reach the database.";
+
+const DATABASE_WRITE_LIMIT_MESSAGE =
+  "The app can read data, but could not save changes right now. This may be a database usage limit or temporary service issue. Try again shortly or ask the organizer for help.";
+
+const NETWORK_MESSAGE =
+  "Network unavailable. Try again when you have a connection.";
+
+const UNKNOWN_SERVICE_MESSAGE =
+  "The app could not reach a required service right now. Try again shortly or ask the organizer for help.";
+
+function errorText(error: unknown) {
+  if (!error) return "";
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function classifyRuntimeError(
+  error: unknown,
+  operation: RuntimeErrorOperation
+): RuntimeErrorInfo {
+  const text = errorText(error).toLowerCase();
+
+  if (
+    text.includes("network") ||
+    text.includes("failed to fetch") ||
+    text.includes("fetch failed") ||
+    text.includes("offline")
+  ) {
+    return {
+      category: "network_unavailable",
+      operation,
+      message: NETWORK_MESSAGE,
+    };
+  }
+
+  if (
+    text.includes("429") ||
+    text.includes("too many requests") ||
+    text.includes("rate limit") ||
+    text.includes("rate-limit") ||
+    text.includes("throttle")
+  ) {
+    return {
+      category:
+        operation === "auth_email" ? "auth_email_rate_limited" : "rate_limited",
+      operation,
+      message: operation === "auth_email" ? EMAIL_LIMIT_MESSAGE : UNKNOWN_SERVICE_MESSAGE,
+    };
+  }
+
+  if (
+    text.includes("quota") ||
+    text.includes("usage limit") ||
+    text.includes("resource exhausted") ||
+    text.includes("email limit")
+  ) {
+    return {
+      category:
+        operation === "auth_email"
+          ? "auth_email_quota_exceeded"
+          : operation === "database_write"
+            ? "database_read_only_or_quota"
+            : "rate_limited",
+      operation,
+      message:
+        operation === "auth_email"
+          ? EMAIL_LIMIT_MESSAGE
+          : operation === "database_write"
+            ? DATABASE_WRITE_LIMIT_MESSAGE
+            : UNKNOWN_SERVICE_MESSAGE,
+    };
+  }
+
+  if (
+    text.includes("read-only transaction") ||
+    text.includes("read only transaction") ||
+    text.includes("readonly") ||
+    text.includes("read-only")
+  ) {
+    return {
+      category: "database_read_only_or_quota",
+      operation,
+      message: DATABASE_WRITE_LIMIT_MESSAGE,
+    };
+  }
+
+  if (
+    operation === "database_read" &&
+    (text.includes("database") ||
+      text.includes("postgrest") ||
+      text.includes("supabase") ||
+      text.includes("jwt") ||
+      text.includes("session") ||
+      text.includes("project") ||
+      text.includes("unavailable"))
+  ) {
+    return {
+      category: "database_unavailable",
+      operation,
+      message: DATABASE_READ_MESSAGE,
+    };
+  }
+
+  if (operation === "database_read") {
+    return {
+      category: "database_unavailable",
+      operation,
+      message: DATABASE_READ_MESSAGE,
+    };
+  }
+
+  if (operation === "database_write") {
+    return {
+      category: "unknown_service_error",
+      operation,
+      message:
+        "Could not save changes right now. Try again shortly or ask the organizer for help.",
+    };
+  }
+
+  if (operation === "auth_email") {
+    return {
+      category: "unknown_service_error",
+      operation,
+      message: EMAIL_LIMIT_MESSAGE,
+    };
+  }
+
+  return {
+    category: "unknown_service_error",
+    operation,
+    message: UNKNOWN_SERVICE_MESSAGE,
+  };
+}
+
+export function serviceErrorMessage(
+  error: unknown,
+  operation: RuntimeErrorOperation
+) {
+  return classifyRuntimeError(error, operation).message;
+}


### PR DESCRIPTION
## Summary
- Add a shared runtime error classifier for auth email limits, rate limits, database quota/read-only failures, network outages, and unknown service failures.
- Surface retry-friendly messages across login, My Songs, shared copy, session start/join/leave/manage, Harmony Brigade, and a friendly app error boundary.
- Add a realtime paused banner with manual refresh for quartet live update interruptions.
- Include the Help acknowledgement update for Sweet Adelines International and Barbershop Harmony Society song-source support.

## Docs and tests
- Added `docs/production-readiness.md` with free-tier/quota/rate-limit monitoring and event-readiness guidance.
- Added classifier, app error boundary, production readiness, service-failure UI, and Help acknowledgement tests.
- Updated existing quartet management expectations for the shared service failure copy.

## Supabase / rollout
- No schema, RLS, or migration changes required.
- Analytics behavior remains guarded behind existing availability checks.

## Verification
- `npm run test:run`
- `npm run build`

Closes #324