### PR TITLE
Add Event Mode analytics and dashboards

### DIFF
--- a/analytics/posthog/dashboards.json
+++ b/analytics/posthog/dashboards.json
@@ -252,6 +252,87 @@
       ]
     },
     {
+      "key": "event-mode",
+      "name": "What Can We Sing - Event Mode Beta",
+      "description": "Event Mode discovery, availability, messaging, and handoff to Start a quartet.",
+      "insights": [
+        {
+          "key": "event-mode-entry-activity",
+          "name": "Event Mode entry activity",
+          "description": "Views, searches, event opens, and event creation.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "event_mode_viewed" },
+            { "event": "event_mode_event_search_submitted" },
+            { "event": "event_mode_event_used" },
+            { "event": "event_mode_event_created" }
+          ]
+        },
+        {
+          "key": "event-mode-search-results",
+          "name": "Average Event Mode search results",
+          "description": "Average listed event result count for submitted searches.",
+          "type": "trend",
+          "display": "ActionsLineGraph",
+          "dateFrom": "-30d",
+          "series": [
+            {
+              "event": "event_mode_event_search_submitted",
+              "math": "avg",
+              "mathProperty": "result_count"
+            }
+          ]
+        },
+        {
+          "key": "event-mode-create-by-visibility",
+          "name": "Event Mode created by visibility",
+          "description": "Listed vs unlisted events created.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "breakdown": "visibility",
+          "series": [{ "event": "event_mode_event_created" }]
+        },
+        {
+          "key": "event-mode-availability",
+          "name": "Event Mode availability activity",
+          "description": "Availability created, updated, and turned off.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "event_mode_availability_created" },
+            { "event": "event_mode_availability_updated" },
+            { "event": "event_mode_availability_turned_off" }
+          ]
+        },
+        {
+          "key": "event-mode-messaging",
+          "name": "Event Mode messaging activity",
+          "description": "Message starts, sends, and replies.",
+          "type": "trend",
+          "display": "ActionsBar",
+          "dateFrom": "-30d",
+          "series": [
+            { "event": "event_mode_message_started" },
+            { "event": "event_mode_message_sent" },
+            { "event": "event_mode_message_replied" }
+          ]
+        },
+        {
+          "key": "event-mode-start-quartet-handoff",
+          "name": "Event Mode to Start quartet handoff",
+          "description": "Clicks from Event Mode into the Start quartet flow.",
+          "type": "trend",
+          "display": "BoldNumber",
+          "dateFrom": "-30d",
+          "series": [{ "event": "event_mode_start_quartet_clicked" }]
+        }
+      ]
+    },
+    {
       "key": "browser-mobile-compatibility",
       "name": "What Can We Sing - Browser / Mobile Compatibility",
       "description": "Key action success and failure by browser, operating system, and device type.",

--- a/app/event-mode/[code]/page.tsx
+++ b/app/event-mode/[code]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AppNav } from "@/components/AppNav";
+import { trackEvent } from "@/lib/analytics";
 import {
   blockEventModeUser,
   closeEventModeEvent,
@@ -82,6 +83,16 @@ function eventLocation(event: EventModeEvent) {
   return [event.city, event.venue_or_location_note].filter(Boolean).join(" · ");
 }
 
+function availabilityAnalyticsProperties(
+  availabilityForm: AvailabilityFormState
+) {
+  return {
+    selected_voice_part_count: availabilityForm.voiceParts.length,
+    has_availability: availabilityForm.availabilityNote.trim().length > 0,
+    has_meetup: availabilityForm.meetupNote.trim().length > 0,
+  };
+}
+
 export default function EventModeDetailPage() {
   const params = useParams<{ code: string }>();
   const code = params.code;
@@ -135,6 +146,16 @@ export default function EventModeDetailPage() {
         setAvailabilityForm(
           loadedEvent ? availabilityFormFromEvent(loadedEvent, myAvailability) : null
         );
+        if (loadedEvent) {
+          trackEvent("event_mode_viewed", {
+            page_area: "detail",
+            signed_in: Boolean(user),
+            visibility: loadedEvent.visibility,
+            lifecycle: getEventModeLifecycle(loadedEvent),
+            availability_count: loadedAvailability.length,
+            message_count: loadedMessages.length,
+          });
+        }
       } catch (err) {
         console.error("Could not load Event Mode event", err);
         setMessageTone("error");
@@ -249,6 +270,7 @@ export default function EventModeDetailPage() {
     setMessage("");
 
     try {
+      const wasAvailable = Boolean(currentAvailability);
       await upsertEventModeAvailability({
         eventId: event.id,
         voiceParts: availabilityForm.voiceParts,
@@ -256,11 +278,33 @@ export default function EventModeDetailPage() {
         meetupNote: availabilityForm.meetupNote,
         availableUntil: availabilityForm.availableUntil,
       });
+      trackEvent(
+        wasAvailable
+          ? "event_mode_availability_updated"
+          : "event_mode_availability_created",
+        {
+          ...availabilityAnalyticsProperties(availabilityForm),
+          visibility: event.visibility,
+          lifecycle: getEventModeLifecycle(event),
+          status: "success",
+        }
+      );
       await reloadAvailability();
       setMessageTone("success");
       setMessage("You are available to sing at this event.");
     } catch (err) {
       console.error("Could not save Event Mode availability", err);
+      trackEvent(
+        currentAvailability
+          ? "event_mode_availability_updated"
+          : "event_mode_availability_created",
+        {
+          ...availabilityAnalyticsProperties(availabilityForm),
+          visibility: event.visibility,
+          lifecycle: getEventModeLifecycle(event),
+          status: "failure",
+        }
+      );
       setMessageTone("error");
       setMessage(
         err instanceof Error ? err.message : "Could not save availability."
@@ -277,11 +321,21 @@ export default function EventModeDetailPage() {
 
     try {
       await turnOffEventModeAvailability(event.id);
+      trackEvent("event_mode_availability_turned_off", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "success",
+      });
       await reloadAvailability();
       setMessageTone("success");
       setMessage("Your Event Mode availability is turned off.");
     } catch (err) {
       console.error("Could not turn off Event Mode availability", err);
+      trackEvent("event_mode_availability_turned_off", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "failure",
+      });
       setMessageTone("error");
       setMessage(
         err instanceof Error
@@ -305,6 +359,12 @@ export default function EventModeDetailPage() {
         recipientAvailabilityId: target.id,
         body: messageBody,
       });
+      trackEvent("event_mode_message_sent", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "success",
+        notification_attempted: Boolean(sentMessage),
+      });
       let notificationSent = true;
       if (sentMessage) {
         await notifyEventModeMessage(sentMessage.id).catch((err) => {
@@ -323,6 +383,11 @@ export default function EventModeDetailPage() {
       );
     } catch (err) {
       console.error("Could not send Event Mode message", err);
+      trackEvent("event_mode_message_sent", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "failure",
+      });
       setMessageTone("error");
       setMessage(err instanceof Error ? err.message : "Could not send message.");
     } finally {
@@ -342,6 +407,12 @@ export default function EventModeDetailPage() {
         recipientUserId,
         body,
       });
+      trackEvent("event_mode_message_replied", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "success",
+        notification_attempted: Boolean(sentMessage),
+      });
       let notificationSent = true;
       if (sentMessage) {
         await notifyEventModeMessage(sentMessage.id).catch((err) => {
@@ -359,6 +430,11 @@ export default function EventModeDetailPage() {
       );
     } catch (err) {
       console.error("Could not send Event Mode reply", err);
+      trackEvent("event_mode_message_replied", {
+        visibility: event.visibility,
+        lifecycle: getEventModeLifecycle(event),
+        status: "failure",
+      });
       setMessageTone("error");
       setMessage(err instanceof Error ? err.message : "Could not send reply.");
     } finally {
@@ -636,11 +712,21 @@ export default function EventModeDetailPage() {
                       </span>
                       <select
                         value={selectedPart}
-                        onChange={(inputEvent) =>
-                          setSelectedPart(
-                            inputEvent.target.value as EventModeVoicePart | "all"
-                          )
-                        }
+                        onChange={(inputEvent) => {
+                          const value = inputEvent.target.value as
+                            | EventModeVoicePart
+                            | "all";
+                          setSelectedPart(value);
+                          trackEvent(
+                            "event_mode_available_singer_filter_used",
+                            {
+                              selected_part_count: value === "all" ? 0 : 1,
+                              availability_count: availability.length,
+                              visibility: event.visibility,
+                              lifecycle: getEventModeLifecycle(event),
+                            }
+                          );
+                        }}
                         className="mt-2 w-full rounded-xl bg-slate-900 px-3 py-2 text-white outline-none ring-cyan-300 focus:ring-2"
                       >
                         <option value="all">All parts</option>
@@ -690,6 +776,11 @@ export default function EventModeDetailPage() {
                               onClick={() => {
                                 setMessageTarget(item);
                                 setMessageBody("");
+                                trackEvent("event_mode_message_started", {
+                                  visibility: event.visibility,
+                                  lifecycle: getEventModeLifecycle(event),
+                                  availability_count: availability.length,
+                                });
                               }}
                               className="rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200"
                             >
@@ -862,6 +953,14 @@ export default function EventModeDetailPage() {
                     </p>
                     <a
                       href="/session"
+                      onClick={() =>
+                        trackEvent("event_mode_start_quartet_clicked", {
+                          visibility: event.visibility,
+                          lifecycle: getEventModeLifecycle(event),
+                          availability_count: availability.length,
+                          message_count: messages.length,
+                        })
+                      }
                       className="mt-3 inline-block rounded-xl bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-cyan-200"
                     >
                       Start a quartet

--- a/app/event-mode/page.tsx
+++ b/app/event-mode/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AppNav } from "@/components/AppNav";
+import { trackEvent } from "@/lib/analytics";
 import {
   createEventModeEvent,
   eventModePathFromCode,
@@ -57,13 +58,29 @@ export default function EventModePage() {
   const [loadingEvents, setLoadingEvents] = useState(false);
   const [creating, setCreating] = useState(false);
 
-  async function loadEvents(searchQuery = query) {
+  async function loadEvents(
+    searchQuery = query,
+    options: { trackSearch?: boolean } = {}
+  ) {
     setLoadingEvents(true);
     try {
       const listedEvents = await searchEventModeEvents(searchQuery);
       setEvents(listedEvents);
+      if (options.trackSearch) {
+        trackEvent("event_mode_event_search_submitted", {
+          result_count: listedEvents.length,
+          has_search: searchQuery.trim().length > 0,
+          status: "success",
+        });
+      }
     } catch (err) {
       console.error("Could not load Event Mode events", err);
+      if (options.trackSearch) {
+        trackEvent("event_mode_event_search_submitted", {
+          has_search: searchQuery.trim().length > 0,
+          status: "failure",
+        });
+      }
       setMessageTone("error");
       setMessage("Could not load events. Check your connection and try again.");
     } finally {
@@ -80,6 +97,15 @@ export default function EventModePage() {
           const searchParams = new URLSearchParams(window.location.search);
           setShowCreateForm(searchParams.get("create") === "1");
           await loadEvents("");
+          trackEvent("event_mode_viewed", {
+            page_area: "landing",
+            signed_in: true,
+          });
+        } else {
+          trackEvent("event_mode_viewed", {
+            page_area: "landing",
+            signed_in: false,
+          });
         }
         setAuthChecked(true);
       } catch (err) {
@@ -110,6 +136,9 @@ export default function EventModePage() {
       return;
     }
 
+    trackEvent("event_mode_event_used", {
+      source: "code_entry",
+    });
     window.location.href = path;
   }
 
@@ -133,11 +162,19 @@ export default function EventModePage() {
       }
 
       const event = await createEventModeEvent(form);
+      trackEvent("event_mode_event_created", {
+        visibility: event.visibility,
+        status: "success",
+      });
       setMessageTone("success");
       setMessage("Event created.");
       window.location.href = `/event-mode/${event.join_code}`;
     } catch (err) {
       console.error("Could not create Event Mode event", err);
+      trackEvent("event_mode_event_created", {
+        visibility: form.visibility,
+        status: "failure",
+      });
       setMessageTone("error");
       setMessage(err instanceof Error ? err.message : "Could not create event.");
       setCreating(false);
@@ -170,8 +207,8 @@ export default function EventModePage() {
             Find singers at an event
           </h1>
           <p className="mt-4 text-lg leading-8 text-slate-300">
-            Event Mode helps singers find pickup singing opportunities at an
-            event. Sign in to find or create an event.
+              Event Mode helps singers find pickup singing opportunities at an
+              event. Sign in to find or create an event.
           </p>
           <p className="mt-3 text-sm leading-6 text-slate-400">
             Beta means this feature may be buggy or incomplete.
@@ -228,7 +265,9 @@ export default function EventModePage() {
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   onKeyDown={(event) => {
-                    if (event.key === "Enter") loadEvents(query);
+                    if (event.key === "Enter") {
+                      loadEvents(query, { trackSearch: true });
+                    }
                   }}
                   placeholder="Search by event name, city, or shorthand like AHB"
                   className="mt-2 w-full rounded-xl bg-slate-900 px-4 py-3 text-white outline-none ring-cyan-300 focus:ring-2"
@@ -236,7 +275,7 @@ export default function EventModePage() {
               </label>
               <button
                 type="button"
-                onClick={() => loadEvents(query)}
+                onClick={() => loadEvents(query, { trackSearch: true })}
                 disabled={loadingEvents}
                 className="rounded-xl bg-cyan-300 px-5 py-3 font-semibold text-slate-950 hover:bg-cyan-200 disabled:opacity-50 sm:self-end"
               >
@@ -271,6 +310,13 @@ export default function EventModePage() {
                     </div>
                     <a
                       href={`/event-mode/${event.join_code}`}
+                      onClick={() =>
+                        trackEvent("event_mode_event_used", {
+                          source: "search_result",
+                          visibility: event.visibility,
+                          lifecycle: getEventModeLifecycle(event),
+                        })
+                      }
                       className="rounded-xl bg-cyan-300 px-4 py-2 text-center text-sm font-semibold text-slate-950 hover:bg-cyan-200"
                     >
                       Use this event
@@ -438,6 +484,13 @@ export default function EventModePage() {
                       </p>
                       <a
                         href={`/event-mode/${candidate.event.join_code}`}
+                        onClick={() =>
+                          trackEvent("event_mode_event_used", {
+                            source: "duplicate_candidate",
+                            visibility: candidate.event.visibility,
+                            lifecycle: getEventModeLifecycle(candidate.event),
+                          })
+                        }
                         className="mt-3 inline-block rounded-xl bg-amber-200 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-amber-100"
                       >
                         Use existing event

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -187,7 +187,8 @@ export default function PrivacyPage() {
               counts, categories, browser/device information, and coarse action
               details. We do not intentionally send feedback text, My Songs
               notes, song titles, arranger names, singer names, email addresses,
-              or quartet join codes to analytics.
+              quartet join codes, Event Mode message text, availability notes,
+              meetup notes, event names, or event location text to analytics.
             </p>
           </div>
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -67,6 +67,18 @@ The app currently tracks these events through `lib/analytics.ts`:
 | `help_viewed` | `app/help/page.tsx` when the help page loads | none | No | Product Health context |
 | `feedback_submitted` | `app/help/page.tsx` after feedback API succeeds | `category`, `length` | No message text | Product Health |
 | `feedback_failed` | `app/help/page.tsx` when feedback API fails | `category`, `status_code` or `reason` | No message text | Reliability / Errors |
+| `event_mode_viewed` | `app/event-mode/page.tsx` and `app/event-mode/[code]/page.tsx` when Event Mode landing/detail pages load | `page_area`, `signed_in`, `visibility`, `lifecycle`, `availability_count`, `message_count` | No event names, codes, notes, or message text | Event Mode Beta |
+| `event_mode_event_search_submitted` | `app/event-mode/page.tsx` after a user submits an Event Mode search | `result_count`, `has_search`, `status` | No raw search text | Event Mode Beta |
+| `event_mode_event_created` | `app/event-mode/page.tsx` after Event Mode event creation succeeds or fails | `visibility`, `status` | No event name or location text | Event Mode Beta |
+| `event_mode_event_used` | `app/event-mode/page.tsx` when a user opens an event from search, duplicate detection, or code entry | `source`, `visibility`, `lifecycle` | No event code, name, or location text | Event Mode Beta |
+| `event_mode_availability_created` | `app/event-mode/[code]/page.tsx` after a user first marks themself available, or the save fails | `selected_voice_part_count`, `has_availability`, `has_meetup`, `visibility`, `lifecycle`, `status` | No availability or meetup note text | Event Mode Beta |
+| `event_mode_availability_updated` | `app/event-mode/[code]/page.tsx` after an existing availability save succeeds or fails | `selected_voice_part_count`, `has_availability`, `has_meetup`, `visibility`, `lifecycle`, `status` | No availability or meetup note text | Event Mode Beta |
+| `event_mode_availability_turned_off` | `app/event-mode/[code]/page.tsx` after availability is turned off, or the action fails | `visibility`, `lifecycle`, `status` | No free text | Event Mode Beta |
+| `event_mode_available_singer_filter_used` | `app/event-mode/[code]/page.tsx` when the available-singer voice-part filter changes | `selected_part_count`, `availability_count`, `visibility`, `lifecycle` | No singer names or raw part labels | Event Mode Beta |
+| `event_mode_message_started` | `app/event-mode/[code]/page.tsx` when a user opens the message composer for an available singer | `visibility`, `lifecycle`, `availability_count` | No display name or message text | Event Mode Beta |
+| `event_mode_message_sent` | `app/event-mode/[code]/page.tsx` after a new Event Mode message succeeds or fails | `visibility`, `lifecycle`, `status`, `notification_attempted` | No message text or contact details | Event Mode Beta |
+| `event_mode_message_replied` | `app/event-mode/[code]/page.tsx` after an Event Mode reply succeeds or fails | `visibility`, `lifecycle`, `status`, `notification_attempted` | No message text or contact details | Event Mode Beta |
+| `event_mode_start_quartet_clicked` | `app/event-mode/[code]/page.tsx` when a user clicks the Start quartet handoff from Event Mode | `visibility`, `lifecycle`, `availability_count`, `message_count` | No event code or message text | Event Mode Beta |
 
 ## Reproducible Dashboards
 
@@ -76,6 +88,7 @@ Dashboard definitions live in `analytics/posthog/dashboards.json`. They cover:
 - Quartet Funnel
 - Repertoire & Matching
 - Reliability / Errors
+- Event Mode Beta
 - Browser / Mobile Compatibility
 
 Validate the dashboard spec locally with:

--- a/lib/__tests__/analytics.test.ts
+++ b/lib/__tests__/analytics.test.ts
@@ -25,6 +25,11 @@ describe("sanitizeAnalyticsProperties", () => {
         arranger_name: "Arranger",
         feedback_text: "Please add this",
         display_name: "Singer",
+        event_name: "District Convention",
+        availability_note: "After contest",
+        meetup_note: "Lobby",
+        message_body: "Want to sing?",
+        raw_search_text: "Denver afterglow",
         notes: "Private note",
         email: "singer@example.com",
         song_count: 12,
@@ -47,6 +52,13 @@ describe("getAnalyticsRoute", () => {
     expect(getAnalyticsRoute("/join/ABC123")).toBe("/join/[code]");
     expect(getAnalyticsRoute("/join/ABC123?intent=join")).toBe(
       "/join/[code]"
+    );
+  });
+
+  it("does not expose Event Mode codes in route analytics", () => {
+    expect(getAnalyticsRoute("/event-mode/ABC123")).toBe("/event-mode/[code]");
+    expect(getAnalyticsRoute("/event-mode/ABC123?from=email")).toBe(
+      "/event-mode/[code]"
     );
   });
 });

--- a/lib/__tests__/eventModeAnalytics.test.ts
+++ b/lib/__tests__/eventModeAnalytics.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ANALYTICS_EVENT_NAMES } from "@/lib/analytics";
+
+const repoRoot = process.cwd();
+const eventModePage = readFileSync(join(repoRoot, "app/event-mode/page.tsx"), "utf8");
+const eventModeDetailPage = readFileSync(
+  join(repoRoot, "app/event-mode/[code]/page.tsx"),
+  "utf8"
+);
+const eventModeSources = `${eventModePage}\n${eventModeDetailPage}`;
+
+describe("Event Mode analytics", () => {
+  const eventModeEvents = [
+    "event_mode_viewed",
+    "event_mode_event_search_submitted",
+    "event_mode_event_created",
+    "event_mode_event_used",
+    "event_mode_availability_created",
+    "event_mode_availability_updated",
+    "event_mode_availability_turned_off",
+    "event_mode_available_singer_filter_used",
+    "event_mode_message_started",
+    "event_mode_message_sent",
+    "event_mode_message_replied",
+    "event_mode_start_quartet_clicked",
+  ];
+
+  it("declares and emits Event Mode events through the shared analytics wrapper", () => {
+    for (const eventName of eventModeEvents) {
+      expect(ANALYTICS_EVENT_NAMES).toContain(eventName);
+      expect(eventModeSources).toContain(eventName);
+    }
+
+    expect(eventModeSources).toContain('import { trackEvent } from "@/lib/analytics"');
+  });
+
+  it("uses bucketed Event Mode properties instead of raw user text", () => {
+    expect(eventModeSources).toContain("result_count");
+    expect(eventModeSources).toContain("has_search");
+    expect(eventModeSources).toContain("selected_voice_part_count");
+    expect(eventModeSources).toContain("has_availability");
+    expect(eventModeSources).toContain("has_meetup");
+    expect(eventModeSources).toContain("availability_count");
+    expect(eventModeSources).toContain("message_count");
+    expect(eventModeSources).toContain("visibility");
+    expect(eventModeSources).toContain("lifecycle");
+    expect(eventModeSources).not.toContain("search_text");
+    expect(eventModeSources).not.toContain("event_name");
+    expect(eventModeSources).not.toContain("event_code");
+    expect(eventModeSources).not.toContain("message_body");
+  });
+});

--- a/lib/__tests__/posthogDashboardSpec.test.ts
+++ b/lib/__tests__/posthogDashboardSpec.test.ts
@@ -30,6 +30,7 @@ describe("PostHog dashboard spec", () => {
       "quartet-funnel",
       "repertoire-matching",
       "reliability-errors",
+      "event-mode",
       "browser-mobile-compatibility",
     ]);
   });
@@ -95,6 +96,8 @@ describe("PostHog dashboard spec", () => {
       "join-by-route": "ActionsBar",
       "repertoire-updates": "ActionsBar",
       "join-errors": "ActionsBar",
+      "event-mode-create-by-visibility": "ActionsBar",
+      "event-mode-start-quartet-handoff": "BoldNumber",
       "leave-flow-by-browser": "ActionsBar",
     });
   });

--- a/lib/__tests__/privacyPage.test.ts
+++ b/lib/__tests__/privacyPage.test.ts
@@ -41,6 +41,9 @@ describe("privacy page copy", () => {
     expect(privacyPage).toContain("other singers in that quartet may see");
     expect(privacyPage).toContain("Feedback forms");
     expect(privacyPage).toContain("PostHog");
+    expect(privacyPage).toContain("Event Mode message text");
+    expect(privacyPage).toContain("availability notes");
+    expect(privacyPage).toContain("event location text");
     expect(privacyPage).toContain("Supabase");
     expect(privacyPage).toContain("Vercel");
     expect(privacyPage).toContain("Resend");

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -28,7 +28,19 @@ export type AnalyticsEventName =
   | "song_mark_sung_failed"
   | "help_viewed"
   | "feedback_submitted"
-  | "feedback_failed";
+  | "feedback_failed"
+  | "event_mode_viewed"
+  | "event_mode_event_search_submitted"
+  | "event_mode_event_created"
+  | "event_mode_event_used"
+  | "event_mode_availability_created"
+  | "event_mode_availability_updated"
+  | "event_mode_availability_turned_off"
+  | "event_mode_available_singer_filter_used"
+  | "event_mode_message_started"
+  | "event_mode_message_sent"
+  | "event_mode_message_replied"
+  | "event_mode_start_quartet_clicked";
 
 export const ANALYTICS_EVENT_NAMES = [
   "analytics_client_ready",
@@ -59,6 +71,18 @@ export const ANALYTICS_EVENT_NAMES = [
   "help_viewed",
   "feedback_submitted",
   "feedback_failed",
+  "event_mode_viewed",
+  "event_mode_event_search_submitted",
+  "event_mode_event_created",
+  "event_mode_event_used",
+  "event_mode_availability_created",
+  "event_mode_availability_updated",
+  "event_mode_availability_turned_off",
+  "event_mode_available_singer_filter_used",
+  "event_mode_message_started",
+  "event_mode_message_sent",
+  "event_mode_message_replied",
+  "event_mode_start_quartet_clicked",
 ] as const satisfies readonly AnalyticsEventName[];
 
 type AnalyticsPropertyValue = string | number | boolean | null | undefined;
@@ -115,6 +139,10 @@ export function getAnalyticsRoute(pathname: string | null | undefined) {
 
   if (segments[0] === "join" && segments.length > 1) {
     return "/join/[code]";
+  }
+
+  if (segments[0] === "event-mode" && segments.length > 1) {
+    return "/event-mode/[code]";
   }
 
   return normalizedPathname || "/";


### PR DESCRIPTION
## Summary
- Add privacy-safe Event Mode analytics for landing/detail views, search, event creation/use, availability create/update/off, singer filtering, messaging, replies, and Start a quartet handoff.
- Add the managed PostHog "Event Mode Beta" dashboard with entry, search, creation, availability, messaging, and handoff insights.
- Update analytics docs, privacy copy, sanitizer coverage, dashboard spec tests, and Event Mode analytics regression tests.

## Privacy, docs, and tests
- Analytics payloads avoid Event Mode message text, availability/meetup notes, event names, event location text, join codes, raw search text, display names, emails, phones, and raw error text.
- Docs updated in `docs/analytics.md`; Privacy page updated for Event Mode analytics exclusions.
- No Supabase schema/RLS changes.

## Verification
- `npm run posthog:dashboards:check`
- `npm run test:run -- analytics eventModeAnalytics eventModeUi posthogDashboardSpec privacyPage supabaseContract`
- `npm run test:run`
- `npm run build`
- Commit hook: `npm run test:run`

## PostHog dashboard sync
- Added the dashboard to `analytics/posthog/dashboards.json` so it can be pushed automatically with `npm run posthog:dashboards:sync`.
- Tried to sync locally, but the environment does not have the private credentials required by the sync script: `POSTHOG_PERSONAL_API_KEY` and `POSTHOG_ENVIRONMENT_ID` or `POSTHOG_PROJECT_ID`.
- `vercel env pull /private/tmp/wcws-posthog-env` also could not retrieve linked project settings from this checkout.

Closes #315
