### PR TITLE
Add Sheet Music Plus Barbershop song source

### DIFF
--- a/data/song_suggestion_catalog.psv
+++ b/data/song_suggestion_catalog.psv
@@ -5796,6 +5796,7 @@ Eleanor Rigby|SATB|Joe Mannherz
 Eleanor Rigby|SSAA|Jim Arns
 Eleanor Rigby|TTBB|Jay Giallombardo
 Eleanor Rigby|TTBB|Jon Nicholas
+Eleanor Rigby|TTBB|Nicholas Hare
 Eleanor Rigby|TTBB|Thomas Degan
 Eleanor Rigby|TTBB|Tom Gentry
 Electricity|TTBB|Simon Arnott
@@ -7010,9 +7011,9 @@ Give It Away|TTBB|Dennis Driscoll
 Give Me A Band and My Baby|SSAA|Janice Wheeler
 Give Me A Band and My Baby|TTBB|Alexander Ronneburg
 Give Me a Barbershop Song|SSAA|Roy Dawson and Steve Hall
+Give Me a Barbershop Song|TTBB|Steve Hall
 Give Me A Barbershop Song|SSAA|Steve Hall
 Give Me A Barbershop Song|TTBB|Roy Dawson
-Give Me A Barbershop Song|TTBB|Steve Hall
 Give Me a Basketball|TTBB|Paul Olguin
 Give Me A Basketball|TTBB|Paul Olquin
 Give Me A Girl|TTBB|Joe Liles
@@ -8730,6 +8731,7 @@ Home on the Range|SSAA|Brian Beck
 Home on the Range|TTBB|Dave Briner
 Home on the Range|TTBB|Don Gray
 Home on the Range|TTBB|Jack Baird
+Home on the Range|TTBB|Lauren Lofton
 Home On The Range|SSAA|Jay Giallombardo
 Home On The Range|SSAA|Nancy Bergman
 Home On The Range|TTBB|Jay Giallombardo
@@ -9121,6 +9123,7 @@ I Aint Worried Bout It All|SATB|Adam Scott
 I Aint Worried Bout It All|TTBB|Adam Scott
 I Almost Do|TTBB|Matt Astle
 I Always Knew The Girl I'd Love Would Be A Girl Like You|TTBB|Toban Dvoretsky
+I Am a Child of God|TTBB|Nathan Owens
 I am A Child of God/I wonder When He Comes Again Medley|SSAA|Aaron Dale
 I am A Child of God/I wonder When He Comes Again Medley|TTBB|Aaron Dale
 I Am a Man of Constant Sorrow|TTBB|Aaron Dale
@@ -12530,6 +12533,7 @@ Jingle Bells|SSAA|Joni Bescos
 Jingle Bells|SSAA|Sheryl Neal
 Jingle Bells|SSAA|Walter Latzko
 Jingle Bells|TTBB|Adam Bock
+Jingle Bells|TTBB|Andrew Henderson
 Jingle Bells|TTBB|Barbershop Harmony Society
 Jingle Bells|TTBB|Brian Mastrull
 Jingle Bells|TTBB|David Harrington
@@ -17531,6 +17535,7 @@ Papa Oom Mow Mow|TTBB|Tom Gentry
 Paparazzi|SATB|Deke Sharon
 Paper Doll|SSAA|Aaron Dale
 Paper Doll|TTBB|Aaron Dale
+Paper Doll|TTBB|Carol Conrad
 Paper Doll|TTBB|David Harrington
 Paper Doll|TTBB|Jim Shubert
 Paper Doll|TTBB|Lou Perry
@@ -17733,6 +17738,7 @@ Pigalle|SSAA|Carolyn Schmidt
 Pigtails & Freckles|SSAA|Sylvia Alsbury
 Pine Cones And Holly Berries|TTBB|Archie Steen
 Pine Cones And Holly Berries|TTBB|Mark Goodney
+Pinin' Just For You|TTBB|Brian Cromer
 Pink|SATB|Liz Garnett
 Piping down the Valleys Wild|SATB|David Avshalomov
 Pirate Medley|TTBB|Greg Volk
@@ -18371,8 +18377,8 @@ Ride Red Ride|TTBB|Emi Mills
 Ride Red Ride|TTBB|Ernie Boring
 Ride the Chariot|SATB|Barbershop Harmony Society
 Ride the Chariot|SSAA|Barbershop Harmony Society
+Ride the Chariot|TTBB|Barbershop Harmony Society
 Ride The Chariot|SSAA|David Wright
-Ride The Chariot|TTBB|Barbershop Harmony Society
 Ride The Chariot|TTBB|David Wright
 Ride The Chariot|TTBB|Jon Nicholas
 Ride The Railroad|TTBB|Robert Disney
@@ -18398,6 +18404,7 @@ Right Now|SATB|Deke Sharon
 Right Round|TTBB|Deke Sharon
 Righteous Brothers Medley|TTBB|Todd Troutman
 Ring a Ding Ding|TTBB|Anthony Bartholemew
+Ring Christmas Bells|SSAA|Kim Kirkman
 Ring de Christmas Bells|TTBB|Dave Briner
 Ring of Fire|TTBB|Kevin Keller
 Ring Of Fire|SATB|Kevin Keller
@@ -18909,6 +18916,7 @@ Sara Lee|SSAA|Joey Minshall
 Sarah|TTBB|Greg Mallett
 Satan's Li'l Lamb|TTBB|Kevin Keller
 Satin Doll|SATB|Joe Mannherz
+Satin Doll|TTBB|Nicholas Hare
 Satin Doll|TTBB|Peter Beers
 Satin Doll|TTBB|Scott Kitzmiller
 Satin Doll|TTBB|Steve Jamison
@@ -21198,6 +21206,7 @@ SWING DOWN SWEET CHARIOT|SSAA|Karen McCarville
 Swing Down, Chariot|SATB|The Vagabonds
 Swing Low|TTBB|Jim West
 Swing Low, Sweet Chariot|TTBB|Maurice Reagan
+Swing Low, Sweet Chariot|TTBB|Nicholas Hare
 Swing Low, Sweet Chariot|TTBB|Peter Knight
 Swing Low, Sweet Chariot|TTBB|Unspecified
 Swing Low, Sweet Chariot Medley|SSAA|Nancy Bergman
@@ -21845,6 +21854,7 @@ The Band Played On|SSAA|Nancy Bergman
 The Band Played On|SSAA|Renee Craig
 The Band Played On|TTBB|Yesteryear
 The Barbershop Cliché|TTBB|Kohl Kitzmiller
+The Barbershop Dreidel Song|SATB|Sarah Shapiro
 THE BARBERSHOP LIMERICK SONG|SSAA|Joan Adler
 The Barbershop Strut|SSAA|Earl Moon
 The Barbershop Strut|TTBB|Earl Moon
@@ -22130,6 +22140,7 @@ The Girl From Ipanema|SATB|Joanna Forbes
 The Girl From Ipanema|SATB|Joe Mannherz
 The Girl From Ipanema|SSAA|Gloria Kuchenbecker
 The Girl From Ipanema|TTBB|Deke Sharon
+The Girl From Ipanema|TTBB|Nicholas Hare
 The Girl from Kodak Town|SSAA|Tom Gentry
 The Girl from Kodak Town|TTBB|Tom Gentry
 The Girl I Love|TTBB|Gary Lewis
@@ -24511,6 +24522,7 @@ Wake Up Everybody|TTBB|Patrick McAlexander
 Wake Up Little Girl|TTBB|Joe Mannherz
 Wake Up Little Girl|TTBB|Norm Benson
 Wake Up Little Susie|TTBB|Larry Wright
+Wake Up Little Susie|TTBB|Nicholas Hare
 Walk a Mile In My Shoes|SSAA|Staffan Paulson
 Walk Away|SSAA|Tom Gentry
 Walk Away|TTBB|Nicholas Wright

--- a/data/sources/sheet_music_plus_barbershop_song_suggestions.psv
+++ b/data/sources/sheet_music_plus_barbershop_song_suggestions.psv
@@ -1,0 +1,22 @@
+Song Title|Voicing|Arranger
+Eleanor Rigby|TTBB|Nicholas Hare
+Firefly|TTBB|Barbershop Harmony Society
+Give Me a Barbershop Song|TTBB|Steve Hall
+Hark! The Herald Angels Sing|SSAA|Dianne Goldrick
+Home on the Range|TTBB|Lauren Lofton
+I Am a Child of God|TTBB|Nathan Owens
+I Love That Old Barbershop Style|TTBB|Val Hicks
+Jingle Bells|TTBB|Andrew Henderson
+Paper Doll|TTBB|Carol Conrad
+Pinin' Just For You|TTBB|Brian Cromer
+Ride the Chariot|TTBB|Barbershop Harmony Society
+Ride The Chariot|SSAA|Barbershop Harmony Society
+Ring Christmas Bells|SSAA|Kim Kirkman
+Satin Doll|TTBB|Nicholas Hare
+Swing Low, Sweet Chariot|TTBB|Nicholas Hare
+That's Life|SATB|Barbershop Harmony Society
+That's Life|SSAA|Barbershop Harmony Society
+That's Life|TTBB|Barbershop Harmony Society
+The Barbershop Dreidel Song|SATB|Sarah Shapiro
+The Girl From Ipanema|TTBB|Nicholas Hare
+Wake Up Little Susie|TTBB|Nicholas Hare

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -285,11 +285,52 @@ supported voicing signal to
 `tmp/song-sources/melody-hine-arrangements-skipped.json`. It does not import
 pricing, media, sheet music, lyrics, checkout, account, or order metadata.
 
+## Sheet Music Plus Barbershop Discovery
+
+Sheet Music Plus is a general sheet-music marketplace, so it is handled as an
+explicit manual discovery/import source rather than part of `song-sources:all`.
+Use the public Barbershop genre search through the importer. The importer reads
+the `sz=20` search form, which matches the published robots allowance for sized
+search results, and fetches text-rendered detail pages because direct HTTP and
+headless browser requests from this environment receive bot-protection
+challenges:
+
+```text
+https://www.sheetmusicplus.com/en/explore?q=barbershop&prefn1=genres&prefv1=Barbershop&sz=20
+```
+
+Run a limited discovery pass:
+
+```bash
+npm run song-sources:import:sheet-music-plus -- --limit=60 --pages=5 --debug
+```
+
+When the source produces high-confidence rows, the importer creates:
+
+```text
+data/sources/sheet_music_plus_barbershop_song_suggestions.psv
+```
+
+The importer only accepts product detail pages with all of:
+
+- clear barbershop context
+- clean individual song title
+- exactly one canonical voicing (`SSAA`, `SATB`, or `TTBB`)
+- explicit `Arranged by ...` metadata
+
+It skips collections/books, broad product titles, non-barbershop products,
+missing or ambiguous arranger metadata, missing or ambiguous voicing, and
+multi-voicing products. Skipped rows are written to
+`tmp/song-sources/sheet-music-plus-skipped.json`. Product fetch failures such as
+reader rate limits are skipped and recorded instead of failing the whole run.
+Sheet Music Plus is listed on the Help song suggestion source list while this
+committed source PSV is active.
+
 After reviewing the source PSV, merge it into the deployed suggestion catalog:
 
 ```bash
-npm run song-suggestions:merge -- --dry-run
-npm run song-suggestions:merge
+npm run song-sources:merge -- --dry-run
+npm run song-sources:merge
 ```
 
 The merge script reads the existing `data/song_suggestion_catalog.psv` plus the

--- a/docs/song-sources.md
+++ b/docs/song-sources.md
@@ -15,6 +15,8 @@ by individual singers.
 - `data/sources/timtracks_song_suggestions.psv`
 - `data/sources/kohl_kitzmiller_music_song_suggestions.psv`
 - `data/sources/melody_hine_arrangements_song_suggestions.psv`
+- `data/sources/sheet_music_plus_barbershop_song_suggestions.psv` (manual
+  discovery/import from the Sheet Music Plus Barbershop genre catalog)
 - `data/sources/bhs_song_catalog_suggestions.psv`
 - `data/sources/sweet_adelines_published_music_song_suggestions.psv`
 - `data/sources/sweet_adelines_arranged_music_song_suggestions.psv`
@@ -56,6 +58,7 @@ npm run song-sources:scrape:barbershoptracks
 npm run song-sources:scrape:timtracks
 npm run song-sources:scrape:kohl-kitzmiller-music
 npm run song-sources:scrape:melody-hine-arrangements
+npm run song-sources:import:sheet-music-plus -- --limit=60 --pages=5 --debug
 npm run song-sources:import:bhs
 npm run song-sources:import:sweet-adelines
 npm run song-sources:import:sweet-adelines-arranged
@@ -133,6 +136,23 @@ Melody Hine Arrangements:
   `tmp/song-sources/melody-hine-arrangements-skipped.json`.
 - Use `--limit=25 --debug` for a quick inspectable run; debug discovery reports
   are written under `tmp/song-sources/melody-hine-arrangements/`.
+
+Sheet Music Plus Barbershop catalog:
+
+- Uses the public Sheet Music Plus Barbershop search/detail pages rendered
+  through a text reader because direct HTTP and headless browser requests from
+  this environment receive bot-protection challenges.
+- Starts as an explicit manual import source and is not included in
+  `song-sources:all`.
+- Reads the `sz=20` search page form, which matches the published robots
+  allowance for sized search results.
+- Imports only product detail pages with a confident title, explicit arranger,
+  clear barbershop context, and one canonical voicing (`SSAA`, `SATB`, or
+  `TTBB`).
+- Skips collections/books, non-barbershop products, ambiguous arranger metadata,
+  missing/ambiguous voicing, multi-voicing rows, and product fetch failures such
+  as reader rate limits.
+- Writes skipped rows to `tmp/song-sources/sheet-music-plus-skipped.json`.
 
 BHS Published Music:
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -222,6 +222,13 @@ Code:
   product records by
   `scripts/song-sources/scrape-melody-hine-arrangements.mjs` into
   `data/sources/melody_hine_arrangements_song_suggestions.psv`
+- Sheet Music Plus Barbershop catalog discovery is handled by the explicit
+  manual importer `scripts/song-sources/import-sheet-music-plus-barbershop.mjs`.
+  It reads the public Barbershop genre search/detail pages through text-rendered
+  pages because direct HTTP/browser requests from this environment receive
+  bot-protection challenges. It writes high-confidence rows to
+  `data/sources/sheet_music_plus_barbershop_song_suggestions.psv` and writes
+  debug/skipped files under `tmp/song-sources/`.
 - Sweet Adelines published music source data is imported from the public PDF by
   `scripts/song-sources/import-sweet-adelines-published-music.mjs` into
   `data/sources/sweet_adelines_published_music_song_suggestions.psv`

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -192,6 +192,7 @@ describe("help content", () => {
       "timtracks.com",
       "kohlkitzmillermusic.com",
       "melodyhinearrangements.com",
+      "sheetmusicplus.com",
     ]);
     expect(helpSongSuggestionSources.map((item) => item.contribution).join(" ")).toContain(
       "Ross Wilkins’ Harmony Brigade database"

--- a/lib/__tests__/sheetMusicPlusSource.test.mjs
+++ b/lib/__tests__/sheetMusicPlusSource.test.mjs
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { formatSourcePsv } from "../../scripts/song-sources/psv.mjs";
+import {
+  parseSheetMusicPlusProduct,
+  productUrlsFromSearchPage,
+  transformSheetMusicPlusProducts,
+} from "../../scripts/song-sources/import-sheet-music-plus-barbershop.mjs";
+
+const ttbbProductText = `
+One More Time TTBB - Digital Sheet Music
+
+Details
+Instrument:
+Voice
+Ensembles:
+TTBB 4-Part
+Genres:
+Barbershop
+Publishers:
+Keep Singing
+Series:
+ArrangeMe
+Detailed Description
+Voice (TTBB) - Level 2 - Digital Download
+SKU: A0.674449
+Composed by James Wiggins. Arranged by James Wiggins. This edition: pdf. Barbershop. Barbershop Quartet. 4 pages.
+`;
+
+const jinaProductText = `
+Title: One More Time - Voice, TTBB, 4-Part - Early Intermediate Digital Sheet Music | Sheet Music Plus
+
+# One More Time - Voice, TTBB, 4-Part - Early Intermediate Digital Sheet Music | Sheet Music Plus
+
+# One More Time  TTBB - Digital Sheet Music
+
+Details
+Instrument: Voice
+Ensembles: TTBB 4-Part
+Genres: Barbershop
+Publishers: Keep Singing
+Series: ArrangeMe
+
+Detailed Description
+Voice (TTBB) - Level 2 - Digital Download
+
+Composed by James Wiggins. Arranged by James Wiggins. This edition: pdf. Barbershop. Barbershop Quartet. 4 pages.
+`;
+
+describe("Sheet Music Plus source importer transforms", () => {
+  it("extracts confident title, voicing, and arranger rows", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText,
+        sourceUrl: "https://www.sheetmusicplus.com/en/product/one-more-time-22224033.html",
+      }).rows
+    ).toEqual([
+      {
+        title: "One More Time",
+        voicing: "TTBB",
+        arranger: "James Wiggins",
+        source: "Sheet Music Plus Barbershop catalog",
+      },
+    ]);
+  });
+
+  it("extracts rows from text-rendered product markdown", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text: jinaProductText,
+        sourceUrl: "https://www.sheetmusicplus.com/en/product/one-more-time-22224033.html",
+      }).rows
+    ).toEqual([
+      {
+        title: "One More Time",
+        voicing: "TTBB",
+        arranger: "James Wiggins",
+        source: "Sheet Music Plus Barbershop catalog",
+      },
+    ]);
+  });
+
+  it("removes marketplace descriptors from rendered titles", () => {
+    const transformed = transformSheetMusicPlusProducts([
+      {
+        text: jinaProductText
+          .replaceAll("One More Time", "Paper Doll, Vocal Score (Barbershop Quartet) - Choir, Voice,")
+          .replaceAll("James Wiggins", "Carol Conrad"),
+      },
+      {
+        text: jinaProductText
+          .replaceAll("One More Time", "Pinin' Just For You - Men's Barbershop Arrangement")
+          .replaceAll("James Wiggins", "Brian Cromer"),
+      },
+      {
+        text: jinaProductText
+          .replaceAll("One More Time", "Hark! The Herald Angels Sing, Women's Barbershop")
+          .replaceAll("James Wiggins", "Dianne Goldrick"),
+      },
+      {
+        text: jinaProductText
+          .replaceAll("One More Time", "Ring Christmas Bells for Female Barbershop")
+          .replaceAll("James Wiggins", "Kim Kirkman"),
+      },
+    ]);
+
+    expect(transformed.rows.map((row) => row.title)).toEqual([
+      "Hark! The Herald Angels Sing",
+      "Paper Doll",
+      "Pinin' Just For You",
+      "Ring Christmas Bells",
+    ]);
+  });
+
+  it("discovers product links from rendered markdown and direct html", () => {
+    expect(
+      productUrlsFromSearchPage(`
+        [One More Time](https://www.sheetmusicplus.com/en/product/one-more-time-22224033.html)
+        <a href="/en/product/barbershop-blues-820685.html">Barbershop Blues</a>
+      `)
+    ).toEqual([
+      "https://www.sheetmusicplus.com/en/product/barbershop-blues-820685.html",
+      "https://www.sheetmusicplus.com/en/product/one-more-time-22224033.html",
+    ]);
+  });
+
+  it("assigns only canonical voicing values", () => {
+    expect(
+      transformSheetMusicPlusProducts([
+        {
+          text: ttbbProductText.replaceAll("TTBB", "SSAA").replace(
+            "Voice (SSAA)",
+            "Voice (SSAA)"
+          ),
+        },
+        {
+          text: ttbbProductText.replaceAll("TTBB", "SATB").replace(
+            "Voice (SATB)",
+            "Voice (SATB)"
+          ),
+        },
+      ]).rows.map((row) => row.voicing)
+    ).toEqual(["SATB", "SSAA"]);
+  });
+
+  it("skips missing or ambiguous arranger and voicing rows", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replace("Arranged by James Wiggins.", ""),
+      }).skipped.reason
+    ).toBe("missing_arranger");
+
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replaceAll("TTBB", "Voice"),
+      }).skipped.reason
+    ).toBe("missing_voicing");
+
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replace("TTBB 4-Part", "TTBB 4-Part SSAA 4-Part"),
+      }).skipped.reason
+    ).toBe("ambiguous_voicing");
+  });
+
+  it("skips collection and non-barbershop products", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replace("One More Time", "15 Barbershop Favorites"),
+      }).skipped.reason
+    ).toBe("collection_or_book");
+
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replaceAll("Barbershop", "Classical"),
+      }).skipped.reason
+    ).toBe("non_barbershop_product");
+  });
+
+  it("ignores recommendation text when deciding if a product is barbershop", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText
+          .replace("One More Time TTBB - Digital Sheet Music", "Solo Violin - Digital Sheet Music")
+          .replace("TTBB 4-Part", "Violin")
+          .replace("Voice (TTBB)", "Violin")
+          .replaceAll("Barbershop", "Classical") +
+          "\n\n## You may also like\n[Barbershop Quartet](https://example.com)",
+      }).skipped.reason
+    ).toBe("non_barbershop_product");
+  });
+
+  it("skips source collections and placeholder arrangers", () => {
+    expect(
+      parseSheetMusicPlusProduct({
+        text:
+          ttbbProductText.replace("One More Time", "Nashville: Barbershop Style") +
+          "\nFormat: Collection / Songbook\nArranged by Various.",
+      }).skipped.reason
+    ).toBe("collection_or_book");
+
+    expect(
+      parseSheetMusicPlusProduct({
+        text: ttbbProductText.replaceAll("James Wiggins", "Various"),
+      }).skipped.reason
+    ).toBe("placeholder_arranger");
+  });
+
+  it("dedupes exact rows while preserving distinct arrangers", () => {
+    const transformed = transformSheetMusicPlusProducts([
+      { text: ttbbProductText },
+      { text: ttbbProductText },
+      { text: ttbbProductText.replaceAll("James Wiggins", "Name Two") },
+    ]);
+
+    expect(transformed.report.duplicateRows).toBe(1);
+    expect(transformed.rows).toEqual([
+      {
+        title: "One More Time",
+        voicing: "TTBB",
+        arranger: "James Wiggins",
+        source: "Sheet Music Plus Barbershop catalog",
+      },
+      {
+        title: "One More Time",
+        voicing: "TTBB",
+        arranger: "Name Two",
+        source: "Sheet Music Plus Barbershop catalog",
+      },
+    ]);
+  });
+
+  it("writes the shared PSV header and escapes pipes", () => {
+    const transformed = parseSheetMusicPlusProduct({
+      text: ttbbProductText
+        .replace("One More Time", "One | More Time")
+        .replaceAll("James Wiggins", "James | Wiggins"),
+    });
+
+    expect(formatSourcePsv(transformed.rows)).toContain(
+      "Song Title|Voicing|Arranger\nOne / More Time|TTBB|James / Wiggins"
+    );
+  });
+});

--- a/lib/__tests__/songSourcePipeline.test.mjs
+++ b/lib/__tests__/songSourcePipeline.test.mjs
@@ -19,7 +19,10 @@ import {
   normalizeBarbershopConnectionsVoices,
 } from "../../scripts/song-sources/scrape-barbershop-connections.mjs";
 import { transformHarmonyBrigadeSongRows } from "../../scripts/song-sources/import-harmony-brigade-db.mjs";
-import { mergeRows } from "../../scripts/merge-song-suggestion-sources.mjs";
+import {
+  defaultSourcePaths,
+  mergeRows,
+} from "../../scripts/merge-song-suggestion-sources.mjs";
 
 const tempDirs = [];
 
@@ -170,6 +173,14 @@ describe("song source pipeline", () => {
       { title: "The Same Song", voicing: "SSAA", arranger: null },
       { title: "The Same Song", voicing: "TTBB", arranger: "Arranger One" },
     ]);
+  });
+
+  it("includes manual Sheet Music Plus source files when present", () => {
+    expect(
+      defaultSourcePaths.some((sourcePath) =>
+        sourcePath.endsWith("sheet_music_plus_barbershop_song_suggestions.psv")
+      )
+    ).toBe(true);
   });
 
   it("loads local song source env without logging or requiring secrets", async () => {

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -346,6 +346,10 @@ export const helpSongSuggestionSources: HelpAcknowledgment[] = [
     name: "melodyhinearrangements.com",
     contribution: "for song suggestion reference data",
   },
+  {
+    name: "sheetmusicplus.com",
+    contribution: "for Barbershop genre catalog song suggestion reference data",
+  },
 ];
 
 export const helpDevelopmentNote =

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "song-sources:scrape:melody-hine-arrangements": "node scripts/song-sources/scrape-melody-hine-arrangements.mjs",
     "song-sources:scrape:timtracks": "node scripts/song-sources/scrape-timtracks.mjs",
     "song-sources:import:bhs": "node scripts/song-sources/import-bhs-catalog.mjs",
+    "song-sources:import:sheet-music-plus": "node scripts/song-sources/import-sheet-music-plus-barbershop.mjs",
     "song-sources:import:sweet-adelines": "node scripts/song-sources/import-sweet-adelines-published-music.mjs",
     "song-sources:import:sweet-adelines-arranged": "node scripts/song-sources/import-sweet-adelines-arranged-music.mjs",
     "song-sources:import:harmony-brigade": "node scripts/song-sources/import-harmony-brigade-db.mjs",

--- a/scripts/merge-song-suggestion-sources.mjs
+++ b/scripts/merge-song-suggestion-sources.mjs
@@ -34,6 +34,7 @@ export const defaultSourcePaths = [
     "data/sources/sweet_adelines_arranged_music_song_suggestions.psv"
   ),
   path.join(repoRoot, "data/sources/harmony_brigade_song_suggestions.psv"),
+  path.join(repoRoot, "data/sources/sheet_music_plus_barbershop_song_suggestions.psv"),
 ];
 
 function optionValue(name) {

--- a/scripts/song-sources/import-sheet-music-plus-barbershop.mjs
+++ b/scripts/song-sources/import-sheet-music-plus-barbershop.mjs
@@ -1,0 +1,514 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { formatSourcePsv } from "./psv.mjs";
+import {
+  cleanSourceText,
+  dedupeSourceRows,
+  normalizeArrangerName,
+  normalizeSourceVoicings,
+  normalizeTitleArticle,
+} from "./source-utils.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+const sourceName = "Sheet Music Plus Barbershop catalog";
+const searchUrl =
+  "https://www.sheetmusicplus.com/en/explore?q=barbershop&prefn1=genres&prefv1=Barbershop&sz=20";
+const defaultPages = 5;
+const defaultDelayMs = 1000;
+const defaultOutputPath = path.join(
+  repoRoot,
+  "data/sources/sheet_music_plus_barbershop_song_suggestions.psv"
+);
+const skippedRowsPath = path.join(
+  repoRoot,
+  "tmp/song-sources/sheet-music-plus-skipped.json"
+);
+const debugPath = path.join(repoRoot, "tmp/song-sources/sheet-music-plus-debug.json");
+const samplePagesDir = path.join(
+  repoRoot,
+  "tmp/song-sources/sheet-music-plus-sample-pages"
+);
+
+function optionValue(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function hasOption(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+function decodeHtmlEntities(value) {
+  return String(value ?? "")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([\da-f]+);/gi, (_, code) =>
+      String.fromCodePoint(Number.parseInt(code, 16))
+    )
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&ndash;/g, "-")
+    .replace(/&mdash;/g, "-")
+    .replace(/&rsquo;/g, "'")
+    .replace(/&lsquo;/g, "'")
+    .replace(/&rdquo;/g, '"')
+    .replace(/&ldquo;/g, '"');
+}
+
+function textFromHtml(value) {
+  return cleanSourceText(
+    decodeHtmlEntities(String(value ?? "").replace(/<script[\s\S]*?<\/script>/gi, " "))
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<[^>]*>/g, " ")
+  );
+}
+
+function stripDigitalSheetMusicSuffix(value) {
+  return String(value ?? "")
+    .replace(/\s*\|\s*Sheet Music Plus\s*$/i, "")
+    .replace(
+      /\s+-\s+(?:Voice|Choir),?\s*(?:SSAA|SATB|TTBB),?\s*4-Part\s+-\s*(?:(?:Late|Early)\s+)?(?:Intermediate\s+)?(?:Digital\s+)?Sheet Music$/i,
+      ""
+    )
+    .replace(/\s+-\s+(?:Digital\s+)?Sheet Music$/i, "")
+    .replace(/\s+-\s+(?:Late|Early)?\s*Intermediate\s+(?:Digital\s+)?Sheet Music$/i, "")
+    .trim();
+}
+
+function cleanMarketplaceTitle(value) {
+  let title = stripDigitalSheetMusicSuffix(value)
+    .replace(/\s+(SSAA|SATB|TTBB)\s*$/i, "")
+    .replace(/\s+(?:Choir|Voice),?\s*(SSAA|SATB|TTBB),?\s*4-Part.*$/i, "")
+    .replace(/\s+-\s+Choir,\s*Voice,?\s*(?:4-Part)?\s*$/i, "")
+    .replace(/,\s*Vocal Score\s*\(Barbershop Quartet\)/i, "")
+    .replace(/\s+-\s*(?:Men's|Women's|Female)\s+Barbershop(?:\s+Arrangement)?$/i, "")
+    .replace(/,\s*(?:Men's|Women's|Female)\s+Barbershop$/i, "")
+    .replace(/\s+for\s+(?:Men's|Women's|Female)\s+Barbershop$/i, "")
+    .replace(/\s+-\s*(?:SSAA|SATB|TTBB)\s+barbershop$/i, "")
+    .replace(/\s+-\s*Barbershop Quartet$/i, "")
+    .replace(/\s*\(arr\.\s*[^)]+\)\s*/i, " ")
+    .replace(/\s*\((?:novello\s+)?(?:ladies'?\s+)?barbershop\)\s*/i, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const byArtist = title.match(/^(.+?)\s+by\s+[^|]+$/i);
+  if (byArtist) title = byArtist[1].trim();
+
+  return normalizeTitleArticle(title);
+}
+
+function isCollectionLikeTitle(value) {
+  return /\b(collection|collections|songbook|song book|anthology|fake book|fakebook|favorites|favourites|album|bundle|package|event invite)\b/i.test(
+    String(value ?? "")
+  );
+}
+
+function isCollectionLikeProduct(value) {
+  return (
+    isCollectionLikeTitle(value) ||
+    /\bFormat:\s*Collection\s*\/\s*Songbook\b/i.test(String(value ?? "")) ||
+    /\b_Collection_\b/i.test(String(value ?? ""))
+  );
+}
+
+function isPlaceholderArranger(value) {
+  return /^(?:various|unknown|n\/a)$/i.test(String(value ?? "").trim());
+}
+
+function normalizeSheetMusicPlusVoicing(value) {
+  const text = cleanSourceText(value);
+  if (!text) return [];
+
+  const explicit = Array.from(text.matchAll(/\b(SSAA|SATB|TTBB)\b/gi)).map((match) =>
+    match[1].toUpperCase()
+  );
+  if (explicit.length > 0) return Array.from(new Set(explicit));
+
+  const normalized = text
+    .toLowerCase()
+    .replace(/[’']/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+  if (/\bbarbershop\b/i.test(text)) {
+    if (/\bwomens barbershop\b|\bwomen s barbershop\b/.test(normalized)) return ["SSAA"];
+    if (/\bmens barbershop\b|\bmen s barbershop\b/.test(normalized)) return ["TTBB"];
+  }
+
+  return normalizeSourceVoicings(text).filter((voicing) => /\bbarbershop\b/i.test(text));
+}
+
+function extractArranger(value) {
+  const text = cleanSourceText(value);
+  if (!text) return null;
+
+  const arrangedBy = text.match(/\bArranged by\s+(.+?)(?:\.|;| This edition:| Barbershop,| A Cappella,|$)/i);
+  if (!arrangedBy) return null;
+
+  const arranger = arrangedBy[1]
+    .replace(/\b(?:and\s+)?(?:Published|Composed|Edited|By)\s+.*$/i, "")
+    .trim();
+  return normalizeArrangerName(arranger);
+}
+
+function textBetween(text, label, nextLabels) {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const nextPattern = nextLabels
+    .map((nextLabel) => nextLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("|");
+  const match = text.match(new RegExp(`${escapedLabel}:?\\s+([\\s\\S]*?)(?=\\s+(?:${nextPattern}):?\\s+|$)`, "i"));
+  return cleanSourceText(match?.[1]);
+}
+
+function firstTextLine(value) {
+  return cleanSourceText(
+    String(value ?? "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean)
+  );
+}
+
+function firstMarkdownHeading(value) {
+  const heading = String(value ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /^#\s+/.test(line) && !/^\s*#\s*Sheet Music Plus\b/i.test(line));
+  return cleanSourceText(heading?.replace(/^#+\s*/, ""));
+}
+
+function extractTitleFromHtml(html, fallbackText) {
+  const h1 = String(html ?? "").match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const titleTag = String(html ?? "").match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return textFromHtml(h1?.[1] ?? titleTag?.[1] ?? fallbackText);
+}
+
+function productMainText({ html = "", text = "" }) {
+  const raw = text || textFromHtml(html);
+  const [main] = String(raw ?? "").split(
+    /\n\s*(?:##\s+You may also like|##\s+Recommended Products Based|##\s+Top-selling|See Similar Sheet Music and Digital Downloads)\b/i
+  );
+  return cleanSourceText(main);
+}
+
+export function productUrlsFromSearchPage(pageText) {
+  const urls = new Set();
+  for (const match of String(pageText ?? "").matchAll(/href=["']([^"']*\/en\/product\/[^"']+\.html[^"']*)["']/gi)) {
+    const url = new URL(decodeHtmlEntities(match[1]), "https://www.sheetmusicplus.com");
+    url.hash = "";
+    urls.add(url.href);
+  }
+  for (const match of String(pageText ?? "").matchAll(/\]\((https:\/\/www\.sheetmusicplus\.com\/en\/product\/[^)\s]+\.html[^)\s]*)\)/gi)) {
+    const url = new URL(decodeHtmlEntities(match[1]));
+    url.hash = "";
+    urls.add(url.href);
+  }
+  return Array.from(urls);
+}
+
+function readerUrlFor(url) {
+  return `https://r.jina.ai/${String(url).replaceAll("&", "%26")}`;
+}
+
+function searchUrlForPage(page) {
+  const url = new URL(searchUrl);
+  if (page > 1) url.searchParams.set("page", String(page));
+  return url.href;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isCloudflareChallenge(response, body) {
+  return (
+    response?.status === 403 &&
+    (/cf-mitigated/i.test(response.headers.get("cf-mitigated") ?? "") ||
+      /Just a moment|challenges\.cloudflare\.com|cf-ray/i.test(body ?? ""))
+  );
+}
+
+export function parseSheetMusicPlusProduct({ html = "", text = "", sourceUrl = null }) {
+  const bodyText = productMainText({ html, text });
+  const rawTitle = text
+    ? firstMarkdownHeading(text) || firstTextLine(text)
+    : extractTitleFromHtml(html, bodyText?.split(/\n/)[0] ?? "");
+  const title = cleanMarketplaceTitle(rawTitle);
+  const arranger = extractArranger(bodyText);
+  const details = textBetween(bodyText ?? "", "Details", [
+    "Detailed Description",
+    "Preview",
+    "Tell A Friend",
+  ]);
+  const ensembles = textBetween(bodyText ?? "", "Ensembles", [
+    "Genres",
+    "Composers",
+    "Publishers",
+    "Series",
+    "Format",
+    "Item types",
+    "Level",
+  ]);
+  const detailedDescription = textBetween(bodyText ?? "", "Detailed Description", [
+    "About Digital Downloads",
+    "Customers Who Bought",
+    "Reviews",
+  ]);
+  const voicings = normalizeSheetMusicPlusVoicing(
+    [rawTitle, ensembles, detailedDescription].filter(Boolean).join(" ")
+  );
+
+  if (!title) return { rows: [], skipped: { sourceUrl, reason: "missing_title" } };
+  if (isCollectionLikeTitle(title) || isCollectionLikeProduct(`${details} ${detailedDescription}`)) {
+    return { rows: [], skipped: { sourceUrl, title, reason: "collection_or_book" } };
+  }
+  if (!/\bbarbershop\b/i.test(bodyText ?? "")) {
+    return { rows: [], skipped: { sourceUrl, title, reason: "non_barbershop_product" } };
+  }
+  if (!arranger) {
+    return { rows: [], skipped: { sourceUrl, title, reason: "missing_arranger" } };
+  }
+  if (voicings.length === 0) {
+    return { rows: [], skipped: { sourceUrl, title, arranger, reason: "missing_voicing" } };
+  }
+  if (isPlaceholderArranger(arranger)) {
+    return { rows: [], skipped: { sourceUrl, title, arranger, reason: "placeholder_arranger" } };
+  }
+  if (voicings.length > 1) {
+    return {
+      rows: [],
+      skipped: { sourceUrl, title, arranger, voicings, reason: "ambiguous_voicing" },
+    };
+  }
+
+  return {
+    rows: voicings.map((voicing) => ({ title, voicing, arranger, source: sourceName })),
+    skipped: null,
+  };
+}
+
+export function transformSheetMusicPlusProducts(products) {
+  const rows = [];
+  const skipped = [];
+
+  for (const product of products) {
+    const transformed = parseSheetMusicPlusProduct(product);
+    rows.push(...transformed.rows);
+    if (transformed.skipped) skipped.push(transformed.skipped);
+  }
+
+  const deduped = dedupeSourceRows(rows);
+  return {
+    rows: deduped.rows,
+    report: {
+      sourceRows: products.length,
+      importedRows: deduped.rows.length,
+      duplicateRows: deduped.duplicateRows,
+      skippedRows: skipped.length,
+      skipped,
+    },
+  };
+}
+
+async function fetchText(url, { retries = 3 } = {}) {
+  const response = await fetch(url, {
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    },
+  });
+  const body = await response.text();
+  if (response.status === 429 && retries > 0) {
+    await delay((4 - retries) * 2500);
+    return fetchText(url, { retries: retries - 1 });
+  }
+  if (isCloudflareChallenge(response, body)) {
+    const error = new Error("Sheet Music Plus returned a Cloudflare challenge.");
+    error.code = "cloudflare_challenge";
+    error.status = response.status;
+    error.url = url;
+    throw error;
+  }
+  if (!response.ok) {
+    throw new Error(`Sheet Music Plus request failed: ${response.status} ${url}`);
+  }
+  return body;
+}
+
+async function discoverProductRecords({
+  limit = null,
+  debug = false,
+  fixturePath = null,
+  pages = defaultPages,
+  delayMs = defaultDelayMs,
+} = {}) {
+  if (fixturePath) {
+    const text = await readFile(fixturePath, "utf8");
+    return {
+      products: [{ text, sourceUrl: fixturePath }],
+      searchPages: [],
+      productUrls: [fixturePath],
+      retrieval: "fixture",
+    };
+  }
+
+  const searchPages = [];
+  const productUrlSet = new Set();
+
+  for (let page = 1; page <= pages; page += 1) {
+    const canonicalUrl = searchUrlForPage(page);
+    const text = await fetchText(readerUrlFor(canonicalUrl));
+    searchPages.push({ page, sourceUrl: canonicalUrl, readerUrl: readerUrlFor(canonicalUrl) });
+    for (const productUrl of productUrlsFromSearchPage(text)) {
+      productUrlSet.add(productUrl);
+    }
+    await delay(Math.min(delayMs, 500));
+  }
+
+  const productUrls = Array.from(productUrlSet);
+  const limitedUrls = limit ? productUrls.slice(0, limit) : productUrls;
+  const products = [];
+  const fetchSkipped = [];
+
+  for (const [index, productUrl] of limitedUrls.entries()) {
+    try {
+      const text = await fetchText(readerUrlFor(productUrl));
+      products.push({ text, sourceUrl: productUrl });
+      if (debug && index < 10) {
+        await mkdir(samplePagesDir, { recursive: true });
+        await writeFile(path.join(samplePagesDir, `${index + 1}.md`), text, "utf8");
+      }
+    } catch (error) {
+      fetchSkipped.push({
+        sourceUrl: productUrl,
+        reason: "fetch_failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+    await delay(delayMs);
+  }
+
+  return { products, searchPages, productUrls, fetchSkipped, retrieval: "jina_reader" };
+}
+
+async function writeJson(filePath, payload) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+async function main() {
+  const debug = hasOption("debug");
+  const headed = hasOption("headed");
+  const outputPath = path.resolve(optionValue("output") ?? defaultOutputPath);
+  const fixturePath = optionValue("fixture");
+  const limitValue = optionValue("limit");
+  const pagesValue = optionValue("pages");
+  const delayValue = optionValue("delay-ms");
+  const limit = limitValue ? Number(limitValue) : null;
+  const pages = pagesValue ? Number(pagesValue) : defaultPages;
+  const delayMs = delayValue ? Number(delayValue) : defaultDelayMs;
+  if (limit !== null && (!Number.isInteger(limit) || limit < 1)) {
+    throw new Error("--limit must be a positive integer.");
+  }
+  if (!Number.isInteger(pages) || pages < 1) {
+    throw new Error("--pages must be a positive integer.");
+  }
+  if (!Number.isInteger(delayMs) || delayMs < 0) {
+    throw new Error("--delay-ms must be a non-negative integer.");
+  }
+  if (headed) {
+    console.log("Sheet Music Plus importer uses text-rendered HTTP discovery; --headed is ignored.");
+  }
+
+  let discovery = {
+    products: [],
+    searchPages: [],
+    productUrls: [],
+    fetchSkipped: [],
+    retrieval: null,
+  };
+  let blocked = null;
+  try {
+    discovery = await discoverProductRecords({ limit, debug, fixturePath, pages, delayMs });
+  } catch (error) {
+    if (error?.code !== "cloudflare_challenge") throw error;
+    blocked = {
+      reason: error.code,
+      status: error.status,
+      url: error.url,
+      note:
+        "Sheet Music Plus is behind a Cloudflare challenge from this environment. " +
+        "No source PSV was written because importing from challenged pages would be brittle.",
+    };
+  }
+
+  if (blocked) {
+    await writeJson(debugPath, {
+      searchUrl,
+      blocked,
+      feasible: false,
+      retrieval: discovery.retrieval,
+      importedRows: 0,
+    });
+    await writeJson(skippedRowsPath, []);
+    console.log("Sheet Music Plus discovery blocked by Cloudflare challenge.");
+    console.log(`Wrote ${path.relative(repoRoot, debugPath)}.`);
+    console.log(`Wrote ${path.relative(repoRoot, skippedRowsPath)}.`);
+    return;
+  }
+
+  const { rows, report } = transformSheetMusicPlusProducts(discovery.products);
+  const skipped = [...discovery.fetchSkipped, ...report.skipped];
+  await writeJson(skippedRowsPath, skipped);
+
+  if (debug) {
+    await writeJson(debugPath, {
+      searchUrl,
+      retrieval: discovery.retrieval,
+      pagesRequested: fixturePath ? 0 : pages,
+      searchPages: discovery.searchPages,
+      discoveredProductUrls: discovery.productUrls.length,
+      inspectedProductUrls: discovery.products.length,
+      fetchSkippedRows: discovery.fetchSkipped.length,
+      feasible: rows.length > 0,
+      sourceRows: report.sourceRows,
+      importedRows: report.importedRows,
+      duplicateRows: report.duplicateRows,
+      skippedRows: skipped.length,
+    });
+  }
+
+  if (rows.length === 0) {
+    console.log("Sheet Music Plus discovery produced no high-confidence rows.");
+    console.log(`Wrote ${path.relative(repoRoot, skippedRowsPath)}.`);
+    if (debug) console.log(`Wrote ${path.relative(repoRoot, debugPath)}.`);
+    return;
+  }
+
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, formatSourcePsv(rows), "utf8");
+
+  console.log(`Sheet Music Plus source rows inspected: ${report.sourceRows}`);
+  console.log(`Sheet Music Plus product URLs discovered: ${discovery.productUrls.length}`);
+  console.log(`Sheet Music Plus imported suggestion rows: ${report.importedRows}`);
+  console.log(`Sheet Music Plus duplicate rows collapsed: ${report.duplicateRows}`);
+  console.log(`Sheet Music Plus skipped rows: ${skipped.length}`);
+  console.log(`Wrote ${path.relative(repoRoot, outputPath)}.`);
+  console.log(`Wrote ${path.relative(repoRoot, skippedRowsPath)}.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- Add a manual Sheet Music Plus Barbershop catalog importer that reads the public `sz=20` genre search via text-rendered pages, fetches product details with pacing/retry handling, and skips low-confidence products.
- Commit the resulting Sheet Music Plus source PSV and merge high-confidence rows into `data/song_suggestion_catalog.psv`.
- Document the source workflow and add Sheet Music Plus to the Help song suggestion source list; keep it out of `song-sources:all`.

## Docs and tests
- Updated `docs/song-sources.md`, `docs/imports.md`, and `docs/supabase-contract.md` for the manual importer and source contract.
- Added importer parser/discovery tests and source pipeline coverage.
- Added Help source-list coverage.

## Verification
- `npm run song-sources:import:sheet-music-plus -- --limit=60 --pages=5 --delay-ms=2000 --debug`
- `npm run song-sources:merge`
- `npm run test:run -- sheetMusicPlusSource songSourcePipeline helpContent supabaseContract`
- `npm run test:run` (commit hook)
- Source sanity checks for blank title/voicing/arranger fields and canonical voicings

## Notes
- No build was run manually because this is a scraper/source update.
- No Supabase schema/RLS changes required; this only changes controlled suggestion source data and importer docs.

Closes #356