### PR TITLE
Polish Event Mode beta copy

### DIFF
--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -430,7 +430,7 @@ export default function EventModeDetailPage() {
         {event && (
           <>
             <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
-              Event Mode
+              Event Mode Beta
             </p>
             <div className="mt-3 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
               <div>
@@ -444,6 +444,11 @@ export default function EventModeDetailPage() {
                 </p>
                 <p className="mt-2 text-sm font-semibold uppercase text-cyan-200">
                   {lifecycle} · {event.visibility}
+                </p>
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-400">
+                  Event Mode is still in beta, so it may be buggy or incomplete.
+                  It is ready to try at events, and your feedback will help
+                  improve it.
                 </p>
               </div>
               <div className="rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-slate-200">
@@ -471,6 +476,9 @@ export default function EventModeDetailPage() {
                   Event Mode helps singers find pickup singing opportunities at
                   an event. Sign in to use this event.
                 </p>
+                <p className="mt-2 text-sm leading-6 text-cyan-50/70">
+                  Beta means this feature may be buggy or incomplete.
+                </p>
                 <a
                   href={`/login?redirect=/event-mode/${event.join_code}`}
                   className="mt-4 inline-block rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200"
@@ -490,6 +498,12 @@ export default function EventModeDetailPage() {
                     This is only shown for this event. Your availability expires
                     automatically.
                   </p>
+                  {!currentAvailability && (
+                    <p className="mt-2 text-sm leading-6 text-cyan-50/80">
+                      Want to sing at this event? Make yourself available and
+                      add a short note about when and where to find you.
+                    </p>
+                  )}
 
                   {availabilityForm && (
                     <div className="mt-5 space-y-5">
@@ -530,7 +544,7 @@ export default function EventModeDetailPage() {
 
                       <label className="block">
                         <span className="text-sm font-semibold text-slate-100">
-                          When are you available?
+                          When are you available at this event?
                         </span>
                         <input
                           value={availabilityForm.availabilityNote}
@@ -547,7 +561,7 @@ export default function EventModeDetailPage() {
 
                       <label className="block">
                         <span className="text-sm font-semibold text-slate-100">
-                          Where should people find you?
+                          Where should people find you at this event?
                         </span>
                         <input
                           value={availabilityForm.meetupNote}
@@ -642,7 +656,9 @@ export default function EventModeDetailPage() {
                   <div className="mt-5 space-y-3">
                     {visibleAvailability.length === 0 && (
                       <p className="rounded-xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
-                        No active available singers match this filter yet.
+                        {selectedPart === "all"
+                          ? "No one is available yet. Make yourself available so other singers know you want to sing."
+                          : "No active available singers match this filter yet."}
                       </p>
                     )}
 

--- a/app/event-mode/page.tsx
+++ b/app/event-mode/page.tsx
@@ -150,7 +150,7 @@ export default function EventModePage() {
         <div className="mx-auto max-w-4xl">
           <AppNav variant="public" />
           <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
-            Event Mode
+            Event Mode Beta
           </p>
           <p className="mt-3 text-slate-300">Loading Event Mode...</p>
         </div>
@@ -164,7 +164,7 @@ export default function EventModePage() {
         <div className="mx-auto max-w-2xl">
           <AppNav variant="public" />
           <p className="mt-10 text-sm font-semibold uppercase text-cyan-300">
-            Event Mode
+            Event Mode Beta
           </p>
           <h1 className="mt-3 text-4xl font-bold tracking-tight">
             Find singers at an event
@@ -172,6 +172,9 @@ export default function EventModePage() {
           <p className="mt-4 text-lg leading-8 text-slate-300">
             Event Mode helps singers find pickup singing opportunities at an
             event. Sign in to find or create an event.
+          </p>
+          <p className="mt-3 text-sm leading-6 text-slate-400">
+            Beta means this feature may be buggy or incomplete.
           </p>
           <a
             href="/login?redirect=/event-mode"
@@ -190,7 +193,7 @@ export default function EventModePage() {
         <AppNav />
 
         <p className="mt-8 text-sm font-semibold uppercase text-cyan-300">
-          Event Mode
+          Event Mode Beta
         </p>
         <h1 className="mt-3 text-4xl font-bold tracking-tight">
           Find singers at an event
@@ -198,6 +201,10 @@ export default function EventModePage() {
         <p className="mt-4 max-w-3xl text-lg leading-8 text-slate-300">
           Find singers at a convention, afterglow, Brigade weekend, or other
           singing event.
+        </p>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400">
+          Event Mode is still in beta, so it may be buggy or incomplete. It is
+          ready to try at events, and your feedback will help improve it.
         </p>
 
         {message && (
@@ -240,7 +247,8 @@ export default function EventModePage() {
             <div className="mt-5 space-y-3">
               {visibleEvents.length === 0 && (
                 <p className="rounded-xl bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
-                  No active or upcoming listed events found yet.
+                  No matching events found. Create one for your event, or check
+                  the spelling, date, or location.
                 </p>
               )}
 
@@ -306,8 +314,8 @@ export default function EventModePage() {
               <h2 className="text-xl font-bold">Create an event</h2>
               <p className="mt-2 text-sm leading-6 text-cyan-50/80">
                 Create an event so singers using WCWS can find each other while
-                they&apos;re there. This does not create an official event
-                listing.
+                they&apos;re there. Event Mode Beta is event-scoped and
+                temporary; it does not create an official event listing.
               </p>
               <button
                 type="button"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -199,11 +199,12 @@ export default function Home() {
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <h2 className="text-lg font-semibold text-white">
-                    Event Mode
+                    Event Mode Beta
                   </h2>
                   <p className="mt-1 text-sm leading-6 text-cyan-50/80">
                     At a convention, afterglow, or singing event? Find other
-                    singers who want to sing.
+                    singers who want to sing. This feature may be buggy or
+                    incomplete while it is in beta.
                   </p>
                 </div>
                 <div className="flex flex-col gap-2 sm:min-w-40">

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -112,6 +112,12 @@ export default function WelcomePage() {
             You can always add more songs later.
           </p>
 
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            At a convention or event? Event Mode Beta can help you find other
+            singers who want to sing. Beta means this feature may be buggy or
+            incomplete.
+          </p>
+
           <button
             type="button"
             onClick={getStarted}

--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -23,7 +23,7 @@ const primaryNavItems = [
   },
   {
     href: "/event-mode",
-    label: "Event Mode",
+    label: "Event Mode Beta",
     isActive: (pathname: string) => pathname.startsWith("/event-mode"),
   },
 ];

--- a/lib/__tests__/eventModeUi.test.ts
+++ b/lib/__tests__/eventModeUi.test.ts
@@ -19,19 +19,25 @@ const eventModeSource = readFileSync(
 
 describe("Event Mode UI copy", () => {
   it("uses Event Mode terminology and the requested core actions", () => {
-    expect(landingPage).toContain("Event Mode");
+    expect(landingPage).toContain("Event Mode Beta");
     expect(appNav).toContain('href: "/event-mode"');
-    expect(appNav).toContain('label: "Event Mode"');
+    expect(appNav).toContain('label: "Event Mode Beta"');
     expect(homePage).toContain("At a convention, afterglow, or singing event?");
+    expect(homePage).toContain("This feature may be buggy or");
     expect(landingPage).toContain("Find my event");
     expect(landingPage).toContain("Create an event");
+    expect(landingPage).toContain("Event Mode is still in beta");
+    expect(landingPage).toContain("No matching events found");
     expect(landingPage).toContain('searchParams.get("create") === "1"');
     expect(landingPage).toContain('<AppNav variant="public" />');
     expect(landingPage).toContain("Enter with a link or code");
     expect(landingPage).toContain("Use this event");
     expect(detailPage).toContain("Start a quartet");
     expect(detailPage).toContain("I&apos;m available to sing");
+    expect(detailPage).toContain("Want to sing at this event?");
+    expect(detailPage).toContain("You are available to sing at this event.");
     expect(detailPage).toContain("Available singers");
+    expect(detailPage).toContain("No one is available yet.");
     expect(detailPage).toContain("Message");
     expect(detailPage).toContain("Send a note to coordinate singing at this");
     expect(detailPage).toContain("Email notification was not sent.");
@@ -72,9 +78,11 @@ describe("Event Mode UI copy", () => {
     );
 
     expect(signedOutBranch).toContain("Sign in to find or create an event");
+    expect(signedOutBranch).toContain("Beta means this feature may be buggy");
     expect(signedOutBranch).toContain('href="/login?redirect=/event-mode"');
     expect(signedOutBranch).not.toContain("visibleEvents.map");
     expect(detailSignedOutBranch).toContain("Sign in to use this event");
+    expect(detailSignedOutBranch).toContain("Beta means this feature may be buggy");
     expect(detailSignedOutBranch).toContain(
       'href={`/login?redirect=/event-mode/${event.join_code}`}'
     );

--- a/lib/__tests__/homePageLinks.test.ts
+++ b/lib/__tests__/homePageLinks.test.ts
@@ -26,10 +26,11 @@ describe("home page links", () => {
     expect(homePage).toContain("Start a quartet");
     expect(homePage).toContain("Join a quartet");
     expect(homePage).toContain("My Songs");
-    expect(homePage).toContain("Event Mode");
+    expect(homePage).toContain("Event Mode Beta");
     expect(homePage).toContain(
       "At a convention, afterglow, or singing event? Find other"
     );
+    expect(homePage).toContain("incomplete while it is in beta");
     expect(homePage).toContain('href="/event-mode"');
     expect(homePage).toContain('href="/event-mode?create=1"');
     expect(homePage).toContain("Find my event");

--- a/lib/__tests__/welcomePage.test.ts
+++ b/lib/__tests__/welcomePage.test.ts
@@ -16,6 +16,8 @@ describe("first-login welcome page", () => {
     expect(welcomePage).toContain("Start a quartet or join one");
     expect(welcomePage).toContain("Use the match list");
     expect(welcomePage).toContain("You can always add more songs later");
+    expect(welcomePage).toContain("Event Mode Beta can help you find other");
+    expect(welcomePage).toContain("Beta means this feature may be buggy or");
   });
 
   it("marks the welcome as seen and routes to the right setup step", () => {


### PR DESCRIPTION
## Summary
- Label Event Mode as beta in signed-in nav, first-login orientation, home/dashboard, and Event Mode screens.
- Add concise beta helper copy that says the feature may be buggy or incomplete without making it sound unusable.
- Improve Event Mode empty states and availability copy so users understand it is event-scoped, temporary, and opt-in.
- Keep messaging and Start quartet bridge copy focused on coordination, not formal invitations.

## Impact audit
- Navigation/home: updated Event Mode nav/home labels and home copy from #313 to include beta status.
- Onboarding/copy: added a brief first-login mention without expanding onboarding into a feature tour.
- Help/Privacy: intentionally unchanged; #316 owns reference docs.
- Analytics: no analytics added; #315 owns instrumentation.
- Mobile/accessibility: beta labels are visible text, not color-only; copy stays short in primary flows.
- Supabase/RLS/data: no schema, RLS, or data behavior changes.
- Tests: updated welcome, home, and Event Mode UI copy guardrails.
- Deployment/env/admin: no new env vars or support steps.

## Verification
- npm run test:run -- welcomePage eventModeUi homePageLinks publicNavigation songsRoute
- npm run test:run
- npm run build
- Commit hook: npm run test:run

Closes #314