### PR TITLE
Integrate Event Mode into navigation and home

### DIFF
--- a/app/event-mode/page.tsx
+++ b/app/event-mode/page.tsx
@@ -76,8 +76,12 @@ export default function EventModePage() {
       try {
         const user = await getCurrentUser();
         setSignedIn(Boolean(user));
+        if (user) {
+          const searchParams = new URLSearchParams(window.location.search);
+          setShowCreateForm(searchParams.get("create") === "1");
+          await loadEvents("");
+        }
         setAuthChecked(true);
-        if (user) await loadEvents("");
       } catch (err) {
         console.error("Could not check Event Mode access", err);
         setAuthChecked(true);
@@ -144,8 +148,11 @@ export default function EventModePage() {
     return (
       <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
         <div className="mx-auto max-w-4xl">
-          <AppNav />
-          <p className="mt-8 text-slate-300">Loading Event Mode...</p>
+          <AppNav variant="public" />
+          <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
+            Event Mode
+          </p>
+          <p className="mt-3 text-slate-300">Loading Event Mode...</p>
         </div>
       </main>
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
 
   return (
     <main className="min-h-screen bg-slate-950 px-5 py-8 text-white">
-      <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-md flex-col justify-center">
+      <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-3xl flex-col justify-center">
         <AppNav />
 
         <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
@@ -194,6 +194,34 @@ export default function Home() {
                 </a>
               ))}
             </div>
+
+            <section className="mt-4 rounded-xl border border-cyan-300/25 bg-cyan-300/10 px-5 py-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-white">
+                    Event Mode
+                  </h2>
+                  <p className="mt-1 text-sm leading-6 text-cyan-50/80">
+                    At a convention, afterglow, or singing event? Find other
+                    singers who want to sing.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 sm:min-w-40">
+                  <a
+                    href="/event-mode"
+                    className="rounded-xl bg-cyan-300 px-4 py-2 text-center text-sm font-semibold text-slate-950 hover:bg-cyan-200"
+                  >
+                    Find my event
+                  </a>
+                  <a
+                    href="/event-mode?create=1"
+                    className="rounded-xl bg-slate-800 px-4 py-2 text-center text-sm font-semibold text-slate-100 hover:bg-slate-700"
+                  >
+                    Create an event
+                  </a>
+                </div>
+              </div>
+            </section>
 
           </>
         )}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -6,6 +6,12 @@ import { SignOutButton } from "@/components/SignOutButton";
 
 const primaryNavItems = [
   {
+    href: "/songs",
+    label: "My Songs",
+    isActive: (pathname: string) =>
+      pathname === "/songs" || pathname === "/repertoire",
+  },
+  {
     href: "/session",
     label: "Start",
     isActive: (pathname: string) => pathname === "/session",
@@ -16,14 +22,18 @@ const primaryNavItems = [
     isActive: (pathname: string) => pathname.startsWith("/join"),
   },
   {
-    href: "/songs",
-    label: "My Songs",
-    isActive: (pathname: string) =>
-      pathname === "/songs" || pathname === "/repertoire",
+    href: "/event-mode",
+    label: "Event Mode",
+    isActive: (pathname: string) => pathname.startsWith("/event-mode"),
   },
 ];
 
 const secondaryNavItems = [
+  {
+    href: "/",
+    label: "Home",
+    isActive: (pathname: string) => pathname === "/",
+  },
   {
     href: "/settings",
     label: "Profile",
@@ -75,7 +85,7 @@ export function AppNav({ variant = "app" }: AppNavProps) {
           What Can We Sing
         </a>
 
-        <div className="grid grid-cols-3 gap-2 sm:flex sm:items-center">
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
           {primaryNavItems.map((item) => {
             const active = item.isActive(pathname);
 

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -10,6 +10,8 @@ const detailPage = readFileSync(
   join(process.cwd(), "app/event-mode/[code]/page.tsx"),
   "utf8"
 );
+const appNav = readFileSync(join(process.cwd(), "components/AppNav.tsx"), "utf8");
+const homePage = readFileSync(join(process.cwd(), "app/page.tsx"), "utf8");
 const eventModeSource = readFileSync(
   join(process.cwd(), "lib/eventMode.ts"),
   "utf8"
@@ -18,8 +20,13 @@ const eventModeSource = readFileSync(
 describe("Event Mode UI copy", () => {
   it("uses Event Mode terminology and the requested core actions", () => {
     expect(landingPage).toContain("Event Mode");
+    expect(appNav).toContain('href: "/event-mode"');
+    expect(appNav).toContain('label: "Event Mode"');
+    expect(homePage).toContain("At a convention, afterglow, or singing event?");
     expect(landingPage).toContain("Find my event");
     expect(landingPage).toContain("Create an event");
+    expect(landingPage).toContain('searchParams.get("create") === "1"');
+    expect(landingPage).toContain('<AppNav variant="public" />');
     expect(landingPage).toContain("Enter with a link or code");
     expect(landingPage).toContain("Use this event");
     expect(detailPage).toContain("Start a quartet");
@@ -52,5 +59,25 @@ describe("Event Mode UI copy", () => {
     expect(combined).not.toContain("Location discovery");
     expect(combined).not.toContain("Public profile");
     expect(combined).not.toContain("Invite to quartet");
+  });
+
+  it("keeps signed-out Event Mode access explanatory instead of browsable", () => {
+    const signedOutBranch = landingPage.slice(
+      landingPage.indexOf("if (!signedIn)"),
+      landingPage.indexOf("\n\n  return (", landingPage.indexOf("if (!signedIn)"))
+    );
+    const detailSignedOutBranch = detailPage.slice(
+      detailPage.indexOf("{!currentUserId && ("),
+      detailPage.indexOf("\n            {currentUserId && (")
+    );
+
+    expect(signedOutBranch).toContain("Sign in to find or create an event");
+    expect(signedOutBranch).toContain('href="/login?redirect=/event-mode"');
+    expect(signedOutBranch).not.toContain("visibleEvents.map");
+    expect(detailSignedOutBranch).toContain("Sign in to use this event");
+    expect(detailSignedOutBranch).toContain(
+      'href={`/login?redirect=/event-mode/${event.join_code}`}'
+    );
+    expect(detailSignedOutBranch).not.toContain("Available singers");
   });
 });

--- a/lib/__tests__/homePageLinks.test.ts
+++ b/lib/__tests__/homePageLinks.test.ts
@@ -14,9 +14,25 @@ describe("home page links", () => {
   });
 
   it("keeps normal navigation and footer help links available", () => {
+    expect(appNav).toContain('href: "/"');
+    expect(appNav).toContain('label: "Home"');
     expect(appNav).toContain('href: "/settings"');
     expect(appNav).toContain('href: "/help"');
     expect(siteFooter).toContain('href: "/help"');
     expect(siteFooter).toContain("Help & Feedback");
+  });
+
+  it("adds Event Mode as a secondary home action without displacing quartet flows", () => {
+    expect(homePage).toContain("Start a quartet");
+    expect(homePage).toContain("Join a quartet");
+    expect(homePage).toContain("My Songs");
+    expect(homePage).toContain("Event Mode");
+    expect(homePage).toContain(
+      "At a convention, afterglow, or singing event? Find other"
+    );
+    expect(homePage).toContain('href="/event-mode"');
+    expect(homePage).toContain('href="/event-mode?create=1"');
+    expect(homePage).toContain("Find my event");
+    expect(homePage).toContain("Create an event");
   });
 });

--- a/lib/__tests__/publicNavigation.test.ts
+++ b/lib/__tests__/publicNavigation.test.ts
@@ -24,6 +24,7 @@ describe("public page navigation", () => {
     expect(appNav).toContain('variant?: "app" | "public"');
     expect(publicVariant).toContain('href="/login"');
     expect(publicVariant).toContain("Log in or sign up");
+    expect(publicVariant).not.toContain("/event-mode");
     expect(publicVariant).not.toContain("ActiveQuartetIndicator");
   });
 


### PR DESCRIPTION
## Summary
- Add Event Mode to signed-in navigation while keeping My Songs, Start, Join, Profile, and Help available.
- Add a secondary Event Mode card on the home page with Find my event and Create an event actions that link into the existing Event Mode route.
- Keep signed-out Event Mode access explanatory by using public navigation while auth is loading and preserving the sign-in prompt before event browsing.

## Impact audit
- Navigation/home: updated signed-in AppNav and home/dashboard entry points; public nav still shows only the login action.
- Onboarding/copy: no broad copy polish; this PR only uses the issue-approved Event Mode labels and avoids location-discovery/public-profile language.
- Help/Privacy: no changes; prior Event Mode docs already describe behavior and #316 owns final copy polish.
- Analytics: no analytics events added; #315 owns instrumentation.
- Mobile/accessibility: nav primary links use a two-column mobile grid and accessible anchors/buttons with clear labels.
- Supabase/RLS/data: no schema or RLS changes.
- Tests: updated nav/home/Event Mode UI guardrail tests for links and signed-out behavior.
- Deployment/env/admin: no new env vars or admin/support steps.

## Verification
- npm run test:run -- eventModeUi homePageLinks publicNavigation songsRoute
- npm run test:run
- npm run build
- Commit hook: npm run test:run

Closes #313