### PR TITLE
Add Event Mode messaging

### DIFF
--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -2,6 +2,7 @@
 
 import { AppNav } from "@/components/AppNav";
 import {
+  blockEventModeUser,
   closeEventModeEvent,
   defaultEventModeAvailableUntil,
   eventModeVoicePartGroups,
@@ -12,12 +13,16 @@ import {
   formatEventModeDateRange,
   getEventModeAvailabilityByCode,
   getEventModeEventByCode,
+  getEventModeMessagesByCode,
   getEventModeLifecycle,
+  reportEventModeMessage,
+  sendEventModeMessage,
   turnOffEventModeAvailability,
   updateEventModeEvent,
   upsertEventModeAvailability,
   type EventModeAvailability,
   type EventModeEvent,
+  type EventModeMessage,
   type EventModeVisibility,
   type EventModeVoicePart,
 } from "@/lib/eventMode";
@@ -91,9 +96,15 @@ export default function EventModeDetailPage() {
   const [availabilityForm, setAvailabilityForm] =
     useState<AvailabilityFormState | null>(null);
   const [availability, setAvailability] = useState<EventModeAvailability[]>([]);
+  const [messages, setMessages] = useState<EventModeMessage[]>([]);
   const [selectedPart, setSelectedPart] = useState<EventModeVoicePart | "all">(
     "all"
   );
+  const [messageTarget, setMessageTarget] =
+    useState<EventModeAvailability | null>(null);
+  const [messageBody, setMessageBody] = useState("");
+  const [replyBodies, setReplyBodies] = useState<Record<string, string>>({});
+  const [busyMessageKey, setBusyMessageKey] = useState<string | null>(null);
   const [message, setMessage] = useState("");
   const [messageTone, setMessageTone] = useState<"error" | "success">("error");
 
@@ -105,13 +116,18 @@ export default function EventModeDetailPage() {
           getCurrentUser().catch(() => null),
         ]);
         let loadedAvailability: EventModeAvailability[] = [];
+        let loadedMessages: EventModeMessage[] = [];
         if (loadedEvent && user) {
-          loadedAvailability = await getEventModeAvailabilityByCode(code);
+          [loadedAvailability, loadedMessages] = await Promise.all([
+            getEventModeAvailabilityByCode(code),
+            getEventModeMessagesByCode(code),
+          ]);
         }
         setEvent(loadedEvent);
         setForm(loadedEvent ? formFromEvent(loadedEvent) : null);
         setCurrentUserId(user?.id ?? null);
         setAvailability(loadedAvailability);
+        setMessages(loadedMessages);
         const myAvailability = loadedAvailability.find(
           (item) => item.user_id === user?.id
         );
@@ -177,6 +193,11 @@ export default function EventModeDetailPage() {
     if (event) {
       setAvailabilityForm(availabilityFormFromEvent(event, myAvailability));
     }
+  }
+
+  async function reloadMessages() {
+    const loadedMessages = await getEventModeMessagesByCode(code);
+    setMessages(loadedMessages);
   }
 
   async function saveEvent() {
@@ -268,6 +289,96 @@ export default function EventModeDetailPage() {
       );
     } finally {
       setTurningOffAvailability(false);
+    }
+  }
+
+  async function sendMessageToAvailability(target: EventModeAvailability) {
+    if (!event) return;
+    setBusyMessageKey(`send-${target.user_id}`);
+    setMessage("");
+
+    try {
+      await sendEventModeMessage({
+        eventId: event.id,
+        recipientUserId: target.user_id,
+        recipientAvailabilityId: target.id,
+        body: messageBody,
+      });
+      setMessageTarget(null);
+      setMessageBody("");
+      await reloadMessages();
+      setMessageTone("success");
+      setMessage("Message sent.");
+    } catch (err) {
+      console.error("Could not send Event Mode message", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not send message.");
+    } finally {
+      setBusyMessageKey(null);
+    }
+  }
+
+  async function sendReply(recipientUserId: string) {
+    if (!event) return;
+    const body = replyBodies[recipientUserId] ?? "";
+    setBusyMessageKey(`reply-${recipientUserId}`);
+    setMessage("");
+
+    try {
+      await sendEventModeMessage({
+        eventId: event.id,
+        recipientUserId,
+        body,
+      });
+      setReplyBodies((current) => ({ ...current, [recipientUserId]: "" }));
+      await reloadMessages();
+      setMessageTone("success");
+      setMessage("Reply sent.");
+    } catch (err) {
+      console.error("Could not send Event Mode reply", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not send reply.");
+    } finally {
+      setBusyMessageKey(null);
+    }
+  }
+
+  async function reportMessage(item: EventModeMessage) {
+    setBusyMessageKey(`report-${item.id}`);
+    setMessage("");
+
+    try {
+      await reportEventModeMessage(item.id);
+      await reloadMessages();
+      setMessageTone("success");
+      setMessage("Message reported.");
+    } catch (err) {
+      console.error("Could not report Event Mode message", err);
+      setMessageTone("error");
+      setMessage(
+        err instanceof Error ? err.message : "Could not report message."
+      );
+    } finally {
+      setBusyMessageKey(null);
+    }
+  }
+
+  async function blockUser(blockedUserId: string) {
+    if (!event) return;
+    setBusyMessageKey(`block-${blockedUserId}`);
+    setMessage("");
+
+    try {
+      await blockEventModeUser(event.id, blockedUserId);
+      await reloadMessages();
+      setMessageTone("success");
+      setMessage("That singer can no longer message you for this event.");
+    } catch (err) {
+      console.error("Could not block Event Mode user", err);
+      setMessageTone("error");
+      setMessage(err instanceof Error ? err.message : "Could not block user.");
+    } finally {
+      setBusyMessageKey(null);
     }
   }
 
@@ -533,8 +644,173 @@ export default function EventModeDetailPage() {
                             {item.meetup_note}
                           </p>
                         )}
+                        {item.user_id !== currentUserId && (
+                          <div className="mt-4">
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setMessageTarget(item);
+                                setMessageBody("");
+                              }}
+                              className="rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+                            >
+                              Message
+                            </button>
+
+                            {messageTarget?.id === item.id && (
+                              <div className="mt-3 rounded-xl border border-cyan-300/30 bg-cyan-300/10 p-3">
+                                <label className="block">
+                                  <span className="text-sm font-semibold text-white">
+                                    Message {item.display_name}
+                                  </span>
+                                  <span className="mt-1 block text-xs leading-5 text-cyan-50/80">
+                                    Send a note to coordinate singing at this
+                                    event. Your email address is not shown.
+                                  </span>
+                                  <textarea
+                                    value={messageBody}
+                                    onChange={(inputEvent) =>
+                                      setMessageBody(inputEvent.target.value)
+                                    }
+                                    rows={3}
+                                    maxLength={1000}
+                                    className="mt-2 w-full rounded-xl bg-slate-950 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                  />
+                                </label>
+                                <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                                  <button
+                                    type="button"
+                                    onClick={() => sendMessageToAvailability(item)}
+                                    disabled={busyMessageKey === `send-${item.user_id}`}
+                                    className="rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"
+                                  >
+                                    {busyMessageKey === `send-${item.user_id}`
+                                      ? "Sending..."
+                                      : "Send message"}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setMessageTarget(null);
+                                      setMessageBody("");
+                                    }}
+                                    className="rounded-xl bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-700"
+                                  >
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
                       </article>
                     ))}
+                  </div>
+
+                  <div className="mt-6 rounded-xl border border-white/10 bg-slate-950/50 p-4">
+                    <h3 className="text-lg font-bold text-white">Messages</h3>
+                    <p className="mt-1 text-sm leading-6 text-slate-300">
+                      Event Mode messages are private to the sender and
+                      recipient for this event.
+                    </p>
+
+                    <div className="mt-4 space-y-3">
+                      {messages.length === 0 && (
+                        <p className="rounded-xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                          No messages for this event yet.
+                        </p>
+                      )}
+
+                      {messages.map((item) => {
+                        const sentByMe = item.sender_user_id === currentUserId;
+                        const otherUserId = sentByMe
+                          ? item.recipient_user_id
+                          : item.sender_user_id;
+                        const otherName = sentByMe
+                          ? item.recipient_display_name
+                          : item.sender_display_name;
+                        const replyBody = replyBodies[otherUserId] ?? "";
+
+                        return (
+                          <article
+                            key={item.id}
+                            className="rounded-xl border border-white/10 bg-slate-900/80 p-4"
+                          >
+                            <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                              <div>
+                                <p className="text-sm font-semibold text-cyan-200">
+                                  {sentByMe
+                                    ? `You messaged ${item.recipient_display_name}`
+                                    : `${item.sender_display_name} messaged you`}
+                                </p>
+                                <p className="mt-1 text-xs text-slate-400">
+                                  {new Date(item.created_at).toLocaleString()}
+                                </p>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => reportMessage(item)}
+                                  disabled={
+                                    item.reported_by_me ||
+                                    busyMessageKey === `report-${item.id}`
+                                  }
+                                  className="rounded-lg bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-100 hover:bg-slate-700 disabled:opacity-50"
+                                >
+                                  {item.reported_by_me ? "Reported" : "Report"}
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => blockUser(otherUserId)}
+                                  disabled={
+                                    item.blocked_by_me ||
+                                    busyMessageKey === `block-${otherUserId}`
+                                  }
+                                  className="rounded-lg bg-rose-200 px-3 py-1 text-xs font-semibold text-slate-950 hover:bg-rose-100 disabled:opacity-50"
+                                >
+                                  {item.blocked_by_me ? "Blocked" : "Block"}
+                                </button>
+                              </div>
+                            </div>
+                            <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-100">
+                              {item.body}
+                            </p>
+
+                            {!item.blocked_by_me && (
+                              <div className="mt-4 rounded-xl bg-white/5 p-3">
+                                <label className="block">
+                                  <span className="text-sm font-semibold text-slate-100">
+                                    Reply to {otherName}
+                                  </span>
+                                  <textarea
+                                    value={replyBody}
+                                    onChange={(inputEvent) =>
+                                      setReplyBodies((current) => ({
+                                        ...current,
+                                        [otherUserId]: inputEvent.target.value,
+                                      }))
+                                    }
+                                    rows={2}
+                                    maxLength={1000}
+                                    className="mt-2 w-full rounded-xl bg-slate-950 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
+                                  />
+                                </label>
+                                <button
+                                  type="button"
+                                  onClick={() => sendReply(otherUserId)}
+                                  disabled={busyMessageKey === `reply-${otherUserId}`}
+                                  className="mt-2 rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50"
+                                >
+                                  {busyMessageKey === `reply-${otherUserId}`
+                                    ? "Sending..."
+                                    : "Reply"}
+                                </button>
+                              </div>
+                            )}
+                          </article>
+                        );
+                      })}
+                    </div>
                   </div>
 
                   <div className="mt-6 rounded-xl border border-cyan-300/30 bg-cyan-300/10 p-4">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -34,6 +34,10 @@ export default function PrivacyPage() {
                 and participant saved-song snapshots used to calculate matches.
               </li>
               <li>
+                Event Mode data you choose to share, including event details,
+                availability, event-scoped messages, message reports, and blocks.
+              </li>
+              <li>
                 Feedback messages you send, including the contact email shown in
                 the form if you leave it there or edit it.
               </li>
@@ -118,6 +122,19 @@ export default function PrivacyPage() {
               Personal notes are stored for you and are not included
               in participant snapshots. Notes may appear to you in your own
               My Songs and match details.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold">Event Mode</h2>
+            <p className="mt-2 text-slate-300">
+              Event Mode lets signed-in singers find an event, mark themselves
+              available there, and send private event-scoped messages to
+              coordinate singing. Event Mode does not show your email address or
+              phone number to other singers, does not expose your My Songs
+              repertoire, and does not create a permanent public profile or
+              global singer directory. Message reports and blocks are private
+              safety controls.
             </p>
           </div>
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -507,6 +507,95 @@ Required database contract:
 Established by migrations:
 - `20260502100000_add_event_mode_availability.sql`
 
+### Event Mode Messages
+
+Purpose: private, event-scoped coordination messages between signed-in singers
+who are using Event Mode. Messages help singers decide where and when to meet;
+they are not a public chat room, global messaging surface, formal
+invite-to-quartet workflow, or repertoire-sharing feature.
+
+Code:
+- Read messages for an event code:
+  `lib/eventMode.ts#getEventModeMessagesByCode`, through
+  `public.get_event_mode_messages_by_code`
+- Send a message or reply:
+  `lib/eventMode.ts#sendEventModeMessage`, through
+  `public.send_event_mode_message`
+- Report a message:
+  `lib/eventMode.ts#reportEventModeMessage`, through
+  `public.report_event_mode_message`
+- Block another event user from messaging the current user:
+  `lib/eventMode.ts#blockEventModeUser`, through
+  `public.block_event_mode_user`
+- Event detail UI: `app/event-mode/[code]/page.tsx`
+- Tests: `lib/__tests__/eventMode.test.ts`,
+  `lib/__tests__/eventModeUi.test.ts`, and this Supabase contract test
+
+Expected context:
+- Browser authenticated user.
+- Users can send a new message only to another singer who has active
+  availability on the same event.
+- Users can reply to another user when a prior valid event message exists
+  between the two users for that event.
+- Users can view only messages they sent or received.
+- Display names come from `profiles.display_name`; message rows do not own
+  display names.
+- Users can report only messages they are authorized to view.
+- Users can block another event user. Blocked users cannot send new messages
+  to the blocker for that event.
+- Message bodies are stored for app-mediated coordination only. They must not
+  expose private email addresses or phone numbers by default, must not expose
+  repertoire, and must not be sent to analytics.
+- Email notification is intentionally deferred until a separate, explicit
+  notification contract is added.
+
+Required database contract:
+- `event_mode_messages`
+  - `id uuid primary key`
+  - `event_id uuid references public.event_mode_events(id) on delete cascade`
+  - `sender_user_id uuid references auth.users(id) on delete cascade`
+  - `recipient_user_id uuid references auth.users(id) on delete cascade`
+  - optional `recipient_availability_id uuid references public.event_mode_availability(id)`
+  - `body text not null`
+  - `created_at timestamptz not null default now()`
+  - optional `read_at timestamptz`
+- `event_mode_message_reports`
+  - `id uuid primary key`
+  - `message_id uuid references public.event_mode_messages(id) on delete cascade`
+  - `reporter_user_id uuid references auth.users(id) on delete cascade`
+  - `event_id uuid references public.event_mode_events(id) on delete cascade`
+  - optional `reason text`
+  - `created_at timestamptz not null default now()`
+- `event_mode_blocks`
+  - `id uuid primary key`
+  - `event_id uuid references public.event_mode_events(id) on delete cascade`
+  - `blocker_user_id uuid references auth.users(id) on delete cascade`
+  - `blocked_user_id uuid references auth.users(id) on delete cascade`
+  - `created_at timestamptz not null default now()`
+- Check constraints prevent self-messages and self-blocks.
+- Check constraint keeps message bodies between 1 and 1000 trimmed characters.
+- Unique report index on `(message_id, reporter_user_id)`.
+- Unique block index on `(event_id, blocker_user_id, blocked_user_id)`.
+- RLS enabled on all three tables.
+- Authenticated users can select only messages they sent or received.
+- Authenticated users can select only their own reports and blocks.
+- Browser writes use security-definer functions with explicit server-side
+  authorization checks rather than direct insert/update policies.
+- `public.event_mode_user_can_message(uuid, uuid, uuid)` checks active event
+  scope, active recipient availability or an existing thread, and block state.
+- `public.send_event_mode_message(uuid, uuid, text, uuid)` inserts messages
+  only when `event_mode_user_can_message` allows the send.
+- `public.get_event_mode_messages_by_code(text)` joins `profiles.display_name`
+  and returns only messages the current user sent or received.
+- `public.report_event_mode_message(uuid, text)` inserts or updates a private
+  report only for a message the current user can view.
+- `public.block_event_mode_user(uuid, uuid)` inserts a private event-scoped
+  block for users connected through event availability or an event message.
+- No authenticated delete policy.
+
+Established by migrations:
+- `20260506100000_add_event_mode_messaging.sql`
+
 ### `sessions`
 
 Purpose: source of truth for quartet join codes and session activity.

--- a/lib/__tests__/eventMode.test.ts
+++ b/lib/__tests__/eventMode.test.ts
@@ -17,6 +17,7 @@ const {
   isEventModeAvailabilityActive,
   normalizeEventModeText,
   parseEventModeCode,
+  validateEventModeMessageBody,
 } = await import("@/lib/eventMode");
 
 const storeSource = readFileSync(
@@ -228,6 +229,23 @@ describe("Event Mode helpers", () => {
     expect(storeSource).toContain("{ onConflict: \"event_id,user_id\" }");
     expect(storeSource).toContain("get_event_mode_availability_by_code");
     expect(storeSource).toContain('.eq("user_id", user.id)');
-    expect(storeSource).not.toContain("event_mode_messages");
+  });
+
+  it("keeps Event Mode messaging event-scoped and app-mediated", () => {
+    expect(validateEventModeMessageBody("  See you in the lobby?  ")).toBe(
+      "See you in the lobby?"
+    );
+    expect(() => validateEventModeMessageBody("   ")).toThrow(
+      "Message is required."
+    );
+    expect(() => validateEventModeMessageBody("x".repeat(1001))).toThrow(
+      "1000 characters"
+    );
+
+    expect(storeSource).toContain("get_event_mode_messages_by_code");
+    expect(storeSource).toContain("send_event_mode_message");
+    expect(storeSource).toContain("report_event_mode_message");
+    expect(storeSource).toContain("block_event_mode_user");
+    expect(storeSource).not.toContain("Invite to quartet");
   });
 });

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -25,6 +25,12 @@ describe("Event Mode UI copy", () => {
     expect(detailPage).toContain("Start a quartet");
     expect(detailPage).toContain("I&apos;m available to sing");
     expect(detailPage).toContain("Available singers");
+    expect(detailPage).toContain("Message");
+    expect(detailPage).toContain("Send a note to coordinate singing at this");
+    expect(detailPage).toContain("Messages");
+    expect(detailPage).toContain("Reply");
+    expect(detailPage).toContain("Report");
+    expect(detailPage).toContain("Block");
     expect(detailPage).toContain("Turn off my availability");
     expect(detailPage).toContain("Filter by voice part");
     expect(detailPage).toContain("Found people to sing with?");
@@ -40,6 +46,8 @@ describe("Event Mode UI copy", () => {
     expect(combined).not.toContain("Create an event board");
     expect(combined).not.toContain("Open event");
     expect(combined).not.toContain("Nearby singers");
+    expect(combined).not.toContain("Public chat room");
+    expect(combined).not.toContain("Global messaging");
     expect(combined).not.toContain("Location discovery");
     expect(combined).not.toContain("Public profile");
     expect(combined).not.toContain("Invite to quartet");

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -72,6 +72,9 @@ describe("help content", () => {
     expect(guideText).toContain("First Time Setup");
     expect(guideText).toContain("copy songs from another singer");
     expect(guideText).toContain("Harmony Brigade songs");
+    expect(guideText).toContain("Event Mode lets signed-in singers");
+    expect(guideText).toContain("private event-scoped messages");
+    expect(guideText).toContain("do not expose your My Songs repertoire");
     expect(guideText).toContain("Song Title Autocomplete");
     expect(guideText).toContain("Suggestions are optional");
     expect(guideText).toContain("does not add it to anyone else’s saved songs");

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -24,6 +24,10 @@ describe("privacy page copy", () => {
     expect(privacyPage).toContain("participant saved-song snapshots");
     expect(privacyPage).toContain("Private copy links");
     expect(privacyPage).toContain("Harmony Brigade songs");
+    expect(privacyPage).toContain("Event Mode");
+    expect(privacyPage).toContain("event-scoped messages");
+    expect(privacyPage).toContain("message reports");
+    expect(privacyPage).toContain("blocks");
     expect(privacyPage).toContain("other singers in that quartet may see");
     expect(privacyPage).toContain("Feedback forms");
     expect(privacyPage).toContain("PostHog");

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -121,6 +121,13 @@ const eventModeAvailabilityMigration = readFileSync(
   ),
   "utf8"
 );
+const eventModeMessagingMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260506100000_add_event_mode_messaging.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -135,6 +142,9 @@ describe("Supabase contract guardrails", () => {
     "harmony_brigade_event_songs",
     "event_mode_events",
     "event_mode_availability",
+    "event_mode_messages",
+    "event_mode_message_reports",
+    "event_mode_blocks",
   ];
   const baseMigrationTables = tables.filter(
     (table) =>
@@ -145,6 +155,9 @@ describe("Supabase contract guardrails", () => {
         "harmony_brigade_event_songs",
         "event_mode_events",
         "event_mode_availability",
+        "event_mode_messages",
+        "event_mode_message_reports",
+        "event_mode_blocks",
       ].includes(table)
   );
 
@@ -444,5 +457,48 @@ describe("Supabase contract guardrails", () => {
     expect(eventModeAvailabilityMigration).not.toContain("to anon");
     expect(eventModeAvailabilityMigration).not.toContain("user_repertoire");
     expect(eventModeAvailabilityMigration).not.toContain("session_participants");
+  });
+
+  it("documents and migrates Event Mode messaging safety controls", () => {
+    expect(contract).toContain("Event Mode Messages");
+    expect(contract).toContain("event_mode_messages");
+    expect(contract).toContain("event_mode_message_reports");
+    expect(contract).toContain("event_mode_blocks");
+    expect(contract).toContain("send_event_mode_message");
+    expect(contract).toContain("get_event_mode_messages_by_code");
+    expect(contract).toContain("report_event_mode_message");
+    expect(contract).toContain("block_event_mode_user");
+    expect(contract).toContain("messages they sent or received");
+    expect(contract).toContain("Blocked users cannot send new messages");
+    expect(eventModeMessagingMigration).toContain(
+      "create table if not exists public.event_mode_messages"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "create table if not exists public.event_mode_message_reports"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "create table if not exists public.event_mode_blocks"
+    );
+    expect(eventModeMessagingMigration).toContain("enable row level security");
+    expect(eventModeMessagingMigration).toContain(
+      "sender_user_id = auth.uid()"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "recipient_user_id = auth.uid()"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "event_mode_user_can_message"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "available_until > now()"
+    );
+    expect(eventModeMessagingMigration).toContain(
+      "event_mode_blocks.blocker_user_id = p_recipient_user_id"
+    );
+    expect(eventModeMessagingMigration).toContain("security definer");
+    expect(eventModeMessagingMigration).toContain("grant execute");
+    expect(eventModeMessagingMigration).toContain("to authenticated");
+    expect(eventModeMessagingMigration).not.toContain("to anon");
+    expect(eventModeMessagingMigration).not.toContain("user_repertoire");
   });
 });

--- a/lib/eventMode.ts
+++ b/lib/eventMode.ts
@@ -75,6 +75,28 @@ export type EventModeAvailabilityInput = {
   availableUntil: string;
 };
 
+export type EventModeMessage = {
+  id: string;
+  event_id: string;
+  sender_user_id: string;
+  sender_display_name: string;
+  recipient_user_id: string;
+  recipient_display_name: string;
+  recipient_availability_id: string | null;
+  body: string;
+  created_at: string;
+  read_at: string | null;
+  reported_by_me: boolean;
+  blocked_by_me: boolean;
+};
+
+export type EventModeMessageInput = {
+  eventId: string;
+  recipientUserId: string;
+  body: string;
+  recipientAvailabilityId?: string | null;
+};
+
 export const eventModeVoicePartGroups = [
   {
     voicing: "TTBB",
@@ -389,6 +411,15 @@ function validateEventModeAvailabilityInput(input: EventModeAvailabilityInput) {
   };
 }
 
+export function validateEventModeMessageBody(value: string | null | undefined) {
+  const body = String(value ?? "").replace(/\s+/g, " ").trim();
+  if (!body) throw new Error("Message is required.");
+  if (body.length > 1000) {
+    throw new Error("Message must be 1000 characters or fewer.");
+  }
+  return body;
+}
+
 export async function searchEventModeEvents(query: string, now = new Date()) {
   const { data, error } = await supabase
     .from("event_mode_events")
@@ -549,4 +580,47 @@ export async function turnOffEventModeAvailability(eventId: string) {
 
   if (error) throw error;
   return data as Omit<EventModeAvailability, "display_name"> | null;
+}
+
+export async function getEventModeMessagesByCode(code: string) {
+  const parsedCode = parseEventModeCode(code);
+  if (!parsedCode) return [];
+
+  const { data, error } = await supabase.rpc("get_event_mode_messages_by_code", {
+    p_code: parsedCode,
+  });
+
+  if (error) throw error;
+  return (data ?? []) as EventModeMessage[];
+}
+
+export async function sendEventModeMessage(input: EventModeMessageInput) {
+  const body = validateEventModeMessageBody(input.body);
+  const { data, error } = await supabase.rpc("send_event_mode_message", {
+    p_event_id: input.eventId,
+    p_recipient_user_id: input.recipientUserId,
+    p_recipient_availability_id: input.recipientAvailabilityId ?? null,
+    p_body: body,
+  });
+
+  if (error) throw error;
+  return ((data ?? []) as EventModeMessage[])[0] ?? null;
+}
+
+export async function reportEventModeMessage(messageId: string, reason?: string) {
+  const { error } = await supabase.rpc("report_event_mode_message", {
+    p_message_id: messageId,
+    p_reason: cleanText(reason),
+  });
+
+  if (error) throw error;
+}
+
+export async function blockEventModeUser(eventId: string, blockedUserId: string) {
+  const { error } = await supabase.rpc("block_event_mode_user", {
+    p_event_id: eventId,
+    p_blocked_user_id: blockedUserId,
+  });
+
+  if (error) throw error;
 }

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -57,6 +57,13 @@ export const helpGuideSections: HelpGuideSection[] = [
           "Start with songs you are likely to sing soon. You can add more later, copy songs from another singer, or add Harmony Brigade songs if that helps you get started faster. If you are already in a quartet, edits to My Songs refresh your active quartet snapshot so matches can update.",
         ],
       },
+      {
+        title: "Finding singers at an event",
+        body: [
+          "Event Mode lets signed-in singers find an event, mark themselves available there, and send private event-scoped messages to coordinate where and when to sing. Event Mode messages do not show your email address or phone number, do not expose your My Songs repertoire, and are separate from starting a quartet.",
+          "Once singers are physically together, use Start a quartet and have the others join by QR code, code, or link.",
+        ],
+      },
     ],
   },
   {

--- a/supabase/migrations/20260506100000_add_event_mode_messaging.sql
+++ b/supabase/migrations/20260506100000_add_event_mode_messaging.sql
@@ -1,0 +1,432 @@
+create table if not exists public.event_mode_messages (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.event_mode_events(id) on delete cascade,
+  sender_user_id uuid not null references auth.users(id) on delete cascade,
+  recipient_user_id uuid not null references auth.users(id) on delete cascade,
+  recipient_availability_id uuid references public.event_mode_availability(id) on delete set null,
+  body text not null check (length(btrim(body)) between 1 and 1000),
+  created_at timestamptz not null default now(),
+  read_at timestamptz,
+  constraint event_mode_messages_no_self_message_chk check (sender_user_id <> recipient_user_id)
+);
+
+create index if not exists event_mode_messages_event_created_idx
+on public.event_mode_messages (event_id, created_at desc);
+
+create index if not exists event_mode_messages_sender_event_idx
+on public.event_mode_messages (sender_user_id, event_id, created_at desc);
+
+create index if not exists event_mode_messages_recipient_event_idx
+on public.event_mode_messages (recipient_user_id, event_id, created_at desc);
+
+create table if not exists public.event_mode_message_reports (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.event_mode_messages(id) on delete cascade,
+  reporter_user_id uuid not null references auth.users(id) on delete cascade,
+  event_id uuid not null references public.event_mode_events(id) on delete cascade,
+  reason text,
+  created_at timestamptz not null default now(),
+  constraint event_mode_message_reports_reason_len_chk check (
+    reason is null or length(btrim(reason)) <= 500
+  )
+);
+
+create unique index if not exists event_mode_message_reports_message_reporter_key
+on public.event_mode_message_reports (message_id, reporter_user_id);
+
+create index if not exists event_mode_message_reports_event_idx
+on public.event_mode_message_reports (event_id, created_at desc);
+
+create table if not exists public.event_mode_blocks (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references public.event_mode_events(id) on delete cascade,
+  blocker_user_id uuid not null references auth.users(id) on delete cascade,
+  blocked_user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  constraint event_mode_blocks_no_self_block_chk check (blocker_user_id <> blocked_user_id)
+);
+
+create unique index if not exists event_mode_blocks_event_blocker_blocked_key
+on public.event_mode_blocks (event_id, blocker_user_id, blocked_user_id);
+
+create index if not exists event_mode_blocks_blocked_event_idx
+on public.event_mode_blocks (blocked_user_id, event_id);
+
+alter table public.event_mode_messages enable row level security;
+alter table public.event_mode_message_reports enable row level security;
+alter table public.event_mode_blocks enable row level security;
+
+grant select on public.event_mode_messages to authenticated;
+grant select on public.event_mode_message_reports to authenticated;
+grant select on public.event_mode_blocks to authenticated;
+
+drop policy if exists "Users can read their own event mode messages"
+on public.event_mode_messages;
+drop policy if exists "Users can read their own event mode message reports"
+on public.event_mode_message_reports;
+drop policy if exists "Users can read their own event mode blocks"
+on public.event_mode_blocks;
+
+create policy "Users can read their own event mode messages"
+on public.event_mode_messages
+for select
+to authenticated
+using (
+  sender_user_id = auth.uid()
+  or recipient_user_id = auth.uid()
+);
+
+create policy "Users can read their own event mode message reports"
+on public.event_mode_message_reports
+for select
+to authenticated
+using (reporter_user_id = auth.uid());
+
+create policy "Users can read their own event mode blocks"
+on public.event_mode_blocks
+for select
+to authenticated
+using (blocker_user_id = auth.uid());
+
+create or replace function public.event_mode_user_can_message(
+  p_event_id uuid,
+  p_sender_user_id uuid,
+  p_recipient_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    p_sender_user_id is not null
+    and p_recipient_user_id is not null
+    and p_sender_user_id <> p_recipient_user_id
+    and exists (
+      select 1
+      from public.event_mode_events
+      where event_mode_events.id = p_event_id
+        and event_mode_events.closed_at is null
+        and event_mode_events.end_at > now()
+    )
+    and not exists (
+      select 1
+      from public.event_mode_blocks
+      where event_mode_blocks.event_id = p_event_id
+        and event_mode_blocks.blocker_user_id = p_recipient_user_id
+        and event_mode_blocks.blocked_user_id = p_sender_user_id
+    )
+    and (
+      exists (
+        select 1
+        from public.event_mode_availability
+        where event_mode_availability.event_id = p_event_id
+          and event_mode_availability.user_id = p_recipient_user_id
+          and event_mode_availability.turned_off_at is null
+          and event_mode_availability.available_until > now()
+      )
+      or exists (
+        select 1
+        from public.event_mode_messages
+        where event_mode_messages.event_id = p_event_id
+          and (
+            (
+              event_mode_messages.sender_user_id = p_sender_user_id
+              and event_mode_messages.recipient_user_id = p_recipient_user_id
+            )
+            or (
+              event_mode_messages.sender_user_id = p_recipient_user_id
+              and event_mode_messages.recipient_user_id = p_sender_user_id
+            )
+          )
+      )
+    );
+$$;
+
+revoke all on function public.event_mode_user_can_message(uuid, uuid, uuid) from public;
+
+create or replace function public.send_event_mode_message(
+  p_event_id uuid,
+  p_recipient_user_id uuid,
+  p_body text,
+  p_recipient_availability_id uuid default null
+)
+returns table (
+  id uuid,
+  event_id uuid,
+  sender_user_id uuid,
+  sender_display_name text,
+  recipient_user_id uuid,
+  recipient_display_name text,
+  recipient_availability_id uuid,
+  body text,
+  created_at timestamptz,
+  read_at timestamptz,
+  reported_by_me boolean,
+  blocked_by_me boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_message_id uuid;
+  v_body text := btrim(coalesce(p_body, ''));
+begin
+  if auth.role() <> 'authenticated' or v_user_id is null then
+    raise exception 'You must be logged in to send a message.';
+  end if;
+
+  if length(v_body) = 0 then
+    raise exception 'Message is required.';
+  end if;
+
+  if length(v_body) > 1000 then
+    raise exception 'Message must be 1000 characters or fewer.';
+  end if;
+
+  if not public.event_mode_user_can_message(p_event_id, v_user_id, p_recipient_user_id) then
+    raise exception 'You cannot message that singer for this event.';
+  end if;
+
+  if p_recipient_availability_id is not null and not exists (
+    select 1
+    from public.event_mode_availability
+    where event_mode_availability.id = p_recipient_availability_id
+      and event_mode_availability.event_id = p_event_id
+      and event_mode_availability.user_id = p_recipient_user_id
+  ) then
+    raise exception 'That availability record is not part of this event.';
+  end if;
+
+  insert into public.event_mode_messages (
+    event_id,
+    sender_user_id,
+    recipient_user_id,
+    recipient_availability_id,
+    body
+  )
+  values (
+    p_event_id,
+    v_user_id,
+    p_recipient_user_id,
+    p_recipient_availability_id,
+    v_body
+  )
+  returning event_mode_messages.id into v_message_id;
+
+  return query
+  select
+    event_mode_messages.id,
+    event_mode_messages.event_id,
+    event_mode_messages.sender_user_id,
+    sender_profiles.display_name as sender_display_name,
+    event_mode_messages.recipient_user_id,
+    recipient_profiles.display_name as recipient_display_name,
+    event_mode_messages.recipient_availability_id,
+    event_mode_messages.body,
+    event_mode_messages.created_at,
+    event_mode_messages.read_at,
+    false as reported_by_me,
+    false as blocked_by_me
+  from public.event_mode_messages
+  join public.profiles sender_profiles
+    on sender_profiles.id = event_mode_messages.sender_user_id
+  join public.profiles recipient_profiles
+    on recipient_profiles.id = event_mode_messages.recipient_user_id
+  where event_mode_messages.id = v_message_id;
+end;
+$$;
+
+create or replace function public.get_event_mode_messages_by_code(p_code text)
+returns table (
+  id uuid,
+  event_id uuid,
+  sender_user_id uuid,
+  sender_display_name text,
+  recipient_user_id uuid,
+  recipient_display_name text,
+  recipient_availability_id uuid,
+  body text,
+  created_at timestamptz,
+  read_at timestamptz,
+  reported_by_me boolean,
+  blocked_by_me boolean
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    event_mode_messages.id,
+    event_mode_messages.event_id,
+    event_mode_messages.sender_user_id,
+    sender_profiles.display_name as sender_display_name,
+    event_mode_messages.recipient_user_id,
+    recipient_profiles.display_name as recipient_display_name,
+    event_mode_messages.recipient_availability_id,
+    event_mode_messages.body,
+    event_mode_messages.created_at,
+    event_mode_messages.read_at,
+    exists (
+      select 1
+      from public.event_mode_message_reports
+      where event_mode_message_reports.message_id = event_mode_messages.id
+        and event_mode_message_reports.reporter_user_id = auth.uid()
+    ) as reported_by_me,
+    exists (
+      select 1
+      from public.event_mode_blocks
+      where event_mode_blocks.event_id = event_mode_messages.event_id
+        and event_mode_blocks.blocker_user_id = auth.uid()
+        and event_mode_blocks.blocked_user_id = case
+          when event_mode_messages.sender_user_id = auth.uid()
+            then event_mode_messages.recipient_user_id
+          else event_mode_messages.sender_user_id
+        end
+    ) as blocked_by_me
+  from public.event_mode_messages
+  join public.event_mode_events
+    on event_mode_events.id = event_mode_messages.event_id
+  join public.profiles sender_profiles
+    on sender_profiles.id = event_mode_messages.sender_user_id
+  join public.profiles recipient_profiles
+    on recipient_profiles.id = event_mode_messages.recipient_user_id
+  where auth.role() = 'authenticated'
+    and event_mode_events.join_code = upper(btrim(p_code))
+    and (
+      event_mode_messages.sender_user_id = auth.uid()
+      or event_mode_messages.recipient_user_id = auth.uid()
+    )
+  order by event_mode_messages.created_at asc;
+$$;
+
+create or replace function public.report_event_mode_message(
+  p_message_id uuid,
+  p_reason text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_event_id uuid;
+  v_reason text := nullif(btrim(coalesce(p_reason, '')), '');
+begin
+  if auth.role() <> 'authenticated' or v_user_id is null then
+    raise exception 'You must be logged in to report a message.';
+  end if;
+
+  if v_reason is not null and length(v_reason) > 500 then
+    raise exception 'Report note must be 500 characters or fewer.';
+  end if;
+
+  select event_mode_messages.event_id
+    into v_event_id
+  from public.event_mode_messages
+  where event_mode_messages.id = p_message_id
+    and (
+      event_mode_messages.sender_user_id = v_user_id
+      or event_mode_messages.recipient_user_id = v_user_id
+    );
+
+  if v_event_id is null then
+    raise exception 'You can only report messages you can view.';
+  end if;
+
+  insert into public.event_mode_message_reports (
+    message_id,
+    reporter_user_id,
+    event_id,
+    reason
+  )
+  values (
+    p_message_id,
+    v_user_id,
+    v_event_id,
+    v_reason
+  )
+  on conflict (message_id, reporter_user_id)
+  do update set reason = excluded.reason;
+end;
+$$;
+
+create or replace function public.block_event_mode_user(
+  p_event_id uuid,
+  p_blocked_user_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if auth.role() <> 'authenticated' or v_user_id is null then
+    raise exception 'You must be logged in to block a user.';
+  end if;
+
+  if v_user_id = p_blocked_user_id then
+    raise exception 'You cannot block yourself.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.event_mode_events
+    where event_mode_events.id = p_event_id
+  ) then
+    raise exception 'Event not found.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.event_mode_messages
+    where event_mode_messages.event_id = p_event_id
+      and (
+        (
+          event_mode_messages.sender_user_id = v_user_id
+          and event_mode_messages.recipient_user_id = p_blocked_user_id
+        )
+        or (
+          event_mode_messages.sender_user_id = p_blocked_user_id
+          and event_mode_messages.recipient_user_id = v_user_id
+        )
+      )
+  ) and not exists (
+    select 1
+    from public.event_mode_availability
+    where event_mode_availability.event_id = p_event_id
+      and event_mode_availability.user_id = p_blocked_user_id
+  ) then
+    raise exception 'You can only block Event Mode users connected to this event.';
+  end if;
+
+  insert into public.event_mode_blocks (
+    event_id,
+    blocker_user_id,
+    blocked_user_id
+  )
+  values (
+    p_event_id,
+    v_user_id,
+    p_blocked_user_id
+  )
+  on conflict (event_id, blocker_user_id, blocked_user_id) do nothing;
+end;
+$$;
+
+revoke all on function public.send_event_mode_message(uuid, uuid, text, uuid) from public;
+revoke all on function public.get_event_mode_messages_by_code(text) from public;
+revoke all on function public.report_event_mode_message(uuid, text) from public;
+revoke all on function public.block_event_mode_user(uuid, uuid) from public;
+
+grant execute on function public.send_event_mode_message(uuid, uuid, text, uuid) to authenticated;
+grant execute on function public.get_event_mode_messages_by_code(text) to authenticated;
+grant execute on function public.report_event_mode_message(uuid, text) to authenticated;
+grant execute on function public.block_event_mode_user(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- Add event-scoped in-app messaging for Event Mode: users can message available singers, view sent/received messages, and reply inside the event page.
- Add Event Mode message reports and event-scoped blocks, with blocked users prevented from sending new messages to the blocker.
- Add Supabase message/report/block tables plus RLS and security-definer RPCs for send, read, report, and block authorization.
- Update Help, Privacy, and Supabase contract docs for the new messaging behavior.

## Scope and deferrals
- Email notifications are intentionally deferred to #376 so this PR stays focused on the in-app messaging/safety/RLS surface.
- No formal invite-to-quartet flow was added; Event Mode still bridges users back to Start a quartet after they coordinate.

## Impact audit
- Navigation/home: no nav entry needed; messaging lives on the existing Event Mode event page.
- Onboarding/copy: Help now mentions Event Mode messages at a high level.
- Help/Privacy: updated for private event-scoped messages, reports, and blocks.
- Analytics: no analytics events added; message text is not sent to analytics.
- Mobile/accessibility: compose, reply, report, and block controls use labeled form controls/buttons in the existing responsive event layout.
- Supabase/RLS: added migration `20260506100000_add_event_mode_messaging.sql` and updated `docs/supabase-contract.md`.
- Tests: added/updated Event Mode helper/UI, Privacy, Help, and Supabase contract tests.
- Deployment/env/email: no new env vars in this PR; email notification work is tracked in #376.
- Admin/support/runbook: no moderation console added; private report/block rows are stored for future support tooling.

## Verification
- `npm run test:run`
- `npm run test:run -- eventMode eventModeUi supabaseContract privacyPage helpContent`
- `npm run test:run -- supabaseContract eventMode eventModeUi`
- `npm run build`
- Commit hook: `npm run test:run`

Closes #312