### PR TITLE
Add Event Mode message email notifications

### DIFF
--- a/app/api/event-mode/messages/notify/route.test.ts
+++ b/app/api/event-mode/messages/notify/route.test.ts
@@ -1,0 +1,205 @@
+import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(),
+}));
+
+const messageId = "11111111-1111-4111-8111-111111111111";
+const privateRecipientEmail = "recipient-private@example.com";
+const privateMessageBody = "Meet me by the lobby at 7 with my phone 555-1234.";
+const senderEmail = "sender-private@example.com";
+
+function notifyRequest(body: unknown) {
+  return {
+    url: "https://www.whatcanwesing.com/api/event-mode/messages/notify",
+    json: async () => body,
+    cookies: {
+      getAll: () => [],
+    },
+  } as never;
+}
+
+function tableResult(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error }),
+  };
+}
+
+async function responseBody(response: Response) {
+  return JSON.stringify(await response.json());
+}
+
+describe("Event Mode message notification API", () => {
+  const originalEnv = process.env;
+  let adminClient: {
+    from: ReturnType<typeof vi.fn>;
+    auth: { admin: { getUserById: ReturnType<typeof vi.fn> } };
+  };
+  let notificationInsertError: { code: string } | null;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SITE_URL: "https://www.whatcanwesing.com",
+      NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+      RESEND_API_KEY: "resend-key",
+      EVENT_MODE_MESSAGE_FROM_EMAIL:
+        "What Can We Sing <messages@example.com>",
+    };
+    notificationInsertError = null;
+
+    vi.mocked(createServerClient).mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "sender-user" } },
+          error: null,
+        }),
+      },
+    } as never);
+
+    adminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "event_mode_messages") {
+          return tableResult({
+            id: messageId,
+            event_id: "event-1",
+            sender_user_id: "sender-user",
+            recipient_user_id: "recipient-user",
+          });
+        }
+        if (table === "event_mode_events") {
+          return tableResult({
+            id: "event-1",
+            name: "RMD Fall Convention",
+            join_code: "ABC123",
+          });
+        }
+        if (table === "profiles") {
+          return tableResult({ display_name: "Tim Singer" });
+        }
+        if (table === "event_mode_message_notifications") {
+          return {
+            insert: vi.fn().mockReturnThis(),
+            select: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: notificationInsertError
+                ? null
+                : { id: "notification-1" },
+              error: notificationInsertError,
+            }),
+            update: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      auth: {
+        admin: {
+          getUserById: vi.fn().mockResolvedValue({
+            data: { user: { email: privateRecipientEmail } },
+            error: null,
+          }),
+        },
+      },
+    };
+    vi.mocked(createClient).mockReturnValue(adminClient as never);
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("sends a private notification link without message body or sender contact info", async () => {
+    const response = await POST(notifyRequest({ messageId, body: privateMessageBody }));
+
+    expect(response.status).toBe(200);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.resend.com/emails",
+      expect.objectContaining({
+        body: expect.stringContaining(`"to":"${privateRecipientEmail}"`),
+      })
+    );
+
+    const emailRequest = JSON.parse(
+      vi.mocked(fetch).mock.calls[0][1]?.body as string
+    );
+    expect(emailRequest.text).toContain(
+      "https://www.whatcanwesing.com/event-mode/ABC123"
+    );
+    expect(emailRequest.text).toContain("does not include the message text");
+    expect(emailRequest.text).not.toContain(privateMessageBody);
+    expect(emailRequest.text).not.toContain(senderEmail);
+    expect(emailRequest.reply_to).toBeUndefined();
+  });
+
+  it("does not send when the logged-in user is not the message sender", async () => {
+    vi.mocked(createServerClient).mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "recipient-user" } },
+          error: null,
+        }),
+      },
+    } as never);
+
+    const response = await POST(notifyRequest({ messageId }));
+
+    expect(response.status).toBe(404);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not expose recipient addresses or provider body on Resend failure", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(`Could not deliver to ${privateRecipientEmail}`, {
+        status: 422,
+        statusText: "Unprocessable Entity",
+      })
+    );
+
+    const response = await POST(notifyRequest({ messageId }));
+
+    expect(response.status).toBe(502);
+    expect(await responseBody(response)).not.toContain(privateRecipientEmail);
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      privateRecipientEmail
+    );
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      "Could not deliver"
+    );
+  });
+
+  it("treats duplicate notification requests as already handled", async () => {
+    notificationInsertError = { code: "23505" };
+
+    const response = await POST(notifyRequest({ messageId }));
+
+    expect(response.status).toBe(200);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not expose server-only configuration values when email is not configured", async () => {
+    delete process.env.EVENT_MODE_MESSAGE_FROM_EMAIL;
+
+    const response = await POST(notifyRequest({ messageId }));
+
+    expect(response.status).toBe(503);
+    expect(await responseBody(response)).not.toContain("messages@example.com");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/event-mode/messages/notify/route.ts
+++ b/app/api/event-mode/messages/notify/route.ts
@@ -1,0 +1,246 @@
+import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse, type NextRequest } from "next/server";
+import { formatEventModeMessageNotificationEmail } from "@/lib/eventModeNotificationEmail";
+
+const resendApiUrl = "https://api.resend.com/emails";
+
+type EventModeMessageRow = {
+  id: string;
+  event_id: string;
+  sender_user_id: string;
+  recipient_user_id: string;
+};
+
+type EventModeEventRow = {
+  id: string;
+  name: string;
+  join_code: string;
+};
+
+type ProfileRow = {
+  display_name: string | null;
+};
+
+type NotificationRow = {
+  id: string;
+};
+
+function jsonResponse(message: string, status: number) {
+  return NextResponse.json({ message }, { status });
+}
+
+function cleanMessageId(value: unknown) {
+  const messageId = typeof value === "string" ? value.trim() : "";
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    messageId
+  )
+    ? messageId
+    : null;
+}
+
+function appOrigin(request: NextRequest) {
+  const configuredOrigin = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (configuredOrigin) return new URL(configuredOrigin).origin;
+  return new URL(request.url).origin;
+}
+
+export async function POST(request: NextRequest) {
+  let messageId: string | null = null;
+
+  try {
+    const body = await request.json();
+    messageId = cleanMessageId(body?.messageId);
+  } catch {
+    return jsonResponse("Could not read notification request.", 400);
+  }
+
+  if (!messageId) {
+    return jsonResponse("Message id is required.", 400);
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.EVENT_MODE_MESSAGE_FROM_EMAIL;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (
+    !resendApiKey ||
+    !fromEmail ||
+    !supabaseUrl ||
+    !supabaseAnonKey ||
+    !serviceRoleKey
+  ) {
+    return jsonResponse("Event Mode message email is not configured yet.", 503);
+  }
+
+  const response = NextResponse.next();
+  const userClient = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          response.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+
+  const {
+    data: { user },
+    error: userError,
+  } = await userClient.auth.getUser();
+
+  if (userError || !user) {
+    return jsonResponse("You must be logged in to send notifications.", 401);
+  }
+
+  const adminClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data: message, error: messageError } = await adminClient
+    .from("event_mode_messages")
+    .select("id,event_id,sender_user_id,recipient_user_id")
+    .eq("id", messageId)
+    .maybeSingle<EventModeMessageRow>();
+
+  if (messageError) {
+    console.error("Event Mode notification message lookup failed", {
+      status: messageError.code,
+    });
+    return jsonResponse("Could not send message notification.", 502);
+  }
+
+  if (!message || message.sender_user_id !== user.id) {
+    return jsonResponse("Message notification is not available.", 404);
+  }
+
+  const [{ data: event, error: eventError }, { data: senderProfile }] =
+    await Promise.all([
+      adminClient
+        .from("event_mode_events")
+        .select("id,name,join_code")
+        .eq("id", message.event_id)
+        .maybeSingle<EventModeEventRow>(),
+      adminClient
+        .from("profiles")
+        .select("display_name")
+        .eq("id", message.sender_user_id)
+        .maybeSingle<ProfileRow>(),
+    ]);
+
+  if (eventError || !event) {
+    console.error("Event Mode notification event lookup failed", {
+      status: eventError?.code,
+    });
+    return jsonResponse("Could not send message notification.", 502);
+  }
+
+  const { data: recipientResult, error: recipientError } =
+    await adminClient.auth.admin.getUserById(message.recipient_user_id);
+  const recipientEmail = recipientResult.user?.email;
+
+  if (recipientError || !recipientEmail) {
+    console.error("Event Mode notification recipient lookup failed", {
+      status: recipientError?.status,
+    });
+    return jsonResponse("Could not send message notification.", 502);
+  }
+
+  const eventUrl = new URL(`/event-mode/${event.join_code}`, appOrigin(request));
+  const senderDisplayName = senderProfile?.display_name ?? "A singer";
+  const emailText = formatEventModeMessageNotificationEmail({
+    eventName: event.name,
+    senderDisplayName,
+    eventUrl: eventUrl.toString(),
+  });
+  const { data: notification, error: notificationError } = await adminClient
+    .from("event_mode_message_notifications")
+    .insert({
+      message_id: message.id,
+      event_id: message.event_id,
+      sender_user_id: message.sender_user_id,
+      recipient_user_id: message.recipient_user_id,
+      status: "pending",
+    })
+    .select("id")
+    .maybeSingle<NotificationRow>();
+
+  if (notificationError) {
+    if (notificationError.code === "23505") {
+      return jsonResponse("Message notification already handled.", 200);
+    }
+
+    console.error("Event Mode notification log insert failed", {
+      status: notificationError.code,
+    });
+    return jsonResponse("Could not send message notification.", 502);
+  }
+
+  try {
+    const resendResponse = await fetch(resendApiUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: fromEmail,
+        to: recipientEmail,
+        subject: `${senderDisplayName} sent you a What Can We Sing message`,
+        text: emailText,
+      }),
+    });
+
+    if (!resendResponse.ok) {
+      if (notification) {
+        await adminClient
+          .from("event_mode_message_notifications")
+          .update({
+            status: "failed",
+            error_status: resendResponse.status,
+          })
+          .eq("id", notification.id);
+      }
+      console.error("Event Mode notification email failed", {
+        status: resendResponse.status,
+        statusText: resendResponse.statusText,
+      });
+      return jsonResponse("Could not send message notification.", 502);
+    }
+
+    let providerMessageId: string | null = null;
+    try {
+      const result = await resendResponse.json();
+      providerMessageId = typeof result?.id === "string" ? result.id : null;
+    } catch {
+      providerMessageId = null;
+    }
+
+    if (notification) {
+      await adminClient
+        .from("event_mode_message_notifications")
+        .update({
+          status: "sent",
+          provider_message_id: providerMessageId,
+          sent_at: new Date().toISOString(),
+        })
+        .eq("id", notification.id);
+    }
+
+    return jsonResponse("Message notification sent.", 200);
+  } catch (err) {
+    if (notification) {
+      await adminClient
+        .from("event_mode_message_notifications")
+        .update({ status: "failed" })
+        .eq("id", notification.id);
+    }
+    console.error("Event Mode notification email request failed", err);
+    return jsonResponse("Could not send message notification.", 502);
+  }
+}

--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -15,6 +15,7 @@ import {
   getEventModeEventByCode,
   getEventModeMessagesByCode,
   getEventModeLifecycle,
+  notifyEventModeMessage,
   reportEventModeMessage,
   sendEventModeMessage,
   turnOffEventModeAvailability,
@@ -298,17 +299,28 @@ export default function EventModeDetailPage() {
     setMessage("");
 
     try {
-      await sendEventModeMessage({
+      const sentMessage = await sendEventModeMessage({
         eventId: event.id,
         recipientUserId: target.user_id,
         recipientAvailabilityId: target.id,
         body: messageBody,
       });
+      let notificationSent = true;
+      if (sentMessage) {
+        await notifyEventModeMessage(sentMessage.id).catch((err) => {
+          notificationSent = false;
+          console.error("Could not send Event Mode message notification", err);
+        });
+      }
       setMessageTarget(null);
       setMessageBody("");
       await reloadMessages();
       setMessageTone("success");
-      setMessage("Message sent.");
+      setMessage(
+        notificationSent
+          ? "Message sent."
+          : "Message sent. Email notification was not sent."
+      );
     } catch (err) {
       console.error("Could not send Event Mode message", err);
       setMessageTone("error");
@@ -325,15 +337,26 @@ export default function EventModeDetailPage() {
     setMessage("");
 
     try {
-      await sendEventModeMessage({
+      const sentMessage = await sendEventModeMessage({
         eventId: event.id,
         recipientUserId,
         body,
       });
+      let notificationSent = true;
+      if (sentMessage) {
+        await notifyEventModeMessage(sentMessage.id).catch((err) => {
+          notificationSent = false;
+          console.error("Could not send Event Mode reply notification", err);
+        });
+      }
       setReplyBodies((current) => ({ ...current, [recipientUserId]: "" }));
       await reloadMessages();
       setMessageTone("success");
-      setMessage("Reply sent.");
+      setMessage(
+        notificationSent
+          ? "Reply sent."
+          : "Reply sent. Email notification was not sent."
+      );
     } catch (err) {
       console.error("Could not send Event Mode reply", err);
       setMessageTone("error");

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -133,8 +133,10 @@ export default function PrivacyPage() {
               coordinate singing. Event Mode does not show your email address or
               phone number to other singers, does not expose your My Songs
               repertoire, and does not create a permanent public profile or
-              global singer directory. Message reports and blocks are private
-              safety controls.
+              global singer directory. When configured, Event Mode sends an
+              email notification for a new message that links you back to the
+              app without including the message text or sender contact details.
+              Message reports and blocks are private safety controls.
             </p>
           </div>
 

--- a/docs/supabase-contract.md
+++ b/docs/supabase-contract.md
@@ -353,7 +353,7 @@ Required database contract:
   - `song_id uuid references harmony_brigade_songs(id) on delete cascade`
   - optional `track_number` and `sort_order`
   - Unique index on `(event_id, song_id)`
-- RLS enabled on all three tables.
+- RLS enabled on all four tables.
 - Authenticated users can select reference rows.
 - No authenticated insert/update/delete policies are granted for reference
   tables.
@@ -546,8 +546,16 @@ Expected context:
 - Message bodies are stored for app-mediated coordination only. They must not
   expose private email addresses or phone numbers by default, must not expose
   repertoire, and must not be sent to analytics.
-- Email notification is intentionally deferred until a separate, explicit
-  notification contract is added.
+- Event Mode message notification email is sent by
+  `app/api/event-mode/messages/notify/route.ts` after a message row is created.
+  The browser sends only the message id. The server re-checks that the
+  authenticated user is the sender, uses the service-role key only on the
+  server to read the recipient auth email, and sends a Resend email that links
+  back to `/event-mode/{code}`.
+- Notification email must not include the message body, sender email address,
+  sender phone number, repertoire, or other contact details. Provider payloads
+  intentionally include recipient email address, sender display name, event
+  name, and the event link only.
 
 Required database contract:
 - `event_mode_messages`
@@ -572,13 +580,27 @@ Required database contract:
   - `blocker_user_id uuid references auth.users(id) on delete cascade`
   - `blocked_user_id uuid references auth.users(id) on delete cascade`
   - `created_at timestamptz not null default now()`
+- `event_mode_message_notifications`
+  - `id uuid primary key`
+  - `message_id uuid references public.event_mode_messages(id) on delete cascade`
+  - `event_id uuid references public.event_mode_events(id) on delete cascade`
+  - `sender_user_id uuid references auth.users(id) on delete cascade`
+  - `recipient_user_id uuid references auth.users(id) on delete cascade`
+  - `status text not null default 'pending'`
+  - optional `provider_message_id text`
+  - optional `error_status integer`
+  - `created_at timestamptz not null default now()`
+  - optional `sent_at timestamptz`
 - Check constraints prevent self-messages and self-blocks.
 - Check constraint keeps message bodies between 1 and 1000 trimmed characters.
 - Unique report index on `(message_id, reporter_user_id)`.
 - Unique block index on `(event_id, blocker_user_id, blocked_user_id)`.
+- Unique notification index on `(message_id)` prevents repeated notification
+  sends for the same Event Mode message.
 - RLS enabled on all three tables.
 - Authenticated users can select only messages they sent or received.
 - Authenticated users can select only their own reports and blocks.
+- Notification rows are server-only; no direct `anon` or `authenticated` grants.
 - Browser writes use security-definer functions with explicit server-side
   authorization checks rather than direct insert/update policies.
 - `public.event_mode_user_can_message(uuid, uuid, uuid)` checks active event
@@ -595,6 +617,17 @@ Required database contract:
 
 Established by migrations:
 - `20260506100000_add_event_mode_messaging.sql`
+- `20260506113000_add_event_mode_message_notifications.sql`
+
+Notification environment:
+- `EVENT_MODE_MESSAGE_FROM_EMAIL`: server-only verified Resend sender address
+  for Event Mode message notifications.
+- `RESEND_API_KEY`: server-only Resend API key shared with other app email
+  delivery.
+- `SUPABASE_SERVICE_ROLE_KEY`: server-only Supabase key used by the
+  notification route to look up the recipient auth email after sender
+  authorization is checked.
+- `NEXT_PUBLIC_SITE_URL`: public app origin used to build the event link.
 
 ### `sessions`
 

--- a/lib/__tests__/eventMode.test.ts
+++ b/lib/__tests__/eventMode.test.ts
@@ -244,6 +244,8 @@ describe("Event Mode helpers", () => {
 
     expect(storeSource).toContain("get_event_mode_messages_by_code");
     expect(storeSource).toContain("send_event_mode_message");
+    expect(storeSource).toContain("notifyEventModeMessage");
+    expect(storeSource).toContain("/api/event-mode/messages/notify");
     expect(storeSource).toContain("report_event_mode_message");
     expect(storeSource).toContain("block_event_mode_user");
     expect(storeSource).not.toContain("Invite to quartet");

--- a/lib/__tests__/eventModeNotificationEmail.test.ts
+++ b/lib/__tests__/eventModeNotificationEmail.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatEventModeMessageNotificationEmail } from "@/lib/eventModeNotificationEmail";
+
+describe("Event Mode notification email", () => {
+  it("points recipients back to the app without including message content or contact info", () => {
+    const text = formatEventModeMessageNotificationEmail({
+      eventName: "RMD Fall Convention",
+      senderDisplayName: "Tim Singer",
+      eventUrl: "https://www.whatcanwesing.com/event-mode/ABC123",
+    });
+
+    expect(text).toContain("Tim Singer sent you a message");
+    expect(text).toContain("RMD Fall Convention");
+    expect(text).toContain("https://www.whatcanwesing.com/event-mode/ABC123");
+    expect(text).toContain("does not include the message text");
+    expect(text).toContain("sender email address");
+    expect(text).toContain("sender phone number");
+    expect(text).not.toContain("Meet me in the lobby");
+    expect(text).not.toContain("@example.com");
+  });
+});

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -27,6 +27,7 @@ describe("Event Mode UI copy", () => {
     expect(detailPage).toContain("Available singers");
     expect(detailPage).toContain("Message");
     expect(detailPage).toContain("Send a note to coordinate singing at this");
+    expect(detailPage).toContain("Email notification was not sent.");
     expect(detailPage).toContain("Messages");
     expect(detailPage).toContain("Reply");
     expect(detailPage).toContain("Report");

--- a/lib/__tests__/helpContent.test.ts
+++ b/lib/__tests__/helpContent.test.ts
@@ -74,6 +74,7 @@ describe("help content", () => {
     expect(guideText).toContain("Harmony Brigade songs");
     expect(guideText).toContain("Event Mode lets signed-in singers");
     expect(guideText).toContain("private event-scoped messages");
+    expect(guideText).toContain("Email notifications");
     expect(guideText).toContain("do not expose your My Songs repertoire");
     expect(guideText).toContain("Song Title Autocomplete");
     expect(guideText).toContain("Suggestions are optional");

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -26,6 +26,8 @@ describe("privacy page copy", () => {
     expect(privacyPage).toContain("Harmony Brigade songs");
     expect(privacyPage).toContain("Event Mode");
     expect(privacyPage).toContain("event-scoped messages");
+    expect(privacyPage).toContain("email notification");
+    expect(privacyPage).toContain("without including the message text");
     expect(privacyPage).toContain("message reports");
     expect(privacyPage).toContain("blocks");
     expect(privacyPage).toContain("other singers in that quartet may see");

--- a/lib/__tests__/supabaseContract.test.ts
+++ b/lib/__tests__/supabaseContract.test.ts
@@ -128,6 +128,13 @@ const eventModeMessagingMigration = readFileSync(
   ),
   "utf8"
 );
+const eventModeMessageNotificationsMigration = readFileSync(
+  join(
+    repoRoot,
+    "supabase/migrations/20260506113000_add_event_mode_message_notifications.sql"
+  ),
+  "utf8"
+);
 
 describe("Supabase contract guardrails", () => {
   const tables = [
@@ -145,6 +152,7 @@ describe("Supabase contract guardrails", () => {
     "event_mode_messages",
     "event_mode_message_reports",
     "event_mode_blocks",
+    "event_mode_message_notifications",
   ];
   const baseMigrationTables = tables.filter(
     (table) =>
@@ -158,6 +166,7 @@ describe("Supabase contract guardrails", () => {
         "event_mode_messages",
         "event_mode_message_reports",
         "event_mode_blocks",
+        "event_mode_message_notifications",
       ].includes(table)
   );
 
@@ -464,10 +473,16 @@ describe("Supabase contract guardrails", () => {
     expect(contract).toContain("event_mode_messages");
     expect(contract).toContain("event_mode_message_reports");
     expect(contract).toContain("event_mode_blocks");
+    expect(contract).toContain("event_mode_message_notifications");
     expect(contract).toContain("send_event_mode_message");
     expect(contract).toContain("get_event_mode_messages_by_code");
     expect(contract).toContain("report_event_mode_message");
     expect(contract).toContain("block_event_mode_user");
+    expect(contract).toContain("app/api/event-mode/messages/notify/route.ts");
+    expect(contract).toContain("EVENT_MODE_MESSAGE_FROM_EMAIL");
+    expect(contract).toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(contract).toContain("must not include the message body");
+    expect(contract).toContain("prevents repeated notification");
     expect(contract).toContain("messages they sent or received");
     expect(contract).toContain("Blocked users cannot send new messages");
     expect(eventModeMessagingMigration).toContain(
@@ -500,5 +515,18 @@ describe("Supabase contract guardrails", () => {
     expect(eventModeMessagingMigration).toContain("to authenticated");
     expect(eventModeMessagingMigration).not.toContain("to anon");
     expect(eventModeMessagingMigration).not.toContain("user_repertoire");
+    expect(eventModeMessageNotificationsMigration).toContain(
+      "create table if not exists public.event_mode_message_notifications"
+    );
+    expect(eventModeMessageNotificationsMigration).toContain(
+      "event_mode_message_notifications_message_key"
+    );
+    expect(eventModeMessageNotificationsMigration).toContain(
+      "enable row level security"
+    );
+    expect(eventModeMessageNotificationsMigration).toContain(
+      "revoke all on table public.event_mode_message_notifications from authenticated"
+    );
+    expect(eventModeMessageNotificationsMigration).not.toContain("grant ");
   });
 });

--- a/lib/eventMode.ts
+++ b/lib/eventMode.ts
@@ -607,6 +607,18 @@ export async function sendEventModeMessage(input: EventModeMessageInput) {
   return ((data ?? []) as EventModeMessage[])[0] ?? null;
 }
 
+export async function notifyEventModeMessage(messageId: string) {
+  const response = await fetch("/api/event-mode/messages/notify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ messageId }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Could not send message notification.");
+  }
+}
+
 export async function reportEventModeMessage(messageId: string, reason?: string) {
   const { error } = await supabase.rpc("report_event_mode_message", {
     p_message_id: messageId,

--- a/lib/eventModeNotificationEmail.ts
+++ b/lib/eventModeNotificationEmail.ts
@@ -1,0 +1,21 @@
+export type EventModeMessageNotificationEmailInput = {
+  eventName: string;
+  senderDisplayName: string;
+  eventUrl: string;
+};
+
+export function formatEventModeMessageNotificationEmail(
+  input: EventModeMessageNotificationEmailInput
+) {
+  const senderName = input.senderDisplayName.trim() || "A singer";
+  const eventName = input.eventName.trim() || "your Event Mode event";
+
+  return [
+    `${senderName} sent you a message for ${eventName}.`,
+    "",
+    "Open Event Mode to read and reply:",
+    input.eventUrl,
+    "",
+    "To protect privacy, this email does not include the message text, sender email address, or sender phone number.",
+  ].join("\n");
+}

--- a/lib/helpContent.ts
+++ b/lib/helpContent.ts
@@ -60,7 +60,7 @@ export const helpGuideSections: HelpGuideSection[] = [
       {
         title: "Finding singers at an event",
         body: [
-          "Event Mode lets signed-in singers find an event, mark themselves available there, and send private event-scoped messages to coordinate where and when to sing. Event Mode messages do not show your email address or phone number, do not expose your My Songs repertoire, and are separate from starting a quartet.",
+          "Event Mode lets signed-in singers find an event, mark themselves available there, and send private event-scoped messages to coordinate where and when to sing. Event Mode messages do not show your email address or phone number, do not expose your My Songs repertoire, and are separate from starting a quartet. Email notifications, when configured, link back to the event without including the message text or sender contact details.",
           "Once singers are physically together, use Start a quartet and have the others join by QR code, code, or link.",
         ],
       },

--- a/supabase/migrations/20260506113000_add_event_mode_message_notifications.sql
+++ b/supabase/migrations/20260506113000_add_event_mode_message_notifications.sql
@@ -1,0 +1,26 @@
+create table if not exists public.event_mode_message_notifications (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.event_mode_messages(id) on delete cascade,
+  event_id uuid not null references public.event_mode_events(id) on delete cascade,
+  sender_user_id uuid not null references auth.users(id) on delete cascade,
+  recipient_user_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending',
+  provider_message_id text,
+  error_status integer,
+  created_at timestamptz not null default now(),
+  sent_at timestamptz,
+  constraint event_mode_message_notifications_status_chk check (
+    status in ('pending', 'sent', 'failed')
+  )
+);
+
+create unique index if not exists event_mode_message_notifications_message_key
+on public.event_mode_message_notifications (message_id);
+
+create index if not exists event_mode_message_notifications_event_created_idx
+on public.event_mode_message_notifications (event_id, created_at desc);
+
+alter table public.event_mode_message_notifications enable row level security;
+
+revoke all on table public.event_mode_message_notifications from anon;
+revoke all on table public.event_mode_message_notifications from authenticated;


### PR DESCRIPTION
## Summary
- Add a server-only Event Mode message notification API that sends Resend emails after a message is created.
- Keep notification payloads privacy-preserving: no message body, sender email, sender phone, repertoire, or reply-to address; recipients get an event link back to the app.
- Add a server-only notification log table with a unique message id to prevent repeated notification sends.
- Update Help, Privacy, and Supabase contract docs for notification behavior and required env vars.

## Impact audit
- Navigation/home: no navigation changes; notifications attach to the existing Event Mode message send/reply flow.
- Onboarding/copy: Help now mentions that notification emails link back to the event without message text.
- Help/Privacy: updated for Event Mode email notification behavior and provider privacy.
- Analytics: no analytics events added; message bodies are not sent to analytics or Resend notification payloads.
- Mobile/accessibility: no layout changes beyond existing status copy after send/reply.
- Supabase/RLS: added migration 20260506113000_add_event_mode_message_notifications.sql and updated docs/supabase-contract.md.
- Tests: added route, formatter, docs/privacy/help, Event Mode, and Supabase contract coverage.
- Deployment/env: requires server-only EVENT_MODE_MESSAGE_FROM_EMAIL, RESEND_API_KEY, SUPABASE_SERVICE_ROLE_KEY, and NEXT_PUBLIC_SITE_URL for production notification delivery.
- Admin/support/runbook: notification delivery metadata is stored server-side; no moderation UI added.

## Verification
- npm run test:run -- app/api/event-mode/messages/notify/route.test.ts supabaseContract eventMode eventModeUi eventModeNotificationEmail privacyPage helpContent
- npm run test:run
- npm run build
- Commit hook: npm run test:run

Closes #376